### PR TITLE
Add version compatibility matrix against CAPI and k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Image URL to use all building/pushing image targets
-PRODUCTION_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:latest
+PRODUCTION_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:0.2.0
 CI_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
 CLUSTERCTL_CI_IMG ?= gcr.io/cnx-cluster-api/clusterctl
 DEV_IMG ?= # <== NOTE:  outside dev, change this!!!

--- a/README.md
+++ b/README.md
@@ -22,3 +22,54 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ### Quick Start
 
 Go [here](docs/README.md) for an example of how to get up and going with the cluster api using vSphere.
+
+### Where to get the containers
+
+The containers for this provider are currently hosted at `gcr.io/cnx-cluster-api/`.  Each release of the
+container are tagged with the release version appropriately.  Please note, the release tagging changed to
+stay uniform with the main cluster api repo.  Also note, these are docker containers.  A container runtime
+must pull them.  They cannot simply be downloaded.
+
+| vSphere provider version | container url |
+| --- | --- |
+| 0.1.0 | gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:v0.1 |
+| 0.2.0 | gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:0.2.0 |
+
+| main Cluster API version | container url |
+| --- | --- |
+| 0.1.0 | gcr.io/k8s-cluster-api/cluster-api-controller:0.1.0 |
+
+To use the appropriate version (instead of `:latest`), replace the version in the generated `provider-components.yaml`,
+described in the quick start guide.
+
+### Compatibility Matrix
+
+Below are tables showing the compatibility between versions of the vSphere provider, the main cluster api,
+kubernetes versions, and OSes.  Please note, this table only shows version 0.2 of the vSphere provider.  Due
+to the way this provider bootstrap nodes (e.g. using Ubuntu package manager to pull some components), there
+were changes in some packages that broke version 0.1 (but may get resolved at some point) so the compatibility
+tables for that provider version are not provided here.
+                              
+Compatibility matrix for Cluster API versions and the vSphere provider versions.
+
+| | Cluster API 0.1.0 |
+|--- | --- |
+| vSphere Provider 0.2.0 | ✓ |
+
+Compatibility matrix for the vSphere provider versions and Kubernetes versions.
+
+| |k8s 1.11.x|k8s 1.12.x|k8s 1.13.x|k8s 1.14.x|
+|---|---|---|---|---|
+| vSphere Provider 0.2.0 | ✓ | ✓ | ✓ | ✓ |
+
+Compatibility matrix for the vSphere provider versions and node OS.  Further OS support may be added in future releases.
+
+| | Ubuntu Xenial Cloud Image | Ubuntu Bionic Cloud Image |
+| --- | --- | --- |
+| vSphere Provider 0.2.0 | ✓ | ✓ |
+
+Users may download the cloud images here:
+
+[Ubuntu Xenial (16.04)](https://cloud-images.ubuntu.com/xenial/current/)
+
+[Ubuntu Bionic (18.04)](https://cloud-images.ubuntu.com/bionic/current/)


### PR DESCRIPTION
Added 3 tables showing a version compatibility matrix against CAPI (main cluster
API), Kubernetes, and OSes.  Currently, these were gathered manually.

Resolves #222