### PR TITLE
Add missing cloud provider config

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -48,9 +48,30 @@ spec:
     apiServer:
       extraArgs:
         cloud-provider: vsphere
+        cloud-config: /etc/kubernetes/vsphere.conf
+      extraVolumes:
+      - name: "cloud-config"
+        hostPath: /etc/kubernetes/vsphere.conf
+        mountPath: /etc/kubernetes/vsphere.conf
+        readOnly: true
+        pathType: File
     controllerManager:
       extraArgs:
         cloud-provider: vsphere
+        cloud-config: /etc/kubernetes/vsphere.conf
+      extraVolumes:
+      - name: "cloud-config"
+        hostPath: /etc/kubernetes/vsphere.conf
+        mountPath: /etc/kubernetes/vsphere.conf
+        readOnly: true
+        pathType: File
+  files:
+  - path: /etc/kubernetes/vsphere.conf
+    owner: root:root
+    permissions: "0600"
+    encoding: base64
+    content: |
+      ${CLOUD_CONFIG_B64ENCODED}
   users:
   - name: capv
     sudo: "ALL=(ALL) NOPASSWD:ALL"

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -208,6 +208,32 @@ VSPHERE_B64ENCODED_PASSWORD="$(printf '%s' "${VSPHERE_PASSWORD}" | base64)"
 export VSPHERE_B64ENCODED_USERNAME VSPHERE_B64ENCODED_PASSWORD
 unset VSPHERE_USERNAME VSPHERE_PASSWORD
 
+# Encode the cloud provider configuration.
+CLOUD_CONFIG_B64ENCODED=$(cat <<EOF | { base64 -w0 2>/dev/null || base64; }
+[Global]
+secret-name = "cloud-provider-vsphere-credentials"
+secret-namespace = "kube-system"
+datacenters = "${VSPHERE_DATACENTER}"
+insecure-flag = "1"
+
+[VirtualCenter "${VSPHERE_SERVER}"]
+
+[Workspace]
+server = "${VSPHERE_SERVER}"
+datacenter = "${VSPHERE_DATACENTER}"
+folder = "${VSPHERE_FOLDER}"
+default-datastore = "${VSPHERE_DATASTORE}"
+resourcepool-path = "${VSPHERE_RESOURCE_POOL}"
+
+[Disk]
+scsicontrollertype = pvscsi
+
+[Network]
+public-network = "${VSPHERE_NETWORK}"
+EOF
+)
+export CLOUD_CONFIG_B64ENCODED
+
 envsubst() {
   python -c 'import os,sys;[sys.stdout.write(os.path.expandvars(l)) for l in sys.stdin]'
 }


### PR DESCRIPTION
/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch adds the missing cloud provider configuration to the control plane machine's kubeadm config data.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```