### PR TITLE
Support a custom, default requeue period

### DIFF
--- a/pkg/cloud/vsphere/actuators/cluster/actuator.go
+++ b/pkg/cloud/vsphere/actuators/cluster/actuator.go
@@ -36,6 +36,7 @@ import (
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/actuators"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/config"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/certificates"
@@ -151,16 +152,16 @@ func (a *Actuator) reconcileReadyState(ctx *context.ClusterContext) error {
 	client, err := remotev1.NewClusterClient(a.controllerClient, ctx.Cluster)
 	if err != nil {
 		ctx.Logger.Error(err, "unable to get client for target cluster")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 	coreClient, err := client.CoreV1()
 	if err != nil {
 		ctx.Logger.Error(err, "unable to get core client for target cluster")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 	if _, err := coreClient.Nodes().List(metav1.ListOptions{}); err != nil {
 		ctx.Logger.Error(err, "unable to list nodes for target cluster")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 
 	// Get the RESTConfig in order to parse its Host to use as the control plane
@@ -168,7 +169,7 @@ func (a *Actuator) reconcileReadyState(ctx *context.ClusterContext) error {
 	restConfig := client.RESTConfig()
 	if restConfig == nil {
 		ctx.Logger.Error(errors.New("restConfig == nil"), "error getting RESTConfig for kube client")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 
 	// Calculate the API endpoint for the cluster.
@@ -214,7 +215,7 @@ func (a *Actuator) reconcileCloudConfigSecret(ctx *context.ClusterContext) error
 	client, err := kubeclient.New(ctx)
 	if err != nil {
 		ctx.Logger.Error(err, "target cluster is not ready")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 	// Define the kubeconfig secret for the target cluster.
 	secret := &apiv1.Secret{
@@ -233,7 +234,7 @@ func (a *Actuator) reconcileCloudConfigSecret(ctx *context.ClusterContext) error
 			return nil
 		}
 		ctx.Logger.Error(err, "unable to create cloud provider secret")
-		return &clusterErr.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 
 	ctx.Logger.V(6).Info("created cloud provider credential secret",

--- a/pkg/cloud/vsphere/config/config.go
+++ b/pkg/cloud/vsphere/config/config.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"time"
+)
+
+var (
+	// DefaultRequeue is the default time for how long to wait when
+	// requeueing a CAPI operation.
+	DefaultRequeue = 20 * time.Second
+)

--- a/pkg/cloud/vsphere/constants/constants.go
+++ b/pkg/cloud/vsphere/constants/constants.go
@@ -17,8 +17,6 @@ limitations under the License.
 package constants
 
 import (
-	"time"
-
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphere"
 )
 
@@ -34,10 +32,6 @@ const (
 	// DefaultBindPort is the default API port used to generate the kubeadm
 	// configurations.
 	DefaultBindPort = 6443
-
-	// DefaultRequeue is the default time for how long to wait when
-	// requeueing a CAPI operation.
-	DefaultRequeue = 20 * time.Second
 
 	// VSphereCredentialSecretUserKey is the key used to store/retrieve the
 	// vSphere username from a Kubernetes secret.

--- a/pkg/cloud/vsphere/services/govmomi/delete.go
+++ b/pkg/cloud/vsphere/services/govmomi/delete.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/vim25/types"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/config"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
 )
@@ -53,7 +53,7 @@ func Delete(ctx *context.MachineContext) error {
 		}
 		ctx.MachineStatus.TaskRef = task.Reference().Value
 		ctx.Logger.V(6).Info("reenqueue to wait for power off op")
-		return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+		return &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
 
 	// At this point the VM is not powered on and can be destroyed. Store the
@@ -65,5 +65,5 @@ func Delete(ctx *context.MachineContext) error {
 	}
 	ctx.MachineStatus.TaskRef = task.Reference().Value
 	ctx.Logger.V(6).Info("reenqueue to wait for destroy op")
-	return &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+	return &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 }

--- a/pkg/cloud/vsphere/services/govmomi/util.go
+++ b/pkg/cloud/vsphere/services/govmomi/util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphere/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/config"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/govmomi/net"
 	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
@@ -184,10 +184,10 @@ func lookupVM(ctx *context.MachineContext) (*object.VirtualMachine, error) {
 		switch task.Info.State {
 		case types.TaskInfoStateQueued:
 			ctx.Logger.V(4).Info("task is still pending", "description-id", task.Info.DescriptionId)
-			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+			return nil, &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 		case types.TaskInfoStateRunning:
 			ctx.Logger.V(4).Info("task is still running", "description-id", task.Info.DescriptionId)
-			return nil, &clustererror.RequeueAfterError{RequeueAfter: constants.DefaultRequeue}
+			return nil, &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 		case types.TaskInfoStateSuccess:
 			ctx.Logger.V(4).Info("task is a success", "description-id", task.Info.DescriptionId)
 			ctx.MachineStatus.TaskRef = ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch introduces support for a custom, default requeue period via the env var `REQUEUE_PERIOD` and/or flag `--requeue-period`. Both take a value parseable by time.ParseDuration. The default value is `20s`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #417

**Special notes for your reviewer**:
Hi @moshloop,

After thinking on this some more, a global value **does** make sense. I conflated the idea of global with something else, and we'll chalk it up to a brain-fart. Thanks for staying on top of this!

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* The CAPV manager's default requeue time may be set via environment variable "REQUEUE_PERIOD" or the flag "--requeue-period". Defaults to "20s".
```