### PR TITLE
clusterctl: generate yaml in docker as current user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ GENERATE_YAML_ENV_VARS := -e CLUSTER_NAME -e SERVICE_CIDR -e CLUSTER_CIDR -e CAP
 dev-yaml: | clusterctl-tools
 	docker run -v $(CWD):/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
+	  -u $$(id -u):$$(id -g) \
 	  $(GENERATE_YAML_ENV_VARS) clusterctl-tools \
 	  bash -c "CAPV_MANAGER_IMAGE=${DEV_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh"
 
@@ -138,6 +139,7 @@ dev-push:
 prod-yaml: | clusterctl-tools
 	docker run -v $(CWD):/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
+	  -u $$(id -u):$$(id -g) \
 	  $(GENERATE_YAML_ENV_VARS) clusterctl-tools \
 	  bash -c "CAPV_MANAGER_IMAGE=${PRODUCTION_IMG} cmd/clusterctl/examples/vsphere/generate-yaml.sh"
 
@@ -161,6 +163,7 @@ prod-push:
 ci-yaml: | clusterctl-tools
 	docker run -v $(CWD):/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
+	  -u $$(id -u):$$(id -g) \
 	  $(GENERATE_YAML_ENV_VARS) clusterctl-tools \
 	  bash -c "CAPV_MANAGER_IMAGE=${CI_IMG}:${VERSION} cmd/clusterctl/examples/vsphere/generate-yaml.sh"
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Run generate-yaml.sh in docker as the current user, otherwise generated yaml files belong to root which end up being unread-able to other users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

