### PR TITLE
Remove redundancies in the kustomize files

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: vsphere-provider-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: vsphere-provider-
+namePrefix: vsphere-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/default/vsphere_manager_image_patch.yaml
+++ b/config/default/vsphere_manager_image_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
+  name: provider-controller-manager
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,19 +3,19 @@ kind: Namespace
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: system
+  name: provider-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: controller-manager-service
+  name: provider-controller-manager-service
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: vsphere-provider-controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
   selector:
-    control-plane: controller-manager
+    control-plane: vsphere-provider-controller-manager
     controller-tools.k8s.io: "1.0"
   ports:
   - port: 443
@@ -23,21 +23,21 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
+  name: provider-controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: vsphere-provider-controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: vsphere-provider-controller-manager
       controller-tools.k8s.io: "1.0"
-  serviceName: controller-manager-service
+  serviceName: provider-controller-manager-service
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: vsphere-provider-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
       tolerations:

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: provider-manager-role
 rules:
 - apiGroups:
   - apps
@@ -20,29 +20,6 @@ rules:
   - vsphereproviderconfig.sigs.k8s.io
   resources:
   - vsphereclusterproviderconfigs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - vsphereproviderconfig.sigs.k8s.io
-  resources:
   - vspheremachineproviderconfigs
   verbs:
   - get

--- a/config/rbac/rbac_role_binding.yaml
+++ b/config/rbac/rbac_role_binding.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: manager-rolebinding
+  name: provider-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: provider-manager-role
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
Also change the prefix to generate the provider specific names
This is important as the current scheme of naming would clash
with the objects created for the core cluster-api deployment

This change will also make it possible to deploy both the core
cluster-api controllers and the vsphere provider controllers in
the same namespace if needed. By default these are deployed in
different namespaces.

Resolves #168

Change-Id: Ie6d82393129549bacd505060b43b5cfa7c8de1ef