### PR TITLE
Add support for specifying vsphere credentials via secrets

### DIFF
--- a/cmd/clusterctl/examples/vsphere/cluster.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/cluster.yaml.template
@@ -16,3 +16,4 @@ spec:
         vsphereUser: ""
         vspherePassword: ""
         vsphereServer: ""
+        vsphereCredentialSecret: ""

--- a/docs/design/vsphereCredentials.md
+++ b/docs/design/vsphereCredentials.md
@@ -1,0 +1,49 @@
+## Passing vsphere credentials
+For the cluster-api vsphere provider to work, the users need to provide the vsphere credentials to access the infrastructure. There are 2 ways how the users can provide these credentials.
+
+* Using kubernetes `secrets`
+   * Create a secret that contains 2 keys namely `username` and `password` in the same namespace as the desired `Cluster` object.
+      ```
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: my-vc-credentials
+      type: Opaque
+      data:
+        # base64 encoded fields
+        username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs
+        password: c2FtcGxl
+      ```
+
+   * Set the `vsphereCredentialSecret` property in the `ProviderSpec` part of the `Cluster` definition
+      ```
+      apiVersion: "cluster.k8s.io/v1alpha1"
+      kind: Cluster
+      metadata:
+        name: sample-cluster
+      spec:
+          ...
+          providerSpec:
+            value:
+              ...
+              # Credentials provided via secrets
+              vsphereCredentialSecret: "my-vc-credentials"
+      ```
+
+* Using plain text credential in the `ProviderSpec` part of the `Cluster` definition
+    ```
+    apiVersion: "cluster.k8s.io/v1alpha1"
+    kind: Cluster
+    metadata:
+      name: sample-cluster
+    spec:
+        ...
+        providerSpec:
+          value:
+            ...
+            # Credentials provided as plain text
+            vsphereUser: "administrator@vsphere.local"
+            vspherePassword: "sample"
+    ```
+
+__Note:__ If `vsphereCredentialSecret` field is set to a non empty string then the controller will ignore the `vsphereUser` and `vspherePassword` fields even if they are set.

--- a/pkg/apis/vsphereproviderconfig/v1alpha1/vsphereclusterproviderconfig_types.go
+++ b/pkg/apis/vsphereproviderconfig/v1alpha1/vsphereclusterproviderconfig_types.go
@@ -47,9 +47,10 @@ type VsphereClusterProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	VsphereUser     string `json:"vsphereUser"`
-	VspherePassword string `json:"vspherePassword"`
-	VsphereServer   string `json:"vsphereServer"`
+	VsphereUser             string `json:"vsphereUser"`
+	VspherePassword         string `json:"vspherePassword"`
+	VsphereServer           string `json:"vsphereServer"`
+	VsphereCredentialSecret string `json:"vsphereCredentialSecret"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -20,5 +20,7 @@ const (
 	RequeueAfterSeconds              = 20 * time.Second
 	KubeConfigSecretName             = "%s-kubeconfig"
 	KubeConfigSecretData             = "admin-kubeconfig"
+	VsphereUserKey                   = "username"
+	VspherePasswordKey               = "password"
 	ClusterIsNullErr                 = "cluster is nil, make sure machines have `clusters.k8s.io/cluster-name` label set and the name references a valid cluster name in the same namespace"
 )


### PR DESCRIPTION
- Adds new field vsphereCredentialSecret that can be specified to
  point to the secret that holds the credentials

Resolves #9

Change-Id: I8e43864302a51386f7f11725b0a966cc9e436c59