### PR TITLE
Use `go env` to get GOPATH

### DIFF
--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -18,7 +18,7 @@
 
 DEBUG=${DEBUG:-}
 set -e -o pipefail +h && [ -n "$DEBUG" ] && set -x
-ROOT_DIR="$GOPATH/src/sigs.k8s.io/cluster-api-provider-vsphere"
+ROOT_DIR="$(go env GOPATH)/src/sigs.k8s.io/cluster-api-provider-vsphere"
 ROOT_WORK_DIR="/go/src/sigs.k8s.io/cluster-api-provider-vsphere"
 
 ROOT_INSTALLER_DIR="${ROOT_DIR}/installer"


### PR DESCRIPTION
At least on my development machine I usually leave `$GOPATH` undefined and let Go use the default. This unfortunately then breaks a lot of scripts that assume `$GOPATH` is always set. I think using `go env GOPATH` is supposed to be the right way to get the current value, since it will give the default path if the environment variable is unset.