### PR TITLE
clusterctl: vsphere provider manager should only run on control plane nodes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,6 +40,8 @@ spec:
         control-plane: vsphere-provider-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

_If_ a management cluster is running on worker nodes and the vSphere provider manager runs on a worker node, it may delete the machine it is running on. In most cases, Kubernetes will reschedule this node but this should be preventable entirely by running the vSphere provider manager on only control plane nodes.