### PR TITLE
re-enable in-tree vsphere cloud provider

### DIFF
--- a/pkg/cloud/vsphere/services/kubeadm/configs.go
+++ b/pkg/cloud/vsphere/services/kubeadm/configs.go
@@ -84,6 +84,24 @@ func WithAPIServerExtraArgs(args map[string]string) ClusterConfigurationOption {
 	}
 }
 
+// WithAPIServerExtraVolumes sets extra volume mounts required for the API server
+func WithAPIServerExtraVolumes(name, hostPath, mountPath string) ClusterConfigurationOption {
+	return func(c *kubeadmv1beta1.ClusterConfiguration) {
+		if c.APIServer.ControlPlaneComponent.ExtraVolumes == nil {
+			c.APIServer.ControlPlaneComponent.ExtraVolumes = []kubeadmv1beta1.HostPathMount{}
+		}
+
+		hostPathMount := kubeadmv1beta1.HostPathMount{
+			Name:      name,
+			HostPath:  hostPath,
+			MountPath: mountPath,
+		}
+
+		c.APIServer.ControlPlaneComponent.ExtraVolumes = append(
+			c.APIServer.ControlPlaneComponent.ExtraVolumes, hostPathMount)
+	}
+}
+
 // WithControllerManagerExtraArgs sets the controller manager's extra arguments in the ClusterConfiguration.
 func WithControllerManagerExtraArgs(args map[string]string) ClusterConfigurationOption {
 	return func(c *kubeadmv1beta1.ClusterConfiguration) {
@@ -93,6 +111,23 @@ func WithControllerManagerExtraArgs(args map[string]string) ClusterConfiguration
 		for key, value := range args {
 			c.ControllerManager.ExtraArgs[key] = value
 		}
+	}
+}
+
+func WithControllerManagerExtraVolumes(name, hostPath, mountPath string) ClusterConfigurationOption {
+	return func(c *kubeadmv1beta1.ClusterConfiguration) {
+		if c.ControllerManager.ExtraVolumes == nil {
+			c.ControllerManager.ExtraVolumes = []kubeadmv1beta1.HostPathMount{}
+		}
+
+		hostPathMount := kubeadmv1beta1.HostPathMount{
+			Name:      name,
+			HostPath:  hostPath,
+			MountPath: mountPath,
+		}
+
+		c.ControllerManager.ExtraVolumes = append(
+			c.ControllerManager.ExtraVolumes, hostPathMount)
 	}
 }
 

--- a/pkg/cloud/vsphere/services/userdata/controlplane_test.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane_test.go
@@ -49,3 +49,61 @@ func TestTemplateYAMLIndent(t *testing.T) {
 	}
 
 }
+
+func Test_CloudConfig(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    *CloudConfigInput
+		userdata string
+		err      error
+	}{
+		{
+			name: "standard cloud config",
+			input: &CloudConfigInput{
+				User:         "admin",
+				Password:     "so_secure",
+				Server:       "10.0.0.1",
+				Datacenter:   "myprivatecloud",
+				ResourcePool: "deadpool",
+				Datastore:    "infinite-data",
+				Network:      "connected",
+			},
+			userdata: `[Global]
+insecure-flag = "1" # set to 1 if the vCenter uses a self-signed cert
+datacenters = "myprivatecloud"
+
+[VirtualCenter "10.0.0.1"]
+user = "admin"
+password = "so_secure"
+
+[Workspace]
+server = "10.0.0.1"
+datacenter = "myprivatecloud"
+folder = "deadpool"
+default-datastore = "infinite-data"
+resourcepool-path = "deadpool"
+
+[Disk]
+scsicontrollertype = pvscsi
+
+[Network]
+public-network = "connected"
+`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			userdata, err := NewCloudConfig(testcase.input)
+			if err != nil {
+				t.Fatalf("error getting cloud config user data: %q", err)
+			}
+
+			if userdata != testcase.userdata {
+				t.Logf("actual user data: %q", userdata)
+				t.Logf("expected user data: %q", testcase.userdata)
+				t.Error("unexpected user data")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
In https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/307 we temporarily removed the vSphere cloud provider, this PR adds it back using the updated custom kubeadm config mechanism. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Re-enable the vSphere cloud provider. 
```

/assign @akutz