### PR TITLE
Set GOPROXY for docker commands for Prow

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -44,6 +44,7 @@ MANAGER_IMAGE_NAME=
 MANIFESTS_IMAGE_NAME=
 VERSION=$(git describe --dirty --always 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
+PROW_JOB_ID="${PROW_JOB_ID:-}"
 
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE-}"
 
@@ -105,10 +106,17 @@ function build_images() {
       ;;
   esac
 
+  # If we are running in Prow, use the Google-hosted goproxy
+  local goproxy="direct"
+  if [ "${PROW_JOB_ID}" ]; then
+    goproxy="https://proxy.golang.org"
+  fi
+
   # Manager image
   echo "building ${MANAGER_IMAGE_NAME}:${VERSION}"
   docker build \
     -f Dockerfile \
+    -e GOPROXY="${goproxy}" \
     -t "${MANAGER_IMAGE_NAME}":"${VERSION}" \
     .
   if [ "${LATEST}" ]; then


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Prow recently started setting GOPROXY for all its jobs by default. This
speeds up builds, but does not appy when using docker-in-docker. For our
jobs that build things in Docker, we need to supply GOPROXY ourselves.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a first attempt at this. Need to see the test output to see if it's working. If it is, builds should be considerably faster.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```