### PR TITLE
Fix login issues in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -139,7 +139,9 @@ function login() {
   # If GCR_KEY_FILE is set, use that service account to login
   if [ "${GCR_KEY_FILE}" ]; then
     trap logout EXIT
+    gcloud auth configure-docker --quiet || fatal "unable to add docker auth helper"
     gcloud auth activate-service-account --key-file "${GCR_KEY_FILE}" || fatal "unable to login"
+    docker login -u _json_key --password-stdin https://gcr.io <"${GCR_KEY_FILE}"
     AUTH=1
   fi
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Since hack/release.sh uses both docker push and gsutil, we need to login
to docker explicitly as well as gcloud. We also configure gcloud docker
auth helper.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I feel like i"m close with the E2E test PR, but might as well get this working sooner rather than later. :)

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @akutz