### PR TITLE
clusterctl: remove generated machine ssh keys

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -36,10 +36,3 @@ bases:
 
 patches:
 - capv_manager_image_patch.yaml
-
-secretGenerator:
-- name: machine-sshkeys
-  files:
-    - vsphere_tmp
-    - vsphere_tmp.pub
-  type: Opaque

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,12 +63,6 @@ spec:
           mountPath: /etc/ssl/certs
         - name: machines-stage
           mountPath: /tmp/cluster-api/machines
-        - name: sshkeys
-          mountPath: /root/.ssh/vsphere_tmp
-          subPath: vsphere_tmp
-        - name: sshkeys
-          mountPath: /root/.ssh/vsphere_tmp.pub
-          subPath: vsphere_tmp.pub
         - name: kubeadm
           mountPath: /usr/bin/kubeadm
         env:
@@ -94,10 +88,6 @@ spec:
           path: /etc/ssl/certs
       - name: machines-stage
         emptyDir: {}
-      - name: sshkeys
-        secret:
-          defaultMode: 0600
-          secretName: machine-sshkeys
       - name: kubeadm
         hostPath:
           path: /usr/bin/kubeadm


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

The generated machine ssh keys are no longer needed after https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/307 