### PR TITLE
Remove building of installer OVA from e2e.sh

### DIFF
--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -33,15 +33,9 @@ get_random_str() {
    fi
 }
 
-get_bootstrap_ssh_pub() {
-   if [ -z "$bootstrap_ssh_pub" ]; then
-      bootstrap_ssh_pub=$(cat ../scripts/e2e/hack/bootstrapper.pub)
-   fi
-}
-
 fill_file_with_value() {
   newfilename="$(echo "$1" | sed 's/template/yml/g')"
-  rm -f "$newfilename" temp.sh  
+  rm -f "$newfilename" temp.sh
   ( echo "cat <<EOF >$newfilename";
     cat "$1";
     echo "EOF";
@@ -53,7 +47,7 @@ fill_file_with_value() {
 revert_bootstrap_vm() {
    bootstrap_vm=$(govc find / -type m -name clusterapi-bootstrap-"$1")
    snapshot_name="cluster-api-provider-vsphere-ci-0.0.2"
-   govc snapshot.revert -vm "${bootstrap_vm}" "${snapshot_name}"  
+   govc snapshot.revert -vm "${bootstrap_vm}" "${snapshot_name}"
    bootstrap_vm_ip=$(govc vm.ip "${bootstrap_vm}")
 }
 
@@ -141,91 +135,6 @@ start_docker() {
    done
 }
 
-clone_clusterapi_vsphere_repo() {
-   mkdir -p /go/src/sigs.k8s.io/cluster-api-provider-vsphere
-   git clone https://github.com/kubernetes-sigs/cluster-api-provider-vsphere.git \
-             /go/src/sigs.k8s.io/cluster-api-provider-vsphere/
-}
-
-install_govc() {
-   govc_bin="/tmp/govc/bin"
-   mkdir -p "${govc_bin}"
-   curl -sL https://github.com/vmware/govmomi/releases/download/v0.19.0/govc_linux_amd64.gz -o "${govc_bin}"/govc.gz
-   gunzip "${govc_bin}"/govc.gz
-   chmod +x "${govc_bin}"/govc
-   export PATH=${govc_bin}:$PATH
-}
-
-build_upload_deploy_ovf() { 
-   # build the ova
-   ova_revision="v0.0.1-debug"
-   get_random_str
-   get_bootstrap_ssh_pub
-   docker volume create ova-tmp
-   docker run -t --rm --privileged -v /dev:/dev \
-     -v ova-tmp:/go/src/sigs.k8s.io/cluster-api-provider-vsphere/installer/bin \
-     gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-installer:"$1" \
-     ova-ci --ci-root-password "${random_str}" --ci-root-ssh-key "${bootstrap_ssh_pub}" \
-     --build-ova-revision "${ova_revision}"
-
-   mkdir -p ./bin
-   CID=$(docker run -d -v ova-tmp:/ova-tmp busybox true)
-   docker cp "${CID}":/ova-tmp/cluster-api-vsphere-"${ova_revision}".ova ./bin/
-   docker stop "${CID}"
-   docker rm "${CID}"
-   docker volume rm ova-tmp
-
-   if [ ! -e ./bin/cluster-api-vsphere-"${ova_revision}".ova ]; then
-      echo "file not exist"
-      exit 1
-   fi
- 
-   # upload and deploy bootstrap VM
-   name_prefix="clusterapi-bootstrap"
-   bootstrap_vm_name="$name_prefix"-"$random_str"
-   bootstrap_vm_folder="clusterapi"
-   bootstrap_vm_rp="clusterapi"
-   bootstrap_vm_network="sddc-cgw-network-3"
-   library_name="clusterapi"
-   datastore_name="WorkloadDatastore"
-   
-   library_id=$(govc library.create -ds="${datastore_name}" "${library_name}")
-   govc library.ova "${library_name}" "./bin/cluster-api-vsphere-${ova_revision}.ova"
-   govc vcenter.deploy -ds="${datastore_name}" -folder="${bootstrap_vm_folder}" -pool="${bootstrap_vm_rp}" "${library_name}" "cluster-api-vsphere-${ova_revision}.ova"  "$bootstrap_vm_name"
-   govc library.rm "${library_id}"
-  
-
-   # wait for bootstrap_vm_ip
-   bootstrap_vm=$(govc find / -type m -name "$bootstrap_vm_name")
-   govc vm.network.change -vm "${bootstrap_vm_name}" -net "${bootstrap_vm_network}" ethernet-0
-   govc vm.power -on "${bootstrap_vm}"
-      
-   bootstrap_vm_ip=$(govc vm.ip "${bootstrap_vm}")
-   echo "bootstrap ip: ${bootstrap_vm_ip}"
-
-   retry=100
-   until run_cmd_on_bootstrap "${bootstrap_vm_ip}" "ls /etc/kubernetes/admin.conf";
-   do
-      sleep 6
-      retry=$((retry - 1))
-      if [ $retry -lt 0 ]
-      then
-         exit 1
-      fi
-   done;
-
-   retry=100
-   until run_cmd_on_bootstrap "${bootstrap_vm_ip}" "kubectl get nodes";
-   do
-      sleep 6
-      retry=$((retry - 1))
-      if [ $retry -lt 0 ]
-      then
-         exit 1
-      fi
-   done;
-}
-
 # the main loop
 vsphere_controller_version=""
 context=""
@@ -255,21 +164,11 @@ get_random_str
 target_vm_prefix="clusterapi-""$random_str"
 export_base64_value "TARGET_VM_PREFIX" "$target_vm_prefix"
 
-# get bootstrap VM
 # install_govc
 go get -u github.com/vmware/govmomi/govc
-if [ -z "$1" ]; then
-   # use vm snapshot by default
-   get_bootstrap_vm "$context"
-else
-   # build ovf and deploy bootstrap ovf
-   cd ../../installer/build/container || exit 1
-   # push the installer container
-   make push
-   cd ../../ || exit 1
-   build_upload_deploy_ovf "${vsphere_controller_version}"
-   cd ../scripts/e2e || exit 1
-fi
+
+# get bootstrap VM
+get_bootstrap_vm "$context"
 
 # bootstrap with kind
 export bootstrap_vm_ip="${bootstrap_vm_ip}"
@@ -293,12 +192,7 @@ run_cmd_on_bootstrap "${bootstrap_vm_ip}" 'bash -s' < wait_for_job.sh
 ret="$?"
 
 # cleanup
-if [ -z "$1" ]; then
-   get_bootstrap_vm "$context"
-else
-   echo "trying to delete bootstrap vm"
-   delete_vm "$bootstrap_vm_name"
-fi
+get_bootstrap_vm "$context"
 delete_vm "$target_vm_prefix"
 
 exit "${ret}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch removes support for the "OVA" arg to scripts/e2e.sh, which
previously triggered the building of a new installer image and OVF, then
pushed that OVF to use as a bootstrap VM. All unused functions within
the script are also removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
This came up as part of #334. We will also need to update the Prow jobs to remove the "ova" flag passed to `scripts/e2e/e2e.sh`.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```