### PR TITLE
add preferred apiserver CIDRs to network devices

### DIFF
--- a/config/crds/vsphereproviderconfig_v1alpha1_vspheremachineproviderconfig.yaml
+++ b/config/crds/vsphereproviderconfig_v1alpha1_vspheremachineproviderconfig.yaml
@@ -395,6 +395,10 @@ spec:
                     - networkName
                     type: object
                   type: array
+                preferredAPIServerCidr:
+                  description: PreferredAPIServeCIDR is the preferred CIDR for the
+                    Kubernetes API server endpoint on this machine
+                  type: string
                 routes:
                   description: Routes is a list of optional, static routes applied
                     to the virtual machine.

--- a/pkg/apis/vsphereproviderconfig/v1alpha1/vspheremachineproviderconfig_types.go
+++ b/pkg/apis/vsphereproviderconfig/v1alpha1/vspheremachineproviderconfig_types.go
@@ -89,6 +89,11 @@ type NetworkSpec struct {
 	// machine.
 	// +optional
 	Routes []NetworkRouteSpec `json:"routes,omitempty"`
+
+	// PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+	// server endpoint on this machine
+	// +optional
+	PreferredAPIServerCIDR string `json:"preferredAPIServerCidr,omitempty"`
 }
 
 // NetworkDeviceSpec defines the network configuration for a virtual machine's

--- a/scripts/e2e/bootstrap_job/spec/provider-components.template
+++ b/scripts/e2e/bootstrap_job/spec/provider-components.template
@@ -845,6 +845,10 @@ spec:
                     - networkName
                     type: object
                   type: array
+                preferredAPIServerCidr:
+                  description: PreferredAPIServeCIDR is the preferred CIDR for the
+                    Kubernetes API server endpoint on this machine
+                  type: string
                 routes:
                   description: Routes is a list of optional, static routes applied
                     to the virtual machine.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Allow preferred CIDRs to be set on a machine network spec which ensures addresses returned in kubeconfig for a given machine is in a known VM network. This is particularly useful for machines that set multiple network devices but only 1 device should be used for the API server address.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```