### PR TITLE
add machineset metadata labels

### DIFF
--- a/cmd/clusterctl/examples/vsphere/machineset.yaml.template
+++ b/cmd/clusterctl/examples/vsphere/machineset.yaml.template
@@ -2,6 +2,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: MachineSet
 metadata:
   name: "${CLUSTER_NAME}-machineset-1"
+  labels:
+    machineset-name: "${CLUSTER_NAME}-machineset-1"
+    cluster.k8s.io/cluster-name: "${CLUSTER_NAME}"
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Adds labels to example machineset, otherwise cluster api controller logs warnings like the following:
```
W0625 17:20:53.061470       1 machinedeployment_controller.go:353] No machine deployments found for MachineSet "workload-example-machineset-1" because it has no labels
W0625 17:22:45.634381       1 machinedeployment_controller.go:353] No machine deployments found for MachineSet "workload-example-machineset-1" because it has no labels
W0625 17:22:45.634421       1 machinedeployment_controller.go:353] No machine deployments found for MachineSet "workload-example-machineset-1" because it has no labels
```

The cluster API controller In [getMachineDeploymentsForMachineSet](https://github.com/kubernetes-sigs/cluster-api/blob/release-0.1/pkg/controller/machinedeployment/machinedeployment_controller.go#L350-L353) will log a warning if there are no labels on a machine set but regardless we should label the machineset resource with at least the cluster name. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```