### PR TITLE
Putting resources used by kustomization.yaml into its sub-folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 *.out
 
 minikube.kubeconfig
+config/default/vsphere_tmp.pub
+config/default/vsphere_tmp
 
 # tmp files
 *.tmp

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -109,6 +109,11 @@ if [ ! -f $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PRIVATE_FILE ]; th
   ssh-keygen -t rsa -f $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PRIVATE_FILE  -N ""
 fi
 
+# With kustomize PR 700 merged, the resources in kustomization.yaml could only be scanned in the sub-folder
+# So putting vsphere_tmp and vsphere_tmp.pub in ../config/default folder
+cp $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PUBLIC_FILE $VSPHERE_CLUSTER_API_CRD_PATH/default/$MACHINE_CONTROLLER_SSH_PUBLIC_FILE
+cp $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PRIVATE_FILE $VSPHERE_CLUSTER_API_CRD_PATH/default/$MACHINE_CONTROLLER_SSH_PRIVATE_FILE
+
 # By default, linux wraps base64 output every 76 cols, so we use 'tr -d' to remove whitespaces.
 # Note 'base64 -w0' doesn't work on Mac OS X, which has different flags.
 MACHINE_CONTROLLER_SSH_PUBLIC=$(cat $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PUBLIC_FILE | base64 | tr -d '\r\n')

--- a/config/crds/kustomization.yaml
+++ b/config/crds/kustomization.yaml
@@ -1,0 +1,8 @@
+# Each entry in this list must resolve to an existing
+# resource definition in YAML.  These are the resource
+# files that kustomize reads, modifies and emits as a
+# YAML string, with resources separated by document
+# markers ("---").
+resources:
+- vsphereproviderconfig_v1alpha1_vsphereclusterproviderconfig.yaml
+- vsphereproviderconfig_v1alpha1_vspheremachineproviderconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,24 +12,34 @@ namePrefix: vsphere-
 #commonLabels:
 #  someName: someValue
 
-# Each entry in this list must resolve to an existing
-# resource definition in YAML.  These are the resource
-# files that kustomize reads, modifies and emits as a
-# YAML string, with resources separated by document
-# markers ("---").
-resources:
-- ../crds/vsphereproviderconfig_v1alpha1_vsphereclusterproviderconfig.yaml
-- ../crds/vsphereproviderconfig_v1alpha1_vspheremachineproviderconfig.yaml
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+# Each entry in this list should resolve to a directory
+# containing a kustomization file, else the
+# customization fails.
+#
+# The entry could be a relative path pointing to a local directory
+# or a url pointing to a directory in a remote repo.
+# The url should follow hashicorp/go-getter URL format
+# https://github.com/hashicorp/go-getter#url-format
+#
+# The presence of this field means this file (the file
+# you a reading) is an _overlay_ that further
+# customizes information coming from these _bases_.
+#
+# Typical use case: a dev, staging and production
+# environment that are mostly identical but differing
+# crucial ways (image tags, a few server arguments,
+# etc. that differ from the common base).
+bases:
+- ../crds/
+- ../rbac/
+- ../manager/
 
 patches:
 - vsphere_manager_image_patch.yaml
 
 secretGenerator:
 - name: machine-sshkeys
-  commands:
-    vsphere_tmp: "cat ~/.ssh/vsphere_tmp"
-    vsphere_tmp.pub: "cat ~/.ssh/vsphere_tmp.pub"
+  files:
+    - vsphere_tmp
+    - vsphere_tmp.pub
   type: Opaque

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,7 @@
+# Each entry in this list must resolve to an existing
+# resource definition in YAML.  These are the resource
+# files that kustomize reads, modifies and emits as a
+# YAML string, with resources separated by document
+# markers ("---").
+resources:
+- manager.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+# Each entry in this list must resolve to an existing
+# resource definition in YAML.  These are the resource
+# files that kustomize reads, modifies and emits as a
+# YAML string, with resources separated by document
+# markers ("---").
+resources:
+- rbac_role.yaml
+- rbac_role_binding.yaml

--- a/docs/self-service/README.md
+++ b/docs/self-service/README.md
@@ -8,7 +8,7 @@ The following is a quick how-to-use guide on using the cluster api on a vCenter 
 3. a type 2 desktop hypervisor (Vmware Fusion/Workstation or VirtualBox)
 4. GOPATH environment set
 5. dep installed (https://github.com/golang/dep)
-6. kustomize installed (https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
+6. kustomize V2 installed (https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
 7. kubebuilder installed (https://book.kubebuilder.io/quick_start.html)
 
 **Be aware, the current repo supports deploying Kubernetes 1.11.x and above.  Older versions maybe supported in the future.**


### PR DESCRIPTION
With kustomize PR 700 merged, in order to avoid attacking, all
resources are needed to saved in its sub-folder.

Fixes: #205 