### PR TITLE
Cluster actuator needs delete permission for secret.

### DIFF
--- a/pkg/cloud/vsphere/actuators/cluster/actuator.go
+++ b/pkg/cloud/vsphere/actuators/cluster/actuator.go
@@ -45,7 +45,7 @@ import (
 
 //+kubebuilder:rbac:groups=vsphere.cluster.k8s.io,resources=vsphereclusterproviderspecs;vsphereclusterproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=,resources=secrets,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=,resources=secrets,verbs=create;get;list;watch;delete
 //+kubebuilder:rbac:groups="",resources=nodes;events;configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Actuator is responsible for maintaining the Cluster objects.

--- a/pkg/cloud/vsphere/services/govmomi/extra/config.go
+++ b/pkg/cloud/vsphere/services/govmomi/extra/config.go
@@ -27,7 +27,7 @@ type Config []types.BaseOptionValue
 
 // SetCloudInitUserData sets the cloud init user data at the key
 // "guestinfo.userdata" as a base64-encoded string.
-func (e *Config) SetCloudInitUserData(data []byte) error {
+func (e *Config) SetCloudInitUserData(data []byte) {
 	*e = append(*e,
 		&types.OptionValue{
 			Key:   "guestinfo.userdata",
@@ -38,13 +38,11 @@ func (e *Config) SetCloudInitUserData(data []byte) error {
 			Value: "base64",
 		},
 	)
-
-	return nil
 }
 
 // SetCloudInitMetadata sets the cloud init user data at the key
 // "guestinfo.metadata" as a base64-encoded string.
-func (e *Config) SetCloudInitMetadata(data []byte) error {
+func (e *Config) SetCloudInitMetadata(data []byte) {
 	*e = append(*e,
 		&types.OptionValue{
 			Key:   "guestinfo.metadata",
@@ -55,6 +53,4 @@ func (e *Config) SetCloudInitMetadata(data []byte) error {
 			Value: "base64",
 		},
 	)
-
-	return nil
 }


### PR DESCRIPTION
Cluster delete is failing because  delete secret permission is missing.

Drive-by: Setters for extra config are returning errors which are not being handled, fix by
removing error return as it never returns error.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cluster delete is failing because secret delete permission is missing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add delete secret permission for cluster actuator.
```