### PR TITLE
Unify machine spec of machine.yaml and machinset.yaml

### DIFF
--- a/cmd/clusterctl/examples/vsphere/machineset.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machineset.yaml.template
@@ -33,7 +33,10 @@ spec:
             - diskLabel: ""
               diskSizeGB: 20
             preloaded: false
+            trustedCerts:
+            - zzzz
+            - aaaa
       versions:
-        kubelet: 1.10.1
+        kubelet: 1.11.3
       roles:
       - Node


### PR DESCRIPTION
I think we should use the same kubelet version in master and workers nodes.

Modify machineset.yaml:
- modify kubelet verison the same 1.11.3
- add trustedCerts field
