### PR TITLE
Add akutz and andrewsykim to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,3 +20,5 @@ aliases:
     - sflxn
     - ssurana
     - figo
+    - akutz
+    - andrewsykim


### PR DESCRIPTION
This patch is to add Andrew Kutz and Andrew Sy Kim to the OWNERS file via the alias "cluster-api-vsphere-maintainers".

cc @andrewsykim @frapposelli 