### PR TITLE
Add License Headers To Code And Script Files

### DIFF
--- a/installer/build/bootable/root/etc/profile.d/kubernetes.sh
+++ b/installer/build/bootable/root/etc/profile.d/kubernetes.sh
@@ -1,3 +1,17 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 if [ -d /opt/bin ]; then
         pathappend /opt/bin
 fi

--- a/installer/build/bootable/root/opt/ova/bin/kubeadm-provisioning.sh
+++ b/installer/build/bootable/root/opt/ova/bin/kubeadm-provisioning.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/bash
 
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Fetch current local Kubernetes version
 KUBEVERSION=$(kubectl version --client -o json | jq -r .clientVersion.gitVersion)
 DCUI_SOCKET="UNIX:/var/run/dcui.sock"

--- a/installer/build/bootable/root/opt/ova/bin/kubernetes-watchdog.sh
+++ b/installer/build/bootable/root/opt/ova/bin/kubernetes-watchdog.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euf -o pipefail
 
 DCUI_SOCKET="UNIX:/var/run/dcui.sock"

--- a/installer/build/scripts/get_logs.sh
+++ b/installer/build/scripts/get_logs.sh
@@ -1,2 +1,16 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 echo "scp -R $(id -un)@$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p'):/logs/ ."
 date +'%d/%m/%Y--%H:%M:%S'

--- a/installer/build/scripts/provisioners/provision_kubernetes.sh
+++ b/installer/build/scripts/provisioners/provision_kubernetes.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euf -o pipefail
 
 echo "Kubernetes version being provisioned: $KUBERNETES_VERSION"

--- a/installer/ovatools/ova-ui/templates.go
+++ b/installer/ovatools/ova-ui/templates.go
@@ -1,5 +1,21 @@
 // +build linux
 
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 type OVAProps struct {

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package constants
 
 import (

--- a/scripts/e2e/bootstrap_job/clusterctl.sh
+++ b/scripts/e2e/bootstrap_job/clusterctl.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # this script takes care of everything after bootstrap cluster created, it means
 # bootstrap need be created beforehand.
 


### PR DESCRIPTION
Some code and script files lacked license headers.  This commit adds headers only to files which lacked any header at all.  It does not modify existing license headers.

Fixes #292