### PR TITLE
Do not error on multiple network devices if at least one has a valid IP address

### DIFF
--- a/pkg/cloud/vsphere/context/cluster_context.go
+++ b/pkg/cloud/vsphere/context/cluster_context.go
@@ -309,13 +309,14 @@ func (c *ClusterContext) ControlPlaneEndpoint() (string, error) {
 		return "", errors.Wrap(err, "error creating machine context while searching for control plane endpoint")
 	}
 
-	if ipAddr := machineCtx.IPAddr(); ipAddr != "" {
-		controlPlaneEndpoint := net.JoinHostPort(ipAddr, strconv.Itoa(int(machineCtx.BindPort())))
-		machineCtx.Logger.V(2).Info("got control plane endpoint from machine", "control-plane-endpoint", controlPlaneEndpoint)
-		return controlPlaneEndpoint, nil
+	ipAddr, err := machineCtx.IPAddr()
+	if err != nil {
+		return "", errors.Wrap(err, "error getting first IP address for machine")
 	}
 
-	return "", errors.New("unable to get control plane endpoint")
+	controlPlaneEndpoint := net.JoinHostPort(ipAddr, strconv.Itoa(int(machineCtx.BindPort())))
+	machineCtx.Logger.V(2).Info("got control plane endpoint from machine", "control-plane-endpoint", controlPlaneEndpoint)
+	return controlPlaneEndpoint, nil
 }
 
 // Patch updates the object and its status on the API server.

--- a/pkg/cloud/vsphere/services/govmomi/update.go
+++ b/pkg/cloud/vsphere/services/govmomi/update.go
@@ -154,10 +154,6 @@ func reconcileNetwork(ctx *context.MachineContext, vm *object.VirtualMachine) er
 	}
 	if powerState == types.VirtualMachinePowerStatePoweredOn {
 		for _, netStatus := range ctx.MachineStatus.Network {
-			if len(netStatus.IPAddrs) == 0 {
-				ctx.Logger.V(6).Info("reenqueue to wait on IP addresses")
-				return &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
-			}
 			for _, ip := range netStatus.IPAddrs {
 				ipAddrs = append(ipAddrs, corev1.NodeAddress{
 					Type:    corev1.NodeInternalIP,
@@ -165,6 +161,12 @@ func reconcileNetwork(ctx *context.MachineContext, vm *object.VirtualMachine) er
 				})
 			}
 		}
+
+		if len(ipAddrs) == 0 {
+			ctx.Logger.V(6).Info("requeuing to wait on IP addresses")
+			return &clustererror.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
+		}
+
 	}
 
 	// Use the collected IP addresses to assign the Machine's addresses.


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
In the case where there are multiple network devices and one of them returns a valid control plane endpoint, the machine actuator could still error if the other network devices don't return an IP address. The actuator should succeed if at least one network device returns a valid address.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/469

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Relaxes network requirements for VMs to support a multi-network device configuration when only a single network device has a valid IP address
```