### PR TITLE
Get control plane machines by cluster name

### DIFF
--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -35,14 +35,16 @@ func (pv *Provisioner) GetKubeadmToken(cluster *clusterv1.Cluster) (string, erro
 			}
 		}
 	}
-	// From the cluster locate the master node
-	master, err := vsphereutils.GetMasterForCluster(cluster, pv.lister)
+	// From the cluster locate the control plane node
+	controlPlaneMachines, err := vsphereutils.GetControlPlaneMachinesForCluster(cluster, pv.lister)
 	if err != nil {
 		return "", err
 	}
-	if len(master) == 0 {
-		return "", errors.New("No master available")
+
+	if len(controlPlaneMachines) == 0 {
+		return "", errors.New("No control plane nodes available")
 	}
+
 	kubeconfig, err := pv.GetKubeConfig(cluster)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
CAPV at the moment fetches control plane machines arbitrarily which means `apiEndpoints` on a cluster resource can have the address of a VM from another cluster. This PR fetches control plane nodes by checking the cluster name label first to ensure only machines associated with a cluster is assigned as part of the apiEndpoints status of the cluster resource. 

Also renames master -> control plane where possible

Signed-off-by: Andrew Sy Kim <kiman@vmware.com>