### PR TITLE
userdata: use VM Folder in cloud config

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -103,6 +103,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 			Server:       ctx.ClusterConfig.VsphereServer,
 			Datacenter:   ctx.MachineConfig.MachineSpec.Datacenter,
 			ResourcePool: ctx.MachineConfig.MachineSpec.ResourcePool,
+			Folder:       ctx.MachineConfig.MachineSpec.VMFolder,
 			Datastore:    ctx.MachineConfig.MachineSpec.Datastore,
 			// assume the first VM network found for the vSphere cloud provider
 			Network: ctx.MachineConfig.MachineSpec.Network.Devices[0].NetworkName,

--- a/pkg/cloud/vsphere/services/userdata/controlplane.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane.go
@@ -35,7 +35,7 @@ password = "{{ .Password }}"
 [Workspace]
 server = "{{ .Server }}"
 datacenter = "{{ .Datacenter }}"
-folder = "{{ .ResourcePool }}"
+folder = "{{ .Folder }}"
 default-datastore = "{{ .Datastore }}"
 resourcepool-path = "{{ .ResourcePool }}"
 
@@ -258,6 +258,7 @@ type CloudConfigInput struct {
 	Server       string
 	Datacenter   string
 	ResourcePool string
+	Folder       string
 	Datastore    string
 	Network      string
 }

--- a/pkg/cloud/vsphere/services/userdata/controlplane_test.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane_test.go
@@ -65,6 +65,7 @@ func Test_CloudConfig(t *testing.T) {
 				Server:       "10.0.0.1",
 				Datacenter:   "myprivatecloud",
 				ResourcePool: "deadpool",
+				Folder:       "vms",
 				Datastore:    "infinite-data",
 				Network:      "connected",
 			},
@@ -79,7 +80,7 @@ password = "so_secure"
 [Workspace]
 server = "10.0.0.1"
 datacenter = "myprivatecloud"
-folder = "deadpool"
+folder = "vms"
 default-datastore = "infinite-data"
 resourcepool-path = "deadpool"
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Based on the discussion here https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/343#discussion_r297422396, correctly using VM folder instead of resource pool in the vSphere cloud config. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @akutz 
cc @mylesagray