### PR TITLE
Ready-state logic changes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -85,10 +85,10 @@ func main() {
 	record.InitFromRecorder(mgr.GetRecorder("vsphere-controller"))
 
 	// Initialize cluster actuator.
-	clusterActuator := cluster.NewActuator(cs.ClusterV1alpha1(), coreClient)
+	clusterActuator := cluster.NewActuator(cs.ClusterV1alpha1(), coreClient, mgr.GetClient())
 
 	// Initialize machine actuator.
-	machineActuator := machine.NewActuator(cs.ClusterV1alpha1(), coreClient)
+	machineActuator := machine.NewActuator(cs.ClusterV1alpha1(), coreClient, mgr.GetClient())
 
 	// Register the cluster actuator as the deployer.
 	common.RegisterClusterProvisioner("vsphere", clusterActuator)

--- a/pkg/cloud/vsphere/context/machine_context.go
+++ b/pkg/cloud/vsphere/context/machine_context.go
@@ -228,7 +228,6 @@ func (c *MachineContext) BindPort() int32 {
 // control plane endpoint if the machine is a control plane node.
 // Otherwise an error is returned.
 func (c *MachineContext) ControlPlaneEndpoint() (string, error) {
-
 	if controlPlaneEndpoint, _ := c.ClusterContext.ControlPlaneEndpoint(); controlPlaneEndpoint != "" {
 		return controlPlaneEndpoint, nil
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -537,6 +537,7 @@ sigs.k8s.io/cluster-api/pkg/controller/machine
 sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1
 sigs.k8s.io/cluster-api/pkg/controller/error
 sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1
+sigs.k8s.io/cluster-api/pkg/controller/remote
 sigs.k8s.io/cluster-api/pkg/util
 sigs.k8s.io/cluster-api/cmd/clusterctl/clientcmd
 sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer
@@ -546,7 +547,6 @@ sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/provider
 sigs.k8s.io/cluster-api/cmd/clusterctl/phases
 sigs.k8s.io/cluster-api/cmd/clusterctl/providercomponents
 sigs.k8s.io/cluster-api/cmd/clusterctl/validation
-sigs.k8s.io/cluster-api/pkg/controller/remote
 sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/scheme
 sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing
 sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates the ready-state logic for the Cluster and Machine objects. A machine is not marked as ready until it is possible to connect to the target cluster and verify the machine is represented
there as a node.
    
Additionally, this patch relocates the code to create the KubeConfig secret from the Cluster's Reconcile function to the Machine's Update function. This is because the KubeConfig secret must be created before a Cluster can verify its ready state. If the Cluster didn't create the KubeConfig until after it was ready, then a circular dependency would be created, and a Cluster would never appear as ready.
    
Finally, several existing calls have been changed to rely on the CAPI NodeRef/Remote packages in order to get a client for a target cluster or retrieve a KubeConfig for the target cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR depends on #394 and will be rebased once #394 merges.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```