### PR TITLE
handle nil cluster at machine actuator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 *.out
 
 minikube.kubeconfig
+
+# tmp files
+*.tmp

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ ci-image: generate fmt vet manifests
 	docker build . -t "$(CI_IMG):$(VERSION)"
 	docker build . -f cmd/clusterctl/Dockerfile -t "$(CLUSTERCTL_CI_IMG):$(VERSION)"
 	@echo "updating kustomize image patch file for manager resource"
-	sed -i'' -e 's@image: .*@image: '"$(CI_IMG):$(VERSION)"'@' ./config/default/vsphere_manager_image_patch.yaml
+	sed -i.tmp -e 's@image: .*@image: '"$(CI_IMG):$(VERSION)"'@' ./config/default/vsphere_manager_image_patch.yaml
 
 ci-push: ci-image
 # Log into the registry with a service account file.  In CI, GCR_KEY_FILE contains the content and not the file name.

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -20,4 +20,5 @@ const (
 	RequeueAfterSeconds              = 20 * time.Second
 	KubeConfigSecretName             = "%s-kubeconfig"
 	KubeConfigSecretData             = "admin-kubeconfig"
+	ClusterIsNullErr                 = "cluster is nil, make sure machines have `clusters.k8s.io/cluster-name` label set and the name references a valid cluster name in the same namespace"
 )

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -28,6 +28,10 @@ import (
 )
 
 func (pv *Provisioner) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	if cluster == nil {
+		return errors.New(ClusterIsNullErr)
+	}
+
 	klog.V(4).Infof("govmomi.Actuator.Create %s", machine.Name)
 	s, err := pv.sessionFromProviderConfig(cluster, machine)
 	if err != nil {

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -29,7 +29,7 @@ import (
 
 func (pv *Provisioner) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if cluster == nil {
-		return errors.New(ClusterIsNullErr)
+		return errors.New(constants.ClusterIsNullErr)
 	}
 
 	klog.V(4).Infof("govmomi.Actuator.Create %s", machine.Name)

--- a/pkg/cloud/vsphere/provisioner/govmomi/delete.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/delete.go
@@ -16,6 +16,10 @@ import (
 
 // Delete the machine
 func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	if cluster == nil {
+		return errors.New(ClusterIsNullErr)
+	}
+
 	s, err := pv.sessionFromProviderConfig(cluster, machine)
 	if err != nil {
 		return err

--- a/pkg/cloud/vsphere/provisioner/govmomi/delete.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -17,7 +18,7 @@ import (
 // Delete the machine
 func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if cluster == nil {
-		return errors.New(ClusterIsNullErr)
+		return errors.New(constants.ClusterIsNullErr)
 	}
 
 	s, err := pv.sessionFromProviderConfig(cluster, machine)

--- a/pkg/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/exists.go
@@ -7,13 +7,14 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 func (pv *Provisioner) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
 	if cluster == nil {
-		return false, errors.New(ClusterIsNullErr)
+		return false, errors.New(constants.ClusterIsNullErr)
 	}
 
 	s, err := pv.sessionFromProviderConfig(cluster, machine)

--- a/pkg/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/exists.go
@@ -2,6 +2,7 @@ package govmomi
 
 import (
 	"context"
+	"errors"
 
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -11,6 +12,10 @@ import (
 )
 
 func (pv *Provisioner) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
+	if cluster == nil {
+		return false, errors.New(ClusterIsNullErr)
+	}
+
 	s, err := pv.sessionFromProviderConfig(cluster, machine)
 	if err != nil {
 		klog.V(4).Infof("Exists check, session from provider config error: %s", err.Error())

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -3,6 +3,7 @@ package govmomi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,6 +20,10 @@ import (
 )
 
 func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	if cluster == nil {
+		return errors.New(ClusterIsNullErr)
+	}
+
 	// Fetch any active task in vsphere if any
 	// If an active task is there,
 

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -21,7 +21,7 @@ import (
 
 func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if cluster == nil {
-		return errors.New(ClusterIsNullErr)
+		return errors.New(constants.ClusterIsNullErr)
 	}
 
 	// Fetch any active task in vsphere if any

--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -25,6 +25,10 @@ var (
 	DefaultSSHPublicKeyFile = "/root/.ssh/vsphere_tmp.pub"
 )
 
+const (
+	ClusterIsNullErr = "cluster is nil"
+)
+
 func (pv *Provisioner) GetKubeadmToken(cluster *clusterv1.Cluster) (string, error) {
 	var token string
 	if cluster.ObjectMeta.Annotations != nil {

--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -25,10 +25,6 @@ var (
 	DefaultSSHPublicKeyFile = "/root/.ssh/vsphere_tmp.pub"
 )
 
-const (
-	ClusterIsNullErr = "cluster is nil, make sure machines have `clusters.k8s.io/cluster-name` label set and the name references a valid cluster name in the same namespace"
-)
-
 func (pv *Provisioner) GetKubeadmToken(cluster *clusterv1.Cluster) (string, error) {
 	var token string
 	if cluster.ObjectMeta.Annotations != nil {

--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	ClusterIsNullErr = "cluster is nil"
+	ClusterIsNullErr = "cluster is nil, make sure machines have `clusters.k8s.io/cluster-name` label set and the name references a valid cluster name in the same namespace"
 )
 
 func (pv *Provisioner) GetKubeadmToken(cluster *clusterv1.Cluster) (string, error) {

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -238,7 +238,7 @@ else
    context="prow"
    if [ -z "${PULL_PULL_SHA}" ] ; then
       # for periodic job
-      vsphere_controller_version="${PULL_JOB_ID}"
+      vsphere_controller_version="${PROW_JOB_ID}"
    else
       # for presubmit job
       vsphere_controller_version="${PULL_PULL_SHA}"


### PR DESCRIPTION
now cluster-api main has made it possible to let cluster object be NULL,
providers can choose to support or not support, but for CAPV, it panic because it assuming
cluster is not NULL, this change is to handle the situation.

a few bonus changes:
1) fix e2e.sh with right ${PROW_JOB_ID} name
2) fix sed usage at Makefile, so it works across Mac/Linux


cc @sflxn @frapposelli @vincepri 