### PR TITLE
Overload the VMTemplate parameter for search purposes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -958,7 +958,6 @@
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
-  branch = "master"
   digest = "1:797d85ec2636b83dafa570b602919912108b913b34e213c9205214361bab722a"
   name = "sigs.k8s.io/cluster-api"
   packages = [
@@ -1002,6 +1001,7 @@
   input-imports = [
     "github.com/ghodss/yaml",
     "github.com/golang/glog",
+    "github.com/google/uuid",
     "github.com/kubernetes-incubator/apiserver-builder/pkg/controller",
     "github.com/spf13/pflag",
     "github.com/vmware/govmomi",

--- a/pkg/cloud/vsphere/utils/utils.go
+++ b/pkg/cloud/vsphere/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/labels"
 	vsphereconfig "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig"
 	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
@@ -196,4 +197,9 @@ func ByteToGiB(n int64) int64 {
 // GiBToByte returns n*1024^3.
 func GiBToByte(n int64) int64 {
 	return int64(n * int64(math.Pow(1024, 3)))
+}
+
+func IsValidUUID(str string) bool {
+	_, err := uuid.Parse(str)
+	return err == nil
 }


### PR DESCRIPTION
The MachineSpec.VMTemplate currently is treated as name of the VM to be searched. In certain cases the name of the VM can be duplicated inside a VC, thus we need a more precise mechanism to point to a VM to be used as a template. For this purpose we are now allowing the VMTemplate to also be a valid UUID that would then be matched with the VMs InstanceUUID property which is guaranteed to be unique.

The modified logic detects if the passed string looks like a valid UUID then it tried to find the VM by InstaceUUID if not found, then it fall back on treating the string as the VM name.

Resolves #109

Change-Id: Ia5e6ca600a71ca784b54336299818b6ec892b949