### PR TITLE
Bug fixes and improvements for v0.3.1

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -49,6 +49,8 @@ func main() {
 
 	flag.Parse()
 
+	klog.Info("Starting the vSphere cluster api provider manager")
+
 	if addr := *profilerAddr; addr != "" {
 		go runProfiler(addr)
 	}

--- a/pkg/cloud/vsphere/actuators/actuators.go
+++ b/pkg/cloud/vsphere/actuators/actuators.go
@@ -56,7 +56,7 @@ func PatchAndHandleError(ctx patchContext, opName string, opErr error) error {
 		// If the requeue error is not the outer-most error then log the outer-most
 		// error since it will be dropped in favor of the requeue.
 		if requeueErr != err {
-			ctx.GetLogger().V(6).Info("requeue after error", "object", ctx.String(), "error", err)
+			ctx.GetLogger().V(6).Info("requeue after error", "object", ctx.String(), "error", err.Error())
 		}
 		err = requeueErr
 	}

--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -39,8 +39,8 @@ const (
 	// hostnameLookup resolves via cloud init and uses cloud provider's metadata service to lookup its own hostname.
 	hostnameLookup = "{{ ds.meta_data.hostname }}"
 
-	// containerdSocket is the path to containerd socket.
-	containerdSocket = "/var/run/containerd/containerd.sock"
+	// criSocket is the path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value.
+	criSocket = ""
 
 	// nodeRole is the label assigned to every node in the cluster.
 	nodeRole = "node-role.kubernetes.io/node="
@@ -127,7 +127,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 					kubeadm.NewNodeRegistration(
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
-						kubeadm.WithCRISocket(containerdSocket),
+						kubeadm.WithCRISocket(criSocket),
 						kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),
 					),
 				),
@@ -206,7 +206,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 					kubeadm.NewNodeRegistration(
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
-						kubeadm.WithCRISocket(containerdSocket),
+						kubeadm.WithCRISocket(criSocket),
 						kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),
 					),
 				),
@@ -253,7 +253,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 			kubeadm.WithJoinNodeRegistrationOptions(
 				kubeadm.NewNodeRegistration(
 					kubeadm.WithNodeRegistrationName(hostnameLookup),
-					kubeadm.WithCRISocket(containerdSocket),
+					kubeadm.WithCRISocket(criSocket),
 					kubeadm.WithKubeletExtraArgs(map[string]string{
 						"cloud-provider": cloudProvider,
 					}),

--- a/pkg/cloud/vsphere/services/govmomi/util.go
+++ b/pkg/cloud/vsphere/services/govmomi/util.go
@@ -115,7 +115,7 @@ func sanitizeIPAddrs(ctx *context.MachineContext, ipAddrs []string) []string {
 	newIPAddrs := []string{}
 	for _, addr := range ipAddrs {
 		if err := net.ErrOnLocalOnlyIPAddr(addr); err != nil {
-			ctx.Logger.V(8).Info("ignoring IP address", "reason", err)
+			ctx.Logger.V(8).Info("ignoring IP address", "reason", err.Error())
 		} else {
 			newIPAddrs = append(newIPAddrs, addr)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
* cherry-picks https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/386 
* uses empty string for CRI socket which allows kubeadm to determine the CRI socket
* logs when the provider manager is started 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* cherry-picks https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/386 
* uses empty string for CRI socket which allows kubeadm to determine the CRI socket
* logs when the provider manager is started 
```