### PR TITLE
Change e2e script/job to use new image locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ CWD := $(abspath .)
 #      nested GOPATH.
 SHELL := hack/shell-with-gopath.sh
 
-# Image URL to use all building/pushing image targets
-CI_IMG ?= gcr.io/cnx-cluster-api/vsphere-cluster-api-provider
-CLUSTERCTL_CI_IMG ?= gcr.io/cnx-cluster-api/clusterctl
-
 # Retrieves the git hash
 VERSION ?= $(shell git describe --always --dirty)
 
@@ -88,24 +84,6 @@ vendor:
 	mkdir -p "$${_dst}" && \
 	cp -rf --no-preserve=mode "$${_src}" "$${_dst}"
 .PHONY: vendor
-
-###################################
-# CI Build and Push targets
-###################################
-
-ci-image: generate fmt vet manifests
-	docker build . -t "$(CI_IMG):$(VERSION)"
-	docker build . -f cmd/clusterctl/Dockerfile -t "$(CLUSTERCTL_CI_IMG):$(VERSION)"
-
-ci-push: ci-image
-# Log into the registry with a service account file.  In CI, GCR_KEY_FILE contains the content and not the file name.
-	@echo "logging into gcr.io registry with key file"
-	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io
-	docker push "$(CI_IMG):$(VERSION)"
-	docker push "$(CLUSTERCTL_CI_IMG):$(VERSION)"
-	@echo docker logout gcr.io
-
-.PHONY: ci-yaml ci-image ci-push
 
 ################################################################################
 ##                          The default targets                               ##

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -139,7 +139,9 @@ function login() {
   # If GCR_KEY_FILE is set, use that service account to login
   if [ "${GCR_KEY_FILE}" ]; then
     trap logout EXIT
+    gcloud auth configure-docker --quiet || fatal "unable to add docker auth helper"
     gcloud auth activate-service-account --key-file "${GCR_KEY_FILE}" || fatal "unable to login"
+    docker login -u _json_key --password-stdin https://gcr.io <"${GCR_KEY_FILE}"
     AUTH=1
   fi
 }

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -67,7 +67,7 @@ test-infra/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere
 
 ## Containers
 
-The CAPV manager images are hosted at [`gcr.io/cnx-cluster-api/vsphere-cluster-api-provider`](gcr.io/cnx-cluster-api/vsphere-cluster-api-provider). The images for CI are hosted at [`gcr/cnx-cluster-api/cluster-api-provider-vsphere-ci`](gcr/cnx-cluster-api/cluster-api-provider-vsphere-ci).
+The CAPV manager images are hosted at [`gcr.io/cluster-api-provider-vsphere`](gcr.io/cluster-api-provider-vsphere).
 
 ## Test CI locally
 

--- a/scripts/e2e/bootstrap_job.template
+++ b/scripts/e2e/bootstrap_job.template
@@ -9,17 +9,12 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-      initContainers:
-      - name: clusterctl-bin
-        image: gcr.io/cnx-cluster-api/clusterctl:${VERSION}
-        command: ['sh', '-c', 'cp /root/clusterctl /tmp/clusterctl/clusterctl && chmod +x /tmp/clusterctl/clusterctl']
-        volumeMounts:
-          - name: shared-data
-            mountPath: /tmp/clusterctl
       containers:
       - name: cluster-api-provider-vsphere-ci
-        image: gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci:${VERSION}
+        image: gcr.io/cluster-api-provider-vsphere/pr/ci:${VERSION}
         env:
+          - name: CLUSTERCTL_VERSION
+            value: ${VERSION}
           - name: TARGET_VM_PREFIX
             valueFrom:
               secretKeyRef:
@@ -65,12 +60,6 @@ spec:
               secretKeyRef:
                 name: clusterapi-provider-vsphere-ci-secret
                 key: bootstrap-kubeconfig
-        volumeMounts:
-          - name: shared-data
-            mountPath: /tmp/clusterctl/
         command:
         - "./clusterctl.sh"
-      volumes:
-      - name: shared-data
-        emptyDir: {}
       restartPolicy: Never

--- a/scripts/e2e/bootstrap_job/Makefile
+++ b/scripts/e2e/bootstrap_job/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 
 VERSION ?= $(shell git describe --always --dirty)
-REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci
+REGISTRY ?=gcr.io/cluster-api-provider-vsphere/pr/ci
 
 all: build
 .PHONY : all
@@ -16,9 +16,12 @@ build: copyspec
 
 push: build
 	@echo "logging into gcr.io registry with key file"
-	@echo $$GCR_KEY_FILE | docker login -u _json_key --password-stdin gcr.io
+	# TODO hardcoded key file location is a temp workaround
+	gcloud auth activate-service-account --key-file /root/.capv/keyfile.json
+	docker login -u _json_key --password-stdin gcr.io </root/.capv/keyfile.json
 	docker push $(REGISTRY):$(VERSION)
 	@echo docker logout gcr.io
+	gcloud auth revoke
 
 clean:
 	docker image rm -f $(REGISTRY):$(VERSION)

--- a/scripts/e2e/bootstrap_job/clusterctl.sh
+++ b/scripts/e2e/bootstrap_job/clusterctl.sh
@@ -59,18 +59,22 @@ do
    fi
 done
 wget https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl \
-     --no-verbose -O /usr/local/bin/kubectl
+    --no-verbose -O /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
 
+# download clusterctl binary
+wget https://storage.googleapis.com/capv-pr/"${CLUSTERCTL_VERSION}"/bin/linux/amd64/clusterctl \
+    --no-verbose -O /usr/local/bin/clusterctl
+chmod +x /usr/local/bin/clusterctl
 
 # run clusterctl
 echo "test ${PROVIDER_COMPONENT_SPEC}"
-/tmp/clusterctl/clusterctl create cluster -e ~/.kube/config -c ./spec/cluster.yml \
+clusterctl create cluster -e ~/.kube/config -c ./spec/cluster.yml \
     -m ./spec/machines.yml \
     -p ./spec/"${PROVIDER_COMPONENT_SPEC}" \
     -a ./spec/addons.yml \
     --provider vsphere \
-    -v 6 
+    -v 6
 
 ret=$?
 if [ "$ret" != 0 ]; then

--- a/scripts/e2e/hack/Makefile
+++ b/scripts/e2e/hack/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 
 VERSION ?= $(shell git describe --always --dirty)
-REGISTRY ?=gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci-debug
+REGISTRY ?=gcr.io/cluster-api-provider-vsphere/pr/ci-debug
 
 all: build push clean
 .PHONY : all

--- a/scripts/e2e/hack/job.yml
+++ b/scripts/e2e/hack/job.yml
@@ -11,7 +11,7 @@ spec:
         key: node-role.kubernetes.io/master
       containers:
       - name: cluster-api-provider-vsphere-ci
-        image: gcr.io/cnx-cluster-api/cluster-api-provider-vsphere-ci-debug:debug
+        image: gcr.io/cluster-api-provider-vsphere/pr/ci-debug:debug
         imagePullPolicy: Never
         securityContext:
           privileged: true


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates e2e.sh and related pieces to use images located at
gcr.io/cluster-api-provider-vsphere/pr instead of the previous location.

It also eliminates the need for a temporary 'clusterctl' container image
as part of the e2e process, because that binary is now being pushed as
part of the automated builds. Therefore we just download the binary
instead of building and pushing a new image just to copy the binary out
of it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@akutz You'll see in the `e2e.sh` script the use of `-k` with `release.sh`. This is why I needed that change in Prow. The e2e tests at this stage need all of the env var sets from that first secret, but that secret also sets `GCR_KEY_FILE`, which would make the `release.sh` script fail... I need all of this stuff to work first and then we can remove `GCR_KEY_FILE` from the first set of exports and then remove this.

I realize I have missed a step, though. I didn't add the preset with the key file to the e2e test. I need to do that before this test will pass. Darn. Back to Prow!

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```