### PR TITLE
clusterctl: disable dhcp6 by default

### DIFF
--- a/cmd/clusterctl/examples/vsphere/machines.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machines.yaml.template
@@ -21,7 +21,7 @@ items:
             devices:
             - networkName: "${VSPHERE_NETWORK}"
               dhcp4: true
-              dhcp6: true
+              dhcp6: false
           numCPUs: ${VSPHERE_NUM_CPUS}
           memoryMB: ${VSPHERE_MEM_MIB}
           diskGiB: ${VSPHERE_DISK_GIB}

--- a/cmd/clusterctl/examples/vsphere/machineset.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machineset.yaml.template
@@ -27,7 +27,7 @@ spec:
               devices:
               - networkName: "${VSPHERE_NETWORK}"
                 dhcp4: true
-                dhcp6: true
+                dhcp6: false
             numCPUs: ${VSPHERE_NUM_CPUS}
             memoryMB: ${VSPHERE_MEM_MIB}
             diskGiB: ${VSPHERE_DISK_GIB}

--- a/scripts/e2e/bootstrap_job/spec/machines.template
+++ b/scripts/e2e/bootstrap_job/spec/machines.template
@@ -22,7 +22,7 @@ items:
             devices:
             - networkName: "sddc-cgw-network-3"
               dhcp4: true
-              dhcp6: true
+              dhcp6: false
           numCPUs: 2
           memoryMB: 2048
           template: "ubuntu-1804-kube-v1.13.6"

--- a/scripts/e2e/bootstrap_job/spec/machineset.template
+++ b/scripts/e2e/bootstrap_job/spec/machineset.template
@@ -27,7 +27,7 @@ spec:
               devices:
               - networkName: "sddc-cgw-network-3"
                 dhcp4: true
-                dhcp6: true
+                dhcp6: false
             numCPUs: 2
             memoryMB: 2048
             template: "ubuntu-1804-kube-v1.13.6"


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Disable dhcp6 by default. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```