### PR TITLE
Fixes YAML generation issues with Docker

### DIFF
--- a/hack/tools/generate-yaml/Dockerfile
+++ b/hack/tools/generate-yaml/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get --assume-no update && apt-get -y install curl python
 COPY --from=kustomize /kustomize /usr/local/bin/kustomize
 
 # Run things out of the /build directory.
+ENV BUILDDIR /build
 WORKDIR /build
 
 # Copy in the hack tooling.
@@ -57,7 +58,11 @@ RUN find . -type d -exec chmod 0777 \{\} \;
 ARG CAPV_MANAGER_IMAGE=gcr.io/cluster-api-provider-vsphere/ci/manager:latest
 ENV CAPV_MANAGER_IMAGE=${CAPV_MANAGER_IMAGE}
 
-# The YAML is always written to the /out directory. Mount the volumes there.
-ENV OUT_DIR /out
+# Change the working directory to /.
+ENV WORKDIR /out
+WORKDIR /out
 
-ENTRYPOINT [ "./hack/generate-yaml.sh" ]
+# Indicate that this is being execute in a container.
+ENV DOCKER_ENABLED 1
+
+ENTRYPOINT [ "/build/hack/generate-yaml.sh" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes incompatibilities with generating manifests using Docker on macOS vs Linux. Changes include:

* Removes the need to pass in the host's user and group IDs
* Mounts `envvars.txt` to `/envvars.txt` in the container
* Paths printed during generation from inside the container are still valid externally on the host
* The current directory should always be mounted to `/out`

Here are two examples on macOS and Linux:

**macOS**

```shell
$ uname -s
Darwin

$ ls out/management-cluster
ls: out/management-cluster: No such file or directory

$ docker run --rm \
>   -v "$(pwd)":/out \
>   -v "$(pwd)/envvars.txt":/envvars.txt:ro \
>   akutz/capv-manifests:latest \
>   -c management-cluster
done generating ./out/management-cluster/addons.yaml
done generating ./config/default/manager_image_patch.yaml
done generating ./out/management-cluster/cluster.yaml
done generating ./out/management-cluster/machines.yaml
done generating ./out/management-cluster/machineset.yaml
done generating ./out/management-cluster/provider-components.yaml

*** Finished creating initial example yamls in ./out/management-cluster

    The files ./out/management-cluster/cluster.yaml and ./out/management-cluster/machines.yaml need to be updated
    with information about the desired Kubernetes cluster and vSphere environment
    on which the Kubernetes cluster will be created.

Enjoy!

$ ls -al out/management-cluster/
total 264
drwxr-xr-x@ 7 akutz  staff   224B Jul 25 16:31 ./
drwxr-xr-x  4 akutz  staff   128B Jul 25 16:31 ../
-rw-r--r--@ 1 akutz  staff    19K Jul 25 16:31 addons.yaml
-rw-r--r--@ 1 akutz  staff   1.2K Jul 25 16:31 cluster.yaml
-rw-r--r--@ 1 akutz  staff   792B Jul 25 16:31 machines.yaml
-rw-r--r--@ 1 akutz  staff   1.0K Jul 25 16:31 machineset.yaml
-rw-r--r--@ 1 akutz  staff    99K Jul 25 16:31 provider-components.yaml
```

**Linux**

```shell
$ uname -s
Linux

$ ls out/management-cluster
ls: cannot access out/management-cluster: No such file or directory

$ docker run --rm \
>   -v "$(pwd)":/out \
>   -v "$(pwd)/envvars.txt":/envvars.txt:ro \
>   akutz/capv-manifests:latest \
>   -c management-cluster
done generating ./out/management-cluster/addons.yaml
done generating ./config/default/manager_image_patch.yaml
done generating ./out/management-cluster/cluster.yaml
done generating ./out/management-cluster/machines.yaml
done generating ./out/management-cluster/machineset.yaml
done generating ./out/management-cluster/provider-components.yaml

*** Finished creating initial example yamls in ./out/management-cluster

    The files ./out/management-cluster/cluster.yaml and ./out/management-cluster/machines.yaml need to be updated
    with information about the desired Kubernetes cluster and vSphere environment
    on which the Kubernetes cluster will be created.

Enjoy!

$ ls -al out/management-cluster/
total 132
drwxr-xr-x. 2 akutz akutz    121 Jul 25 16:33 .
drwxr-xr-x. 5 akutz akutz     57 Jul 25 16:33 ..
-rw-r--r--. 1 akutz akutz  19828 Jul 25 16:33 addons.yaml
-rw-r--r--. 1 akutz akutz   1249 Jul 25 16:33 cluster.yaml
-rw-r--r--. 1 akutz akutz   1035 Jul 25 16:33 machineset.yaml
-rw-r--r--. 1 akutz akutz    792 Jul 25 16:33 machines.yaml
-rw-r--r--. 1 akutz akutz 101240 Jul 25 16:33 provider-components.yaml
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Please test the macOS and Linux examples. The image listed in the examples was built from this PR, but if you want to build one yourself, just run the following from the root of this repo:

```shell
docker build -t IMAGE_NAME -f hack/tools/generate-yaml/Dockerfile .
```

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Portable manifest generation across macOS and Linux
```