### PR TITLE
Fix missing addons file in generated manifests

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -98,6 +98,7 @@ COMPONENTS_CLUSTER_API_GENERATED_FILE=${SRC_DIR}/provider-components/provider-co
 COMPONENTS_KUBEADM_GENERATED_FILE=${SRC_DIR}/provider-components/provider-components-kubeadm.yaml
 COMPONENTS_VSPHERE_GENERATED_FILE=${SRC_DIR}/provider-components/provider-components-vsphere.yaml
 
+ADDONS_GENERATED_FILE=${OUT_DIR}/addons.yaml
 PROVIDER_COMPONENTS_GENERATED_FILE=${OUT_DIR}/provider-components.yaml
 CLUSTER_GENERATED_FILE=${OUT_DIR}/cluster.yaml
 CONTROLPLANE_GENERATED_FILE=${OUT_DIR}/controlplane.yaml
@@ -117,7 +118,7 @@ for f in COMPONENTS_CLUSTER_API COMPONENTS_KUBEADM COMPONENTS_VSPHERE; do \
 done
 
 # Ensure that the actual outputs are only overwritten if the flag is provided.
-for f in PROVIDER_COMPONENTS CLUSTER CONTROLPLANE MACHINEDEPLOYMENT; do
+for f in ADDONS PROVIDER_COMPONENTS CLUSTER CONTROLPLANE MACHINEDEPLOYMENT; do
   [ -n "${OVERWRITE}" ] || eval "no_file \"\${${f}_GENERATED_FILE}\""
 done
 
@@ -182,6 +183,10 @@ unset VSPHERE_USERNAME VSPHERE_PASSWORD
 envsubst() {
   python -c 'import os,sys;[sys.stdout.write(os.path.expandvars(l)) for l in sys.stdin]'
 }
+
+# Generate the addons file.
+envsubst >"${ADDONS_GENERATED_FILE}" <"${SRC_DIR}/addons.yaml"
+echo "Generated ${ADDONS_GENERATED_FILE}"
 
 # Generate cluster resources.
 kustomize build "${SRC_DIR}/cluster" | envsubst >"${CLUSTER_GENERATED_FILE}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates the generation process to include the addons file.

/feature bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```