### PR TITLE
Cloud provider credentials as secret

### DIFF
--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -23,6 +23,14 @@ import (
 )
 
 const (
+	// CloudProviderSecretName is the name of the Secret that stores the
+	// cloud provider credentials.
+	CloudProviderSecretName = "cloud-provider-vsphere-credentials"
+
+	// CloudProviderSecretNamespace is the namespace in which the cloud provider
+	// credentials secret is located.
+	CloudProviderSecretNamespace = "kube-system"
+
 	// DefaultBindPort is the default API port used to generate the kubeadm
 	// configurations.
 	DefaultBindPort = 6443

--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -95,13 +95,13 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 	// apply values based on the role of the machine
 	if ctx.HasControlPlaneRole() {
 		cloudConfig, err := userdata.NewCloudConfig(&userdata.CloudConfigInput{
-			User:         ctx.ClusterConfig.Username,
-			Password:     ctx.ClusterConfig.Password,
-			Server:       ctx.ClusterConfig.Server,
-			Datacenter:   ctx.MachineConfig.Datacenter,
-			ResourcePool: ctx.MachineConfig.ResourcePool,
-			Folder:       ctx.MachineConfig.Folder,
-			Datastore:    ctx.MachineConfig.Datastore,
+			SecretName:      constants.CloudProviderSecretName,
+			SecretNamespace: constants.CloudProviderSecretNamespace,
+			Server:          ctx.ClusterConfig.Server,
+			Datacenter:      ctx.MachineConfig.Datacenter,
+			ResourcePool:    ctx.MachineConfig.ResourcePool,
+			Folder:          ctx.MachineConfig.Folder,
+			Datastore:       ctx.MachineConfig.Datastore,
 			// assume the first VM network found for the vSphere cloud provider
 			Network: ctx.MachineConfig.Network.Devices[0].NetworkName,
 		})

--- a/pkg/cloud/vsphere/services/kubeclient/kubeclient.go
+++ b/pkg/cloud/vsphere/services/kubeclient/kubeclient.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeclient
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	remotev1 "sigs.k8s.io/cluster-api/pkg/controller/remote"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Context is used to get a Kubernetes client for a target cluster.
+type Context interface {
+	context.Context
+	GetCluster() *clusterv1.Cluster
+	GetControllerClient() controllerClient.Client
+}
+
+// New returns a new client for the target cluster using the KubeConfig
+// secret stored in the management cluster.
+func New(ctx Context) (corev1.CoreV1Interface, error) {
+	client, err := remotev1.NewClusterClient(ctx.GetControllerClient(), ctx.GetCluster())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get client for target cluster")
+	}
+	coreClient, err := client.CoreV1()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get core client for target cluster")
+	}
+	return coreClient, nil
+}

--- a/pkg/cloud/vsphere/services/userdata/controlplane.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane.go
@@ -25,12 +25,12 @@ import (
 
 const (
 	cloudConfig = `[Global]
+secret-name = "{{ .SecretName }}"
+secret-namespace = "{{ .SecretNamespace }}"
 insecure-flag = "1" # set to 1 if the vCenter uses a self-signed cert
 datacenters = "{{ .Datacenter }}"
 
 [VirtualCenter "{{ .Server }}"]
-user = "{{ .User }}"
-password = "{{ .Password }}"
 
 [Workspace]
 server = "{{ .Server }}"
@@ -253,14 +253,14 @@ type ContolPlaneJoinInput struct {
 // CloudConfigInput defines parameters required to generate the
 // vSphere Cloud Provider cloud config file
 type CloudConfigInput struct {
-	User         string
-	Password     string
-	Server       string
-	Datacenter   string
-	ResourcePool string
-	Folder       string
-	Datastore    string
-	Network      string
+	SecretName      string
+	SecretNamespace string
+	Server          string
+	Datacenter      string
+	ResourcePool    string
+	Folder          string
+	Datastore       string
+	Network         string
 }
 
 func (cpi *ControlPlaneInput) validateCertificates() error {

--- a/pkg/cloud/vsphere/services/userdata/controlplane_test.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package userdata
 
-import "testing"
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+)
 
 func TestTemplateYAMLIndent(t *testing.T) {
 	testcases := []struct {
@@ -60,22 +64,22 @@ func Test_CloudConfig(t *testing.T) {
 		{
 			name: "standard cloud config",
 			input: &CloudConfigInput{
-				User:         "admin",
-				Password:     "so_secure",
-				Server:       "10.0.0.1",
-				Datacenter:   "myprivatecloud",
-				ResourcePool: "deadpool",
-				Folder:       "vms",
-				Datastore:    "infinite-data",
-				Network:      "connected",
+				SecretName:      constants.CloudProviderSecretName,
+				SecretNamespace: constants.CloudProviderSecretNamespace,
+				Server:          "10.0.0.1",
+				Datacenter:      "myprivatecloud",
+				ResourcePool:    "deadpool",
+				Folder:          "vms",
+				Datastore:       "infinite-data",
+				Network:         "connected",
 			},
 			userdata: `[Global]
+secret-name = "` + constants.CloudProviderSecretName + `"
+secret-namespace = "` + constants.CloudProviderSecretNamespace + `"
 insecure-flag = "1" # set to 1 if the vCenter uses a self-signed cert
 datacenters = "myprivatecloud"
 
 [VirtualCenter "10.0.0.1"]
-user = "admin"
-password = "so_secure"
 
 [Workspace]
 server = "10.0.0.1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch changes the way the cloud provider obtains its credential information. Instead of directly via the cloud config file, a Kubernetes Secret object is created on the target cluster used by the cloud
provider. This is a much more secure design as credentials are no longer transported via the GuestInfo RPC mechanism as base64-encoded, plain-text data, over an unencrypted transport.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #194

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* The cloud provider credentials are now transported securely and stored/accessed as a Kubernetes secret "kube-system/cloud-provider-vsphere-credentials"
```