### PR TITLE
properly log requeue error messages with klogr

### DIFF
--- a/pkg/cloud/vsphere/actuators/actuators.go
+++ b/pkg/cloud/vsphere/actuators/actuators.go
@@ -56,7 +56,7 @@ func PatchAndHandleError(ctx patchContext, opName string, opErr error) error {
 		// If the requeue error is not the outer-most error then log the outer-most
 		// error since it will be dropped in favor of the requeue.
 		if requeueErr != err {
-			ctx.GetLogger().V(6).Info("requeue after error", "object", ctx.String(), "error", err)
+			ctx.GetLogger().V(6).Info("requeue after error", "object", ctx.String(), "error", err.Error())
 		}
 		err = requeueErr
 	}

--- a/pkg/cloud/vsphere/services/govmomi/util.go
+++ b/pkg/cloud/vsphere/services/govmomi/util.go
@@ -115,7 +115,7 @@ func sanitizeIPAddrs(ctx *context.MachineContext, ipAddrs []string) []string {
 	newIPAddrs := []string{}
 	for _, addr := range ipAddrs {
 		if err := net.ErrOnLocalOnlyIPAddr(addr); err != nil {
-			ctx.Logger.V(8).Info("ignoring IP address", "reason", err)
+			ctx.Logger.V(8).Info("ignoring IP address", "reason", err.Error())
 		} else {
 			newIPAddrs = append(newIPAddrs, addr)
 		}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
k8s.io/klogr does not log raw error values (it calls `json.Marshal` on the value) so we have to explicitly call `err.Error()` to pass the string value. 

Before:
```
I0628 14:43:20.470520       1 actuators.go:59] [cluster-actuator]/cluster.k8s.io/v1alpha1/default/workload-log-err/workload-log-err-controlplane-1 "level"=6 "msg"="requeue after error"  "error"={} "object"="default/workload-log-err"
```

After:
```
I0628 14:46:56.782602       1 actuators.go:59] [cluster-actuator]/cluster.k8s.io/v1alpha1/default/workload-log-err/workload-log-err-controlplane-1 "level"=6 "msg"="requeue after error"  "error"="unable to get control plane status for cluster \"default/workload-log-err\": unable to get kubeconfig for cluster \"default/workload-log-err\": unable to get control plane endpoint: requeue in: 20s" "object"="default/workload-log-err"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```