### PR TITLE
Replace relative path with absolute for ssh call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-vsphere


### PR DESCRIPTION
It would seem that some shells don't expand relative paths correctly in exec.Command(). The ssh call in clusterctl on the Mac was failing with:

```
I0507 14:04:00.305127    2608 getkubeconfig.go:60] Waiting for kubeconfig on vs-master-rk7lw to become ready...
I0507 14:04:00.305545    2608 utils.go:170] pulling kubeconfig (using ssh) from 10.118.69.111
Warning: Identity file ~/.ssh/vsphere_tmp not accessible: No such file or directory.
I0507 14:04:00.780473    2608 utils.go:183] ssh failed with error = exit status 255
I0507 14:04:00.780534    2608 getkubeconfig.go:63] error getting kubeconfig: exit status 255
```
Simple fix was to get the home dir for the current user and set it as an absolute path