### PR TITLE
Match release tag script

### DIFF
--- a/hack/match-release-tag.sh
+++ b/hack/match-release-tag.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat <<EOF
+usage: ${0} [TAG]
+  Verifies the provided tag is a release tag.
+
+TAG
+  If no tag is provided then "git describe --dirty" is used to obtain the tag.
+
+FLAGS
+  -h    prints this help screen
+  -x    run the examples
+EOF
+}
+
+while getopts ':hx' opt; do
+  case "${opt}" in
+  h)
+    usage 1>&2; exit 1
+    ;;
+  x)
+    EXAMPLES=1
+    ;;
+  \?)
+    { echo "invalid option: -${OPTARG}"; usage; } 1>&2; exit 1
+    ;;
+  :)
+    echo "option -${OPTARG} requires an argument" 1>&2; exit 1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+# The regular expression matches the following strings:
+#   * v1.0.0-alpha.0
+#   * v1.0.0-beta.0
+#   * v1.0.0-rc.0
+#   * v1.0.0
+# Any occurence of a digit in the above examples may be multiple digits.
+REGEX='^[[:space:]]{0,}v[[:digit:]]{1,}\.[[:digit:]]{1,}\.[[:digit:]]{1,}(-(alpha|beta|rc)\.[[:digit:]]{1,}){0,1}[[:space:]]{0,}$'
+
+# Match the tag against the regular expression for a release tag.
+match() {
+  if [[ ${1} =~ ${REGEX} ]]; then
+    echo "yay: ${1}"
+  else
+    exit_code="${?}"
+    echo "nay: ${1}"
+    return "${exit_code}"
+  fi
+}
+
+# Run examples to illustrate valid and invalid values.
+examples() {
+  local semvers=" \
+    v1.0.0-alpha.0 \
+    v1.0.0-beta.0 \
+    v1.0.0-rc.0 \
+    v1.0.0 \
+    v10.0.0 \
+    v1.10.0 \
+    v1.0.10 \
+    v10.0.0-alpha.10 \
+    v1.10.0-beta.10 \
+    v1.0.10-rc.10 \
+    1.0.0 \
+    v1.0.0+rc.0 \
+    v10a.0.0 \
+    1.1.0-alpha.1 \
+    v1.0.0-alpha.0a"
+  set +o errexit
+  for v in ${semvers}; do match "${v}"; done
+  return 0
+}
+
+main() {
+  # Get the tag from the remaining arguments or from "git describe --dirty"
+  [ "${#}" -eq "0" ] || tag="${1}"
+  [ -n "${tag-}" ] || tag="$(git describe --dirty)"
+
+  # Match the tag against the regular expression for a release tag.
+  match "${tag}" 1>&2
+}
+
+{ [ "${EXAMPLES-}" ] && examples; } || main "${@-}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch adds a new script for matching a release tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
Related to #426

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```