### PR TITLE
add support for periodic job

### DIFF
--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -236,7 +236,13 @@ if [ -z "${PROW_JOB_ID}" ] ; then
       git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 else
    context="prow"
-   vsphere_controller_version="${PULL_PULL_SHA}"
+   if [ -z "${PULL_PULL_SHA}" ] ; then
+      # for periodic job
+      vsphere_controller_version="${PULL_JOB_ID}"
+   else
+      # for presubmit job
+      vsphere_controller_version="${PULL_PULL_SHA}"
+   fi
 fi
 
 export VERSION="${vsphere_controller_version}"

--- a/scripts/e2e/wait_for_job.sh
+++ b/scripts/e2e/wait_for_job.sh
@@ -38,12 +38,12 @@ echo "all jobs finished";
 
 
 
-echo "--------- vsphere manager log begin ----------"
+echo "--------- vsphere-provider-controller-manager log begin ----------"
 manager_pod_name=$(kubectl get pods -a --no-headers -n vsphere-provider-system | grep vsphere | awk -F" " '{print $1}')
 kubectl logs "${manager_pod_name}" -n vsphere-provider-system
-echo "--------- vsphere manager log end ----------"
+echo "--------- vsphere-provider-controller-manager log end ----------"
 
-job_pod_names=$(kubectl get pods -a --no-headers | grep cluster-api-provider-vsphere-ci | awk -F" " '{print $1}' | tr "\\\n" "\n")
+job_pod_names=$(kubectl get pods -a --no-headers | grep cluster-api-provider-vsphere-ci | awk -F" " '{print $1}')
 for job_pod_name in ${job_pod_names}
 do
    echo "--------- ci job log begin ----------"


### PR DESCRIPTION
need this hot fix to support the periodic job for OVA e2e, the job is already running at Prow,
it is failing due to e2e.sh does not handle this.

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cluster-api-provider-vsphere-ova-e2e/2/build-log.txt

not able to find out when test it locally, because local testing is still a simulation of Prow.

cc @sflxn  @frapposelli 