### PR TITLE
fix permissoin issue in make clusterctl-in-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ clusterctl-in-docker:
 	docker run --rm -v $(CWD):/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -e CGO_ENABLED=0 -e GOOS="$${GOOS:-linux}" -e GOARCH="$${GOARCH:-amd64}" \
-	  golang:1.12 \
-	  go build -ldflags '-extldflags "-static" -w -s' \
-	  -o bin/clusterctl."$${GOOS:-linux}"_"$${GOARCH:-amd64}" ./cmd/clusterctl
-	  @cp -f bin/clusterctl."$${GOOS:-linux}"_"$${GOARCH:-amd64}" bin/clusterctl
+	  golang:1.12 sh -c "\
+	  go build -ldflags '-extldflags \"-static\" -w -s' \
+	  -o bin/clusterctl.\"$${GOOS:-linux}\"_\"$${GOARCH:-amd64}\" ./cmd/clusterctl && \
+	  cp -f bin/clusterctl.\"$${GOOS:-linux}\"_\"$${GOARCH:-amd64}\" bin/clusterctl"
 .PHONY: clusterctl-in-docker
 
 # Run against the configured Kubernetes cluster in ~/.kube/config

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clusterctl-in-docker:
 	docker run --rm -v $(CWD):/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
 	  -e CGO_ENABLED=0 -e GOOS="$${GOOS:-linux}" -e GOARCH="$${GOARCH:-amd64}" \
-	  golang:1.12 sh -c "\
+	  golang:1.12.6 sh -c "\
 	  go build -ldflags '-extldflags \"-static\" -w -s' \
 	  -o bin/clusterctl.\"$${GOOS:-linux}\"_\"$${GOARCH:-amd64}\" ./cmd/clusterctl && \
 	  cp -f bin/clusterctl.\"$${GOOS:-linux}\"_\"$${GOARCH:-amd64}\" bin/clusterctl"


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
`make clusterctl-in-docker` is broken:
```
$ GOOS=linux make clusterctl-in-docker
docker run --rm -v /home/ubuntu/go/src/sigs.k8s.io/cluster-api-provider-vsphere:/go/src/sigs.k8s.io/cluster-api-provider-vsphere \
  -w /go/src/sigs.k8s.io/cluster-api-provider-vsphere \
  -e CGO_ENABLED=0 -e GOOS="${GOOS:-linux}" -e GOARCH="${GOARCH:-amd64}" \
  golang:1.12 \
  go build -ldflags '-extldflags "-static" -w -s' \
  -o bin/clusterctl."${GOOS:-linux}"_"${GOARCH:-amd64}" ./cmd/clusterctl
cp: cannot remove 'bin/clusterctl': Permission denied
Makefile:51: recipe for target 'clusterctl-in-docker' failed
make: *** [clusterctl-in-docker] Error 1
```

Can be fixed by cping the output binary inside the build container. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```