### PR TITLE
Fix the kubelet config for version 1.11 and above for worker nodes

### DIFF
--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -302,6 +302,8 @@ cat > /etc/systemd/system/kubelet.service.d/20-cloud.conf << EOF
 Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
 Environment="KUBELET_EXTRA_ARGS=--cloud-provider=vsphere"
 EOF
+# clear the content of the /etc/default/kubelet otherwise in v 1.11.* it causes failure to use the env variable set in the 20-cloud.conf file above
+echo > /etc/default/kubelet
 systemctl daemon-reload
 systemctl restart kubelet.service
 


### PR DESCRIPTION
The systemd unit definition of the kubelet sources the file
/etc/default/kubelet for any env variables. The default file
generated for /etc/default/kubelet has an empty value like
`KUBELET_EXTRA_ARGS=`. This causes the kubelet to not use the
actual value of KUBELET_EXTRA_ARGS set in the override file
/etc/systemd/system/kubelet.service.d/20-cloud.conf

This is the same fix as [PR#68](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/68) which fixed this issue with master
node. This PR expands the same fix to worker nodes as well

The root issue is without this the kubelet on the node starts
without the `--cloud-provider=vsphere` flag causing the node to
be not recognized as a cloud instance

Resolves: #89 

Change-Id: Ia73dc7e86ca193b42cea3ac7dc7cc22bebcd7ab4