### PR TITLE
reduce requeue period for expected wait operations

### DIFF
--- a/pkg/cloud/vsphere/actuators/machine/actuator.go
+++ b/pkg/cloud/vsphere/actuators/machine/actuator.go
@@ -204,7 +204,7 @@ func (a *Actuator) Exists(
 func (a *Actuator) reconcilePKI(ctx *context.MachineContext) error {
 	if !ctx.ClusterConfig.CAKeyPair.HasCertAndKey() {
 		ctx.Logger.V(6).Info("cluster config is missing pki toolchain, requeue machine")
-		return &clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clustererr.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 	}
 	return nil
 }

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -29,6 +29,10 @@ const (
 	// requeueing a CAPI operation.
 	DefaultRequeue = 20 * time.Second
 
+	// WaitRequeue is the time for how long to wait when
+	// requeueing a CAPI operation due an operation in progress
+	WaitRequeue = 3 * time.Second
+
 	// VsphereUserKey is the key used to store/retrieve the vSphere user
 	// name from a Kubernetes secret.
 	VsphereUserKey = "username"

--- a/pkg/cloud/vsphere/services/govmomi/delete.go
+++ b/pkg/cloud/vsphere/services/govmomi/delete.go
@@ -53,7 +53,7 @@ func Delete(ctx *context.MachineContext) error {
 		}
 		ctx.MachineStatus.TaskRef = task.Reference().Value
 		ctx.Logger.V(6).Info("reenqueue to wait for power off op")
-		return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 	}
 
 	// At this point the VM is not powered on and can be destroyed. Store the
@@ -65,5 +65,5 @@ func Delete(ctx *context.MachineContext) error {
 	}
 	ctx.MachineStatus.TaskRef = task.Reference().Value
 	ctx.Logger.V(6).Info("reenqueue to wait for destroy op")
-	return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+	return &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 }

--- a/pkg/cloud/vsphere/services/govmomi/update.go
+++ b/pkg/cloud/vsphere/services/govmomi/update.go
@@ -89,7 +89,7 @@ func reconcileMetadata(ctx *context.MachineContext, vm *object.VirtualMachine) e
 	}
 	ctx.MachineStatus.TaskRef = task.Reference().Value
 	ctx.Logger.V(6).Info("reenqueue to track update metadata task")
-	return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+	return &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 }
 
 // reconcileNetwork updates the machine's network spec and status
@@ -129,7 +129,7 @@ func reconcileNetwork(ctx *context.MachineContext, vm *object.VirtualMachine) er
 		for _, netStatus := range ctx.MachineStatus.Network {
 			if len(netStatus.IPAddrs) == 0 {
 				ctx.Logger.V(6).Info("reenqueue to wait on IP addresses")
-				return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+				return &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 			}
 			for _, ip := range netStatus.IPAddrs {
 				ipAddrs = append(ipAddrs, corev1.NodeAddress{

--- a/pkg/cloud/vsphere/services/govmomi/util.go
+++ b/pkg/cloud/vsphere/services/govmomi/util.go
@@ -184,10 +184,10 @@ func lookupVM(ctx *context.MachineContext) (*object.VirtualMachine, error) {
 		switch task.Info.State {
 		case types.TaskInfoStateQueued:
 			ctx.Logger.V(4).Info("task is still pending", "description-id", task.Info.DescriptionId)
-			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 		case types.TaskInfoStateRunning:
 			ctx.Logger.V(4).Info("task is still running", "description-id", task.Info.DescriptionId)
-			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.WaitRequeue}
 		case types.TaskInfoStateSuccess:
 			ctx.Logger.V(4).Info("task is a success", "description-id", task.Info.DescriptionId)
 			ctx.MachineStatus.TaskRef = ""


### PR DESCRIPTION
This PR reduces the re-queue period for standard operations like power on/off, destroy etc.. 
Most of the time these operations return quickly and waiting 20 seconds to retry wastes time.

This should reduce testing time without adding too much logging verbosity