### PR TITLE
Add CI parameters to OVA build

### DIFF
--- a/docs/ova/README.md
+++ b/docs/ova/README.md
@@ -42,6 +42,11 @@ If called with the values below, `build.sh` will include Kubernetes version v1.1
 ./build/build.sh ova-dev --kubernetes-version v1.12.1
 ```
 
+The `build.sh` script can also prefill default values for root password and root ssh key, this is used by our CI when deploying the OVA on VMC for testing
+```
+./build/build.sh ova-dev --ci-root-password '<my password>' --ci-root-ssh-key 'ssh-rsa <my rsa key> <my comment>'
+```
+
 ## Deploy
 
 The OVA must be deployed to a vCenter.

--- a/installer/build/bootable/build-main.sh
+++ b/installer/build/bootable/build-main.sh
@@ -145,6 +145,8 @@ function main {
     cd "${PACKAGE}"
     log2 "updating version number"
     sed -i -e "s|--version--|${BUILD_OVA_REVISION}|" cluster-api-vsphere-${BUILD_OVA_REVISION}.ovf
+    sed -i -e "s|--ci-root-password--|${CI_ROOT_PASSWORD}|" cluster-api-vsphere-${BUILD_OVA_REVISION}.ovf
+    sed -i -e "s|--ci-root-ssh-key--|${CI_ROOT_SSH_KEY}|" cluster-api-vsphere-${BUILD_OVA_REVISION}.ovf
     log2 "updating image sizes"
     for image in "${IMAGEFILES[@]}"
     do

--- a/installer/build/bootable/config/builder.ovf
+++ b/installer/build/bootable/config/builder.ovf
@@ -42,11 +42,11 @@
     <ProductSection ovf:class="appliance" ovf:required="false">
       <Info>Appliance Properties</Info>
       <Category>1. Appliance Configuration</Category>
-      <Property ovf:key="root_pwd" ovf:password="true" ovf:qualifiers="MinLen(8),MaxLen(128)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+      <Property ovf:key="root_pwd" ovf:password="true" ovf:qualifiers="MinLen(8),MaxLen(128)" ovf:type="string" ovf:userConfigurable="true" ovf:value="--ci-root-password--">
         <Label>1.1. Root Password</Label>
         <Description>The initial password of the root user. Subsequent changes of password should be performed in operating system. (8-128 characters)</Description>
       </Property>
-      <Property ovf:key="root_ssh_key" ovf:qualifiers="MinLen(8),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+      <Property ovf:key="root_ssh_key" ovf:qualifiers="MinLen(8),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="--ci-root-ssh-key--">
         <Label>1.2. Root SSH Key</Label>
         <Description>Specifies a SSH key for the root user can log in using SSH.</Description>
       </Property>

--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -22,12 +22,12 @@ KUBERNETES_DEFAULT_VERSION=$(curl -sSL https://dl.k8s.io/release/stable-1.txt)
 
 # Check if it's a file in `scripts`, URL, or REVISION
 function setenv() {
-  tmpvar=$1
-  fallback=$2
+  tmpvar="$1"
+  fallback="$2"
   if [ -n "${!tmpvar}" ]; then
-    export $1_VERSION="${!tmpvar}"
+    export "$1"="${!tmpvar}"
   else
-    export $1_VERSION="${fallback}"
+    export "$1"="${fallback}"
   fi
 }
 
@@ -37,7 +37,15 @@ do
 
   case $key in
     --kubernetes-version)
-      KUBERNETES="$2"
+      KUBERNETES_VERSION="$2"
+      shift 2 # past argument
+      ;;
+    --ci-root-password)
+      CI_ROOT_PASSWORD="$2"
+      shift 2 # past argument
+      ;;
+    --ci-root-ssh-key)
+      CI_ROOT_SSH_KEY="$2"
       shift 2 # past argument
       ;;
     *)
@@ -47,13 +55,17 @@ do
 done
 
 # set Kubernetes Version
-setenv KUBERNETES "$KUBERNETES_DEFAULT_VERSION"
+setenv KUBERNETES_VERSION "$KUBERNETES_DEFAULT_VERSION"
+setenv CI_ROOT_PASSWORD ""
+setenv CI_ROOT_SSH_KEY ""
 
 
 ENV_FILE="${CACHE}/installer.env"
 touch $ENV_FILE
 cat > $ENV_FILE <<EOF
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-}
+export CI_ROOT_PASSWORD=${CI_ROOT_PASSWORD:-}
+export CI_ROOT_SSH_KEY=${CI_ROOT_SSH_KEY:-}
 EOF
 
 echo -e "--------------------------------------------------

--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -56,14 +56,14 @@ if [ "$step" == "ova-dev" ]; then
     -e TAG=${TAG} \
     -e BUILD_NUMBER=${BUILD_NUMBER} \
     -e TERM -w ${ROOT_INSTALLER_WORK_DIR} \
-    gcr.io/cnx-cluster-api/cluster-api-ova-build:latest ./build/build-ova.sh $*
+    gcr.io/cnx-cluster-api/cluster-api-ova-build:latest ./build/build-ova.sh "$@"
 elif [ "$step" == "ova-ci" ]; then
   echo "starting ci build..."
   export DEBUG=${DEBUG}
   export BUILD_OVA_REVISION=${BUILD_OVA_REVISION}
   export TAG=${TAG}
   export BUILD_NUMBER=${BUILD_NUMBER}
-  ./build/build-ova.sh $*
+  ./build/build-ova.sh "$@"
 else
   usage
 fi


### PR DESCRIPTION
To facilitate CI testing, we're adding two parameters to the `installer/build/build.sh` script:

- `CI_ROOT_PASSWORD`: sets a root password as default value in the OVA
- `CI_ROOT_SSH_KEY`: sets a root ssh public key as default value in the OVA

These parameters are to be used during CI only, and not intended to be used while generating a release artifact.

/cc @figo