### PR TITLE
cluster actuator: don't block delete if kubeconfig secret doesn't exist

### DIFF
--- a/pkg/cloud/vsphere/actuators/cluster/actuator.go
+++ b/pkg/cloud/vsphere/actuators/cluster/actuator.go
@@ -236,5 +236,11 @@ func (a *Actuator) reconcileKubeConfig(ctx *context.ClusterContext) error {
 
 func (a *Actuator) deleteKubeConfig(ctx *context.ClusterContext) error {
 	secretName := fmt.Sprintf("%s-kubeconfig", ctx.Cluster.Name)
-	return a.coreClient.Secrets(ctx.Cluster.Namespace).Delete(secretName, &metav1.DeleteOptions{})
+
+	err := a.coreClient.Secrets(ctx.Cluster.Namespace).Delete(secretName, &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
If for whatever reason the kubeconfig secret for a cluster being delete doesn't exist, then the delete call will hang forever. We should account for the case where the kubeconfig secret doesn't exist either because of a previous error or the initial delete was successful but delete was re-queued. 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```