### PR TITLE
Remove sig-vmware from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - sig-cluster-lifecycle-leads
-  - sig-vmware-leads
   - cluster-api-admins
   - cluster-api-vsphere-maintainers
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,9 +12,6 @@ aliases:
     - luxas
     - roberthbailey
     - kris-nova
-  sig-vmware-leads:
-    - frapposelli
-    - cantbewong
   cluster-api-vsphere-maintainers:
     - frapposelli
     - sflxn


### PR DESCRIPTION
This change is due to kubernetes/community#3895 that folds all the cloud provider SIGs into sig-cloud-provider