### PR TITLE
moved preferredAPIServerCidr in troubleshooting doc to correct line

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -319,8 +319,8 @@ Another reason a machine with two networks can lead to failure is because the or
 
 ```yaml
 network:
-  devices:
   preferredAPIServerCidr: "192.168.5.0/24"
+  devices:
   - networkName: "sddc-cgw-network-6"
     ipAddrs:
     - 192.168.6.20/24


### PR DESCRIPTION
Signed-off-by: Jim Weber <jpweber@gmail.com>


**What this PR does / why we need it**:
Updates the troubleshooting document to fix the example of Preferring an IP address. the property of `preferredAPIServerCidr` was in line that created errors. 

Fixes #479 

**Special notes for your reviewer**:



```release-note
NONE
```