### PR TITLE
Removed unused Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,11 @@ CWD := $(abspath .)
 SHELL := hack/shell-with-gopath.sh
 
 # Image URL to use all building/pushing image targets
-PRODUCTION_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:0.3.0
 CI_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
 CLUSTERCTL_CI_IMG ?= gcr.io/cnx-cluster-api/clusterctl
-DEV_IMG ?= # <== NOTE:  outside dev, change this!!!
 
 # Retrieves the git hash
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-	   git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty)
 
 # Build manager binary
 manager: check
@@ -92,51 +89,9 @@ vendor:
 	cp -rf --no-preserve=mode "$${_src}" "$${_dst}"
 .PHONY: vendor
 
-####################################
-# DEVELOPMENT Build and Push targets
-####################################
-
-# Create YAML file for deployment
-dev-yaml:
-	CAPV_MANAGER_IMAGE=$(DEV_IMG) hack/generate-yaml.sh
-
-# Build the docker image
-dev-build: #test
-	docker build . -t $(DEV_IMG)
-
-# Push the docker image
-dev-push:
-	docker push $(DEV_IMG)
-
-.PHONY: dev-yaml dev-build dev-push
-
-###################################
-# PRODUCTION Build and Push targets
-###################################
-
-# Create YAML file for deployment
-prod-yaml:
-	CAPV_MANAGER_IMAGE=$(PRODUCTION_IMG) hack/generate-yaml.sh
-
-# Build the docker image
-prod-build: test
-	docker build . -t $(PRODUCTION_IMG)
-
-# Push the docker image
-prod-push:
-	@echo "logging into gcr.io registry with key file"
-	@docker login -u _json_key --password-stdin gcr.io <"$(GCR_KEY_FILE)"
-	docker push $(PRODUCTION_IMG)
-
-.PHONY: prod-yaml prod-build prod-push
-
 ###################################
 # CI Build and Push targets
 ###################################
-
-# Create YAML file for deployment into CI
-ci-yaml:
-	CAPV_MANAGER_IMAGE=$(CI_IMG) hack/generate-yaml.sh
 
 ci-image: generate fmt vet manifests
 	docker build . -t "$(CI_IMG):$(VERSION)"

--- a/scripts/e2e/bootstrap_job/Makefile
+++ b/scripts/e2e/bootstrap_job/Makefile
@@ -1,7 +1,6 @@
 # Makefile
 
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty)
 REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci
 
 all: build

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -166,8 +166,7 @@ vsphere_controller_version=""
 if [ -z "${PROW_JOB_ID}" ] ; then
    CONTEXT="debug"
    start_docker
-   vsphere_controller_version=$(shell git describe --exact-match 2> /dev/null || \
-      git describe --match="$(git rev-parse --short=8 HEAD)" --always --dirty --abbrev=8)
+   vsphere_controller_version=$(shell git describe --always --dirty)
 else
    CONTEXT="prow"
    if [ -z "${PULL_PULL_SHA}" ] ; then

--- a/scripts/e2e/hack/Makefile
+++ b/scripts/e2e/hack/Makefile
@@ -1,17 +1,16 @@
 # Makefile
 
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty)
 REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci-debug
 
 all: build push clean
 .PHONY : all
 
 .PHONY : build
-build: 
+build:
 	cd ../../../../ && docker build . -f ./cluster-api-provider-vsphere/scripts/e2e/hack/Dockerfile --tag $(REGISTRY):$(VERSION)
 	docker tag $(REGISTRY):$(VERSION) $(REGISTRY):debug
-        
+
 push: build
 	@echo "logging into gcr.io registry with key file"
 	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io


### PR DESCRIPTION

**What this PR does / why we need it**:
This patch removes unused Makefile targets as a step towards using the
new hack/release.sh script. To that end, we also standardize the version
string retrieved via `git describe` across the project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I believe this should still allow the e2e tests to work. I'm doing this is in small pieces so I don't break anything along the way. I tried doing more at first, but there are a lot of moving parts. This should be a simple one we can first.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```