### PR TITLE
Fix govmomi actuator's Create when using clusterctl

### DIFF
--- a/cloud/vsphere/clusteractuator.go
+++ b/cloud/vsphere/clusteractuator.go
@@ -92,8 +92,10 @@ func (vc *ClusterActuator) updateK8sAPIStatus(cluster *clusterv1.Cluster) error 
 // In case the secret does not exist, then it fetches from the target master node and caches it for
 func (vc *ClusterActuator) fetchKubeConfig(cluster *clusterv1.Cluster, masters []*clusterv1.Machine) (string, error) {
 	var kubeconfig string
+	glog.Infof("attempting to fetch kubeconfig")
 	secret, err := vc.k8sClient.Core().Secrets(cluster.Namespace).Get(fmt.Sprintf(constants.KubeConfigSecretName, cluster.UID), metav1.GetOptions{})
 	if err != nil {
+		glog.Info("could not pull secrets for kubeconfig")
 		// TODO: Check for the proper err type for *not present* case. rather than all other cases
 		// Fetch the kubeconfig and create the secret saving it
 		// Currently we support only a single master thus the below assumption
@@ -118,6 +120,7 @@ func (vc *ClusterActuator) fetchKubeConfig(cluster *clusterv1.Cluster, masters [
 			glog.Warningf("Could not create the secret for the saving kubeconfig: err [%s]", err.Error())
 		}
 	} else {
+		glog.Info("found kubeconfig in secrets")
 		kubeconfig = string(secret.Data[constants.KubeConfigSecretData])
 	}
 	return kubeconfig, nil

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -75,9 +75,6 @@ func NewTerraformMachineActuator(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1
 }
 
 func (vc *VsphereClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	//creator := nativeprovisioner.NewCreator()
-	//creator.Create(cluster, machine)
-
 	if vc.provisioner != nil {
 		err := vc.provisioner.Create(cluster, machine)
 		if err != nil {
@@ -91,9 +88,6 @@ func (vc *VsphereClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.M
 }
 
 func (vc *VsphereClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	//deleter := nativeprovisioner.NewDeleter()
-	//deleter.Delete(cluster, machine)
-
 	if vc.provisioner != nil {
 		return vc.provisioner.Delete(cluster, machine)
 	}
@@ -102,9 +96,6 @@ func (vc *VsphereClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.M
 }
 
 func (vc *VsphereClient) Update(cluster *clusterv1.Cluster, goalMachine *clusterv1.Machine) error {
-	//updater := nativeprovisioner.NewUpdater()
-	//updater.Update(cluster, goalMachine)
-
 	if vc.provisioner != nil {
 		return vc.provisioner.Update(cluster, goalMachine)
 	}
@@ -113,9 +104,6 @@ func (vc *VsphereClient) Update(cluster *clusterv1.Cluster, goalMachine *cluster
 }
 
 func (vc *VsphereClient) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
-	//validator := nativeprovisioner.NewValidator()
-	//validator.Exists(cluster, goalMachine)
-
 	if vc.provisioner != nil {
 		return vc.provisioner.Exists(cluster, machine)
 	}

--- a/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/cloud/vsphere/provisioner/govmomi/exists.go
@@ -3,6 +3,7 @@ package govmomi
 import (
 	"context"
 
+	"github.com/golang/glog"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/cloud/vsphere/utils"
@@ -10,6 +11,11 @@ import (
 )
 
 func (vc *Provisioner) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
+	glog.Infof("govmomi.Actuator.Exists %s", machine.Spec.Name)
+	if machine.Status.NodeRef != nil {
+		glog.Infof("govmomi.Actuator.Exists() - running on target cluster, returning exist")
+		return true, nil
+	}
 	s, err := vc.sessionFromProviderConfig(cluster, machine)
 	if err != nil {
 		return false, err

--- a/cloud/vsphere/provisioner/govmomi/provisioner.go
+++ b/cloud/vsphere/provisioner/govmomi/provisioner.go
@@ -3,7 +3,6 @@ package govmomi
 import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
-	vpshereprovisionercommon "sigs.k8s.io/cluster-api-provider-vsphere/cloud/vsphere/provisioner/common"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
 )
@@ -13,7 +12,7 @@ type Provisioner struct {
 	lister          v1alpha1.Interface
 	eventRecorder   record.EventRecorder
 	sessioncache    map[string]interface{}
-	utils           *vpshereprovisionercommon.ProvisionerUtil
+	k8sClient       kubernetes.Interface
 }
 
 func New(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface, k8sClient kubernetes.Interface, lister v1alpha1.Interface, eventRecorder record.EventRecorder) (*Provisioner, error) {
@@ -22,6 +21,6 @@ func New(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface, k8sClient kub
 		lister:          lister,
 		eventRecorder:   eventRecorder,
 		sessioncache:    make(map[string]interface{}),
-		utils:           vpshereprovisionercommon.New(clusterV1alpha1, k8sClient, lister, eventRecorder),
+		k8sClient:		k8sClient,
 	}, nil
 }

--- a/cloud/vsphere/vsphereproviderconfig/types.go
+++ b/cloud/vsphere/vsphereproviderconfig/types.go
@@ -44,6 +44,8 @@ type VsphereMachineProviderStatus struct {
 	metav1.TypeMeta `json:",inline"`
 
 	LastUpdated string `json:"lastUpdated"`
+	MachineRef  string `json:"machineRef"`
+	TaskRef     string `json:"taskRef"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Clusterctl create cluster was not able to properly create the target cluster.  It would sit
in an infinite loop, attempting to clone the VM template.  The fix was to not use annotations
for task ref and vm ref during create.  Instead, use provider status.  Once this fix was in,
the Target cluster would then sit in an infinite loop, attempting to clone the VM template.
The fix was to check for nodeRef in the actuator's Exists() function.

In addition, moved utils from provisioner/common to provisioner/govmomi as it's only ever
used by the govmomi actuator.

Fixes #70