### PR TITLE
docs/getting_started.md: install clusterctl release binary vs building it

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -60,18 +60,18 @@ $ GO111MODULE="on" go get -mod readonly sigs.k8s.io/kind@v0.3.0
 
 #### clusterctl
 
-A version of `clusterctl` that is built from **this** repository must be installed. You can build `clusterctl` with docker using
-the `clusterctl-in-docker` make target:
+Install the official release binary of `clusterctl` for CAPV with the following:
 
 ```
-# set GOOS based on your environment (linux, darwin, windows, etc)
-$ GOOS=linux make clusterctl-in-docker
-```
+# Linux
+$ curl -Lo ./clusterctl.linux_amd64 https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.3.0/clusterctl.linux_amd64
+$ chmod +x ./clusterctl.linux_amd64
+$ sudo mv ./clusterctl.linux_amd64 /usr/local/bin/clusterctl
 
-The `clusterctl-in-docker` make target installs `clusterctl` in `bin/clusterctl`. Temporarily add this folder to your PATH to use it
-for the rest of this guide:
-```
-$ export PATH="$PATH:$(pwd)/bin"
+# Darwin
+$ curl -Lo ./clusterctl.darwin_amd64 https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.3.0/clusterctl.darwin_amd64
+$ chmod +x ./clusterctl.darwin_amd64
+$ sudo mv ./clusterctl.darwin_amd64 /usr/local/bin/clusterctl
 ```
 
 #### kubectl


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Update docs to install the official clusterctl binary instead of building clusterctl. Avoids building `clusterctl` against master which may not always be compatible with the release version of the provider manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```