### PR TITLE
Fix Kubeadm Init and Join NodeRegistration Options

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -124,7 +124,8 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 					),
 				),
 				kubeadm.WithJoinNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(
+					kubeadm.SetNodeRegistration(
+						&ctx.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
 						kubeadm.WithCRISocket(containerdSocket),
@@ -203,7 +204,8 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 			kubeadm.SetInitConfigurationOptions(
 				&ctx.MachineConfig.KubeadmConfiguration.Init,
 				kubeadm.WithNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(
+					kubeadm.SetNodeRegistration(
+						&ctx.MachineConfig.KubeadmConfiguration.Init.NodeRegistration,
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
 						kubeadm.WithCRISocket(containerdSocket),
@@ -251,7 +253,8 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				),
 			),
 			kubeadm.WithJoinNodeRegistrationOptions(
-				kubeadm.NewNodeRegistration(
+				kubeadm.SetNodeRegistration(
+					&ctx.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 					kubeadm.WithNodeRegistrationName(hostnameLookup),
 					kubeadm.WithCRISocket(containerdSocket),
 					kubeadm.WithKubeletExtraArgs(map[string]string{

--- a/pkg/cloud/vsphere/services/kubeadm/configs_test.go
+++ b/pkg/cloud/vsphere/services/kubeadm/configs_test.go
@@ -40,7 +40,7 @@ func TestInitConfiguration(t *testing.T) {
 			},
 			options: []kubeadm.InitConfigurationOption{
 				kubeadm.WithNodeRegistrationOptions(
-					kubeadm.NewNodeRegistration(),
+					kubeadm.SetNodeRegistration(&kubeadmv1beta1.NodeRegistrationOptions{}),
 				),
 			},
 		},

--- a/pkg/cloud/vsphere/services/kubeadm/noderegistration.go
+++ b/pkg/cloud/vsphere/services/kubeadm/noderegistration.go
@@ -26,13 +26,12 @@ import (
 // NodeRegistrationOption is a function that sets a value on a Kubeadm NodeRegistrationOptions.
 type NodeRegistrationOption func(*kubeadmv1beta1.NodeRegistrationOptions)
 
-// NewNodeRegistration will create a kubeadmNodeRegistrationOptions with some defaults and the ability to provide customizations.
-func NewNodeRegistration(opts ...NodeRegistrationOption) kubeadmv1beta1.NodeRegistrationOptions {
-	nro := &kubeadmv1beta1.NodeRegistrationOptions{}
+// SetNodeRegistration will create a kubeadmNodeRegistrationOptions with some defaults and the ability to provide customizations.
+func SetNodeRegistration(base *kubeadmv1beta1.NodeRegistrationOptions, opts ...NodeRegistrationOption) kubeadmv1beta1.NodeRegistrationOptions {
 	for _, opt := range opts {
-		opt(nro)
+		opt(base)
 	}
-	return *nro
+	return *base
 }
 
 // WithTaints will set the taints on the NodeRegistration.

--- a/pkg/cloud/vsphere/services/kubeadm/noderegistration_test.go
+++ b/pkg/cloud/vsphere/services/kubeadm/noderegistration_test.go
@@ -48,7 +48,8 @@ func TestNewNodeRegistration(t *testing.T) {
 					},
 				},
 			},
-			actual: kubeadm.NewNodeRegistration(
+			actual: kubeadm.SetNodeRegistration(
+				&kubeadmv1beta1.NodeRegistrationOptions{},
 				kubeadm.WithNodeRegistrationName("test name"),
 				kubeadm.WithCRISocket("/test/path/to/socket.sock"),
 				kubeadm.WithTaints([]corev1.Taint{
@@ -68,7 +69,8 @@ func TestNewNodeRegistration(t *testing.T) {
 					"node-labels": "test value one,test value two",
 				},
 			},
-			actual: kubeadm.NewNodeRegistration(
+			actual: kubeadm.SetNodeRegistration(
+				&kubeadmv1beta1.NodeRegistrationOptions{},
 				kubeadm.WithKubeletExtraArgs(map[string]string{"node-labels": "test value one"}),
 				kubeadm.WithKubeletExtraArgs(map[string]string{"node-labels": "test value two"}),
 			),


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubeadm init and join Node Registration options currently overwrites values passed in through the provider config.  This fix replaces the NewNodeRegistration function so that it does not start with empty Node Registration Options