### PR TITLE
Fix the cloud-init ethernets IDs

### DIFF
--- a/pkg/cloud/vsphere/services/metadata/constants.go
+++ b/pkg/cloud/vsphere/services/metadata/constants.go
@@ -22,8 +22,8 @@ local-hostname: "{{ .Hostname }}"
 network:
   version: 2
   ethernets:
-    {{- range $net := .Devices }}
-    "{{ $net.NetworkName }}":
+    {{- range $i, $net := .Devices }}
+    id{{ $i }}:
       match:
         macaddress: "{{ $net.MACAddr }}"
       wakeonlan: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes the issue where the cloud-init ethernets IDs were using invalid characters according to netplan. IDs are now simply "id$i" where "$i" is the index of the network device spec.

This issue was reported by @jpweber. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```