### PR TITLE
Add a new MachineSpec for defining the instance on vsphere

### DIFF
--- a/cmd/clusterctl/examples/vsphere/machines.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machines.yaml.template
@@ -22,6 +22,27 @@ items:
           disk_label: ""
           disk_size: ""
           virtual_machine_domain: ""
+        # machineSpec:
+        #   datacenter: ""
+        #   datastore: ""
+        #   resourcePool: ""
+        #   networks:
+        #   - networkName: ""
+        #     ipConfig:
+        #       networkType: static
+        #       ip: ""
+        #       netmask: ""
+        #       gateway: ""
+        #       dns:
+        #       - xxxx
+        #       - yyyy
+        #   numCPUs: 2
+        #   memoryMB: 2048
+        #   template: ""
+        #   disks:
+        #   - diskLabel: ""
+        #     diskSizeGB: 20
+        #   preloaded: false
     versions:
       kubelet: 1.10.1
       controlPlane: 1.10.1

--- a/cmd/clusterctl/examples/vsphere/machineset.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machineset.yaml.template
@@ -28,6 +28,21 @@ spec:
             disk_label: ""
             disk_size: ""
             virtual_machine_domain: ""
+          # machineSpec:
+          #   datacenter: ""
+          #   datastore: ""
+          #   resourcePool: ""
+          #   networks:
+          #   - networkName: ""
+          #     ipConfig:
+          #       networkType: dhcp
+          #   numCPUs: 2
+          #   memoryMB: 2048
+          #   template: ""
+          #   disks:
+          #   - diskLabel: ""
+          #     diskSizeGB: 20
+          #   preloaded: false
       versions:
         kubelet: 1.10.1
       roles:

--- a/pkg/apis/vsphereproviderconfig/types.go
+++ b/pkg/apis/vsphereproviderconfig/types.go
@@ -28,7 +28,8 @@ type VsphereMachineProviderConfig struct {
 	VsphereMachine string `json:"vsphereMachine"`
 	MachineRef     string `json:"machineRef,omitempty"`
 	// List of variables for the chosen machine.
-	MachineVariables map[string]string `json:"machineVariables"`
+	MachineVariables map[string]string  `json:"machineVariables"`
+	MachineSpec      VsphereMachineSpec `json:"machineSpec,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -54,6 +55,44 @@ type VsphereClusterProviderStatus struct {
 
 	LastUpdated string    `json:"lastUpdated"`
 	APIStatus   APIStatus `json:"clusterApiStatus"`
+}
+
+type VsphereMachineSpec struct {
+	Datacenter       string        `json:"datacenter"`
+	Datastore        string        `json:"datastore"`
+	ResourcePool     string        `json:"resourcePool,omitempty"`
+	Networks         []NetworkSpec `json:"networks"`
+	NumCPUs          int32         `json:"numCPUs,omitempty"`
+	MemoryMB         int64         `json:"memoryMB,omitempty"`
+	VMTemplate       string        `json:"template"`
+	Disks            []DiskSpec    `json:"disks"`
+	Preloaded        bool          `json:"preloaded,omitempty"`
+	VsphereCloudInit bool          `json:"vsphereCloudInit,omitempty"`
+}
+
+type NetworkSpec struct {
+	NetworkName string   `json:"networkName"`
+	IPConfig    IPConfig `json:"ipConfig,omitempty"`
+}
+
+type IPConfig struct {
+	NetworkType NetworkType `json:"networkType"`
+	IP          string      `json:"ip,omitempty"`
+	Netmask     string      `json:"netmask,omitempty"`
+	Gateway     string      `json:"gateway,omitempty"`
+	Dns         []string    `json:"dns,omitempty"`
+}
+
+type NetworkType string
+
+const (
+	Static NetworkType = "static"
+	DHCP   NetworkType = "dhcp"
+)
+
+type DiskSpec struct {
+	DiskSizeGB int64  `json:"diskSizeGB,omitempty"`
+	DiskLabel  string `json:"diskLabel,omitempty"`
 }
 
 type APIStatus string

--- a/pkg/apis/vsphereproviderconfig/types.go
+++ b/pkg/apis/vsphereproviderconfig/types.go
@@ -26,6 +26,7 @@ type VsphereMachineProviderConfig struct {
 
 	// Name of the machine that's registered in the NamedMachines ConfigMap.
 	VsphereMachine string `json:"vsphereMachine"`
+	MachineRef     string `json:"machineRef,omitempty"`
 	// List of variables for the chosen machine.
 	MachineVariables map[string]string `json:"machineVariables"`
 }
@@ -44,7 +45,6 @@ type VsphereMachineProviderStatus struct {
 	metav1.TypeMeta `json:",inline"`
 
 	LastUpdated string `json:"lastUpdated"`
-	MachineRef  string `json:"machineRef"`
 	TaskRef     string `json:"taskRef"`
 }
 

--- a/pkg/apis/vsphereproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/vsphereproviderconfig/v1alpha1/types.go
@@ -28,7 +28,8 @@ type VsphereMachineProviderConfig struct {
 	VsphereMachine string `json:"vsphereMachine"`
 	MachineRef     string `json:"machineRef,omitempty"`
 	// List of variables for the chosen machine.
-	MachineVariables map[string]string `json:"machineVariables"`
+	MachineVariables map[string]string  `json:"machineVariables"`
+	MachineSpec      VsphereMachineSpec `json:"machineSpec,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -54,6 +55,44 @@ type VsphereClusterProviderStatus struct {
 
 	LastUpdated string    `json:"lastUpdated"`
 	APIStatus   APIStatus `json:"clusterApiStatus"`
+}
+
+type VsphereMachineSpec struct {
+	Datacenter       string        `json:"datacenter"`
+	Datastore        string        `json:"datastore"`
+	ResourcePool     string        `json:"resourcePool,omitempty"`
+	Networks         []NetworkSpec `json:"networks"`
+	NumCPUs          int32         `json:"numCPUs,omitempty"`
+	MemoryMB         int64         `json:"memoryMB,omitempty"`
+	VMTemplate       string        `json:"template"`
+	Disks            []DiskSpec    `json:"disks"`
+	Preloaded        bool          `json:"preloaded,omitempty"`
+	VsphereCloudInit bool          `json:"vsphereCloudInit,omitempty"`
+}
+
+type NetworkSpec struct {
+	NetworkName string   `json:"networkName"`
+	IPConfig    IPConfig `json:"ipConfig,omitempty"`
+}
+
+type IPConfig struct {
+	NetworkType NetworkType `json:"networkType"`
+	IP          string      `json:"ip,omitempty"`
+	Netmask     string      `json:"netmask,omitempty"`
+	Gateway     string      `json:"gateway,omitempty"`
+	Dns         []string    `json:"dns,omitempty"`
+}
+
+type NetworkType string
+
+const (
+	Static NetworkType = "static"
+	DHCP   NetworkType = "dhcp"
+)
+
+type DiskSpec struct {
+	DiskSizeGB int64  `json:"diskSizeGB,omitempty"`
+	DiskLabel  string `json:"diskLabel,omitempty"`
 }
 
 type APIStatus string

--- a/pkg/apis/vsphereproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/vsphereproviderconfig/v1alpha1/types.go
@@ -26,6 +26,7 @@ type VsphereMachineProviderConfig struct {
 
 	// Name of the machine that's registered in the NamedMachines ConfigMap.
 	VsphereMachine string `json:"vsphereMachine"`
+	MachineRef     string `json:"machineRef,omitempty"`
 	// List of variables for the chosen machine.
 	MachineVariables map[string]string `json:"machineVariables"`
 }
@@ -44,6 +45,7 @@ type VsphereMachineProviderStatus struct {
 	metav1.TypeMeta `json:",inline"`
 
 	LastUpdated string `json:"lastUpdated"`
+	TaskRef     string `json:"taskRef"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/exists.go
@@ -3,7 +3,6 @@ package govmomi
 import (
 	"context"
 
-	"github.com/golang/glog"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
@@ -11,11 +10,6 @@ import (
 )
 
 func (pv *Provisioner) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
-	glog.Infof("govmomi.Actuator.Exists %s", machine.Spec.Name)
-	if machine.Status.NodeRef != nil {
-		glog.Infof("govmomi.Actuator.Exists() - running on target cluster, returning exist")
-		return true, nil
-	}
 	s, err := pv.sessionFromProviderConfig(cluster, machine)
 	if err != nil {
 		return false, err

--- a/pkg/cloud/vsphere/provisioner/terraform/terraform.go
+++ b/pkg/cloud/vsphere/provisioner/terraform/terraform.go
@@ -651,7 +651,7 @@ func (pv *Provisioner) updateAnnotations(cluster *clusterv1.Cluster, machine *cl
 		return err
 	}
 	// Update the cluster status with updated time stamp for tracking purposes
-	status := &vsphereconfig.VsphereClusterProviderStatus{LastUpdated: time.Now().UTC().String()}
+	status := &vsphereconfigv1.VsphereClusterProviderStatus{LastUpdated: time.Now().UTC().String()}
 	out, err := json.Marshal(status)
 	cluster.Status.ProviderStatus = &runtime.RawExtension{Raw: out}
 	_, err = pv.clusterV1alpha1.Clusters(cluster.Namespace).UpdateStatus(cluster)

--- a/pkg/cloud/vsphere/utils/utils.go
+++ b/pkg/cloud/vsphere/utils/utils.go
@@ -50,11 +50,11 @@ func GetIP(_ *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
 	return "", errors.New("could not get IP")
 }
 
-func GetMachineProviderStatus(machine *clusterv1.Machine) (*vsphereconfig.VsphereMachineProviderStatus, error) {
+func GetMachineProviderStatus(machine *clusterv1.Machine) (*vsphereconfigv1.VsphereMachineProviderStatus, error) {
 	if machine.Status.ProviderStatus == nil {
 		return nil, nil
 	}
-	status := &vsphereconfig.VsphereMachineProviderStatus{}
+	status := &vsphereconfigv1.VsphereMachineProviderStatus{}
 	err := json.Unmarshal(machine.Status.ProviderStatus.Raw, status)
 	if err != nil {
 		return nil, err
@@ -62,11 +62,11 @@ func GetMachineProviderStatus(machine *clusterv1.Machine) (*vsphereconfig.Vspher
 	return status, nil
 }
 
-func GetClusterProviderStatus(cluster *clusterv1.Cluster) (*vsphereconfig.VsphereClusterProviderStatus, error) {
+func GetClusterProviderStatus(cluster *clusterv1.Cluster) (*vsphereconfigv1.VsphereClusterProviderStatus, error) {
 	if cluster.Status.ProviderStatus == nil {
 		return nil, nil
 	}
-	status := &vsphereconfig.VsphereClusterProviderStatus{}
+	status := &vsphereconfigv1.VsphereClusterProviderStatus{}
 	err := json.Unmarshal(cluster.Status.ProviderStatus.Raw, status)
 	if err != nil {
 		return nil, err
@@ -83,12 +83,10 @@ func GetMachineProviderConfig(providerConfig clusterv1.ProviderConfig) (*vsphere
 	if err != nil {
 		return nil, fmt.Errorf("machine providerconfig decoding failure: %v", err)
 	}
-
 	config, ok := obj.(*vsphereconfig.VsphereMachineProviderConfig)
 	if !ok {
 		return nil, fmt.Errorf("machine providerconfig failure to cast to vsphere; type: %v", gvk)
 	}
-
 	return config, nil
 }
 
@@ -101,12 +99,10 @@ func GetClusterProviderConfig(providerConfig clusterv1.ProviderConfig) (*vsphere
 	if err != nil {
 		return nil, fmt.Errorf("cluster providerconfig decoding failure: %v", err)
 	}
-
 	config, ok := obj.(*vsphereconfig.VsphereClusterProviderConfig)
 	if !ok {
 		return nil, fmt.Errorf("cluster providerconfig failure to cast to vsphere; type: %v", gvk)
 	}
-
 	return config, nil
 }
 
@@ -119,11 +115,11 @@ func GetSubnet(netRange clusterv1.NetworkRanges) string {
 }
 
 func GetVMId(machine *clusterv1.Machine) (string, error) {
-	ps, err := GetMachineProviderStatus(machine)
-	if err != nil || ps == nil {
+	pc, err := GetMachineProviderConfig(machine.Spec.ProviderConfig)
+	if err != nil {
 		return "", err
 	}
-	return ps.MachineRef, nil
+	return pc.MachineRef, nil
 }
 
 func GetActiveTasks(machine *clusterv1.Machine) string {


### PR DESCRIPTION
With the new structure we should be able to:
* Support defining multiple nics
* Support providing dhcp/static IP configuration for each nic
* Support customizing multiple disks if present
* Adds a optional flag called `vsphereCloudInit` to indicate if
  the template used has the vsphere datasource for cloud-init
  present and enabled (see [vsphere cloud-init datasource](https://github.com/akutz/cloud-init-vmware-guestinfo/))

Note: This change does not change the existing behavior of using
the `MachineVariables` string map. This will be handled in the
subsequent patches.

Partially Resolves #24
Partially Resolves #28