### PR TITLE
Create simple make target for container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,17 @@ CWD := $(abspath .)
 #      nested GOPATH.
 SHELL := hack/shell-with-gopath.sh
 
-# Image URL to use all building/pushing image targets
-PRODUCTION_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:0.3.0-alpha.1
-CI_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
-CLUSTERCTL_CI_IMG ?= gcr.io/cnx-cluster-api/clusterctl
+# Image URLs to use for building/pushing image targets
+CAPV_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
+CLUSTERCTL_IMG ?= gcr.io/cnx-cluster-api/clusterctl
 DEV_IMG ?= # <== NOTE:  outside dev, change this!!!
 
 # Retrieves the git hash
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-	   git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty --abbrev=8)
+
+CAPV_IMG_VERSION := $(CAPV_IMG):$(VERSION)
+CLUSTERCTL_IMG_VERSION := $(CLUSTERCTL_IMG):$(VERSION)
+CAPV_PROD_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:0.3.0-alpha.1
 
 # Build manager binary
 manager: fmt vet
@@ -118,46 +120,44 @@ dev-push:
 .PHONY: dev-yaml dev-build dev-push
 
 ###################################
-# PRODUCTION Build and Push targets
+# Build and Push targets
 ###################################
 
 # Create YAML file for deployment
 prod-yaml:
-	CAPV_MANAGER_IMAGE=$(PRODUCTION_IMG) hack/generate-yaml.sh
+	CAPV_MANAGER_IMAGE=$(CAPV_PROD_IMG) hack/generate-yaml.sh
 
 # Build the docker image
-prod-build: test
-	docker build . -t $(PRODUCTION_IMG)
+build-images: test
+	docker build . -t $(CAPV_IMG_VERSION)
+	docker build . -f cmd/clusterctl/Dockerfile -t $(CLUSTERCTL_IMG_VERSION)
 
 # Push the docker image
-prod-push:
+push-images: build-images
 	@echo "logging into gcr.io registry with key file"
-	@docker login -u _json_key --password-stdin gcr.io <"$(GCR_KEY_FILE)"
-	docker push $(PRODUCTION_IMG)
+	@docker login -u _json_key --password-stdin https://gcr.io <"$(GCR_KEY_FILE)"
+	docker push $(CAPV_IMG_VERSION)
+	docker push $(CLUSTERCTL_IMG_VERSION)
 
-.PHONY: prod-yaml prod-build prod-push
+.PHONY: prod-yaml build-images push-images
 
 ###################################
-# CI Build and Push targets
+# CI
 ###################################
 
 # Create YAML file for deployment into CI
 ci-yaml:
-	CAPV_MANAGER_IMAGE=$(CI_IMG) hack/generate-yaml.sh
+	CAPV_MANAGER_IMAGE=$(CAPV_IMG) hack/generate-yaml.sh
 
-ci-image: generate fmt vet manifests
-	docker build . -t "$(CI_IMG):$(VERSION)"
-	docker build . -f cmd/clusterctl/Dockerfile -t "$(CLUSTERCTL_CI_IMG):$(VERSION)"
+.PHONY: ci-yaml
 
-ci-push: ci-image
-# Log into the registry with a service account file.  In CI, GCR_KEY_FILE contains the content and not the file name.
-	@echo "logging into gcr.io registry with key file"
-	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io
-	docker push "$(CI_IMG):$(VERSION)"
-	docker push "$(CLUSTERCTL_CI_IMG):$(VERSION)"
-	@echo docker logout gcr.io
+###############################################################################
+#                               PRINT VERSION                                ##
+###############################################################################
+PHONY: version
+version:
+	@echo $(VERSION)
 
-.PHONY: ci-yaml ci-image ci-push
 
 ################################################################################
 ##                          The default targets                               ##

--- a/scripts/e2e/bootstrap_job/Makefile
+++ b/scripts/e2e/bootstrap_job/Makefile
@@ -1,7 +1,6 @@
 # Makefile
 
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty --abbrev=8)
 REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci
 
 all: build push clean
@@ -14,7 +13,7 @@ copyspec:
 .PHONY : build
 build: copyspec
 	docker build . --tag $(REGISTRY):$(VERSION)
-        
+
 push: build
 	@echo "logging into gcr.io registry with key file"
 	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -141,8 +141,7 @@ context=""
 if [ -z "${PROW_JOB_ID}" ] ; then
    context="debug"
    start_docker
-   vsphere_controller_version=$(shell git describe --exact-match 2> /dev/null || \
-      git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+   vsphere_controller_version=$(shell git describe --always --dirty --abbrev=8)
 else
    context="prow"
    if [ -z "${PULL_PULL_SHA}" ] ; then
@@ -155,7 +154,7 @@ else
 fi
 
 export VERSION="${vsphere_controller_version}"
-make ci-push
+make push-images
 cd ./scripts/e2e/bootstrap_job && make && cd .. || exit 1
 echo "build vSphere controller version: ${vsphere_controller_version}"
 

--- a/scripts/e2e/hack/Makefile
+++ b/scripts/e2e/hack/Makefile
@@ -1,17 +1,16 @@
 # Makefile
 
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty --abbrev=8)
 REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci-debug
 
 all: build push clean
 .PHONY : all
 
 .PHONY : build
-build: 
+build:
 	cd ../../../../ && docker build . -f ./cluster-api-provider-vsphere/scripts/e2e/hack/Dockerfile --tag $(REGISTRY):$(VERSION)
 	docker tag $(REGISTRY):$(VERSION) $(REGISTRY):debug
-        
+
 push: build
 	@echo "logging into gcr.io registry with key file"
 	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io


### PR DESCRIPTION

**What this PR does / why we need it**:
The previous make targets prod-images, prod-push, ci-images, and ci-push
essentially did the same thing for prod vs CI. The prod targets were
never meant to be invoked by CI and used a hard-coded image version that
needed to be updated whenever a new tag was made. The CI targets are
invoked on every PR by CI, and pushed a new CAPV and clusterctl image
tagged with the git SHA.

Instead, we now combine them into a single set of targets, build-images
and push-images, that set the image version to a simpler version of `git
describe` that will always show the changes since the last annotated
tag. This conveys more meaning than a simple SHA, and the git hash is
still included. With that done, we can then just always build and push
images in the same fashion, with no distinction between CI and
Production. This will allow the CI system to build images for us both as
part of CI/testing, and post merge to master.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```