### PR TITLE
Remove E2E use of hardcoded path to key file

### DIFF
--- a/scripts/e2e/bootstrap_job/Makefile
+++ b/scripts/e2e/bootstrap_job/Makefile
@@ -17,8 +17,8 @@ build: copyspec
 push: build
 	@echo "logging into gcr.io registry with key file"
 	# TODO hardcoded key file location is a temp workaround
-	gcloud auth activate-service-account --key-file /root/.capv/keyfile.json
-	docker login -u _json_key --password-stdin gcr.io </root/.capv/keyfile.json
+	gcloud auth activate-service-account --key-file $(GCR_KEY_FILE)
+	docker login -u _json_key --password-stdin gcr.io <"$(GCR_KEY_FILE)"
 	docker push $(REGISTRY):$(VERSION)
 	@echo docker logout gcr.io
 	gcloud auth revoke

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -182,8 +182,7 @@ export_base64_value "TARGET_VM_PREFIX" "${TARGET_VM_PRE}"
 go get -u github.com/vmware/govmomi/govc
 
 # Push new container images
-# TODO the `-k` flag here is a workaround until we can set GCR_KEY_FILE properly
-hack/release.sh -t pr -p -k /root/.capv/keyfile.json
+hack/release.sh -t pr -p
 cd ./scripts/e2e/bootstrap_job && make push && cd .. || exit 1
 
 # get bootstrap VM


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates the E2E tests to no longer use a hardcoded path to
the GCR keyfile, instead taking the location for the the env var.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This patch requires https://github.com/kubernetes/test-infra/pull/13773 to merged first. Tests should fail until it is.
/hold
^ to wait for dependency

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```