### PR TITLE
Distroless manager image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,38 @@
-# Build the manager binary
-FROM golang:1.12 as builder
+################################################################################
+##                               BUILD ARGS                                   ##
+################################################################################
+# This build arg allows the specification of a custom Golang image.
+ARG GOLANG_IMAGE=golang:1.12.6
 
-# Copy in the go src
+# The distroless image on which the CAPV manager image is built.
+#
+# Please do not use "latest". Explicit tags should be used to provide
+# deterministic builds. This image doesn't have semantic version tags, but
+# the fully-qualified image can be obtained by entering
+# "gcr.io/distroless/static:latest" in a browser and then copying the
+# fully-qualified image from the web page.
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:48e0d165f07d499c02732d924e84efbc73df8021b12c24940e18a9306589430e
+
+################################################################################
+##                              BUILD STAGE                                   ##
+################################################################################
+# Build the manager as a statically compiled binary so it has no dependencies
+# libc, muscl, etc. This allows the binary to be shipped inside of a static,
+# distroless container image.
+FROM ${GOLANG_IMAGE} as builder
 WORKDIR /build
 COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
+ENV CGO_ENABLED=0
+RUN go build -mod=vendor -a -ldflags='-w -s -extldflags="static"' -o manager ./cmd/manager
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod vendor -a -o manager ./cmd/manager
-
-# Copy the controller-manager into a thin image
-FROM debian:stretch-slim
-WORKDIR /root/
-
-RUN apt-get update && apt-get install -y ca-certificates openssh-client
-
-COPY --from=builder /build/manager .
-ENTRYPOINT ["./manager"]
+################################################################################
+##                               MAIN STAGE                                   ##
+################################################################################
+# Copy the manager into the distroless image.
+FROM ${DISTROLESS_IMAGE}
+LABEL "maintainer" "Andrew Kutz <akutz@vmware.com>"
+COPY --from=builder /build/manager /manager
+ENTRYPOINT [ "/manager" ]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
         operator: Exists
       containers:
       - command:
-        - /root/manager
+        - /manager
         image: controller:latest
         name: manager
         volumeMounts:

--- a/scripts/e2e/bootstrap_job/spec/provider-components.template
+++ b/scripts/e2e/bootstrap_job/spec/provider-components.template
@@ -1101,7 +1101,7 @@ spec:
         - --logtostderr
         - -v=6
         command:
-        - /root/manager
+        - /manager
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates the CAPV manager image to a static, distroless image. This saves space as well as enhances security by removing possible attack vectors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #258

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* CAPV manager now based on Google's static, distroless image
```