### PR TITLE
Refactor template.go out of terraform to be used as common code

### DIFF
--- a/cloud/vsphere/provisioner/common/templates.go
+++ b/cloud/vsphere/provisioner/common/templates.go
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package terraform
+package common
 
 import (
 	"bytes"
 	"fmt"
 	"text/template"
 
+	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-type templateParams struct {
+type TemplateParams struct {
 	Token        string
 	Cluster      *clusterv1.Cluster
 	Machine      *clusterv1.Machine
@@ -33,7 +34,7 @@ type templateParams struct {
 }
 
 // Returns the startup script for the nodes.
-func getNodeStartupScript(params templateParams) (string, error) {
+func GetNodeStartupScript(params TemplateParams) (string, error) {
 	var buf bytes.Buffer
 	tName := "fullScript"
 	if isPreloaded(params) {
@@ -46,7 +47,7 @@ func getNodeStartupScript(params templateParams) (string, error) {
 	return buf.String(), nil
 }
 
-func getMasterStartupScript(params templateParams) (string, error) {
+func GetMasterStartupScript(params TemplateParams) (string, error) {
 	var buf bytes.Buffer
 	tName := "fullScript"
 	if isPreloaded(params) {
@@ -59,7 +60,7 @@ func getMasterStartupScript(params templateParams) (string, error) {
 	return buf.String(), nil
 }
 
-func isPreloaded(params templateParams) bool {
+func isPreloaded(params TemplateParams) bool {
 	return params.Preloaded
 }
 
@@ -75,7 +76,7 @@ func PreloadNodeScript(version string, dockerImages []string) (string, error) {
 
 func preloadScript(t *template.Template, version string, dockerImages []string) (string, error) {
 	var buf bytes.Buffer
-	params := templateParams{
+	params := TemplateParams{
 		Machine:      &clusterv1.Machine{},
 		DockerImages: dockerImages,
 	}
@@ -96,10 +97,10 @@ func init() {
 	// Force a compliation error if getSubnet changes. This is the
 	// signature the templates expect, so changes need to be
 	// reflected in templates below.
-	var _ func(clusterv1.NetworkRanges) string = getSubnet
+	var _ func(clusterv1.NetworkRanges) string = vsphereutils.GetSubnet
 	funcMap := map[string]interface{}{
 		"endpoint":  endpoint,
-		"getSubnet": getSubnet,
+		"getSubnet": vsphereutils.GetSubnet,
 	}
 	nodeStartupScriptTemplate = template.Must(template.New("nodeStartupScript").Funcs(funcMap).Parse(nodeStartupScript))
 	nodeStartupScriptTemplate = template.Must(nodeStartupScriptTemplate.Parse(genericTemplates))

--- a/cloud/vsphere/utils/utils.go
+++ b/cloud/vsphere/utils/utils.go
@@ -118,3 +118,11 @@ func GetClusterProviderConfig(providerConfig clusterv1.ProviderConfig) (*vsphere
 
 	return config, nil
 }
+
+// Just a temporary hack to grab a single range from the config.
+func GetSubnet(netRange clusterv1.NetworkRanges) string {
+	if len(netRange.CIDRBlocks) == 0 {
+		return ""
+	}
+	return netRange.CIDRBlocks[0]
+}


### PR DESCRIPTION
Now that we are adding a govmomi based implementation as well, the script templates as they stand today should be used by both govmomi and terraform implementations. Thus refactoring the template.go to be consumable with both implementations

Resolves #57 