### PR TITLE
Remove docker.sock mount from OVA build script

### DIFF
--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -50,7 +50,6 @@ if [ "$step" == "ova-dev" ]; then
   docker run -it --rm --privileged -v /dev:/dev \
     -v ${ROOT_DIR}:${ROOT_WORK_DIR}:ro \
     -v ${ROOT_INSTALLER_DIR}/bin:${ROOT_INSTALLER_WORK_DIR}/bin \
-    -v /var/run/docker.sock:/var/run/docker.sock \
     -e DEBUG=${DEBUG} \
     -e BUILD_OVA_REVISION=${BUILD_OVA_REVISION} \
     -e TAG=${TAG} \


### PR DESCRIPTION
Remove the mount from the build script as it's not needed for the build to succeed.