### PR TITLE
Fix e2e unbound var PULL_PULL_SHA

### DIFF
--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -42,6 +42,9 @@ TARGET_VM_PRE=
 # RANDOM_STR holds a random string
 RANDOM_STR=""
 
+PROW_JOB_ID=${PROW_JOB_ID:-}
+PULL_PULL_SHA=${PULL_PULL_SHA:-}
+
 get_random_str() {
    if [ -z "${RANDOM_STR}" ]; then
       RANDOM_STR=$(date | { md5sum || md5; } 2>/dev/null | cut -c 1-8)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fixes error seen here: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cluster-api-provider-vsphere-ova-e2e/1151904458888712193

This started happening once we set `-o nounset`, but I missed that it was happening because it's only happening for the periodic, not the pre-submit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```