### PR TITLE
Update object patch logic

### DIFF
--- a/pkg/cloud/vsphere/actuators/actuators.go
+++ b/pkg/cloud/vsphere/actuators/actuators.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clustererr "sigs.k8s.io/cluster-api/pkg/controller/error"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 )
 
@@ -33,21 +32,17 @@ type patchContext interface {
 	fmt.Stringer
 	GetObject() runtime.Object
 	GetLogger() logr.Logger
-	Patch() error
+	Patch()
 }
 
 // PatchAndHandleError is used by actuators to patch objects and handle any
 // errors that may occur.
 func PatchAndHandleError(ctx patchContext, opName string, opErr error) error {
 
-	err := opErr
+	// Patch the object.
+	ctx.Patch()
 
-	// Attempt to patch the object. If it fails then requeue the operation.
-	if patchErr := ctx.Patch(); patchErr != nil {
-		err = errors.Wrapf(
-			&clustererr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue},
-			"opErr=%q patchErr=%q", opErr, patchErr)
-	}
+	err := opErr
 
 	// Always make sure an underlying requeue error is returned if one is present
 	// and log the op error if one is replaced with the requeue error.


### PR DESCRIPTION
This patch fixes a bug in the patch logic for clusters and machines. If the provider spec and status are not reencoded back into their original locations, no patch is generated for either. Please note this does not affect the cluster/machine spec/status -- only the provider analogues.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```