### PR TITLE
Update getting started guide with info about v1a2'isms

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,7 +30,27 @@ This is a guide on how to get started with CAPV (Cluster API Provider vSphere). 
 
 #### clusterctl
 
-Please download `clusterctl` from the Cluster API, GitHub [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
+Please download `clusterctl` from the Cluster API (CAPI), GitHub [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
+
+------
+
+**Note**: CAPI v1alpha2 may not yet have published a `clusterctl` binary. Docker may be used to build `clusterctl` from source using the `master` branch of the CAPI repository:
+
+```shell
+docker run --rm \
+  -v "$(pwd)":/out \
+  -e CGO_ENABLED=0 \
+  -e GOOS="$(uname -s | tr '[:upper:]' '[:lower:]')" \
+  -e GOARCH=amd64 \
+  -e GOFLAGS="-ldflags=-extldflags=-static" \
+  -e GOPROXY="https://proxy.golang.org" \
+  -w /build \
+  golang:1.12 \
+  /bin/bash -c 'git clone https://github.com/kubernetes-sigs/cluster-api.git . && \
+                go build -o /out/clusterctl.${GOOS}_${GOARCH} ./cmd/clusterctl'
+```
+
+------
 
 #### Docker
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -122,7 +122,7 @@ With the above environment variable file it is now possible to generate the mani
 $ docker run --rm \
   -v "$(pwd)":/out \
   -v "$(pwd)/envvars.txt":/envvars.txt:ro \
-  gcr.io/cluster-api-provider-vsphere/release/manifests:latest \
+  gcr.io/cluster-api-provider-vsphere/ci/manifests:latest \
   -c management-cluster
 
 Generated ./out/management-cluster/cluster.yaml
@@ -163,7 +163,7 @@ Using the same Docker command as above, generate resources for a new cluster, th
 $ docker run --rm \
   -v "$(pwd)":/out \
   -v "$(pwd)/envvars.txt":/envvars.txt:ro \
-  gcr.io/cluster-api-provider-vsphere/release/manifests:latest \
+  gcr.io/cluster-api-provider-vsphere/ci/manifests:latest \
   -c workload-cluster-1
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR updates the getting started guide to reflect a few in-progress notes about the state of v1a2:

* Instructions for building `clusterctl` until the CAPI project publishes the artifact
* References the `ci/manifests` image instead of `release/manifests` since the latter is based on v1alpha1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR should be reverted once CAPI v1alpha2 and CAPV v1alpha2 are both released.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```