### PR TITLE
Fix recurring VM re-clone issue

### DIFF
--- a/pkg/cloud/vsphere/provisioner/govmomi/delete.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/delete.go
@@ -24,7 +24,7 @@ func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, m
 	defer cancel()
 
 	if exists, _ := pv.Exists(ctx, cluster, machine); exists {
-		moref, err := vsphereutils.GetVMId(machine)
+		moref, err := vsphereutils.GetMachineRef(machine)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/exists.go
@@ -19,11 +19,16 @@ func (pv *Provisioner) Exists(ctx context.Context, cluster *clusterv1.Cluster, m
 	existsctx, cancel := context.WithCancel(*s.context)
 	defer cancel()
 
-	moref, err := vsphereutils.GetVMId(machine)
+	moref, err := vsphereutils.GetMachineRef(machine)
 	if err != nil {
-		klog.V(4).Infof("Exists check, GetVMId failed: %s", err.Error())
+		klog.V(4).Infof("Exists check, GetMachineRef failed: %s", err.Error())
 		return false, err
 	}
+
+	if moref == "" {
+		return false, nil
+	}
+
 	var vm mo.VirtualMachine
 	vmref := types.ManagedObjectReference{
 		Type:  "VirtualMachine",

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -31,7 +31,7 @@ func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, m
 	updatectx, cancel := context.WithCancel(*s.context)
 	defer cancel()
 
-	moref, err := vsphereutils.GetVMId(machine)
+	moref, err := vsphereutils.GetMachineRef(machine)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/vsphere/utils/utils.go
+++ b/pkg/cloud/vsphere/utils/utils.go
@@ -108,7 +108,7 @@ func GetSubnet(netRange clusterv1.NetworkRanges) string {
 	return netRange.CIDRBlocks[0]
 }
 
-func GetVMId(machine *clusterv1.Machine) (string, error) {
+func GetMachineRef(machine *clusterv1.Machine) (string, error) {
 	pc, err := GetMachineProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
There is a chance in original code:  VM clone success, but "vmref" not been added to machine status, at the same time, "taskref" been removed.
this leads to unrecoverable state: Exists() return false since
"vmref" not there, "taskref" is gone, every reconcile loop will try to 
clone VM, eventually, vCenter will throw error. 

we need to pay extra attention to verifyAndUpdateTask() to make sure:
if VM clone success, only remove "taskref"
when "vmref" been added to machine status

Resolves: #139