### PR TITLE
Enable the latest Kustomize version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ DEV_IMG ?= # <== NOTE:  outside dev, change this!!!
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 	   git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 
+KUSTOMIZE_VERSION := $(shell kustomize version | awk '{ print $$2 }' | awk -F':' '{ print $$2} ')
+
 all: test manager clusterctl
 
 # Run tests
@@ -72,9 +74,13 @@ generate:
 
 # Create YAML file for deployment
 dev-yaml:
+ifeq ($(KUSTOMIZE_VERSION),$(filter $(KUSTOMIZE_VERSION),unknown v1))
+	@echo "please upgrade kustomize version to v2 at least."
+else
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${DEV_IMG}"'@' ./config/default/vsphere_manager_image_patch.yaml
 	cmd/clusterctl/examples/vsphere/generate-yaml.sh
+endif
 
 # Build the docker image
 dev-build: test
@@ -93,9 +99,13 @@ dev-push:
 
 # Create YAML file for deployment
 prod-yaml:
+ifeq ($(KUSTOMIZE_VERSION),$(filter $(KUSTOMIZE_VERSION),unknown v1))
+	@echo "please upgrade kustomize version to v2 at least."
+else
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${PRODUCTION_IMG}"'@' ./config/default/vsphere_manager_image_patch.yaml
 	cmd/clusterctl/examples/vsphere/generate-yaml.sh
+endif
 
 # Build the docker image
 prod-build: test

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -80,6 +80,12 @@ while test $# -gt 0; do
         esac
 done
 
+KUSTOMIZE_VERSION=$(kustomize version | awk '{ print $2 }' | awk -F ':' '{ print $2} ')
+if [[ $KUSTOMIZE_VERSION == *"v1"* || $KUSTOMIZE_VERSION == "unknown" ]]; then
+    echo "Please upgrade the kustomize version to v2 at least."
+    exit 1
+fi
+
 if [ $OVERWRITE -ne 1 ] && [ -f $MACHINE_GENERATED_FILE ]; then
   echo File $MACHINE_GENERATED_FILE already exists. Delete it manually before running this script.
   exit 1


### PR DESCRIPTION
With the kustomize code changes, some resources, for example, 'commands'
is not supported, and new resources are introduced into the latest
code, so we add the kustomize version check.

Fixes: #214 