### PR TITLE
Use pkg/deployer in the Cluster actuator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/actuators/cluster"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/actuators/machine"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/deployer"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 )
 
@@ -84,14 +85,14 @@ func main() {
 	// Initialize event recorder.
 	record.InitFromRecorder(mgr.GetRecorder("vsphere-controller"))
 
+	// Register the deployer.
+	common.RegisterClusterProvisioner("vsphere", deployer.Deployer{})
+
 	// Initialize cluster actuator.
 	clusterActuator := cluster.NewActuator(cs.ClusterV1alpha1(), coreClient, mgr.GetClient())
 
 	// Initialize machine actuator.
 	machineActuator := machine.NewActuator(cs.ClusterV1alpha1(), coreClient, mgr.GetClient())
-
-	// Register the cluster actuator as the deployer.
-	common.RegisterClusterProvisioner("vsphere", clusterActuator)
 
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)

--- a/pkg/cloud/vsphere/actuators/cluster/actuator.go
+++ b/pkg/cloud/vsphere/actuators/cluster/actuator.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/certificates"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/kubeclient"
 )
 
 // Actuator is responsible for maintaining the Cluster objects.
@@ -113,47 +112,6 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster) (opErr error) {
 	}
 
 	return nil
-}
-
-// GetIP returns the control plane endpoint for the cluster.
-func (a *Actuator) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	clusterContext, err := context.NewClusterContext(&context.ClusterContextParams{
-		Cluster:    cluster,
-		Client:     a.client,
-		CoreClient: a.coreClient,
-	})
-	if err != nil {
-		return "", err
-	}
-	machineContext, err := context.NewMachineContextFromClusterContext(clusterContext, machine)
-	if err != nil {
-		return "", err
-	}
-	return machineContext.ControlPlaneEndpoint()
-}
-
-// GetKubeConfig returns the contents of a Kubernetes configuration file that
-// may be used to access the cluster.
-func (a *Actuator) GetKubeConfig(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	clusterContext, err := context.NewClusterContext(&context.ClusterContextParams{
-		Cluster:    cluster,
-		Client:     a.client,
-		CoreClient: a.coreClient,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if machine == nil {
-		return kubeclient.GetKubeConfig(clusterContext)
-	}
-
-	machineContext, err := context.NewMachineContextFromClusterContext(clusterContext, machine)
-	if err != nil {
-		return "", err
-	}
-
-	return kubeclient.GetKubeConfig(machineContext)
 }
 
 func (a *Actuator) reconcilePKI(ctx *context.ClusterContext) error {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -23,6 +23,19 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/kubeclient"
 )
 
+var d Deployer
+
+// GetIP returns the control plane endpoint for the cluster.
+func GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
+	return d.GetIP(cluster, machine)
+}
+
+// GetKubeConfig returns the contents of a Kubernetes configuration file that
+// may be used to access the cluster.
+func GetKubeConfig(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
+	return d.GetKubeConfig(cluster, machine)
+}
+
 // Deployer satisfies the ProviderDeployer (https://github.com/kubernetes-sigs/cluster-api/blob/master/cmd/clusterctl/clusterdeployer/clusterdeployer.go) interface.
 type Deployer struct{}
 
@@ -31,6 +44,9 @@ func (d Deployer) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) 
 	clusterContext, err := context.NewClusterContext(&context.ClusterContextParams{Cluster: cluster})
 	if err != nil {
 		return "", err
+	}
+	if machine == nil {
+		return clusterContext.ControlPlaneEndpoint()
 	}
 	machineContext, err := context.NewMachineContextFromClusterContext(clusterContext, machine)
 	if err != nil {
@@ -45,6 +61,9 @@ func (d Deployer) GetKubeConfig(cluster *clusterv1.Cluster, machine *clusterv1.M
 	clusterContext, err := context.NewClusterContext(&context.ClusterContextParams{Cluster: cluster})
 	if err != nil {
 		return "", err
+	}
+	if machine == nil {
+		return kubeclient.GetKubeConfig(clusterContext)
 	}
 	machineContext, err := context.NewMachineContextFromClusterContext(clusterContext, machine)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This package removes the functions GetIP and GetKubeConfig from the Cluster actuator and has it defer to pkg/deployer for the analogous logic. This removes any confusion about the two functions as they existed in the Cluster actuator. They were not to get any special values from secrets, etc. They were just to perform the exact same behavior as from the deployer package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```