### PR TITLE
Fix issue generating manifests due to Docker perms

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -94,6 +94,7 @@ With the above environment variable file it is now possible to generate the mani
 
 ```shell
 $ docker run --rm \
+  --user "$(id -u):$(id -g)" \
   -v "$(pwd)/management-cluster":/out \
   -v "$(pwd)/envvars.txt":/out/envvars.txt:ro \
   gcr.io/cluster-api-provider-vsphere/release/manifests:latest \
@@ -142,6 +143,7 @@ Using the same Docker command as above, generate resources for a new cluster, th
 
 ```shell
 docker run --rm \
+  --user "$(id -u):$(id -g)" \
   -v "$(pwd)/workload-cluster-1":/out \
   -v "$(pwd)/envvars.txt":/out/envvars.txt:ro \
   gcr.io/cluster-api-provider-vsphere/release/manifests:latest \

--- a/hack/tools/generate-yaml/Dockerfile
+++ b/hack/tools/generate-yaml/Dockerfile
@@ -49,6 +49,9 @@ COPY ./vendor/sigs.k8s.io/cluster-api/config ./vendor/sigs.k8s.io/cluster-api/co
 # Copy in the examples directory.
 COPY ./cmd/clusterctl/examples/vsphere/*.template ./cmd/clusterctl/examples/vsphere/
 
+# Ensure all the directories in the /build directory are writeable.
+RUN find . -type d -exec chmod 0777 \{\} \;
+
 # This build arg specifies the value of the -m flag for generate-yaml.sh, the
 # CAPV manager image inserted into the generated provider components.
 ARG CAPV_MANAGER_IMAGE=gcr.io/cnx-cluster-api/vsphere-cluster-api-provider:latest


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes an issue with generating manifests using the manifests image due to Docker permissions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #453

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```