### PR TITLE
docs: remove controlPlane version field for worker…

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -239,7 +239,6 @@ spec:
           template: "ubuntu-1804-kube-v1.13.6"
       versions:
         kubelet: "1.13.6"
-        controlPlane: "1.13.6"
 ```
 
 Use `kubectl` with the `kubeconfig` for the management cluster to provision the new workload cluster:


### PR DESCRIPTION
**What this PR does / why we need it**:

When I read docs/getting_started.md, I was confused about how to judge the ControlPlane node. 

I saw this in the code:

```go
// HasControlPlaneRole returns a flag indicating whether or not a machine has
// the control plane role.
func (c *MachineContext) HasControlPlaneRole() bool {
	if c.Machine == nil {
		return false
	}
	return clusterUtilv1.IsControlPlaneMachine(c.Machine)
}
```

```go
// IsControlPlaneMachine checks machine is a control plane node.
func IsControlPlaneMachine(machine *clusterv1.Machine) bool {
	return machine.Spec.Versions.ControlPlane != ""
}
```

So maybe need delete this field when adding a worker node?


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```