### PR TITLE
Fix exists logic since Exist doesn't requeue

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -54,18 +54,15 @@ const (
 
 // Create creates a new machine.
 func Create(ctx *context.MachineContext, bootstrapToken string) error {
-
 	// Check to see if the VM exists first since no error is returned if the VM
 	// does not exist, only when there's an error checking or when the op should
 	// be requeued, like when the VM has an in-flight task.
-	vm, err := findVM(ctx)
+	vm, err := lookupVM(ctx)
 	if err != nil {
 		return err
 	}
-
-	// If the VM already exists then do nothing.
 	if vm != nil {
-		return nil
+		return errors.Errorf("vm already exists for %q", ctx)
 	}
 
 	userData, err := generateUserData(ctx, bootstrapToken)

--- a/pkg/cloud/vsphere/services/govmomi/delete.go
+++ b/pkg/cloud/vsphere/services/govmomi/delete.go
@@ -31,12 +31,10 @@ func Delete(ctx *context.MachineContext) error {
 	// Check to see if the VM exists first since no error is returned if the VM
 	// does not exist, only when there's an error checking or when the op should
 	// be requeued, like when the VM has an in-flight task.
-	if _, err := Exists(ctx); err != nil {
+	vm, err := lookupVM(ctx)
+	if err != nil {
 		return err
 	}
-
-	// Try to get the VM. If it does not exist, return success.
-	vm := getVM(ctx)
 	if vm == nil {
 		return nil
 	}

--- a/pkg/cloud/vsphere/services/govmomi/exists.go
+++ b/pkg/cloud/vsphere/services/govmomi/exists.go
@@ -17,75 +17,10 @@ limitations under the License.
 package govmomi
 
 import (
-	"time"
-
-	"github.com/vmware/govmomi/vim25/types"
-	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
-
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 )
 
 // Exists returns a flag indicating whether or not a machine exists.
 func Exists(ctx *context.MachineContext) (bool, error) {
-	// Check to see if the VM exists.
-	vm, err := findVM(ctx)
-	if err != nil {
-		return false, err
-	}
-	if vm != nil {
-		return true, nil
-	}
-
-	// If there is no task reference then the VM cannot be determined to exist.
-	if ctx.MachineStatus.TaskRef == "" {
-		return false, nil
-	}
-
-	// Update the logger with the task ID.
-	ctx = context.NewMachineLoggerContext(ctx, ctx.MachineStatus.TaskRef)
-
-	// Check to see if a task exists.
-	task := getTask(ctx)
-	if task == nil {
-		ctx.Logger.V(4).Info("task does not exist")
-		ctx.MachineStatus.TaskRef = ""
-		return false, nil
-	}
-
-	// Since a task was discovered, let's find out if it indicates a VM is
-	// being, or has been, created/cloned.
-	ctx.Logger.V(4).Info("task found", "state", task.Info.State)
-	switch task.Info.State {
-	case types.TaskInfoStateQueued:
-		ctx.Logger.V(4).Info("task is still pending")
-	case types.TaskInfoStateRunning:
-		ctx.Logger.V(4).Info("task is still running")
-	case types.TaskInfoStateSuccess:
-		ctx.Logger.V(4).Info("task is a success")
-		if ref, ok := task.Info.Result.(types.ManagedObjectReference); ok {
-			if ref.Type == "VirtualMachine" {
-				ctx.MachineStatus.TaskRef = ""
-				ctx.MachineConfig.MachineRef = ref.Value
-			}
-		}
-		// Remove the machine reference if this was a destroy task.
-		if task.Info.DescriptionId == taskVMDestroy {
-			ctx.MachineConfig.MachineRef = ""
-		}
-	case types.TaskInfoStateError:
-		ctx.Logger.V(2).Info("task failed", "description-id", task.Info.DescriptionId)
-		ctx.MachineStatus.TaskRef = ""
-	}
-
-	// If a MachineRef was discovered or there is still a TaskRef set on
-	// the machine, then requeue this method so the next time it is called it
-	// can use the MachineRef or TaskRef to try and figure out the state of
-	// the VM.
-	if ctx.MachineConfig.MachineRef != "" || ctx.MachineStatus.TaskRef != "" {
-		ctx.Logger.V(6).Info("reenqueue to wait for VM exists check")
-		return false, &clustererror.RequeueAfterError{RequeueAfter: time.Second * 5}
-	}
-
-	// No VM could be found.
-	return false, nil
+	return ctx.MachineConfig.MachineRef != "" || ctx.MachineStatus.TaskRef != "", nil
 }

--- a/pkg/cloud/vsphere/services/govmomi/update.go
+++ b/pkg/cloud/vsphere/services/govmomi/update.go
@@ -36,14 +36,12 @@ func Update(ctx *context.MachineContext) error {
 	// Check to see if the VM exists first since no error is returned if the VM
 	// does not exist, only when there's an error checking or when the op should
 	// be requeued, like when the VM has an in-flight task.
-	vm, err := findVM(ctx)
+	vm, err := lookupVM(ctx)
 	if err != nil {
 		return err
 	}
-
-	// A VM is supposed to exist by this point. Otherwise return an error.
 	if vm == nil {
-		return errors.Errorf("vm is supposed to exist %q", ctx)
+		return errors.Errorf("vm should already exist for %q", ctx)
 	}
 
 	if err := reconcileNetwork(ctx, vm); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes how the existence checks for VMs are handled since the MachineController doesn't reenqueue Exists calls that return a requeue error. Therefore all requeue logic had to be shifted into the CUD operations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: NA

**Special notes for your reviewer**:
I haven't tested this locally at all yet. My morning has been nuts. I just wanted to push a WiP PR so that reviews could start. I plan to test and handle bugs after lunch.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @sidharthsurana 