### PR TITLE
run dep ensure when run make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ push: depend
 
 check: depend fmt vet
 
-test:
+test: depend
 	go test -race -cover ./cmd/... ./cloud/...
 
 fmt:


### PR DESCRIPTION
we want to be able to run unit tests by running a single command `make test`.
i have a immediate following pull request to setup a CI job that trigger `make test` 

/cc @frapposelli @sflxn 