### PR TITLE
docs/getting_started.md: document workaround for linux mount permission issues

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -93,6 +93,10 @@ EOF
 With the above environment variable file it is now possible to generate the manifests needed to bootstrap the management cluster. The following command uses Docker to run an image that has all of the necessary templates and tools to generate the YAML manifests. Please note that the example mounts the current directory as the location where the YAML will be generated. Additionally, the `envvars.txt` file created above is mounted inside the the image in order to provide the generation routine with its default values:
 
 ```shell
+# create the output directory for the management cluster manifests,
+# only required for Linux to work around permissions issues on volume mounts
+$ mkdir -p management-cluster
+
 $ docker run --rm \
   --user "$(id -u):$(id -g)" \
   -v "$(pwd)/management-cluster":/out \
@@ -142,12 +146,16 @@ With your management cluster bootstrapped, it's time to reap the benefits of Clu
 Using the same Docker command as above, generate resources for a new cluster, this time with a different name:
 
 ```shell
-docker run --rm \
-  --user "$(id -u):$(id -g)" \
-  -v "$(pwd)/workload-cluster-1":/out \
-  -v "$(pwd)/envvars.txt":/out/envvars.txt:ro \
-  gcr.io/cluster-api-provider-vsphere/release/manifests:latest \
-  -c workload-cluster-1
+# create the output directory for the workload cluster manifests,
+# only required for Linux to work around permissions issues on volume mounts
+$ mkdir -p workload-cluster-1
+
+$ docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -v "$(pwd)/workload-cluster-1":/out \
+    -v "$(pwd)/envvars.txt":/out/envvars.txt:ro \
+    gcr.io/cluster-api-provider-vsphere/release/manifests:latest \
+    -c workload-cluster-1
 ```
 
 **NOTE**: The above step is not required to manage your Cluster API resources at this point but is used to simplify this guide. You should manage your Cluster API resources in the same way you would manage your Kubernetes application manifests. Please use the generated manifests only as a reference.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Document a workaround for docker volume mounts not being accessible to the current host user. 

```
$ docker run --rm   --user "$(id -u):$(id -g)"   -v "$(pwd)/management-cluster":/out   -v "$(pwd)/envvars.txt":/out/envvars.txt:ro   gcr.io/cluster-api-provider-vsphere/release/manifests:v0.4.0-beta.1   -c management-cluster
./hack/generate-yaml.sh: line 179: /out/addons.yaml: Permission denied
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```