### PR TITLE
[WIP] Refactor CRUD operations

### DIFF
--- a/pkg/cloud/vsphere/deployer.go
+++ b/pkg/cloud/vsphere/deployer.go
@@ -17,7 +17,7 @@ limitations under the License.
 package vsphere
 
 import (
-	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/provisioner/govmomi"
 	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -38,9 +38,17 @@ func NewDeploymentClient() *DeploymentClient {
 }
 
 func (d *DeploymentClient) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	return vsphereutils.GetIP(cluster, machine)
+	gomachine, err := govmomi.NewGovmomiMachine(cluster, machine, nil, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	return gomachine.GetIP()
 }
 
 func (d *DeploymentClient) GetKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.Machine) (string, error) {
-	return vsphereutils.GetKubeConfig(cluster, master)
+	gomachine, err := govmomi.NewGovmomiMachine(cluster, master, nil, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	return gomachine.GetIP()
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/cluster.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/cluster.go
@@ -1,0 +1,186 @@
+package govmomi
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+
+	"encoding/json"
+
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+)
+
+type GovmomiCluster struct {
+	clusterAPI clusterv1alpha1.ClusterV1alpha1Interface
+	cluster    *clusterv1.Cluster
+	config     *vsphereconfigv1.VsphereClusterProviderConfig
+	status     *vsphereconfigv1.VsphereClusterProviderStatus
+	k8sClient  kubernetes.Interface
+	s          *SessionContext
+}
+
+func newGovmomiCluster(cluster *clusterv1.Cluster) (*GovmomiCluster, error) {
+	config := &vsphereconfigv1.VsphereClusterProviderConfig{}
+	status := &vsphereconfigv1.VsphereClusterProviderStatus{}
+	if cluster.Spec.ProviderSpec.Value == nil {
+		return nil, fmt.Errorf("cluster providerconfig is invalid (nil)")
+	}
+
+	err := yaml.Unmarshal(cluster.Spec.ProviderSpec.Value.Raw, config)
+	if err != nil {
+		return nil, fmt.Errorf("cluster providerconfig unmarshalling failure: %s", err)
+	}
+
+	if cluster.Status.ProviderStatus != nil {
+		err = json.Unmarshal(cluster.Status.ProviderStatus.Raw, status)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &GovmomiCluster{
+		status:  status,
+		config:  config,
+		cluster: cluster,
+	}, nil
+}
+
+func (c *GovmomiCluster) GetTask(ctx context.Context, ref string) *mo.Task {
+	var taskmo mo.Task
+	taskref := types.ManagedObjectReference{
+		Type:  "Task",
+		Value: ref,
+	}
+	err := c.s.session.RetrieveOne(ctx, taskref, []string{"info"}, &taskmo)
+	if err != nil {
+		return nil
+	}
+	return &taskmo
+}
+
+func (c *GovmomiCluster) findVMByInstanceUUID(ctx context.Context, uuid string) (string, error) {
+	klog.V(6).Infof("[find] Trying to check existence of the VM via InstanceUUID %s", uuid)
+	si := object.NewSearchIndex(c.s.session.Client)
+	instanceUUID := true
+	vmRef, err := si.FindByUuid(ctx, nil, string(uuid), true, &instanceUUID)
+	if err != nil {
+		return "", fmt.Errorf("error quering virtual machine or template using FindByUuid: %s", err)
+	}
+	if vmRef != nil {
+		klog.V(4).Infof("[find] lookup uuid %s -> ref: %s", uuid, vmRef.Reference().Value)
+		return vmRef.Reference().Value, nil
+	}
+	return "", nil
+}
+
+func isValidUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
+}
+
+func (c *GovmomiCluster) FindVM(ctx context.Context, dc *object.Datacenter, nameOrUid string) (*object.VirtualMachine, error) {
+	// Let's check to make sure we can find the template earlier on... Plus, we need
+	// the cluster/host info if we want to deploy direct to the cluster/host.
+	var src *object.VirtualMachine
+	var err error
+
+	if isValidUUID(nameOrUid) {
+		// If the passed VMTemplate is a valid UUID, then first try to find it treating that as InstanceUUID
+		// In case if are not able to locate a matching VM then fall back to searching using the VMTemplate
+		// as a name
+		klog.V(4).Infof("Trying to resolve the VMTemplate as InstanceUUID %s", nameOrUid)
+		si := object.NewSearchIndex(c.s.session.Client)
+		instanceUUID := true
+		templateref, err := si.FindByUuid(ctx, dc, nameOrUid, true, &instanceUUID)
+		if err != nil {
+			return nil, fmt.Errorf("error querying virtual machine or template using FindByUuid: %s", err)
+		}
+		if templateref != nil {
+			src = object.NewVirtualMachine(c.s.session.Client, templateref.Reference())
+		}
+	}
+	if src == nil {
+		klog.V(4).Infof("Trying to resolve the VMTemplate as Name %s", nameOrUid)
+		src, err = c.s.finder.VirtualMachine(ctx, nameOrUid)
+		if err != nil {
+			return nil, fmt.Errorf("VirtualMachine finder failed. err=%s", err)
+		}
+	}
+	return src, nil
+}
+
+func (c *GovmomiCluster) GetVirtualMachineMO(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
+	klog.V(6).Infof("[get] Fetching properties for VM %q", vm.InventoryPath)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout)
+	defer cancel()
+	var props mo.VirtualMachine
+	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}
+
+func (c *GovmomiCluster) GetHostMO(host *object.HostSystem) (*mo.HostSystem, error) {
+	klog.V(6).Infof("[DEBUG] Fetching properties for host %q", host.InventoryPath)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout)
+	defer cancel()
+	var props mo.HostSystem
+	if err := host.Properties(ctx, host.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}
+
+func (c *GovmomiCluster) Touch() error {
+	status := &vsphereconfigv1.VsphereClusterProviderStatus{LastUpdated: time.Now().UTC().String()}
+	out, err := json.Marshal(status)
+	ncluster := c.cluster.DeepCopy()
+	ncluster.Status.ProviderStatus = &runtime.RawExtension{Raw: out}
+	_, err = c.clusterAPI.Clusters(ncluster.Namespace).UpdateStatus(ncluster)
+	return err
+
+}
+
+func (c *GovmomiCluster) GetHost() string {
+	// cloud provider requires bare IP:port, so if it is parseable as a url with a scheme, then
+	// strip the scheme and path.  Otherwise continue.
+	// TODO replace with better input validation.
+	serverURL, err := url.Parse(c.config.VsphereServer)
+	if err == nil && serverURL.Host != "" {
+		return serverURL.Host
+	}
+	return c.config.VsphereServer
+}
+
+func (c *GovmomiCluster) GetCredentials() (username string, password string, err error) {
+	// If the vsphereCredentialSecret is specified then read that secret to get the credentials
+	if c.config.VsphereCredentialSecret != "" {
+		klog.V(4).Infof("Fetching vsphere credentials from secret %s", c.config.VsphereCredentialSecret)
+		secret, err := c.k8sClient.Core().Secrets(c.cluster.Namespace).Get(c.config.VsphereCredentialSecret, metav1.GetOptions{})
+		if err != nil {
+			return "", "", fmt.Errorf("Error reading secret %s", c.config.VsphereCredentialSecret)
+		}
+		if username, ok := secret.Data[constants.VsphereUserKey]; ok {
+			if password, ok := secret.Data[constants.VspherePasswordKey]; ok {
+				return string(username), string(password), nil
+			}
+		}
+		return "", "", fmt.Errorf("Improper secret: Secret %s should have the keys `%s` and `%s` defined in it", c.config.VsphereCredentialSecret, constants.VsphereUserKey, constants.VspherePasswordKey)
+	}
+	return c.config.VsphereUser, c.config.VspherePassword, nil
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -2,551 +2,122 @@ package govmomi
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
-	"reflect"
+	"strings"
 	"time"
 
-	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/version"
+
 	"k8s.io/klog"
-	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
-	vpshereprovisionercommon "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/provisioner/common"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
-	apierrors "sigs.k8s.io/cluster-api/pkg/errors"
-	"sigs.k8s.io/cluster-api/pkg/util"
 )
 
-func (pv *Provisioner) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	if cluster == nil {
-		return errors.New(constants.ClusterIsNullErr)
+func (pv *Provisioner) Create(ctx context.Context, cluster *clusterv1.Cluster, _machine *clusterv1.Machine) error {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
+	if err != nil {
+		return err
 	}
 
-	klog.V(4).Infof("govmomi.Actuator.Create %s", machine.Name)
-	s, err := pv.sessionFromProviderConfig(cluster, machine)
-	if err != nil {
-		return err
-	}
-	createctx, cancel := context.WithCancel(*s.context)
-	defer cancel()
-	usersession, err := s.session.SessionManager.UserSession(createctx)
-	if err != nil {
-		return err
-	}
-	klog.V(4).Infof("Using session %v", usersession)
-	task := vsphereutils.GetActiveTasks(machine)
+	task := machine.status.TaskRef
 	if task != "" {
 		// In case an active task is going on, wait for its completion
-		return pv.verifyAndUpdateTask(s, machine, task)
+		return pv.verifyAndUpdateTask(ctx, machine, task)
 	}
 	// Before going for cloning, check if we can locate a VM with the InstanceUUID
 	// as this Machine. If found, that VM is the right match for this machine
-	vmRef, err := pv.findVMByInstanceUUID(ctx, s, machine)
+	vmRef, err := machine.GetCluster().findVMByInstanceUUID(ctx, string(machine.machine.UID))
 	if err != nil {
 		return err
 	}
 	if vmRef != "" {
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Created", "Created Machine %s(%s)", machine.Name, vmRef)
-		// Update the Machine object with the VM Reference annotation
-		_, err := pv.updateVMReference(machine, vmRef)
-		if err != nil {
+		machine.Eventf("Created", "Created Machine %s(%s)", machine.Name, vmRef)
+		if err := machine.UpdateVMReference(vmRef); err != nil {
 			return err
 		}
 	}
 
 	// Use the appropriate path if we're connected to a vCenter
-	if s.session.IsVC() {
-		return pv.cloneVirtualMachineOnVCenter(s, cluster, machine)
+	if machine.s.session.IsVC() {
+		return pv.cloneVirtualMachineOnVCenter(ctx, machine)
 	}
 
 	// fallback in case we're connected to a standalone ESX host
-	return pv.cloneVirtualMachineOnESX(s, cluster, machine)
+	return pv.cloneVirtualMachineOnESX(ctx, machine)
 }
 
-func (pv *Provisioner) findVMByInstanceUUID(ctx context.Context, s *SessionContext, machine *clusterv1.Machine) (string, error) {
-	klog.V(4).Infof("Trying to check existence of the VM via InstanceUUID %s", machine.UID)
-	si := object.NewSearchIndex(s.session.Client)
-	instanceUUID := true
-	vmRef, err := si.FindByUuid(ctx, nil, string(machine.UID), true, &instanceUUID)
-	if err != nil {
-		return "", fmt.Errorf("error quering virtual machine or template using FindByUuid: %s", err)
-	}
-	if vmRef != nil {
-		return vmRef.Reference().Value, nil
-	}
-	return "", nil
-}
+func (pv *Provisioner) verifyAndUpdateTask(ctx context.Context, machine *GovmomiMachine, taskmoref string) error {
+	task := machine.GetCluster().GetTask(ctx, taskmoref)
 
-func (pv *Provisioner) verifyAndUpdateTask(s *SessionContext, machine *clusterv1.Machine, taskmoref string) error {
-	klog.V(4).Infof("[DEBUG] Verifying and updating Tasks")
-	ctx, cancel := context.WithCancel(*s.context)
-	defer cancel()
-	// If a task does exist on the
-	var taskmo mo.Task
-	taskref := types.ManagedObjectReference{
-		Type:  "Task",
-		Value: taskmoref,
+	if task == nil {
+		machine.SetTaskRef("")
+		return nil
 	}
-	klog.V(4).Infof("[DEBUG] Retrieving the Task")
-	err := s.session.RetrieveOne(ctx, taskref, []string{"info"}, &taskmo)
-	if err != nil {
-		klog.V(4).Infof("[DEBUG] task does not exist for moref %s", taskmoref)
-		// The task does not exist any more, thus no point tracking it. Thus clear it from the machine
-		return pv.setTaskRef(machine, "")
+
+	vmref := task.Info.Result.(types.ManagedObjectReference)
+	if machine.config.MachineRef != "" && vmref.Value != machine.config.MachineRef {
+		return fmt.Errorf("assertion failed task %s for vm %s, referenced from %s", taskmoref, machine.config.MachineRef, vmref)
 	}
-	klog.V(4).Infof("[DEBUG] task state = %s", taskmo.Info.State)
-	switch taskmo.Info.State {
+
+	klog.V(4).Infof("[%s] %s = %s ", machine.Name, task.Info.DescriptionId, task.Info.State)
+	switch task.Info.State {
 	// Queued or Running
 	case types.TaskInfoStateQueued, types.TaskInfoStateRunning:
 		// Requeue the machine update to check back in 5 seconds on the task
 		return &clustererror.RequeueAfterError{RequeueAfter: time.Second * 5}
 	// Successful
 	case types.TaskInfoStateSuccess:
-		klog.V(4).Infof("[DEBUG] Task is a Success")
-		if taskmo.Info.DescriptionId == "Folder.createVm" {
-			klog.V(4).Infof("[DEBUG] Task is a CreateVM")
-			vmref := taskmo.Info.Result.(types.ManagedObjectReference)
-			vm := object.NewVirtualMachine(s.session.Client, vmref)
-			klog.V(4).Infof("[DEBUG] Powering On the VM")
-			task, err := vm.PowerOn(ctx)
-			if err != nil {
-				return err
-			}
-			klog.V(4).Infof("[DEBUG] Waiting for PowerOn to happen")
-			_, err = task.WaitForResult(ctx, nil)
-			if err != nil {
+		if task.Info.DescriptionId == "Folder.createVm" {
+			if err := machine.PowerOn(ctx).WaitFor(); err != nil {
 				return err
 			}
 
-			klog.V(4).Infof("[DEBUG] Recording the event")
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Created", "Created Machine %s(%s)", machine.Name, vmref.Value)
-			// Update the Machine object with the VM Reference annotation
-			updatedmachine, err := pv.updateVMReference(machine, vmref.Value)
+			machine.Eventf("Created", "Created Machine %s(%s)", machine.Name, vmref.Value)
+			err := machine.UpdateVMReference(vmref.Value)
 			if err != nil {
 				return err
 			}
-			// This is needed otherwise the update status on the original machine object would fail as the resource has been updated by the previous call
-			// Note: We are not mutating the object retrieved from the informer ever. The updatedmachine is the updated resource generated using DeepCopy
-			// This would just update the reference to be the newer object so that the status update works
-			machine = updatedmachine
-			return pv.setTaskRef(machine, "")
-		} else if taskmo.Info.DescriptionId == "VirtualMachine.clone" {
-			vmref := taskmo.Info.Result.(types.ManagedObjectReference)
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Created", "Created Machine %s(%s)", machine.Name, vmref.Value)
+			return machine.SetTaskRef("")
+		} else if task.Info.DescriptionId == "VirtualMachine.clone" {
+			vmref := task.Info.Result.(types.ManagedObjectReference)
+			machine.Eventf("Created", "Created Machine %s(%s)", machine.Name, vmref.Value)
 			// Update the Machine object with the VM Reference annotation
-			updatedmachine, err := pv.updateVMReference(machine, vmref.Value)
+			err := machine.UpdateVMReference(vmref.Value)
 			if err != nil {
 				return err
 			}
-			// This is needed otherwise the update status on the original machine object would fail as the resource has been updated by the previous call
-			// Note: We are not mutating the object retrieved from the informer ever. The updatedmachine is the updated resource generated using DeepCopy
-			// This would just update the reference to be the newer object so that the status update works
-			machine = updatedmachine
-			return pv.setTaskRef(machine, "")
-		} else if taskmo.Info.DescriptionId == "VirtualMachine.reconfigure" {
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Reconfigured", "Reconfigured Machine %s", taskmo.Info.EntityName)
+			return machine.SetTaskRef("")
+		} else if task.Info.DescriptionId == "VirtualMachine.reconfigure" {
+			machine.Eventf("Reconfigured", "Reconfigured Machine %s", task.Info.EntityName)
 		}
-		return pv.setTaskRef(machine, "")
+		return machine.SetTaskRef("")
 	case types.TaskInfoStateError:
-		klog.Infof("[DEBUG] task error condition, description = %s", taskmo.Info.DescriptionId)
+		klog.Infof("[DEBUG] task error condition, description = %s", task.Info.DescriptionId)
 		// If the machine was created via the ESXi "cloning", the description id will likely be "Folder.createVm"
-		if taskmo.Info.DescriptionId == "VirtualMachine.clone" || taskmo.Info.DescriptionId == "Folder.createVm" {
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Failed", "Creation failed for Machine %v", machine.Name)
+		if task.Info.DescriptionId == "VirtualMachine.clone" || task.Info.DescriptionId == "Folder.createVm" {
+			machine.Eventf("Failed", "Creation failed for Machine %v", machine.Name)
 			// Clear the reference to the failed task so that the next reconcile loop can re-create it
-			return pv.setTaskRef(machine, "")
+			return machine.SetTaskRef("")
 		}
 	default:
-		klog.Warningf("unknown state %s for task %s detected", taskmoref, taskmo.Info.State)
-		return fmt.Errorf("Unknown state %s for task %s detected", taskmoref, taskmo.Info.State)
+		return fmt.Errorf("Unknown state %s for task %s detected", taskmoref, task.Info.State)
 	}
 	return nil
 }
 
-// CloneVirtualMachine clones the template to a virtual machine.
-func (pv *Provisioner) cloneVirtualMachineOnVCenter(s *SessionContext, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	klog.V(4).Infof("Starting the clone process on vCenter")
-	ctx, cancel := context.WithCancel(*s.context)
-	defer cancel()
-
-	machineConfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return err
-	}
-
-	dc, err := s.finder.DatacenterOrDefault(ctx, machineConfig.MachineSpec.Datacenter)
-	if err != nil {
-		return err
-	}
-	s.finder.SetDatacenter(dc)
-
-	// Let's check to make sure we can find the template earlier on... Plus, we need
-	// the cluster/host info if we want to deploy direct to the cluster/host.
-	var src *object.VirtualMachine
-	if vsphereutils.IsValidUUID(machineConfig.MachineSpec.VMTemplate) {
-		// If the passed VMTemplate is a valid UUID, then first try to find it treating that as InstanceUUID
-		// In case if are not able to locate a matching VM then fall back to searching using the VMTemplate
-		// as a name
-		klog.V(4).Infof("Trying to resolve the VMTemplate as InstanceUUID %s", machineConfig.MachineSpec.VMTemplate)
-		si := object.NewSearchIndex(s.session.Client)
-		instanceUUID := true
-		templateref, err := si.FindByUuid(ctx, dc, machineConfig.MachineSpec.VMTemplate, true, &instanceUUID)
-		if err != nil {
-			return fmt.Errorf("error querying virtual machine or template using FindByUuid: %s", err)
-		}
-		if templateref != nil {
-			src = object.NewVirtualMachine(s.session.Client, templateref.Reference())
-		}
-	}
-	if src == nil {
-		klog.V(4).Infof("Trying to resolve the VMTemplate as Name %s", machineConfig.MachineSpec.VMTemplate)
-		src, err = s.finder.VirtualMachine(ctx, machineConfig.MachineSpec.VMTemplate)
-		if err != nil {
-			klog.Errorf("VirtualMachine finder failed. err=%s", err)
-			return err
-		}
-	}
-
-	host, err := src.HostSystem(ctx)
-	if err != nil {
-		klog.Errorf("HostSystem failed. err=%s", err)
-		return err
-	}
-	hostProps, err := PropertiesHost(host)
-	if err != nil {
-		return fmt.Errorf("error fetching host properties: %s", err)
-	}
-
-	// Since it's assumed that the ResourcePool name has been provided in the config, if we
-	// want to deploy directly to the cluster/host, then we need to override the ResourcePool
-	// path before generating the Cloud Provider config. This is done below in:
-	// getCloudInitUserData()
-	// +--- getCloudProviderConfig()
-	resourcePoolPath := ""
-	if len(machineConfig.MachineSpec.ResourcePool) == 0 {
-
-		resourcePoolPath = fmt.Sprintf("/%s/host/%s/Resource", machineConfig.MachineSpec.Datacenter, hostProps.Name)
-		klog.Infof("Attempting to deploy directly to cluster/host RP: %s", resourcePoolPath)
-	}
-
-	// Fetch the user-data for the cloud-init first, so that we can fail fast before even trying to connect to pv
-	userData, err := pv.getCloudInitUserData(cluster, machine, resourcePoolPath, true)
-	if err != nil {
-		// err returned by the getCloudInitUserData would be of type RequeueAfterError in case kubeadm is not ready yet
-		return err
-	}
-	metaData, err := pv.getCloudInitMetaData(cluster, machine)
-	if err != nil {
-		// err returned by the getCloudInitMetaData would be of type RequeueAfterError in case kubeadm is not ready yet
-		return err
-	}
-
-	var spec types.VirtualMachineCloneSpec
-	klog.V(4).Infof("[cloneVirtualMachine]: Preparing clone spec for VM %s", machine.Name)
-	klog.V(4).Infof("clone VM to folder %s", machineConfig.MachineSpec.VMFolder)
-	vmFolder, err := s.finder.FolderOrDefault(ctx, machineConfig.MachineSpec.VMFolder)
-	if err != nil {
-		return err
-	}
-
-	ds, err := s.finder.DatastoreOrDefault(ctx, machineConfig.MachineSpec.Datastore)
-	if err != nil {
-		return err
-	}
-	spec.Location.Datastore = types.NewReference(ds.Reference())
-
-	spec.Config = &types.VirtualMachineConfigSpec{}
-	// Use the object UID as the instanceUUID for the VM
-	spec.Config.InstanceUuid = string(machine.UID)
-	diskUUIDEnabled := true
-	spec.Config.Flags = &types.VirtualMachineFlagInfo{
-		DiskUuidEnabled: &diskUUIDEnabled,
-	}
-	if machineConfig.MachineSpec.NumCPUs > 0 {
-		spec.Config.NumCPUs = int32(machineConfig.MachineSpec.NumCPUs)
-	}
-	if machineConfig.MachineSpec.MemoryMB > 0 {
-		spec.Config.MemoryMB = machineConfig.MachineSpec.MemoryMB
-	}
-	spec.Config.Annotation = fmt.Sprintf("Virtual Machine is part of the cluster %s managed by cluster-api", cluster.Name)
-	spec.Location.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndConsolidate)
-
-	vmProps, err := PropertiesVM(src)
-	if err != nil {
-		return fmt.Errorf("error fetching vm/template properties: %s", err)
-	}
-
-	if len(machineConfig.MachineSpec.ResourcePool) > 0 {
-		pool, err := s.finder.ResourcePoolOrDefault(ctx, machineConfig.MachineSpec.ResourcePool)
-
-		if _, ok := err.(*find.NotFoundError); ok {
-			klog.Warningf("Failed to find ResourcePool=%s err=%s. Attempting to create it.", machineConfig.MachineSpec.ResourcePool, err)
-
-			poolRoot, errRoot := host.ResourcePool(ctx)
-			if errRoot != nil {
-				klog.Errorf("Failed to find root ResourcePool. err=%s", errRoot)
-				return errRoot
-			}
-
-			klog.Info("Creating ResourcePool using default values. These values can be modified after ResourcePool creation.")
-			pool, err = poolRoot.Create(ctx, machineConfig.MachineSpec.ResourcePool, types.DefaultResourceConfigSpec())
-			if err != nil {
-				klog.Errorf("Create ResourcePool failed. err=%s", err)
-				return err
-			}
-		}
-
-		spec.Location.Pool = types.NewReference(pool.Reference())
-	} else {
-		klog.Infof("Attempting to use Host ResourcePool")
-		pool, err := host.ResourcePool(ctx)
-
-		if err != nil {
-			klog.Errorf("Host ResourcePool failed. err=%s", err)
-			return err
-		}
-
-		spec.Location.Pool = types.NewReference(pool.Reference())
-	}
-	spec.PowerOn = true
-
-	if machineConfig.MachineSpec.VsphereCloudInit {
-		// In case of vsphere cloud-init datasource present, set the appropriate extraconfig options
-		var extraconfigs []types.BaseOptionValue
-		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.metadata", Value: metaData})
-		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.metadata.encoding", Value: "base64"})
-		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.userdata", Value: userData})
-		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.userdata.encoding", Value: "base64"})
-		spec.Config.ExtraConfig = extraconfigs
-	} else {
-		// This case is to support backwords compatibility, where we are using the ubuntu cloud image ovf properties
-		// to drive the cloud-init workflow. Once the vsphere cloud-init datastore is merged as part of the official
-		// cloud-init, then we can potentially remove this flag from the spec as then all the native cloud images
-		// available for the different distros will include this new datasource.
-		// See (https://github.com/akutz/cloud-init-vmware-guestinfo/ - vmware cloud-init datasource) for details
-		if vmProps.Config.VAppConfig == nil {
-			return fmt.Errorf("this source VM lacks a vApp configuration and cannot have vApp properties set on it")
-		}
-		allProperties := vmProps.Config.VAppConfig.GetVmConfigInfo().Property
-		var props []types.VAppPropertySpec
-		for _, p := range allProperties {
-			defaultValue := " "
-			if p.DefaultValue != "" {
-				defaultValue = p.DefaultValue
-			}
-			prop := types.VAppPropertySpec{
-				ArrayUpdateSpec: types.ArrayUpdateSpec{
-					Operation: types.ArrayUpdateOperationEdit,
-				},
-				Info: &types.VAppPropertyInfo{
-					Key:   p.Key,
-					Id:    p.Id,
-					Value: defaultValue,
-				},
-			}
-			if p.Id == "user-data" {
-				prop.Info.Value = userData
-			}
-			if p.Id == "public-keys" {
-				prop.Info.Value, err = pv.GetSSHPublicKey(cluster)
-				if err != nil {
-					return err
-				}
-			}
-			if p.Id == "hostname" {
-				prop.Info.Value = machine.Name
-			}
-			props = append(props, prop)
-		}
-		spec.Config.VAppConfig = &types.VmConfigSpec{
-			Property: props,
-		}
-	}
-
-	l := object.VirtualDeviceList(vmProps.Config.Hardware.Device)
-	deviceSpecs := []types.BaseVirtualDeviceConfigSpec{}
-	disks := l.SelectByType((*types.VirtualDisk)(nil))
-	// For the disks listed under the MachineSpec.Disks property, they are used
-	// only for resizing a maching disk on the template. Currently, no new disk
-	// is added. Only the matched disks via the DiskLabel are resized. If the
-	// MachineSpec.Disks is specified but none of the disks matched to the disks
-	// present in the VM Template then error is returned. This is to avoid the
-	// case when the user did want to resize but accidentally passed a wrong
-	// disk label. A 100% matching of disks in not enforced as the user might be
-	// interested in resizing only a subset of disks and thus we don't want to
-	// force the user to list all the disk and sizes if they don't want to change
-	// all.
-	diskMap := func(diskSpecs []vsphereconfigv1.DiskSpec) map[string]int64 {
-		diskMap := make(map[string]int64)
-		for _, s := range diskSpecs {
-			diskMap[s.DiskLabel] = s.DiskSizeGB
-		}
-		return diskMap
-	}(machineConfig.MachineSpec.Disks)
-	diskChange := false
-	for _, dev := range disks {
-		disk := dev.(*types.VirtualDisk)
-		if newSize, ok := diskMap[disk.DeviceInfo.GetDescription().Label]; ok {
-			if disk.CapacityInBytes > vsphereutils.GiBToByte(newSize) {
-				return errors.New("[FATAL] Disk size provided should be more than actual disk size of the template. Please correct the machineSpec to proceed")
-			}
-			klog.V(4).Infof("[cloneVirtualMachine] Resizing the disk \"%s\" to new size \"%d\"", disk.DeviceInfo.GetDescription().Label, newSize)
-			diskChange = true
-			disk.CapacityInBytes = vsphereutils.GiBToByte(newSize)
-			diskspec := &types.VirtualDeviceConfigSpec{}
-			diskspec.Operation = types.VirtualDeviceConfigSpecOperationEdit
-			diskspec.Device = disk
-			deviceSpecs = append(deviceSpecs, diskspec)
-		}
-	}
-	if !diskChange && len(machineConfig.MachineSpec.Disks) > 0 {
-		klog.V(4).Info("[cloneVirtualMachine] No disks were resized while cloning from template")
-		return fmt.Errorf("[FATAL] None of the disks specified in the MachineSpec matched with the disks on the template %s", machineConfig.MachineSpec.VMTemplate)
-	}
-
-	nics := l.SelectByType((*types.VirtualEthernetCard)(nil))
-	// Remove any existing nics on the source vm
-	for _, dev := range nics {
-		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-		nicspec := &types.VirtualDeviceConfigSpec{}
-		nicspec.Operation = types.VirtualDeviceConfigSpecOperationRemove
-		nicspec.Device = nic
-		deviceSpecs = append(deviceSpecs, nicspec)
-	}
-	// Add new nics based on the user info
-	nicid := int32(-100)
-	for _, network := range machineConfig.MachineSpec.Networks {
-		netRef, err := s.finder.Network(ctx, network.NetworkName)
-		if err != nil {
-			return err
-		}
-		nic := types.VirtualVmxnet3{}
-		nic.Key = nicid
-		nic.Backing, err = netRef.EthernetCardBackingInfo(ctx)
-		if err != nil {
-			return err
-		}
-		nicspec := &types.VirtualDeviceConfigSpec{}
-		nicspec.Operation = types.VirtualDeviceConfigSpecOperationAdd
-		nicspec.Device = &nic
-		deviceSpecs = append(deviceSpecs, nicspec)
-		nicid--
-	}
-	spec.Config.DeviceChange = deviceSpecs
-	if pv.eventRecorder != nil { // TODO: currently supporting nil for testing
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Creating", "Creating Machine %v", machine.Name)
-	}
-	task, err := src.Clone(ctx, vmFolder, machine.Name, spec)
-	klog.V(6).Infof("clone VM with spec %v", spec)
-	if err != nil {
-		return err
-	}
-	return pv.setTaskRef(machine, task.Reference().Value)
-}
-
-// cloneVirtualMachineOnESX clones the template to a virtual machine.
-func (pv *Provisioner) cloneVirtualMachineOnESX(s *SessionContext, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	klog.V(4).Infof("Starting the clone process on standalone ESX")
-	ctx, cancel := context.WithCancel(*s.context)
-	defer cancel()
-
-	machineConfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return err
-	}
-	klog.V(4).Infof("[cloneVirtualMachineOnESX]: Preparing clone spec for VM %s", machine.Name)
-
-	dc, err := s.finder.DefaultDatacenter(ctx)
-	//dc, err := s.finder.DatacenterOrDefault(ctx, machineConfig.MachineSpec.Datacenter)
-	if err != nil {
-		return err
-	}
-	s.finder.SetDatacenter(dc)
-
-	folders, err := dc.Folders(ctx)
-	if err != nil {
-		return err
-	}
-
-	pool, err := s.finder.ResourcePoolOrDefault(ctx, machineConfig.MachineSpec.ResourcePool)
-	if err != nil {
-		return err
-	}
-
-	// Fetch info from templateVM
-	src, err := s.finder.VirtualMachine(ctx, machineConfig.MachineSpec.VMTemplate)
-	if err != nil {
-		return err
-	}
-	vmProps, err := PropertiesVM(src)
-	if err != nil {
-		return fmt.Errorf("error fetching virtual machine or template properties: %s", err)
-	}
-
-	spec := &types.VirtualMachineConfigSpec{}
-	var devices object.VirtualDeviceList
-
-	if err := pv.addMachineBase(s, cluster, machine, machineConfig, spec, vmProps); err != nil {
-		return err
-	}
-
-	if devices, err = pv.copyDisks(ctx, s, machine, machineConfig, devices, vmProps); err != nil {
-		return err
-	}
-
-	if devices, err = pv.addNetworking(ctx, s, machineConfig, devices); err != nil {
-		return err
-	}
-
-	if devices, err = pv.addSerialPort(ctx, devices, vmProps); err != nil {
-		return err
-	}
-
-	deviceChange, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
-	if err != nil {
-		return err
-	}
-
-	spec.DeviceChange = deviceChange
-
-	// get current hostsystem from source vm
-	ch, err := src.HostSystem(ctx)
-	if err != nil {
-		return err
-	}
-
-	pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Creating", "Creating Machine %v", machine.Name)
-
-	task, err := folders.VmFolder.CreateVM(ctx, *spec, pool, ch)
-	if err != nil {
-		klog.Infof("[DEBUG] VmFolder.CreateVM() FAILED: %s", err.Error())
-		return err
-	}
-
-	return pv.setTaskRef(machine, task.Reference().Value)
-
-}
-
-func (pv *Provisioner) addMachineBase(s *SessionContext, cluster *clusterv1.Cluster, machine *clusterv1.Machine, machineConfig *vsphereconfigv1.VsphereMachineProviderConfig, spec *types.VirtualMachineConfigSpec, vmProps *mo.VirtualMachine) error {
+func (pv *Provisioner) addMachineBase(ctx context.Context, machine *GovmomiMachine, spec *types.VirtualMachineConfigSpec, vmProps *mo.VirtualMachine) error {
 	// Fetch the user-data for the cloud-init first, so that we can fail fast before even trying to connect to VC
-	userData, err := pv.getCloudInitUserData(cluster, machine, "", false)
+	userData, err := pv.getCloudInitUserData(machine.cluster, machine.machine, "", false)
 	if err != nil {
 		// err returned by the getCloudInitUserData would be of type RequeueAfterError in case kubeadm is not ready yet
 		return err
 	}
-	metaData, err := pv.getCloudInitMetaData(cluster, machine)
+	metaData, err := pv.getCloudInitMetaData(machine.cluster, machine.machine)
 	if err != nil {
 		// err returned by the getCloudInitUserData would be of type RequeueAfterError in case kubeadm is not ready yet
 		return err
@@ -562,89 +133,36 @@ func (pv *Provisioner) addMachineBase(s *SessionContext, cluster *clusterv1.Clus
 	spec.Firmware = vmProps.Config.Firmware       // set Firmware from template
 	spec.BootOptions = vmProps.Config.BootOptions // set BootOptions from Template
 
-	if machineConfig.MachineSpec.NumCPUs > 0 {
-		spec.NumCPUs = int32(machineConfig.MachineSpec.NumCPUs)
+	if machine.config.MachineSpec.NumCPUs > 0 {
+		spec.NumCPUs = int32(machine.config.MachineSpec.NumCPUs)
 	}
-	if machineConfig.MachineSpec.MemoryMB > 0 {
-		spec.MemoryMB = machineConfig.MachineSpec.MemoryMB
-	}
-
-	//spec.PowerOpInfo.
-	spec.Annotation = fmt.Sprintf("Virtual Machine is part of the cluster %s managed by cluster-api", cluster.Name)
-
-	// OVF Environment
-	// build up Environment in order to marshal to xml
-
-	var opts []types.BaseOptionValue
-
-	if machineConfig.MachineSpec.VsphereCloudInit {
-		// In case of vsphere cloud-init datasource present, set the appropriate extraconfig options
-		opts = append(opts, &types.OptionValue{Key: "guestinfo.metadata", Value: metaData})
-		opts = append(opts, &types.OptionValue{Key: "guestinfo.metadata.encoding", Value: "base64"})
-		opts = append(opts, &types.OptionValue{Key: "guestinfo.userdata", Value: userData})
-		opts = append(opts, &types.OptionValue{Key: "guestinfo.userdata.encoding", Value: "base64"})
-	} else {
-		// This case is to support backwards compatibility, where we are using the ubuntu cloud image ovf properties
-		// to drive the cloud-init workflow. Once the vsphere cloud-init datastore is merged as part of the official
-		// cloud-init, then we can potentially remove this flag from the spec as then all the native cloud images
-		// available for the different distros will include this new datasource.
-		// See (https://github.com/akutz/cloud-init-vmware-guestinfo/ - vmware cloud-init datasource) for details
-		var props []ovf.EnvProperty
-		sshKey, _ := pv.GetSSHPublicKey(cluster)
-		props = append(props, ovf.EnvProperty{
-			Key:   "user-data",
-			Value: userData,
-		},
-			ovf.EnvProperty{
-				Key:   "public-keys",
-				Value: sshKey,
-			},
-			ovf.EnvProperty{
-				Key:   "hostname",
-				Value: machine.Name,
-			})
-		a := s.session.ServiceContent.About
-		env := ovf.Env{
-			EsxID: vmProps.Reference().Value,
-			Platform: &ovf.PlatformSection{
-				Kind:    a.Name,
-				Version: a.Version,
-				Vendor:  a.Vendor,
-				Locale:  "US",
-			},
-			Property: &ovf.PropertySection{
-				Properties: props,
-			},
-		}
-
-		opts = append(opts, &types.OptionValue{
-			Key:   "guestinfo.ovfEnv",
-			Value: env.MarshalManual(),
-		})
+	if machine.config.MachineSpec.MemoryMB > 0 {
+		spec.MemoryMB = machine.config.MachineSpec.MemoryMB
 	}
 
-	spec.ExtraConfig = opts
+	spec.Annotation = fmt.Sprintf("Virtual Machine is part of the cluster %s managed by cluster-api", machine.cluster.Name)
+
+	spec.ExtraConfig = pv.addOvfEnv(machine, machine.config, vmProps, userData, metaData)
 
 	spec.Files = &types.VirtualMachineFileInfo{
-		VmPathName: fmt.Sprintf("[%s]", machineConfig.MachineSpec.Datastore),
+		VmPathName: fmt.Sprintf("[%s]", machine.config.MachineSpec.Datastore),
 	}
 
 	return nil
 }
 
-func (pv *Provisioner) copyDisks(ctx context.Context, s *SessionContext, machine *clusterv1.Machine, machineConfig *vsphereconfigv1.VsphereMachineProviderConfig, devices object.VirtualDeviceList, vmProps *mo.VirtualMachine) (object.VirtualDeviceList, error) {
-	ds, err := s.finder.DatastoreOrDefault(ctx, machineConfig.MachineSpec.Datastore)
+func (pv *Provisioner) copyDisks(ctx context.Context, machine *GovmomiMachine, devices object.VirtualDeviceList, vmProps *mo.VirtualMachine) (object.VirtualDeviceList, error) {
+	ds, err := machine.s.finder.DatastoreOrDefault(ctx, machine.config.MachineSpec.Datastore)
 	if err != nil {
 		return devices, err
 	}
-	dc, err := s.finder.DefaultDatacenter(ctx)
+	dc, err := machine.s.finder.DefaultDatacenter(ctx)
 	if err != nil {
 		return devices, err
 	}
-	s.finder.SetDatacenter(dc)
 
-	// Create datastore directory for our VM
-	dstf := fmt.Sprintf("[%s] %s", machineConfig.MachineSpec.Datastore, machine.Name)
+	machine.s.finder.SetDatacenter(dc)
+	dstf := fmt.Sprintf("[%s] %s", machine.config.MachineSpec.Datastore, machine.Name)
 	m := ds.NewFileManager(dc, false)
 	err = m.FileManager.MakeDirectory(ctx, dstf, dc, true)
 	if err != nil {
@@ -672,10 +190,8 @@ func (pv *Provisioner) copyDisks(ctx context.Context, s *SessionContext, machine
 		return devices, err
 	}
 
-	var dstdisk string
-
 	// Iterate through the machine spec and then iterate over the VM's disks
-	for _, diskSpec := range machineConfig.MachineSpec.Disks {
+	for _, diskSpec := range machine.config.MachineSpec.Disks {
 		for _, dev := range disks {
 			srcdisk := dev.(*types.VirtualDisk)
 
@@ -686,18 +202,14 @@ func (pv *Provisioner) copyDisks(ctx context.Context, s *SessionContext, machine
 				}
 				srcdisk.CapacityInBytes = vsphereutils.GiBToByte(newSize)
 			}
+			root := fmt.Sprintf("/vmfs/volumes/%s/%s", ds.Reference().Value, machine.Name)
+			dstPath := fmt.Sprintf("%s/%s-%s.vmdk", root, machine.Name, diskSpec.DiskLabel)
+			src := srcdisk.Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
+			srcPath := fmt.Sprintf("/vmfs/volumes/%s/%s", src.Datastore.Value, strings.Split(src.FileName, " ")[1])
 
-			dstdisk = fmt.Sprintf("%s/%s-%s.vmdk", dstf, machine.Name, diskSpec.DiskLabel)
-			srcfile := srcdisk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
-
-			// copy happens here
-			klog.V(4).Infof("[DEBUG] Cloning template disk to %s", dstdisk)
-			cp := m.Copy
-			if err := cp(ctx, srcfile.GetVirtualDeviceFileBackingInfo().FileName, dstdisk); err != nil {
-				klog.V(4).Infof("[DEBUG] Copying vmdk, src(%s), dst(%s)", srcfile.GetVirtualDeviceFileBackingInfo().FileName, dstdisk)
+			if err := pv.thinCopyDisks(ctx, machine, srcPath, dstPath); err != nil {
 				return devices, err
 			}
-
 			// attach disk to VM
 			disk := devices.CreateDisk(controller, ds.Reference(), ds.Path(fmt.Sprintf("%s/%s-%s.vmdk", machine.Name, machine.Name, diskSpec.DiskLabel)))
 			devices = append(devices, disk)
@@ -707,10 +219,10 @@ func (pv *Provisioner) copyDisks(ctx context.Context, s *SessionContext, machine
 	return devices, nil
 }
 
-func (pv *Provisioner) addNetworking(ctx context.Context, s *SessionContext, machineConfig *vsphereconfigv1.VsphereMachineProviderConfig, devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
-	klog.V(4).Infof("[DEBUG] Adding NICs")
-	for _, network := range machineConfig.MachineSpec.Networks {
-		netRef, err := s.finder.Network(ctx, network.NetworkName)
+func (pv *Provisioner) addNetworking(ctx context.Context, machine *GovmomiMachine, devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
+	klog.V(4).Infof("[provision] Adding NICs")
+	for _, network := range machine.config.MachineSpec.Networks {
+		netRef, err := machine.s.finder.Network(ctx, network.NetworkName)
 		if err != nil {
 			return devices, err
 		}
@@ -732,13 +244,13 @@ func (pv *Provisioner) addNetworking(ctx context.Context, s *SessionContext, mac
 
 func (pv *Provisioner) addSerialPort(ctx context.Context, devices object.VirtualDeviceList, vmProps *mo.VirtualMachine) (object.VirtualDeviceList, error) {
 	// Add SIO Controller
-	klog.V(4).Infof("[DEBUG] Adding SIO controller")
+	klog.V(4).Infof("[provision] Adding SIO controller")
 	l := object.VirtualDeviceList(vmProps.Config.Hardware.Device)
 	controllers := l.SelectByType((*types.VirtualSIOController)(nil))
 
 	if len(controllers) == 0 {
 		// Add a serial port
-		klog.V(4).Infof("[DEBUG] Adding SIO controller")
+		klog.V(4).Infof("[provision] Adding SIO controller")
 		c := &types.VirtualSIOController{}
 		c.Key = devices.NewKey()
 		devices = append(devices, c)
@@ -754,11 +266,10 @@ func (pv *Provisioner) addSerialPort(ctx context.Context, devices object.Virtual
 	ports := l.SelectByType((*types.VirtualSerialPort)(nil))
 
 	if len(ports) == 0 {
-		klog.V(4).Infof("[DEBUG] Adding serial port")
+		klog.V(4).Infof("[provision] Adding serial port")
 		portSpec, err := devices.CreateSerialPort()
 		if err != nil {
-			klog.V(4).Infof("[DEBUG] Failed to add serial port: %s", err.Error())
-			return devices, err
+			return nil, fmt.Errorf("[provision] Failed to add serial port: %s", err)
 		}
 		portSpec.Key = devices.NewKey()
 		devices = append(devices, portSpec)
@@ -771,263 +282,4 @@ func (pv *Provisioner) addSerialPort(ctx context.Context, devices object.Virtual
 	}
 
 	return devices, nil
-}
-
-// Properties is a convenience method that wraps fetching the
-// VirtualMachine MO from its higher-level object.
-func PropertiesVM(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
-	klog.V(4).Infof("[DEBUG] Fetching properties for VM %q", vm.InventoryPath)
-	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout)
-	defer cancel()
-	var props mo.VirtualMachine
-	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {
-		return nil, err
-	}
-	return &props, nil
-}
-
-// PropertiesHost is a convenience method that wraps fetching the
-// HostSystem MO from its higher-level object.
-func PropertiesHost(host *object.HostSystem) (*mo.HostSystem, error) {
-	klog.V(4).Infof("[DEBUG] Fetching properties for host %q", host.InventoryPath)
-	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout)
-	defer cancel()
-	var props mo.HostSystem
-	if err := host.Properties(ctx, host.Reference(), nil, &props); err != nil {
-		return nil, err
-	}
-	return &props, nil
-}
-
-func (vc *Provisioner) updateVMReference(machine *clusterv1.Machine, vmref string) (*clusterv1.Machine, error) {
-	providerSpec, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		klog.Infof("Error fetching MachineProviderConfig: %s", err)
-		return machine, err
-	}
-	providerSpec.MachineRef = vmref
-	// Set the Kind and APIVersion again since they are not returned
-	// See the following Issues for details:
-	// https://github.com/kubernetes/client-go/issues/308
-	// https://github.com/kubernetes/kubernetes/issues/3030
-	providerSpec.Kind = reflect.TypeOf(*providerSpec).Name()
-	providerSpec.APIVersion = vsphereconfigv1.SchemeGroupVersion.String()
-	newMachine := machine.DeepCopy()
-	out, err := json.Marshal(providerSpec)
-	if err != nil {
-		klog.Infof("Error marshaling ProviderConfig: %s", err)
-		return machine, err
-	}
-	newMachine.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: out}
-	newMachine, err = vc.clusterV1alpha1.Machines(newMachine.Namespace).Update(newMachine)
-	if err != nil {
-		klog.Infof("Error in updating the machine ref: %s", err)
-		return machine, err
-	}
-	return newMachine, nil
-}
-
-func (pv *Provisioner) setTaskRef(machine *clusterv1.Machine, taskref string) error {
-	oldProviderStatus, err := vsphereutils.GetMachineProviderStatus(machine)
-	if err != nil {
-		return err
-	}
-
-	if oldProviderStatus != nil && oldProviderStatus.TaskRef == taskref {
-		// Nothing to update
-		return nil
-	}
-	newProviderStatus := &vsphereconfigv1.VsphereMachineProviderStatus{}
-	// create a copy of the old status so that any other fields except the ones we want to change can be retained
-	if oldProviderStatus != nil {
-		newProviderStatus = oldProviderStatus.DeepCopy()
-	}
-	newProviderStatus.TaskRef = taskref
-	newProviderStatus.LastUpdated = time.Now().UTC().String()
-	out, err := json.Marshal(newProviderStatus)
-	newMachine := machine.DeepCopy()
-	newMachine.Status.ProviderStatus = &runtime.RawExtension{Raw: out}
-	if pv.clusterV1alpha1 == nil { // TODO: currently supporting nil for testing
-		return nil
-	}
-	_, err = pv.clusterV1alpha1.Machines(newMachine.Namespace).UpdateStatus(newMachine)
-	if err != nil {
-		klog.Infof("Error in updating the machine ref: %s", err)
-		return err
-	}
-	return nil
-}
-
-func (pv *Provisioner) getCloudInitMetaData(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	machineconfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return "", err
-	}
-	metadata, err := vpshereprovisionercommon.GetCloudInitMetaData(machine.Name, machineconfig)
-	if err != nil {
-		return "", err
-	}
-	metadata = base64.StdEncoding.EncodeToString([]byte(metadata))
-	return metadata, nil
-}
-
-func (pv *Provisioner) getCloudInitUserData(cluster *clusterv1.Cluster, machine *clusterv1.Machine,
-	resourcePoolPath string, deployOnVC bool) (string, error) {
-	script, err := pv.getStartupScript(cluster, machine, deployOnVC)
-	if err != nil {
-		return "", err
-	}
-	config, err := pv.getCloudProviderConfig(cluster, machine, resourcePoolPath, deployOnVC)
-	if err != nil {
-		return "", err
-	}
-	publicKey, err := pv.GetSSHPublicKey(cluster)
-	if err != nil {
-		return "", err
-	}
-	machineconfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return "", err
-	}
-	userdata, err := vpshereprovisionercommon.GetCloudInitUserData(
-		vpshereprovisionercommon.CloudInitTemplate{
-			Script:              script,
-			IsMaster:            util.IsControlPlaneMachine(machine),
-			CloudProviderConfig: config,
-			SSHPublicKey:        publicKey,
-			TrustedCerts:        machineconfig.MachineSpec.TrustedCerts,
-			NTPServers:          machineconfig.MachineSpec.NTPServers,
-		},
-		deployOnVC,
-	)
-	if err != nil {
-		return "", err
-	}
-	userdata = base64.StdEncoding.EncodeToString([]byte(userdata))
-	return userdata, nil
-}
-
-func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, machine *clusterv1.Machine,
-	resourcePoolPath string, deployOnVC bool) (string, error) {
-	clusterConfig, err := vsphereutils.GetClusterProviderSpec(cluster.Spec.ProviderSpec)
-	if err != nil {
-		return "", err
-	}
-	machineconfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return "", err
-	}
-
-	// cloud provider requires bare IP:port, so if it is parseable as a url with a scheme, then
-	// strip the scheme and path.  Otherwise continue.  TODO replace with better input validation.
-	var server string
-	serverURL, err := url.Parse(clusterConfig.VsphereServer)
-	if err == nil && serverURL.Host != "" {
-		server = serverURL.Host
-		klog.Infof("Extracted vSphere server url: %s", server)
-	} else {
-		server = clusterConfig.VsphereServer
-		klog.Infof("Using input vSphere server url: %s", server)
-	}
-
-	username, password, err := pv.GetVsphereCredentials(cluster)
-	if err != nil {
-		return "", err
-	}
-
-	// TODO(ssurana): revisit once we solve https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/60
-	cpc := vpshereprovisionercommon.CloudProviderConfigTemplate{
-		Datacenter:   machineconfig.MachineSpec.Datacenter,
-		Server:       server,
-		Insecure:     true, // TODO(ssurana): Needs to be a user input
-		UserName:     username,
-		Password:     password,
-		ResourcePool: machineconfig.MachineSpec.ResourcePool,
-		Datastore:    machineconfig.MachineSpec.Datastore,
-		Network:      "",
-	}
-	if len(resourcePoolPath) > 0 {
-		cpc.ResourcePool = resourcePoolPath
-	}
-	if len(machineconfig.MachineSpec.Networks) > 0 {
-		cpc.Network = machineconfig.MachineSpec.Networks[0].NetworkName
-	}
-
-	cloudProviderConfig, err := vpshereprovisionercommon.GetCloudProviderConfigConfig(cpc, deployOnVC)
-	if err != nil {
-		return "", err
-	}
-	cloudProviderConfig = base64.StdEncoding.EncodeToString([]byte(cloudProviderConfig))
-	return cloudProviderConfig, nil
-}
-
-// Builds and returns the startup script for the passed machine and cluster.
-// Returns the full path of the saved startup script and possible error.
-func (pv *Provisioner) getStartupScript(cluster *clusterv1.Cluster, machine *clusterv1.Machine, deployOnVC bool) (string, error) {
-	machineconfig, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return "", pv.HandleMachineError(machine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal providerSpec field: %v", err), constants.CreateEventAction)
-	}
-	preloaded := machineconfig.MachineSpec.Preloaded
-	var startupScript string
-	if util.IsControlPlaneMachine(machine) {
-		if machine.Spec.Versions.ControlPlane == "" {
-			return "", pv.HandleMachineError(machine, apierrors.InvalidMachineConfiguration(
-				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), constants.CreateEventAction)
-		}
-		parsedVersion, err := version.ParseSemantic(machine.Spec.Versions.ControlPlane)
-		if err != nil {
-			return "", err
-		}
-
-		startupScript, err = vpshereprovisionercommon.GetMasterStartupScript(
-			vpshereprovisionercommon.TemplateParams{
-				MajorMinorVersion: fmt.Sprintf("%d.%d", parsedVersion.Major(), parsedVersion.Minor()),
-				Cluster:           cluster,
-				Machine:           machine,
-				Preloaded:         preloaded,
-			},
-			deployOnVC,
-		)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		clusterstatus, err := vsphereutils.GetClusterProviderStatus(cluster)
-		if err != nil {
-			klog.Infof("Error fetching cluster ProviderStatus field: %s", err)
-			return "", err
-		}
-		if clusterstatus == nil || clusterstatus.APIStatus != vsphereconfigv1.ApiReady {
-			duration := vsphereutils.GetNextBackOff()
-			klog.Infof("Waiting for Kubernetes API Status to be \"Ready\". Retrying in %s", duration)
-			return "", &clustererror.RequeueAfterError{RequeueAfter: duration}
-		}
-		kubeadmToken, err := pv.GetKubeadmToken(cluster)
-		if err != nil {
-			duration := vsphereutils.GetNextBackOff()
-			klog.Infof("Error generating kubeadm token, will retry in %s error: %s", duration, err.Error())
-			return "", &clustererror.RequeueAfterError{RequeueAfter: duration}
-		}
-		parsedVersion, err := version.ParseSemantic(machine.Spec.Versions.Kubelet)
-		if err != nil {
-			return "", err
-		}
-		startupScript, err = vpshereprovisionercommon.GetNodeStartupScript(
-			vpshereprovisionercommon.TemplateParams{
-				Token:             kubeadmToken,
-				MajorMinorVersion: fmt.Sprintf("%d.%d", parsedVersion.Major(), parsedVersion.Minor()),
-				Cluster:           cluster,
-				Machine:           machine,
-				Preloaded:         preloaded,
-			},
-			deployOnVC,
-		)
-		if err != nil {
-			return "", err
-		}
-	}
-	startupScript = base64.StdEncoding.EncodeToString([]byte(startupScript))
-	return startupScript, nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/delete.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/delete.go
@@ -2,70 +2,37 @@ package govmomi
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
-	"github.com/vmware/govmomi/object"
-
-	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
-	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // Delete the machine
-func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	if cluster == nil {
-		return errors.New(constants.ClusterIsNullErr)
-	}
-
-	s, err := pv.sessionFromProviderConfig(cluster, machine)
+func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, _machine *clusterv1.Machine) error {
+	gomachine, err := pv.NewGovmomiMachine(cluster, _machine)
 	if err != nil {
 		return err
 	}
-	deletectx, cancel := context.WithCancel(*s.context)
-	defer cancel()
 
-	if exists, _ := pv.Exists(ctx, cluster, machine); exists {
-		moref, err := vsphereutils.GetMachineRef(machine)
+	if on, err := gomachine.IsPoweredOn(ctx); on {
 		if err != nil {
 			return err
 		}
-		var vm mo.VirtualMachine
-		vmref := types.ManagedObjectReference{
-			Type:  "VirtualMachine",
-			Value: moref,
-		}
-		err = s.session.RetrieveOne(deletectx, vmref, []string{"name", "runtime.powerState"}, &vm)
-		if err != nil {
+		// TODO(moshloop): Don't wait, requeue and reconcile on the next loop
+		gomachine.Eventf("PoweringOff", "Powering off machine")
+		if err := gomachine.PowerOff(ctx).WaitFor(ctx); err != nil {
 			return err
 		}
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killing", "Killing machine %v", machine.Name)
-		vmo := object.NewVirtualMachine(s.session.Client, vmref)
-		if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-			task, err := vmo.PowerOff(deletectx)
-			if err != nil {
-				klog.Infof("Error trigerring power off operation on the Virtual Machine %s", vm.Name)
-				return err
-			}
-			err = task.Wait(deletectx)
-			if err != nil {
-				klog.Infof("Error powering off the Virtual Machine %s", vm.Name)
-				return err
-			}
-		}
-		task, err := vmo.Destroy(deletectx)
-		taskinfo, err := task.WaitForResult(deletectx, nil)
-		if taskinfo.State == types.TaskInfoStateSuccess {
-			klog.Infof("Virtual Machine %v deleted successfully", vm.Name)
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
-			return nil
-		}
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
-		klog.Errorf("VM Deletion failed on pv with following reason %v", taskinfo.Reason)
-		return errors.New("VM Deletion failed")
+	}
+	gomachine.Eventf("Killing", "Killing machine %v", gomachine.Name)
+	if err = gomachine.Delete(ctx).WaitFor(); err == nil {
+		gomachine.Eventf("Killed", "Machine deletion complete")
+	} else if err.Error() == "ServerFaultCode: The object 'vim.VirtualMachine:' has already been deleted or has not been completely created" {
+		gomachine.Eventf("Killed", fmt.Sprintf("Machine deletion ignored, %s", err))
+		return nil
+	} else {
+		gomachine.Eventf("Killed", fmt.Sprintf("Machine deletion failed %s", err))
+		return err
 	}
 	return nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/esxi.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/esxi.go
@@ -1,0 +1,103 @@
+package govmomi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/klog"
+)
+
+func (pv *Provisioner) thinCopyDisks(ctx context.Context, machine *GovmomiMachine, srcPath string, dstPath string) error {
+	var err error
+	var username, password string
+	if username, password, err = machine.GetCluster().GetCredentials(); err != nil {
+		return err
+	}
+
+	vsphereConfig := machine.GetCluster().config
+	klog.V(4).Infof("[clone] thin cloning disk to %s", dstPath)
+
+	cmd := fmt.Sprintf("vmkfstools -i \"%s\" \"%s\" -d thin", srcPath, dstPath)
+	klog.V(5).Infof("[clone] ssh: %s", cmd)
+	host := vsphereConfig.VsphereServer + ":22"
+	err = runSSHCommand(cmd, host, username, password)
+	klog.V(4).Infof("[clone] thin cloned vmdk, src(%s) ->  dst(%s)", srcPath, dstPath)
+	return err
+}
+
+// cloneVirtualMachineOnESX clones the template to a virtual machine.
+func (pv *Provisioner) cloneVirtualMachineOnESX(ctx context.Context, machine *GovmomiMachine) error {
+	klog.V(4).Infof("[clone] via ESX for VM %s", machine.Name)
+
+	dc, err := machine.s.finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return err
+	}
+	machine.s.finder.SetDatacenter(dc)
+
+	folders, err := dc.Folders(ctx)
+	if err != nil {
+		return err
+	}
+
+	pool, err := machine.s.finder.ResourcePoolOrDefault(ctx, machine.config.MachineSpec.ResourcePool)
+	if err != nil {
+		return err
+	}
+
+	// Fetch info from templateVM
+	src, err := machine.GetCluster().FindVM(ctx, dc, machine.config.MachineSpec.VMTemplate)
+	if err != nil {
+		return err
+	}
+	var vmProps *mo.VirtualMachine
+	vmProps, err = machine.GetCluster().GetVirtualMachineMO(src)
+	if err != nil {
+		return fmt.Errorf("error fetching virtual machine or template properties: %s", err)
+	}
+
+	spec := &types.VirtualMachineConfigSpec{}
+	var devices object.VirtualDeviceList
+
+	if err := pv.addMachineBase(ctx, machine, spec, vmProps); err != nil {
+		return err
+	}
+
+	if devices, err = pv.copyDisks(ctx, machine, devices, vmProps); err != nil {
+		return err
+	}
+
+	if devices, err = pv.addNetworking(ctx, machine, devices); err != nil {
+		return err
+	}
+
+	if devices, err = pv.addSerialPort(ctx, devices, vmProps); err != nil {
+		return err
+	}
+
+	deviceChange, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return err
+	}
+
+	spec.DeviceChange = deviceChange
+
+	// get current hostsystem from source vm
+	ch, err := src.HostSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	machine.Eventf("Creating", "Creating Machine %v", machine.Name)
+
+	task, err := folders.VmFolder.CreateVM(ctx, *spec, pool, ch)
+	if err != nil {
+		return fmt.Errorf("[DEBUG] VmFolder.CreateVM() FAILED: %s", err.Error())
+	}
+
+	return machine.SetTaskRef(task.Reference().Value)
+
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/exists.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/exists.go
@@ -2,50 +2,14 @@ package govmomi
 
 import (
 	"context"
-	"errors"
 
-	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
-	"k8s.io/klog"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
-	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 func (pv *Provisioner) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
-	if cluster == nil {
-		return false, errors.New(constants.ClusterIsNullErr)
-	}
-
-	s, err := pv.sessionFromProviderConfig(cluster, machine)
+	gomachine, err := pv.NewGovmomiMachine(cluster, machine)
 	if err != nil {
-		klog.V(4).Infof("Exists check, session from provider config error: %s", err.Error())
 		return false, err
 	}
-	existsctx, cancel := context.WithCancel(*s.context)
-	defer cancel()
-
-	moref, err := vsphereutils.GetMachineRef(machine)
-	if err != nil {
-		klog.V(4).Infof("Exists check, GetMachineRef failed: %s", err.Error())
-		return false, err
-	}
-
-	if moref == "" {
-		return false, nil
-	}
-
-	var vm mo.VirtualMachine
-	vmref := types.ManagedObjectReference{
-		Type:  "VirtualMachine",
-		Value: moref,
-	}
-	err = s.session.RetrieveOne(existsctx, vmref, []string{"name"}, &vm)
-	if err != nil {
-		klog.V(4).Infof("Exists check, RetrieveOne failed: %s", err.Error())
-		return false, nil
-	}
-	klog.V(4).Infof("Exists check, found [%s, %s]", cluster.Name, machine.Name)
-
-	return true, nil
+	return gomachine.config.MachineRef != "", nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/machine.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/machine.go
@@ -1,0 +1,274 @@
+package govmomi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	"sigs.k8s.io/yaml"
+)
+
+type GovmomiMachine struct {
+	s             *SessionContext
+	k8sClient     kubernetes.Interface
+	clusterAPI    clusterv1alpha1.ClusterV1alpha1Interface
+	cluster       *clusterv1.Cluster
+	machine       *clusterv1.Machine
+	config        *vsphereconfigv1.VsphereMachineProviderConfig
+	status        *vsphereconfigv1.VsphereMachineProviderStatus
+	eventRecorder record.EventRecorder
+	Name          string
+}
+
+func NewGovmomiMachine(cluster *clusterv1.Cluster, machine *clusterv1.Machine, s *SessionContext, eventRecorder record.EventRecorder, k8sClient kubernetes.Interface, clusterAPI clusterv1alpha1.ClusterV1alpha1Interface) (*GovmomiMachine, error) {
+
+	config := &vsphereconfigv1.VsphereMachineProviderConfig{}
+	if machine.Spec.ProviderSpec.Value == nil {
+		return nil, fmt.Errorf("machine providerconfig is invalid (nil)")
+	}
+
+	err := yaml.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, config)
+	if err != nil {
+		return nil, fmt.Errorf("machine providerconfig unmarshalling failure: %s", err)
+	}
+
+	status := &vsphereconfigv1.VsphereMachineProviderStatus{}
+	if machine.Status.ProviderStatus != nil {
+		err := json.Unmarshal(machine.Status.ProviderStatus.Raw, status)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling machine provider status: %s", err)
+		}
+	}
+
+	// fail fast on any cluster level config issues, we can then safely ignore parsing errors returned in the future
+	_, err = newGovmomiCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+	return &GovmomiMachine{
+		s:             s,
+		cluster:       cluster,
+		machine:       machine,
+		status:        status,
+		config:        config,
+		eventRecorder: eventRecorder,
+		k8sClient:     k8sClient,
+		clusterAPI:    clusterAPI,
+		Name:          machine.Name,
+	}, nil
+}
+
+func (m *GovmomiMachine) IsExists(ctx context.Context) bool {
+	var vm mo.VirtualMachine
+	err := m.s.session.RetrieveOne(ctx, m.GetMOF(), []string{"name"}, &vm)
+	return err == nil
+}
+
+func (m *GovmomiMachine) GetCluster() *GovmomiCluster {
+	cluster, _ := newGovmomiCluster(m.cluster)
+	cluster.s = m.s
+	cluster.k8sClient = m.k8sClient
+	return cluster
+}
+
+func (m *GovmomiMachine) GetActiveTasks() {
+
+}
+
+func (m *GovmomiMachine) GetVM(ctx context.Context) (*object.VirtualMachine, error) {
+	return object.NewVirtualMachine(m.s.session.Client, m.GetMOF()), nil
+}
+
+func (m *GovmomiMachine) GetIP() (string, error) {
+	if m.machine.ObjectMeta.Annotations == nil {
+		return "", errors.New("could not get IP")
+	}
+	if ip, ok := m.machine.ObjectMeta.Annotations[constants.VmIpAnnotationKey]; ok && ip != "" {
+		return ip, nil
+	}
+	return "", errors.New("could not get IP")
+}
+
+func (m *GovmomiMachine) WaitForIP(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (m *GovmomiMachine) Eventf(name string, message string, args ...interface{}) {
+	klog.V(4).Infof(fmt.Sprintf("[%s] %s: ", m.machine.Name, name) + fmt.Sprintf(message, args...))
+	m.eventRecorder.Eventf(m.machine, corev1.EventTypeNormal, name, message, args...)
+}
+
+func (m *GovmomiMachine) GetMOF() types.ManagedObjectReference {
+	return types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: m.config.MachineRef,
+	}
+}
+
+func (m *GovmomiMachine) IsPoweredOn(ctx context.Context) (bool, error) {
+	var vm mo.VirtualMachine
+	err := m.s.session.RetrieveOne(ctx, m.GetMOF(), []string{"name", "runtime.powerState"}, &vm)
+	if err != nil {
+		return false, err
+	}
+	return vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn, nil
+
+	return false, nil
+}
+
+func (m *GovmomiMachine) PowerOn(ctx context.Context) *Task {
+	vm, err := m.GetVM(ctx)
+	if err != nil {
+		return &Task{err: err, ctx: ctx}
+	}
+
+	task, err := vm.PowerOn(ctx)
+	return &Task{
+		err:  err,
+		task: task,
+		ctx:  ctx,
+	}
+}
+
+func (m *GovmomiMachine) Delete(ctx context.Context) *Task {
+	vm, err := m.GetVM(ctx)
+	if err != nil {
+		return &Task{err: err, ctx: ctx}
+	}
+	task, err := vm.Destroy(ctx)
+	return &Task{
+		err:  err,
+		task: task,
+		ctx:  ctx,
+	}
+}
+
+func (m *GovmomiMachine) PowerOff(ctx context.Context) *Task {
+	vm, err := m.GetVM(ctx)
+	if err != nil {
+		return &Task{err: err, ctx: ctx}
+	}
+	task, err := vm.PowerOff(ctx)
+	return &Task{
+		err:  err,
+		task: task,
+		ctx:  ctx,
+	}
+}
+
+func (m *GovmomiMachine) UpdateVMReference(vmref string) error {
+	providerSpec := m.config
+	providerSpec.MachineRef = vmref
+	// Set the Kind and APIVersion again since they are not returned
+	// See the following Issues for details:
+	// https://github.com/kubernetes/client-go/issues/308
+	// https://github.com/kubernetes/kubernetes/issues/3030
+	providerSpec.Kind = reflect.TypeOf(*providerSpec).Name()
+	providerSpec.APIVersion = vsphereconfigv1.SchemeGroupVersion.String()
+	newMachine := m.machine.DeepCopy()
+	out, err := json.Marshal(providerSpec)
+	if err != nil {
+		return fmt.Errorf("Error marshaling ProviderConfig: %s", err)
+	}
+	newMachine.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: out}
+	newMachine, err = m.clusterAPI.Machines(newMachine.Namespace).Update(newMachine)
+	if err != nil {
+		return fmt.Errorf("Error in updating the machine ref: %s", err)
+	}
+
+	// This is needed otherwise the update status on the original machine object would fail as the resource has been updated by the previous call
+	// Note: We are not mutating the object retrieved from the informer ever. The updatedmachine is the updated resource generated using DeepCopy
+	// This would just update the reference to be the newer object so that the status update works
+	m.machine = newMachine
+	m.config = providerSpec
+	return nil
+}
+
+func (m *GovmomiMachine) SetTaskRef(taskref string) error {
+	oldProviderStatus := m.status
+
+	if oldProviderStatus != nil && oldProviderStatus.TaskRef == taskref {
+		// Nothing to update
+		return nil
+	}
+	newProviderStatus := &vsphereconfigv1.VsphereMachineProviderStatus{}
+	// create a copy of the old status so that any other fields except the ones we want to change can be retained
+	if oldProviderStatus != nil {
+		newProviderStatus = oldProviderStatus.DeepCopy()
+	}
+	newProviderStatus.TaskRef = taskref
+	newProviderStatus.LastUpdated = time.Now().UTC().String()
+	out, err := json.Marshal(newProviderStatus)
+	newMachine := m.machine.DeepCopy()
+	newMachine.Status.ProviderStatus = &runtime.RawExtension{Raw: out}
+	if m.clusterAPI == nil { // TODO: currently supporting nil for testing
+		return nil
+	}
+	_, err = m.clusterAPI.Machines(newMachine.Namespace).UpdateStatus(newMachine)
+	if err != nil {
+		return fmt.Errorf("Error in updating the machine ref: %s", err)
+	}
+	return nil
+}
+
+func (m *GovmomiMachine) UpdateAnnotations(annotations map[string]string) error {
+	nmachine := m.machine.DeepCopy()
+	if nmachine.ObjectMeta.Annotations == nil {
+		nmachine.ObjectMeta.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		nmachine.ObjectMeta.Annotations[k] = v
+	}
+	_, err := m.clusterAPI.Machines(nmachine.Namespace).Update(nmachine)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *GovmomiMachine) GetKubeConfig() (string, error) {
+	ip, err := m.GetIP()
+	if err != nil {
+		klog.Info("cannot get kubeconfig because found no IP")
+		return "", err
+	}
+	klog.Infof("pulling kubeconfig (using ssh) from %s", ip)
+	var out bytes.Buffer
+	cmd := exec.Command(
+		"ssh", "-i", "~/.ssh/vsphere_tmp",
+		"-q",
+		"-o", "StrictHostKeyChecking no",
+		"-o", "UserKnownHostsFile /dev/null",
+		fmt.Sprintf("ubuntu@%s", ip),
+		"sudo cat /etc/kubernetes/admin.conf")
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		klog.Infof("ssh failed with error = %s", err.Error())
+	}
+	result := strings.TrimSpace(out.String())
+	if len(result) > 0 {
+		klog.Info("ssh pulled kubeconfig")
+	}
+	return result, err
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/ovf.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/ovf.go
@@ -1,0 +1,62 @@
+package govmomi
+
+import (
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
+)
+
+func (pv *Provisioner) addOvfEnv(machine *GovmomiMachine, machineConfig *vsphereconfigv1.VsphereMachineProviderConfig, vmProps *mo.VirtualMachine, userData string, metaData string) []types.BaseOptionValue {
+	// OVF Environment
+	// build up Environment in order to marshal to xml
+
+	var opts []types.BaseOptionValue
+
+	if machineConfig.MachineSpec.VsphereCloudInit {
+		// In case of vsphere cloud-init datasource present, set the appropriate extraconfig options
+		opts = append(opts, &types.OptionValue{Key: "guestinfo.metadata", Value: metaData})
+		opts = append(opts, &types.OptionValue{Key: "guestinfo.metadata.encoding", Value: "base64"})
+		opts = append(opts, &types.OptionValue{Key: "guestinfo.userdata", Value: userData})
+		opts = append(opts, &types.OptionValue{Key: "guestinfo.userdata.encoding", Value: "base64"})
+	} else {
+		// This case is to support backwards compatibility, where we are using the ubuntu cloud image ovf properties
+		// to drive the cloud-init workflow. Once the vsphere cloud-init datastore is merged as part of the official
+		// cloud-init, then we can potentially remove this flag from the spec as then all the native cloud images
+		// available for the different distros will include this new datasource.
+		// See (https://github.com/akutz/cloud-init-vmware-guestinfo/ - vmware cloud-init datasource) for details
+		var props []ovf.EnvProperty
+		sshKey, _ := pv.GetSSHPublicKey(machine.cluster)
+		props = append(props, ovf.EnvProperty{
+			Key:   "user-data",
+			Value: userData,
+		},
+			ovf.EnvProperty{
+				Key:   "public-keys",
+				Value: sshKey,
+			},
+			ovf.EnvProperty{
+				Key:   "hostname",
+				Value: machine.Name,
+			})
+		a := machine.s.session.ServiceContent.About
+		env := ovf.Env{
+			EsxID: vmProps.Reference().Value,
+			Platform: &ovf.PlatformSection{
+				Kind:    a.Name,
+				Version: a.Version,
+				Vendor:  a.Vendor,
+				Locale:  "US",
+			},
+			Property: &ovf.PropertySection{
+				Properties: props,
+			},
+		}
+
+		opts = append(opts, &types.OptionValue{
+			Key:   "guestinfo.ovfEnv",
+			Value: env.MarshalManual(),
+		})
+	}
+	return opts
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
@@ -1,8 +1,12 @@
 package govmomi
 
 import (
+	"errors"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
 )
@@ -23,4 +27,22 @@ func New(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface, k8sClient kub
 		sessioncache:    make(map[string]interface{}),
 		k8sClient:       k8sClient,
 	}, nil
+}
+
+func (pv *Provisioner) NewGovmomiMachine(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (*GovmomiMachine, error) {
+	if cluster == nil {
+		return nil, errors.New(constants.ClusterIsNullErr)
+	}
+
+	s, err := pv.sessionFromProviderConfig(cluster, machine)
+	if err != nil {
+		return nil, err
+	}
+
+	gomachine, err := NewGovmomiMachine(cluster, machine, s, pv.eventRecorder, pv.k8sClient, pv.clusterV1alpha1)
+	if err != nil {
+		return nil, err
+	}
+
+	return gomachine, nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/scripts.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/scripts.go
@@ -1,0 +1,171 @@
+package govmomi
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/klog"
+	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	vpshereprovisionercommon "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/provisioner/common"
+	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
+	apierrors "sigs.k8s.io/cluster-api/pkg/errors"
+	"sigs.k8s.io/cluster-api/pkg/util"
+)
+
+func (pv *Provisioner) getCloudInitMetaData(cluster *clusterv1.Cluster, _machine *clusterv1.Machine) (string, error) {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
+	if err != nil {
+		return "", err
+	}
+	metadata, err := vpshereprovisionercommon.GetCloudInitMetaData(machine.Name, machine.config)
+	if err != nil {
+		return "", err
+	}
+	metadata = base64.StdEncoding.EncodeToString([]byte(metadata))
+	return metadata, nil
+}
+
+func (pv *Provisioner) getCloudInitUserData(cluster *clusterv1.Cluster, _machine *clusterv1.Machine,
+	resourcePoolPath string, deployOnVC bool) (string, error) {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
+	script, err := pv.getStartupScript(cluster, _machine, deployOnVC)
+	if err != nil {
+		return "", err
+	}
+	config, err := pv.getCloudProviderConfig(cluster, _machine, resourcePoolPath, deployOnVC)
+	if err != nil {
+		return "", err
+	}
+	publicKey, err := pv.GetSSHPublicKey(cluster)
+	if err != nil {
+		return "", err
+	}
+	if err != nil {
+		return "", err
+	}
+	userdata, err := vpshereprovisionercommon.GetCloudInitUserData(
+		vpshereprovisionercommon.CloudInitTemplate{
+			Script:              script,
+			IsMaster:            util.IsControlPlaneMachine(machine.machine),
+			CloudProviderConfig: config,
+			SSHPublicKey:        publicKey,
+			TrustedCerts:        machine.config.MachineSpec.TrustedCerts,
+			NTPServers:          machine.config.MachineSpec.NTPServers,
+		},
+		deployOnVC,
+	)
+	if err != nil {
+		return "", err
+	}
+	userdata = base64.StdEncoding.EncodeToString([]byte(userdata))
+	return userdata, nil
+}
+
+func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, _machine *clusterv1.Machine,
+	resourcePoolPath string, deployOnVC bool) (string, error) {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
+	username, password, err := machine.GetCluster().GetCredentials()
+	if err != nil {
+		return "", err
+	}
+
+	// TODO(ssurana): revisit once we solve https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/60
+	cpc := vpshereprovisionercommon.CloudProviderConfigTemplate{
+		Datacenter:   machine.config.MachineSpec.Datacenter,
+		Server:       machine.GetCluster().GetHost(),
+		Insecure:     true, // TODO(ssurana): Needs to be a user input
+		UserName:     username,
+		Password:     password,
+		ResourcePool: machine.config.MachineSpec.ResourcePool,
+		Datastore:    machine.config.MachineSpec.Datastore,
+		Network:      "",
+	}
+	if len(resourcePoolPath) > 0 {
+		cpc.ResourcePool = resourcePoolPath
+	}
+	if len(machine.config.MachineSpec.Networks) > 0 {
+		cpc.Network = machine.config.MachineSpec.Networks[0].NetworkName
+	}
+
+	cloudProviderConfig, err := vpshereprovisionercommon.GetCloudProviderConfigConfig(cpc, deployOnVC)
+	if err != nil {
+		return "", err
+	}
+	cloudProviderConfig = base64.StdEncoding.EncodeToString([]byte(cloudProviderConfig))
+	return cloudProviderConfig, nil
+}
+
+// Builds and returns the startup script for the passed machine and cluster.
+// Returns the full path of the saved startup script and possible error.
+func (pv *Provisioner) getStartupScript(cluster *clusterv1.Cluster, _machine *clusterv1.Machine, deployOnVC bool) (string, error) {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
+	if err != nil {
+		return "", pv.HandleMachineError(machine.machine, apierrors.InvalidMachineConfiguration(
+			"Cannot unmarshal providerSpec field: %v", err), constants.CreateEventAction)
+	}
+	preloaded := machine.config.MachineSpec.Preloaded
+	var startupScript string
+	if util.IsControlPlaneMachine(machine.machine) {
+		if machine.machine.Spec.Versions.ControlPlane == "" {
+			return "", pv.HandleMachineError(machine.machine, apierrors.InvalidMachineConfiguration(
+				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), constants.CreateEventAction)
+		}
+		parsedVersion, err := version.ParseSemantic(machine.machine.Spec.Versions.ControlPlane)
+		if err != nil {
+			return "", err
+		}
+
+		startupScript, err = vpshereprovisionercommon.GetMasterStartupScript(
+			vpshereprovisionercommon.TemplateParams{
+				MajorMinorVersion: fmt.Sprintf("%d.%d", parsedVersion.Major(), parsedVersion.Minor()),
+				Cluster:           cluster,
+				Machine:           machine.machine,
+				Preloaded:         preloaded,
+			},
+			deployOnVC,
+		)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		clusterstatus, err := vsphereutils.GetClusterProviderStatus(cluster)
+		if err != nil {
+			klog.Infof("Error fetching cluster ProviderStatus field: %s", err)
+			return "", err
+		}
+		if clusterstatus == nil || clusterstatus.APIStatus != vsphereconfigv1.ApiReady {
+			duration := vsphereutils.GetNextBackOff()
+			klog.Infof("[pending] Waiting for Kubernetes API Status to be \"Ready\". Retrying in %s", duration)
+			return "", &clustererror.RequeueAfterError{RequeueAfter: duration}
+		}
+		kubeadmToken, err := pv.GetKubeadmToken(cluster)
+		if err != nil {
+			duration := vsphereutils.GetNextBackOff()
+			klog.Infof("Error generating kubeadm token, will retry in %s error: %s", duration, err.Error())
+			return "", &clustererror.RequeueAfterError{RequeueAfter: duration}
+		}
+		parsedVersion, err := version.ParseSemantic(machine.machine.Spec.Versions.Kubelet)
+		if err != nil {
+			return "", err
+		}
+		startupScript, err = vpshereprovisionercommon.GetNodeStartupScript(
+			vpshereprovisionercommon.TemplateParams{
+				Token:             kubeadmToken,
+				MajorMinorVersion: fmt.Sprintf("%d.%d", parsedVersion.Major(), parsedVersion.Minor()),
+				Cluster:           cluster,
+				Machine:           machine.machine,
+				Preloaded:         preloaded,
+			},
+			deployOnVC,
+		)
+		if err != nil {
+			return "", err
+		}
+	}
+	startupScript = base64.StdEncoding.EncodeToString([]byte(startupScript))
+	return startupScript, nil
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/task.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/task.go
@@ -1,0 +1,34 @@
+package govmomi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Task struct {
+	task *object.Task
+	err  error
+	ctx  context.Context
+}
+
+func (t *Task) WaitFor(ctx ...context.Context) error {
+	if t.err != nil {
+		return t.err
+	}
+	_ctx := t.ctx
+	if len(ctx) > 0 {
+		_ctx = ctx[0]
+	}
+
+	taskinfo, err := t.task.WaitForResult(_ctx, nil)
+	if err != nil {
+		return err
+	}
+	if taskinfo.State != types.TaskInfoStateSuccess {
+		return fmt.Errorf("task %s, with result: %s %s", taskinfo.State, taskinfo.Result, taskinfo.Error)
+	}
+	return nil
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -2,88 +2,26 @@ package govmomi
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"time"
 
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
-	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
-	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	if cluster == nil {
-		return errors.New(constants.ClusterIsNullErr)
-	}
-
-	// Fetch any active task in vsphere if any
-	// If an active task is there,
-
-	klog.V(4).Infof("govmomi.Actuator.Update %s", machine.Spec.Name)
-
-	s, err := pv.sessionFromProviderConfig(cluster, machine)
+func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, _machine *clusterv1.Machine) error {
+	machine, err := pv.NewGovmomiMachine(cluster, _machine)
 	if err != nil {
 		return err
 	}
-	updatectx, cancel := context.WithCancel(*s.context)
-	defer cancel()
 
-	moref, err := vsphereutils.GetMachineRef(machine)
-	if err != nil {
-		return err
-	}
-	var vmmo mo.VirtualMachine
-	vmref := types.ManagedObjectReference{
-		Type:  "VirtualMachine",
-		Value: moref,
-	}
-	err = s.session.RetrieveOne(updatectx, vmref, []string{"name", "runtime"}, &vmmo)
-	if err != nil {
-		return nil
-	}
-	if vmmo.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
-		klog.Warningf("Machine %s is not running, rather it is in %s state", vmmo.Name, vmmo.Runtime.PowerState)
-		return fmt.Errorf("Machine %s is not running, rather it is in %s state", vmmo.Name, vmmo.Runtime.PowerState)
-	}
+	ip, err := machine.GetIP()
 
-	if _, err := vsphereutils.GetIP(cluster, machine); err != nil {
-		klog.V(4).Info("actuator.Update() - did not find IP, waiting on IP")
-		vm := object.NewVirtualMachine(s.session.Client, vmref)
-		vmIP, err := vm.WaitForIP(updatectx)
+	if err != nil {
+		// TODO(moshloop): don't wait for the IP, requeue and check on the next reconcile loop
+		ip, err = machine.WaitForIP(ctx)
 		if err != nil {
 			return err
 		}
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "IP Detected", "IP %s detected for Virtual Machine %s", vmIP, vm.Name())
-		return pv.updateIP(cluster, machine, vmIP)
 	}
-	return nil
-}
-
-// Updates the detected IP for the machine and updates the cluster object signifying a change in the infrastructure
-func (pv *Provisioner) updateIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine, vmIP string) error {
-	nmachine := machine.DeepCopy()
-	if nmachine.ObjectMeta.Annotations == nil {
-		nmachine.ObjectMeta.Annotations = make(map[string]string)
-	}
-	klog.V(4).Infof("updateIP - IP = %s", vmIP)
-	nmachine.ObjectMeta.Annotations[constants.VmIpAnnotationKey] = vmIP
-	_, err := pv.clusterV1alpha1.Machines(nmachine.Namespace).Update(nmachine)
-	if err != nil {
-		return err
-	}
-	// Update the cluster status with updated time stamp for tracking purposes
-	status := &vsphereconfigv1.VsphereClusterProviderStatus{LastUpdated: time.Now().UTC().String()}
-	out, err := json.Marshal(status)
-	ncluster := cluster.DeepCopy()
-	ncluster.Status.ProviderStatus = &runtime.RawExtension{Raw: out}
-	_, err = pv.clusterV1alpha1.Clusters(ncluster.Namespace).UpdateStatus(ncluster)
-	return err
+	machine.Eventf("IP Detected", "%s", ip)
+	return machine.UpdateAnnotations(map[string]string{constants.VmIpAnnotationKey: ip})
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/vcenter.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/vcenter.go
@@ -1,0 +1,339 @@
+package govmomi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vmware/govmomi/find"
+
+	"github.com/vmware/govmomi/object"
+
+	vsphereconfigv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphereproviderconfig/v1alpha1"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/klog"
+	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
+)
+
+type GovmomiVcenter struct {
+	s *SessionContext
+}
+
+func runSSHCommand(cmd string, host string, username string, password string) error {
+	config := &ssh.ClientConfig{
+		User: username,
+		Auth: []ssh.AuthMethod{
+			// ssh.Password needs to be explictly allowed, and by default ESXi only allows public + keyboard interactive
+			ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+				// Just send the password back for all questions
+				answers := make([]string, len(questions))
+				for i, _ := range answers {
+					answers[i] = password
+				}
+
+				return answers, nil
+			}),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	fmt.Printf("[clone] Connecting to %s@%s", host, username)
+	conn, err := ssh.Dial("tcp", host, config)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	var sess *ssh.Session
+	var sessStdOut, sessStderr io.Reader
+	if sess, err = conn.NewSession(); err != nil {
+		return err
+	}
+
+	defer sess.Close()
+	if sessStdOut, err = sess.StdoutPipe(); err != nil {
+		return err
+	}
+	go io.Copy(os.Stdout, sessStdOut)
+	if sessStderr, err = sess.StderrPipe(); err != nil {
+		return err
+	}
+	go io.Copy(os.Stderr, sessStderr)
+	return sess.Run(cmd)
+}
+
+// CloneVirtualMachine clones the template to a virtual machine.
+func (pv *Provisioner) cloneVirtualMachineOnVCenter(ctx context.Context, machine *GovmomiMachine) error {
+	klog.V(4).Infof("[clone] Starting on vCenter")
+
+	dc, err := machine.s.finder.DatacenterOrDefault(ctx, machine.config.MachineSpec.Datacenter)
+	if err != nil {
+		return err
+	}
+	machine.s.finder.SetDatacenter(dc)
+
+	// Let's check to make sure we can find the template earlier on... Plus, we need
+	// the cluster/host info if we want to deploy direct to the cluster/host.
+	src, err := machine.GetCluster().FindVM(ctx, dc, machine.config.MachineSpec.VMTemplate)
+	if err != nil {
+		return err
+	}
+
+	host, err := src.HostSystem(ctx)
+	if err != nil {
+		return fmt.Errorf("HostSystem failed. err=%s", err)
+	}
+	hostProps, err := machine.GetCluster().GetHostMO(host)
+	if err != nil {
+		return fmt.Errorf("error fetching host properties: %s", err)
+	}
+
+	// Since it's assumed that the ResourcePool name has been provided in the config, if we
+	// want to deploy directly to the cluster/host, then we need to override the ResourcePool
+	// path before generating the Cloud Provider config. This is done below in:
+	// getCloudInitUserData()
+	// +--- getCloudProviderConfig()
+	resourcePoolPath := ""
+	if len(machine.config.MachineSpec.ResourcePool) == 0 {
+		resourcePoolPath = fmt.Sprintf("/%s/host/%s/Resource", machine.config.MachineSpec.Datacenter, hostProps.Name)
+		klog.Infof("[clone] Attempting to deploy directly to cluster/host RP: %s", resourcePoolPath)
+	}
+
+	// Fetch the user-data for the cloud-init first, so that we can fail fast before even trying to connect to pv
+	userData, err := pv.getCloudInitUserData(machine.cluster, machine.machine, resourcePoolPath, true)
+	if err != nil {
+		// err returned by the getCloudInitUserData would be of type RequeueAfterError in case kubeadm is not ready yet
+		return err
+	}
+	metaData, err := pv.getCloudInitMetaData(machine.cluster, machine.machine)
+	if err != nil {
+		// err returned by the getCloudInitMetaData would be of type RequeueAfterError in case kubeadm is not ready yet
+		return err
+	}
+
+	var spec types.VirtualMachineCloneSpec
+	klog.V(4).Infof("[clone] Preparing clone spec for VM %s/%s", machine.config.MachineSpec.VMFolder, machine.Name)
+	vmFolder, err := machine.s.finder.FolderOrDefault(ctx, machine.config.MachineSpec.VMFolder)
+	if err != nil {
+		return err
+	}
+
+	ds, err := machine.s.finder.DatastoreOrDefault(ctx, machine.config.MachineSpec.Datastore)
+	if err != nil {
+		return err
+	}
+	spec.Location.Datastore = types.NewReference(ds.Reference())
+
+	spec.Config = &types.VirtualMachineConfigSpec{}
+	// Use the object UID as the instanceUUID for the VM
+	spec.Config.InstanceUuid = string(machine.machine.UID)
+	diskUUIDEnabled := true
+	spec.Config.Flags = &types.VirtualMachineFlagInfo{
+		DiskUuidEnabled: &diskUUIDEnabled,
+	}
+	if machine.config.MachineSpec.NumCPUs > 0 {
+		spec.Config.NumCPUs = int32(machine.config.MachineSpec.NumCPUs)
+	}
+	if machine.config.MachineSpec.MemoryMB > 0 {
+		spec.Config.MemoryMB = machine.config.MachineSpec.MemoryMB
+	}
+	spec.Config.Annotation = fmt.Sprintf("Virtual Machine is part of the cluster %s managed by cluster-api", machine.cluster.Name)
+	spec.Location.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndConsolidate)
+
+	vmProps, err := machine.GetCluster().GetVirtualMachineMO(src)
+	if err != nil {
+		return fmt.Errorf("error fetching vm/template properties: %s", err)
+	}
+
+	if len(machine.config.MachineSpec.ResourcePool) > 0 {
+		pool, err := machine.s.finder.ResourcePoolOrDefault(ctx, machine.config.MachineSpec.ResourcePool)
+
+		if _, ok := err.(*find.NotFoundError); ok {
+			klog.Warningf("[provision] Failed to find ResourcePool=%s err=%s. Attempting to create it.", machine.config.MachineSpec.ResourcePool, err)
+
+			poolRoot, errRoot := host.ResourcePool(ctx)
+			if errRoot != nil {
+				return fmt.Errorf("[provision] Failed to find root ResourcePool. err=%s", errRoot)
+			}
+
+			klog.Info("[provision] Creating ResourcePool using default values. These values can be modified after ResourcePool creation.")
+			pool, err = poolRoot.Create(ctx, machine.config.MachineSpec.ResourcePool, types.DefaultResourceConfigSpec())
+			if err != nil {
+				return fmt.Errorf("[provision] Create ResourcePool failed. err=%s", err)
+			}
+		}
+
+		spec.Location.Pool = types.NewReference(pool.Reference())
+	} else {
+		klog.Infof("Attempting to use Host ResourcePool")
+		pool, err := host.ResourcePool(ctx)
+
+		if err != nil {
+			return fmt.Errorf("Host ResourcePool failed. err=%s", err)
+		}
+
+		spec.Location.Pool = types.NewReference(pool.Reference())
+	}
+	spec.PowerOn = true
+
+	if machine.config.MachineSpec.VsphereCloudInit {
+		// In case of vsphere cloud-init datasource present, set the appropriate extraconfig options
+		var extraconfigs []types.BaseOptionValue
+		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.metadata", Value: metaData})
+		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.metadata.encoding", Value: "base64"})
+		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.userdata", Value: userData})
+		extraconfigs = append(extraconfigs, &types.OptionValue{Key: "guestinfo.userdata.encoding", Value: "base64"})
+		spec.Config.ExtraConfig = extraconfigs
+	} else {
+		// This case is to support backwords compatibility, where we are using the ubuntu cloud image ovf properties
+		// to drive the cloud-init workflow. Once the vsphere cloud-init datastore is merged as part of the official
+		// cloud-init, then we can potentially remove this flag from the spec as then all the native cloud images
+		// available for the different distros will include this new datasource.
+		// See (https://github.com/akutz/cloud-init-vmware-guestinfo/ - vmware cloud-init datasource) for details
+		if vmProps.Config.VAppConfig == nil {
+			return fmt.Errorf("this source VM lacks a vApp configuration and cannot have vApp properties set on it")
+		}
+		allProperties := vmProps.Config.VAppConfig.GetVmConfigInfo().Property
+		var props []types.VAppPropertySpec
+		for _, p := range allProperties {
+			defaultValue := " "
+			if p.DefaultValue != "" {
+				defaultValue = p.DefaultValue
+			}
+			prop := types.VAppPropertySpec{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationEdit,
+				},
+				Info: &types.VAppPropertyInfo{
+					Key:   p.Key,
+					Id:    p.Id,
+					Value: defaultValue,
+				},
+			}
+			if p.Id == "user-data" {
+				prop.Info.Value = userData
+			}
+			if p.Id == "public-keys" {
+				prop.Info.Value, err = pv.GetSSHPublicKey(machine.cluster)
+				if err != nil {
+					return err
+				}
+			}
+			if p.Id == "hostname" {
+				prop.Info.Value = machine.Name
+			}
+			props = append(props, prop)
+		}
+		spec.Config.VAppConfig = &types.VmConfigSpec{
+			Property: props,
+		}
+	}
+
+	l := object.VirtualDeviceList(vmProps.Config.Hardware.Device)
+	deviceSpecs := []types.BaseVirtualDeviceConfigSpec{}
+	disks := l.SelectByType((*types.VirtualDisk)(nil))
+	// For the disks listed under the MachineSpec.Disks property, they are used
+	// only for resizing a maching disk on the template. Currently, no new disk
+	// is added. Only the matched disks via the DiskLabel are resized. If the
+	// MachineSpec.Disks is specified but none of the disks matched to the disks
+	// present in the VM Template then error is returned. This is to avoid the
+	// case when the user did want to resize but accidentally passed a wrong
+	// disk label. A 100% matching of disks in not enforced as the user might be
+	// interested in resizing only a subset of disks and thus we don't want to
+	// force the user to list all the disk and sizes if they don't want to change
+	// all.
+	diskMap := func(diskSpecs []vsphereconfigv1.DiskSpec) map[string]int64 {
+		diskMap := make(map[string]int64)
+		for _, s := range diskSpecs {
+			diskMap[s.DiskLabel] = s.DiskSizeGB
+		}
+		return diskMap
+	}(machine.config.MachineSpec.Disks)
+	diskChange := false
+	for _, dev := range disks {
+		disk := dev.(*types.VirtualDisk)
+		if newSize, ok := diskMap[disk.DeviceInfo.GetDescription().Label]; ok {
+			if disk.CapacityInBytes > vsphereutils.GiBToByte(newSize) {
+				return errors.New("[resize] [FATAL] Disk size provided should be more than actual disk size of the template. Please correct the machineSpec to proceed")
+			}
+			klog.V(4).Infof("[resize] Resizing the disk \"%s\" to new size \"%d\"", disk.DeviceInfo.GetDescription().Label, newSize)
+			diskChange = true
+			disk.CapacityInBytes = vsphereutils.GiBToByte(newSize)
+			diskspec := &types.VirtualDeviceConfigSpec{}
+			diskspec.Operation = types.VirtualDeviceConfigSpecOperationEdit
+			diskspec.Device = disk
+			deviceSpecs = append(deviceSpecs, diskspec)
+		}
+	}
+	if !diskChange && len(machine.config.MachineSpec.Disks) > 0 {
+		return fmt.Errorf("[resize] None of the disks specified in the MachineSpec matched with the disks on the template %s", machine.config.MachineSpec.VMTemplate)
+	}
+
+	nics := l.SelectByType((*types.VirtualEthernetCard)(nil))
+	// Remove any existing nics on the source vm
+	for _, dev := range nics {
+		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		nicspec := &types.VirtualDeviceConfigSpec{}
+		nicspec.Operation = types.VirtualDeviceConfigSpecOperationRemove
+		nicspec.Device = nic
+		deviceSpecs = append(deviceSpecs, nicspec)
+	}
+	// Add new nics based on the user info
+	nicid := int32(-100)
+	for _, network := range machine.config.MachineSpec.Networks {
+		netRef, err := machine.s.finder.Network(ctx, network.NetworkName)
+		if err != nil {
+			return err
+		}
+		nic := types.VirtualVmxnet3{}
+		nic.Key = nicid
+		nic.Backing, err = netRef.EthernetCardBackingInfo(ctx)
+		if err != nil {
+			return err
+		}
+		nicspec := &types.VirtualDeviceConfigSpec{}
+		nicspec.Operation = types.VirtualDeviceConfigSpecOperationAdd
+		nicspec.Device = &nic
+		deviceSpecs = append(deviceSpecs, nicspec)
+		nicid--
+	}
+	spec.Config.DeviceChange = deviceSpecs
+	machine.Eventf("Creating", "Creating Machine %v", machine.Name)
+
+	task, err := src.Clone(ctx, vmFolder, machine.Name, spec)
+	klog.V(6).Infof("[clone] with spec %v", spec)
+	if err != nil {
+		return err
+	}
+	return machine.SetTaskRef(task.Reference().Value)
+}
+
+func (pv *Provisioner) thickCopyDisks(ctx context.Context, machine *GovmomiMachine, srcPath string, dstPath string) error {
+	var ds *object.Datastore
+	var dc *object.Datacenter
+	var err error
+
+	if ds, err = machine.s.finder.DatastoreOrDefault(ctx, machine.config.MachineSpec.Datastore); err != nil {
+		return err
+	}
+
+	if dc, err = machine.s.finder.DefaultDatacenter(ctx); err != nil {
+		return err
+	}
+
+	m := ds.NewFileManager(dc, false)
+
+	// copy happens here
+	klog.V(4).Infof("[copy] Copying template disk to %s", dstPath)
+	cp := m.Copy
+	if err := cp(ctx, srcPath, dstPath); err != nil {
+		klog.V(4).Infof("[copy] thick copied vmdk, src(%s) ->  dst(%s)", srcPath, dstPath)
+	} else {
+		return err
+	}
+	return nil
+
+}


### PR DESCRIPTION
First off I am sorry for the size of this PR, I went down a rabbit hole, and this is what emerged at the end.

My goal with the refactoring (like most) was to make future changes quicker and safer. 

This refactoring includes:
* Breaking down the monolithic `create.go` in something a bit more manageable. 
* Reduce the function argument length's by introducing new `GovmomiMachine` and `GovmomiCluster` cluster objects that include references to CAPI, K8s and govc object that were being copied across function calls
* Reducing duplicated code into common methods (While I agree with the go idiom of A little copy and paste is better than a little dependency, I think within a package there should be limited duplication of code)
* Removing duplicated log and return errors (I might not be aware of the context or go idiom used here, but from my experience logging and then returning an error is an anti-pattern, You do 1 or the other, not both)
* Moving most utils methods into the `GovmomiMachine` or `GovmomiCluster` objects
* Decoupling of CAPI behavior vs general infrastructure behavior (i.e. when introducing new CAPI behavior you shouldn't need to go through working provisioning code that isn't being changed)

1 new feature: 
* Thin cloning for ESXi 


While this PR is not ready for merge, I wanted to get it out there to a) ensure it isn't duplicating any existing efforts b) Get early review, feedback, and criticism. 

TODO:
- Unit tests against vcsim
- Integration testing against ESXi and vCenter
- More inline comments and comments for exported methods