### PR TITLE
compile clusterctl for every e2e ci job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 # Image URL to use all building/pushing image targets
 PRODUCTION_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:latest
 CI_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
+CLUSTERCTL_CI_IMG ?= gcr.io/cnx-cluster-api/clusterctl
 DEV_IMG ?= # <== NOTE:  outside dev, change this!!!
 
 # Retrieves the git hash
@@ -121,6 +122,7 @@ ci-yaml:
 
 ci-image: generate fmt vet manifests
 	docker build . -t "$(CI_IMG):$(VERSION)"
+	docker build . -f cmd/clusterctl/Dockerfile -t "$(CLUSTERCTL_CI_IMG):$(VERSION)"
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"$(CI_IMG):$(VERSION)"'@' ./config/default/vsphere_manager_image_patch.yaml
 
@@ -129,4 +131,5 @@ ci-push: ci-image
 	@echo "logging into gcr.io registry with key file"
 	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io
 	docker push "$(CI_IMG):$(VERSION)"
+	docker push "$(CLUSTERCTL_CI_IMG):$(VERSION)"
 	@echo docker logout gcr.io

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -1,0 +1,20 @@
+# Build the cluster binary
+FROM golang:1.10.3 as builder
+
+# Copy in the go src
+WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-vsphere
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+COPY vendor/ vendor/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o clusterctl sigs.k8s.io/cluster-api-provider-vsphere/cmd/clusterctl
+
+# Copy clusterctl into a thin image
+FROM debian:stretch-slim
+WORKDIR /root/
+
+RUN apt-get update && apt-get install -y ca-certificates openssh-client
+
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-vsphere/clusterctl .
+ENTRYPOINT ["./clusterctl"]

--- a/scripts/e2e/bootstrap_job.template
+++ b/scripts/e2e/bootstrap_job.template
@@ -9,6 +9,13 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      initContainers:
+      - name: clusterctl-bin
+      image: gcr.io/cnx-cluster-api/clusterctl:${VERSION}
+      command: ['sh', '-c', 'cp /root/clusterctl /tmp/clusterctl/clusterctl && chmod +x /tmp/clusterctl/clusterctl']
+      volumeMounts:
+        - name: shared-data
+          mountPath: /tmp/clusterctl
       containers:
       - name: cluster-api-provider-vsphere-ci
         image: gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci:latest
@@ -53,6 +60,8 @@ spec:
             mountPath: /root/.kube
           - name: sshkeys
             mountPath: /root/.ssh
+          - name: shared-data
+            mountPath: /tmp/clusterctl/
         command:
         - "./clusterctl.sh"
       volumes:
@@ -62,4 +71,6 @@ spec:
       - name: sshkeys
         hostPath:
           path: /home/vmware/.ssh
+      - name: shared-data
+        emptyDir: {}
       restartPolicy: Never

--- a/scripts/e2e/bootstrap_job/clusterctl.sh
+++ b/scripts/e2e/bootstrap_job/clusterctl.sh
@@ -46,7 +46,7 @@ chmod +x /usr/local/bin/kubectl
 
 # run clusterctl
 echo "test ${PROVIDER_COMPONENT_SPEC}"
-./bin/clusterctl create cluster --existing-bootstrap-cluster-kubeconfig ~/.kube/config -c ./spec/cluster.yml \
+/tmp/clusterctl/clusterctl create cluster --existing-bootstrap-cluster-kubeconfig ~/.kube/config -c ./spec/cluster.yml \
     -m ./spec/machines.yml \
     -p ./spec/${PROVIDER_COMPONENT_SPEC} \
     --provider vsphere \

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -166,6 +166,7 @@ get_bootstrap_vm
 apply_secret_to_bootstrap "${vsphere_controller_version}"
 
 # launch the job at bootstrap cluster
+fill_file_with_value "bootstrap_job.template"
 run_cmd_on_bootstrap "${bootstrap_vm_ip}" "cat > /tmp/bootstrap_job.yml" < bootstrap_job.yml
 run_cmd_on_bootstrap "${bootstrap_vm_ip}" "kubectl create -f /tmp/bootstrap_job.yml"
 


### PR DESCRIPTION
With this patch, clusterctl will be compiled, packaged into container and uploaded to gcr during the build phase.  During the test phase, the container will be used to execute with the latest version of the code.

/cc @sflxn @sidharthsurana @dougm @frapposelli 

resolve #6 