### PR TITLE
Enable custom boot timeout, VNC, & packer flags

### DIFF
--- a/build/images/Makefile
+++ b/build/images/Makefile
@@ -26,8 +26,10 @@ KUBE_JSON ?= config/kubernetes.json
 
 # The flags to give to Packer.
 PACKER_VAR_FILES := $(KUBE_JSON)
+OLD_PACKER_FLAGS := $(PACKER_FLAGS)
 PACKER_FLAGS := -var="capv_version=$(shell git describe --dirty)"
 PACKER_FLAGS += $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" )
+PACKER_FLAGS += $(OLD_PACKER_FLAGS)
 
 BUILD_TARGETS := $(addprefix build-,$(BUILD_NAMES))
 $(BUILD_TARGETS):

--- a/build/images/packer/packer.json
+++ b/build/images/packer/packer.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",
     "capi_version": "v1alpha1",
     "capv_version": "",
@@ -8,7 +9,10 @@
     "kubernetes_cni_version": "0.7.5-00",
     "kubernetes_semver": "v1.13.6",
     "kubernetes_source": "pkg",
-    "kubernetes_version": "1.13.6-00"
+    "kubernetes_version": "1.13.6-00",
+    "vnc_bind_address": "127.0.0.1",
+    "vnc_port_min": "5900",
+    "vnc_port_max": "6000"
   },
   "builders": [
     {
@@ -23,7 +27,7 @@
       "disk_size": 20480,
       "disk_type_id": 0,
       "disk_adapter_type": "scsi",
-      "boot_wait": "5s",
+      "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./linux/{{user `distro_name`}}/http/",
       "guest_os_type": "{{user `guest_os_type`}}",
       "headless": "{{user `headless`}}",
@@ -40,7 +44,10 @@
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E {{user `shutdown_command`}}",
-      "skip_compaction": false
+      "skip_compaction": false,
+      "vnc_bind_address": "{{user `vnc_bind_address`}}",
+      "vnc_port_min": "{{user `vnc_port_min`}}",
+      "vnc_port_max": "{{user `vnc_port_max`}}"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This patch updates the image building process to allow for runtime customization of the image's boot timeout, its VNC properties, and the Packer flags via `PACKER_FLAGS` and the Makefile.

This patch also updates the default timeout to `10s` as `5s` is not long enough on VMware Workstation running headless on a Linux server.