### PR TITLE
Fix the kubelet config for version 1.11 and above

### DIFF
--- a/cloud/vsphere/provisioner/common/templates.go
+++ b/cloud/vsphere/provisioner/common/templates.go
@@ -387,6 +387,8 @@ cat > /etc/systemd/system/kubelet.service.d/20-cloud.conf << EOF
 Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
 Environment="KUBELET_EXTRA_ARGS=--cloud-provider=vsphere --cloud-config=/etc/kubernetes/cloud-config/cloud-config.yaml"
 EOF
+# clear the content of the /etc/default/kubelet otherwise in v 1.11.* it causes failure to use the env variable set in the 20-cloud.conf file above
+echo > /etc/default/kubelet
 systemctl daemon-reload
 systemctl restart kubelet.service
 ` +


### PR DESCRIPTION
The systemd unit definition of the kubelet sources the file
/etc/default/kubelet for any env variables. The default file
generated for /etc/default/kubelet has an empty value like
`KUBELET_EXTRA_ARGS=`. This causes the kubelet to not use the
actual value of KUBELET_EXTRA_ARGS set in the override file
/etc/systemd/system/kubelet.service.d/20-cloud.conf