### PR TITLE
Add support for Machine maintenance window

### DIFF
--- a/pkg/cloud/vsphere/actuators/machine/actuator.go
+++ b/pkg/cloud/vsphere/actuators/machine/actuator.go
@@ -78,6 +78,11 @@ func (a *Actuator) Create(
 		return err
 	}
 
+	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
+		return errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
+			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
+	}
+
 	defer func() {
 		opErr = actuators.PatchAndHandleError(ctx, "Create", opErr)
 	}()
@@ -111,6 +116,11 @@ func (a *Actuator) Delete(
 		})
 	if err != nil {
 		return err
+	}
+
+	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
+		return errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
+			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
 	}
 
 	defer func() {
@@ -177,6 +187,11 @@ func (a *Actuator) Exists(
 		})
 	if err != nil {
 		return false, err
+	}
+
+	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
+		return false, errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
+			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
 	}
 
 	defer func() {

--- a/pkg/cloud/vsphere/actuators/machine/actuator.go
+++ b/pkg/cloud/vsphere/actuators/machine/actuator.go
@@ -79,8 +79,8 @@ func (a *Actuator) Create(
 	}
 
 	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
-		return errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
-			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
+		ctx.Logger.V(4).Info("skipping operations on machine", "reason", "annotation", "annotation-key", constants.MaintenanceAnnotationLabel)
+		return &clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
 	}
 
 	defer func() {
@@ -119,8 +119,8 @@ func (a *Actuator) Delete(
 	}
 
 	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
-		return errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
-			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
+		ctx.Logger.V(4).Info("skipping operations on machine", "reason", "annotation", "annotation-key", constants.MaintenanceAnnotationLabel)
+		return &clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
 	}
 
 	defer func() {
@@ -190,8 +190,8 @@ func (a *Actuator) Exists(
 	}
 
 	if _, ok := machine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
-		return false, errors.Wrapf(&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
-			"detected `capv.sigs.k8s.io/maintenance` annotation on the machine, skipping all operations for machine %q", ctx)
+		ctx.Logger.V(4).Info("skipping operations on machine", "reason", "annotation", "annotation-key", constants.MaintenanceAnnotationLabel)
+		return false, &clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
 	}
 
 	defer func() {

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -40,4 +40,8 @@ const (
 	// ReadyAnnotationLabel is the annotation used to indicate a machine and/or
 	// cluster are ready.
 	ReadyAnnotationLabel = "capv.sigs.k8s.io/ready"
+
+	// MaintenanceAnnotationLabel is the annotation used to indicate a machine and/or
+	// cluster are in maintenance mode.
+	MaintenanceAnnotationLabel = "capv.sigs.k8s.io/maintenance"
 )


### PR DESCRIPTION
This patch introduces a new annotation "capv.sigs.k8s.io/maintenance"
that currenly anyone can put on the Machine object to instruct the
actuator to skip any kind of reconciliation on the machine object.

This can be used for various situations like(only sample use cases):
- admin wants to perform maintenance on the underlying infra for which
  they might need to power down VMs
- create bulk machine objects without the actuator creating them all at once,
  but only have them realized as needed by removing this annotation

Change-Id: I5a22c7abbe819f34a05c482c19d8625a661eaeaf

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #369

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```