### PR TITLE
set clone status on error

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -21,7 +21,6 @@ import (
 	"net"
 
 	"github.com/pkg/errors"
-
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/certificates"
@@ -58,6 +57,7 @@ func Create(ctx *context.MachineContext, bootstrapToken string) error {
 	// does not exist, only when there's an error checking or when the op should
 	// be requeued, like when the VM has an in-flight task.
 	vm, err := lookupVM(ctx)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/vsphere/services/govmomi/util.go
+++ b/pkg/cloud/vsphere/services/govmomi/util.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/apis/vsphere/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/config"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"

--- a/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
+++ b/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/govmomi/extra"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/govmomi/template"
@@ -122,7 +121,10 @@ func Clone(ctx *context.MachineContext, userData []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "error trigging clone op for machine %q", ctx)
 	}
-
+	_, err = task.WaitForResult(ctx, nil)
+	if err != nil {
+		return err
+	}
 	ctx.MachineStatus.TaskRef = task.Reference().Value
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Updates the status of a machine if a clone operation is unsuccessful due to duplicate machine name.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #431 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

Hi,

I wanted to have a crack at this one. But wasn't sure on a few things.
- where to update the status? I have used annotations in this PR but happy to change to whatever is appropriate. I was wondering wether this should be `MachineRef` or a new field in the MachineStatus.
- Wether waiting for the clone operation is appropriate?



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update machine status on failed create when machine name exists.
```