### PR TITLE
populate CloudProviderConfig with credentials from secret

### DIFF
--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -499,13 +499,18 @@ func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, machin
 		klog.Infof("Using input vSphere server url: %s", server)
 	}
 
+	username, password, err := pv.GetVsphereCredentials(cluster)
+	if err != nil {
+		return "", err
+	}
+
 	// TODO(ssurana): revisit once we solve https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/60
 	cpc := vpshereprovisionercommon.CloudProviderConfigTemplate{
 		Datacenter:   machineconfig.MachineSpec.Datacenter,
 		Server:       server,
 		Insecure:     true, // TODO(ssurana): Needs to be a user input
-		UserName:     clusterConfig.VsphereUser,
-		Password:     clusterConfig.VspherePassword,
+		UserName:     username,
+		Password:     password,
 		ResourcePool: machineconfig.MachineSpec.ResourcePool,
 		Datastore:    machineconfig.MachineSpec.Datastore,
 		Network:      "",


### PR DESCRIPTION
This PR contains a bugfix.

cluster-api-provider-vsphere recently got the ability to read VSphere credentials from secret. Previously they were stored in plaintext in the ClusterProviderSpec.

However, when populating the CloudProviderConfig we would still only look for the credentials in the ClusterProviderSpec, disregarding the credential secret. If a username and password are not specified in the ClusterProviderSpec, we would inject empty username and password fields into the cloud-config on the cluster VMs.

This PR fixes that, getting the credentials to inject to CloudProviderConfig using the same mechanism as when creating govmomi sessions, i.e. preferring credentials from secret but falling back on the ClusterProviderConfig if no credential secret is defined.