### PR TITLE
clusterctl: templatize more env vars for clusterctl yaml generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ vendor:
 
 # Create YAML file for deployment
 dev-yaml: | $(KUSTOMIZE)
-	VSPHERE_MANAGER_IMG=${DEV_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh
+	CAPV_MANAGER_IMAGE=${DEV_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh
 
 # Build the docker image
 dev-build: #test
@@ -121,7 +121,7 @@ dev-push:
 
 # Create YAML file for deployment
 prod-yaml: | $(KUSTOMIZE)
-	VSPHERE_MANAGER_IMG=${PRODUCTION_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh
+	CAPV_MANAGER_IMAGE=${PRODUCTION_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh
 
 # Build the docker image
 prod-build: test
@@ -140,7 +140,7 @@ prod-push:
 
 # Create YAML file for deployment into CI
 ci-yaml: | $(KUSTOMIZE)
-	VSPHERE_MANAGER_IMG=${CI_IMG}:${VERSION} cmd/clusterctl/examples/vsphere/generate-yaml.sh
+	CAPV_MANAGER_IMAGE=${CI_IMG}:${VERSION} cmd/clusterctl/examples/vsphere/generate-yaml.sh
 
 ci-image: generate fmt vet manifests
 	docker build . -t "$(CI_IMG):$(VERSION)"

--- a/cmd/clusterctl/examples/vsphere/capv_manager_image_patch.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/capv_manager_image_patch.yaml.template
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: ${VSPHERE_MANAGER_IMG}
+      - image: ${CAPV_MANAGER_IMAGE}
         name: manager

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -117,57 +117,57 @@ export VSPHERE_DISK_SIZE_GB=${VSPHERE_DISK_SIZE_GB:-20}
 
 # validate all required variables before generating any files
 
-if [ -z ${VSPHERE_USER} ]; then
+if [ -z "${VSPHERE_USER}" ]; then
   echo "env var VSPHERE_USER is required" 1>&2
   exit 1
 fi
 
-if [ -z ${VSPHERE_PASSWORD} ]; then
+if [ -z "${VSPHERE_PASSWORD}" ]; then
   echo "env var VSPHERE_PASSWORD is required" 1>&2
   exit 1
 fi
 
-if [ -z ${VSPHERE_SERVER} ]; then
+if [ -z "${VSPHERE_SERVER}" ]; then
   echo "env var VSPHERE_SERVER is required" 1>&2
   exit 1
 fi
 
-if [ -z $CAPV_MANAGER_IMAGE ]; then
+if [ -z "${CAPV_MANAGER_IMAGE}" ]; then
   echo "env var CAPV_MANAGER_IMAGE is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_DATACENTER ]; then
+if [ -z "${VSPHERE_DATACENTER}" ]; then
   echo "env var VSPHERE_DATACENTER is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_DATASTORE ]; then
+if [ -z "${VSPHERE_DATASTORE}" ]; then
   echo "env var VSPHERE_DATASTORE is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_NETWORK ]; then
+if [ -z "${VSPHERE_NETWORK}" ]; then
   echo "env var VSPHERE_NETWORK is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_RESOURCE_POOL ]; then
+if [ -z "${VSPHERE_RESOURCE_POOL}" ]; then
   echo "env var VSPHERE_RESOURCE_POOL is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_FOLDER ]; then
+if [ -z "${VSPHERE_FOLDER}" ]; then
   echo "env var VSPHERE_FOLDER is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_TEMPLATE ]; then
+if [ -z "${VSPHERE_TEMPLATE}" ]; then
   echo "env var VSPHERE_TEMPLATE is required" 1>&2
   exit 1
 fi
 
-if [ -z $VSPHERE_DISK ]; then
+if [ -z "${VSPHERE_DISK}" ]; then
   echo "env var VSPHERE_DISK is required" 1>&2
   exit 1
 fi

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -98,14 +98,22 @@ mkdir -p ${OUTPUT_DIR}
 
 # all variables used for yaml generation
 
-CLUSTER_NAME=${CLUSTER_NAME:-vsphere-cluster}
-SERVICE_CIDR=${SERVICE_CIDR:-100.64.0.0/13}
-CLUSTER_CIDR=${CLUSTER_CIDR:-100.96.0.0/11}
+export CLUSTER_NAME=${CLUSTER_NAME:-vsphere-cluster}
+export SERVICE_CIDR=${SERVICE_CIDR:-100.64.0.0/13}
+export CLUSTER_CIDR=${CLUSTER_CIDR:-100.96.0.0/11}
 
-VSPHERE_USER=${VSPHERE_USER:-}
-VSPHERE_PASSWORD=${VSPHERE_PASSWORD:-}
-VSPHERE_SERVER=${VSPHERE_SERVER:-}
-VSPHERE_MANAGER_IMG=${VSPHERE_MANAGER_IMG:-}
+export VSPHERE_USER=${VSPHERE_USER:-}
+export VSPHERE_PASSWORD=${VSPHERE_PASSWORD:-}
+export VSPHERE_SERVER=${VSPHERE_SERVER:-}
+export VSPHERE_MANAGER_IMG=${VSPHERE_MANAGER_IMG:-}
+export VSPHERE_DATACENTER=${VSPHERE_DATACENTER:-}
+export VSPHERE_DATASTORE=${VSPHERE_DATASTORE:-}
+export VSPHERE_NETWORK=${VSPHERE_NETWORK:-}
+export VSPHERE_RESOURCE_POOL=${VSPHERE_RESOURCE_POOL:-}
+export VSPHERE_FOLDER=${VSPHERE_FOLDER:-}
+export VSPHERE_TEMPLATE=${VSPHERE_TEMPLATE:-}
+export VSPHERE_DISK=${VSPHERE_DISK:-}
+export VSPHERE_DISK_SIZE_GB=${VSPHERE_DISK_SIZE_GB:-20}
 
 # validate all required variables before generating any files
 
@@ -126,6 +134,46 @@ fi
 
 if [ -z $VSPHERE_MANAGER_IMG ]; then
   echo "env var VSPHERE_MANAGE_IMG is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_DATACENTER ]; then
+  echo "env var VSPHERE_DATACENTER is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_DATASTORE ]; then
+  echo "env var VSPHERE_DATASTORE is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_NETWORK ]; then
+  echo "env var VSPHERE_NETWORK is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_RESOURCE_POOL ]; then
+  echo "env var VSPHERE_RESOURCE_POOL is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_FOLDER ]; then
+  echo "env var VSPHERE_FOLDER is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_TEMPLATE ]; then
+  echo "env var VSPHERE_TEMPLATE is required"
+  exit 1
+fi
+
+if [ -z $VSPHERE_DISK ]; then
+  echo "env var VSPHERE_DISK is required"
+  exit 1
+fi
+
+if [ ${VSPHERE_DISK_SIZE_GB} -lt 20 ]; then
+  echo "env var VSPHERE_DISK_SIZE_GB must be >= 20" 1>&2
   exit 1
 fi
 

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -98,7 +98,7 @@ mkdir -p ${OUTPUT_DIR}
 
 # all variables used for yaml generation
 
-export CLUSTER_NAME=${CLUSTER_NAME:-vsphere-cluster}
+export CLUSTER_NAME=${CLUSTER_NAME:-capv-mgmt-example}
 export SERVICE_CIDR=${SERVICE_CIDR:-100.64.0.0/13}
 export CLUSTER_CIDR=${CLUSTER_CIDR:-100.96.0.0/11}
 

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -36,8 +36,8 @@ CLUSTER_API_CRD_PATH=./vendor/sigs.k8s.io/cluster-api/config
 VSPHERE_CLUSTER_API_CRD_PATH=./config
 
 PROVIDERCOMPONENT_GENERATED_FILE=${OUTPUT_DIR}/provider-components.yaml
-VSPHERE_MANAGER_TEMPLATE_FILE=${TEMPLATE_DIR}/vsphere_manager_image_patch.yaml.template
-VSPHERE_MANAGER_GENERATED_FILE=$VSPHERE_CLUSTER_API_CRD_PATH/default/vsphere_manager_image_patch.yaml
+CAPV_MANAGER_TEMPLATE_FILE=${TEMPLATE_DIR}/capv_manager_image_patch.yaml.template
+CAPV_MANAGER_GENERATED_FILE=$VSPHERE_CLUSTER_API_CRD_PATH/default/capv_manager_image_patch.yaml
 
 MACHINE_CONTROLLER_SSH_PUBLIC_FILE=vsphere_tmp.pub
 MACHINE_CONTROLLER_SSH_PUBLIC=
@@ -105,7 +105,7 @@ export CLUSTER_CIDR=${CLUSTER_CIDR:-100.96.0.0/11}
 export VSPHERE_USER=${VSPHERE_USER:-}
 export VSPHERE_PASSWORD=${VSPHERE_PASSWORD:-}
 export VSPHERE_SERVER=${VSPHERE_SERVER:-}
-export VSPHERE_MANAGER_IMG=${VSPHERE_MANAGER_IMG:-}
+export CAPV_MANAGER_IMAGE=${CAPV_MANAGER_IMAGE:-}
 export VSPHERE_DATACENTER=${VSPHERE_DATACENTER:-}
 export VSPHERE_DATASTORE=${VSPHERE_DATASTORE:-}
 export VSPHERE_NETWORK=${VSPHERE_NETWORK:-}
@@ -132,8 +132,8 @@ if [ -z ${VSPHERE_SERVER} ]; then
   exit 1
 fi
 
-if [ -z $VSPHERE_MANAGER_IMG ]; then
-  echo "env var VSPHERE_MANAGE_IMG is required"
+if [ -z $CAPV_MANAGER_IMAGE ]; then
+  echo "env var CAPV_MANAGER_IMAGE is required"
   exit 1
 fi
 
@@ -186,7 +186,7 @@ echo "Done generating $CLUSTER_GENERATED_FILE"
 envsubst < $ADDON_TEMPLATE_FILE > "${ADDON_GENERATED_FILE}"
 echo "Done generating $ADDON_GENERATED_FILE"
 
-envsubst < $VSPHERE_MANAGER_TEMPLATE_FILE > "${VSPHERE_MANAGER_GENERATED_FILE}"
+envsubst < $CAPV_MANAGER_TEMPLATE_FILE > "${CAPV_MANAGER_GENERATED_FILE}"
 
 # Check if the ssh key already exists. If not, generate and copy to the .ssh dir.
 if [ ! -f $MACHINE_CONTROLLER_SSH_HOME$MACHINE_CONTROLLER_SSH_PRIVATE_FILE ]; then

--- a/cmd/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/cmd/clusterctl/examples/vsphere/generate-yaml.sh
@@ -118,57 +118,57 @@ export VSPHERE_DISK_SIZE_GB=${VSPHERE_DISK_SIZE_GB:-20}
 # validate all required variables before generating any files
 
 if [ -z ${VSPHERE_USER} ]; then
-  echo "env var VSPHERE_USER is required"
+  echo "env var VSPHERE_USER is required" 1>&2
   exit 1
 fi
 
 if [ -z ${VSPHERE_PASSWORD} ]; then
-  echo "env var VSPHERE_PASSWORD is required"
+  echo "env var VSPHERE_PASSWORD is required" 1>&2
   exit 1
 fi
 
 if [ -z ${VSPHERE_SERVER} ]; then
-  echo "env var VSPHERE_SERVER is required"
+  echo "env var VSPHERE_SERVER is required" 1>&2
   exit 1
 fi
 
 if [ -z $CAPV_MANAGER_IMAGE ]; then
-  echo "env var CAPV_MANAGER_IMAGE is required"
+  echo "env var CAPV_MANAGER_IMAGE is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_DATACENTER ]; then
-  echo "env var VSPHERE_DATACENTER is required"
+  echo "env var VSPHERE_DATACENTER is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_DATASTORE ]; then
-  echo "env var VSPHERE_DATASTORE is required"
+  echo "env var VSPHERE_DATASTORE is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_NETWORK ]; then
-  echo "env var VSPHERE_NETWORK is required"
+  echo "env var VSPHERE_NETWORK is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_RESOURCE_POOL ]; then
-  echo "env var VSPHERE_RESOURCE_POOL is required"
+  echo "env var VSPHERE_RESOURCE_POOL is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_FOLDER ]; then
-  echo "env var VSPHERE_FOLDER is required"
+  echo "env var VSPHERE_FOLDER is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_TEMPLATE ]; then
-  echo "env var VSPHERE_TEMPLATE is required"
+  echo "env var VSPHERE_TEMPLATE is required" 1>&2
   exit 1
 fi
 
 if [ -z $VSPHERE_DISK ]; then
-  echo "env var VSPHERE_DISK is required"
+  echo "env var VSPHERE_DISK is required" 1>&2
   exit 1
 fi
 

--- a/cmd/clusterctl/examples/vsphere/machines.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machines.yaml.template
@@ -4,7 +4,7 @@ items:
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine
     metadata:
-      generateName: vs-master-
+      name: ${CLUSTER_NAME}-mgmt
       labels:
         set: master
         cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -14,29 +14,21 @@ items:
           apiVersion: "vsphereproviderconfig/v1alpha1"
           kind: "VsphereMachineProviderConfig"
           machineSpec:
-            datacenter: ""
-            datastore: ""
-            resourcePool: ""
+            datacenter: "${VSPHERE_DATACENTER}"
+            datastore: "${VSPHERE_DATASTORE}"
+            resourcePool: "${VSPHERE_RESOURCE_POOL}"
+            vmFolder: "${VSPHERE_FOLDER}"
             networks:
-            - networkName: ""
+            - networkName: "${VSPHERE_NETWORK}"
               ipConfig:
-                networkType: static
-                ip: ""
-                netmask: ""
-                gateway: ""
-                dns:
-                - xxxx
-                - yyyy
+                networkType: "dhcp"
             numCPUs: 2
             memoryMB: 2048
-            template: ""
+            template: "${VSPHERE_TEMPLATE}"
             disks:
-            - diskLabel: ""
-              diskSizeGB: 20
+            - diskLabel: "${VSPHERE_DISK}"
+              diskSizeGB: ${VSPHERE_DISK_SIZE_GB}
             preloaded: false
-            ntpServers:
-            - 0.pool.ntp.org
-            - 1.pool.ntp.org
       versions:
         kubelet: 1.11.3
         controlPlane: 1.11.3

--- a/cmd/clusterctl/examples/vsphere/machines.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machines.yaml.template
@@ -4,7 +4,7 @@ items:
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine
     metadata:
-      name: ${CLUSTER_NAME}-mgmt
+      name: ${CLUSTER_NAME}-controlplane
       labels:
         set: master
         cluster.k8s.io/cluster-name: ${CLUSTER_NAME}

--- a/cmd/clusterctl/examples/vsphere/machineset.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machineset.yaml.template
@@ -15,30 +15,25 @@ spec:
         cluster.k8s.io/cluster-name: ${CLUSTER_NAME}
     spec:
       providerSpec:
-        value:
-          apiVersion: "vsphereproviderconfig/v1alpha1"
-          kind: "VsphereMachineProviderConfig"
-          machineSpec:
-            datacenter: ""
-            datastore: ""
-            resourcePool: ""
-            networks:
-            - networkName: ""
-              ipConfig:
-                networkType: dhcp
-            numCPUs: 2
-            memoryMB: 2048
-            template: ""
-            disks:
-            - diskLabel: ""
-              diskSizeGB: 20
-            preloaded: false
-            trustedCerts:
-            - zzzz
-            - aaaa
-            ntpServers:
-            - 0.pool.ntp.org
-            - 1.pool.ntp.org
+	value:
+	  apiVersion: "vsphereproviderconfig/v1alpha1"
+	  kind: "VsphereMachineProviderConfig"
+	  machineSpec:
+	    datacenter: "${VSPHERE_DATACENTER}"
+	    datastore: "${VSPHERE_DATASTORE}"
+	    resourcePool: "${VSPHERE_RESOURCE_POOL}"
+	    vmFolder: "${VSPHERE_FOLDER}"
+	    networks:
+	    - networkName: "${VSPHERE_NETWORK}"
+	      ipConfig:
+		networkType: "dhcp"
+	    numCPUs: 2
+	    memoryMB: 2048
+	    template: "${VSPHERE_TEMPLATE}"
+	    disks:
+	    - diskLabel: "${VSPHERE_DISK}"
+	      diskSizeGB: ${VSPHERE_DISK_SIZE_GB}
+	    preloaded: false
       versions:
         kubelet: 1.11.3
       roles:

--- a/config/default/.gitignore
+++ b/config/default/.gitignore
@@ -1,1 +1,1 @@
-vsphere_manager_image_patch.yaml
+capv_manager_image_patch.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,7 +35,7 @@ bases:
 - ../manager/
 
 patches:
-- vsphere_manager_image_patch.yaml
+- capv_manager_image_patch.yaml
 
 secretGenerator:
 - name: machine-sshkeys


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

Adding the following env vars for generating yaml files for the clusterctl bootstrap cluster:
```
VSPHERE_DATACENTER
VSPHERE_DATASTORE
VSPHERE_NETWORK
VSPHERE_RESOURCE_POOL
VSPHERE_FOLDER
VSPHERE_TEMPLATE
VSPHERE_DISK
```

