### PR TITLE
Modify -ci image makefile to default to build only

### DIFF
--- a/scripts/e2e/bootstrap_job/Makefile
+++ b/scripts/e2e/bootstrap_job/Makefile
@@ -4,7 +4,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci
 
-all: build push clean
+all: build
 .PHONY : all
 
 .PHONY : copyspec
@@ -14,7 +14,7 @@ copyspec:
 .PHONY : build
 build: copyspec
 	docker build . --tag $(REGISTRY):$(VERSION)
-        
+
 push: build
 	@echo "logging into gcr.io registry with key file"
 	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -156,7 +156,7 @@ fi
 
 export VERSION="${vsphere_controller_version}"
 make ci-push
-cd ./scripts/e2e/bootstrap_job && make && cd .. || exit 1
+cd ./scripts/e2e/bootstrap_job && make push && cd .. || exit 1
 echo "build vSphere controller version: ${vsphere_controller_version}"
 
 # set target cluster vm name prefix


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
When running `make` with no arguments in scripts/e2e/bootstrap_job, the
default behavior was to build the image, push the image to gcr.io, and
delete the local copy of the image. That's not a useful default.
Instead, change the "all" target to just have "build" as a pre-req,
making "make" the equivalent of "make build". If someone wants to push
images, they can run "make push" instead. Deleting the local image is an
explicit step left to "make clean".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/hold