### PR TITLE
hack/generate-yaml: templatize sshAuthorizedKeys

### DIFF
--- a/cmd/clusterctl/examples/vsphere/cluster.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/cluster.yaml.template
@@ -17,3 +17,5 @@ spec:
       vspherePassword: "${VSPHERE_PASSWORD}"
       vsphereServer: "${VSPHERE_SERVER}"
       vsphereCredentialSecret: ""
+      sshAuthorizedKeys:
+      - "${SSH_AUTHORIZED_KEY}"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -121,6 +121,7 @@ export VSPHERE_TEMPLATE="ubuntu-1804-kube-v1.13.6"  # (required) The VM template
 export VSPHERE_DISK_GIB="50"                        # (optional) The VM Disk size in GB, defaults to 20 if not set
 export VSPHERE_NUM_CPUS="2"                         # (optional) The # of CPUs for control plane nodes in your management cluster, defaults to 2 if not set
 export VSPHERE_MEM_MIB="2048"                       # (optional) The memory (in MiB) for control plane nodes in your management cluster, defaults to 208 if not set
+export SSH_AUTHORIZED_KEY="ssh-rsa AAAAB3N..."      # (optional) The public ssh authorized key on all machines in this cluster
 
 # Kubernetes configs
 export KUBERNETES_VERSION=1.13.6       # (optional) The Kubernetes version to use, defaults to 1.13.6

--- a/hack/generate-yaml.sh
+++ b/hack/generate-yaml.sh
@@ -56,7 +56,7 @@ KUSTOMIZE="$(command -v kustomize 2>/dev/null || echo "docker")"
 PYTHON="$(command -v python 2>/dev/null || command -v python3 2>/dev/null || echo "docker")"
 
 usage() {
-  cat <<EOF 
+  cat <<EOF
 usage: ${0} [FLAGS]
   Generates input manifests for the Cluster API Provider for vSphere (CAPV)
 
@@ -149,6 +149,7 @@ record_and_export VSPHERE_NETWORK       ':?required'
 record_and_export VSPHERE_RESOURCE_POOL ':-'
 record_and_export VSPHERE_FOLDER        ':-'
 record_and_export VSPHERE_TEMPLATE      ':-'
+record_and_export SSH_AUTHORIZED_KEY    ':-'
 
 verify_cpu_mem_dsk() {
   eval "[[ \${${1}-} =~ [[:digit:]]+ ]] || ${1}=\"${2}\"; \


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Allows ssh authorized keys to be set in hack/generate-yaml.sh by setting the `SSH_AUTHORIZED_KEY` env var.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```