### PR TITLE
Selectable CRI socket

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -39,8 +39,8 @@ const (
 	// hostnameLookup resolves via cloud init and uses cloud provider's metadata service to lookup its own hostname.
 	hostnameLookup = "{{ ds.meta_data.hostname }}"
 
-	// containerdSocket is the path to containerd socket.
-	containerdSocket = "/var/run/containerd/containerd.sock"
+	// criSocket is the path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value.
+	criSocket = ""
 
 	// nodeRole is the label assigned to every node in the cluster.
 	nodeRole = "node-role.kubernetes.io/node="
@@ -131,7 +131,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 						&ctx.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
-						kubeadm.WithCRISocket(containerdSocket),
+						kubeadm.WithCRISocket(criSocket),
 						kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),
 					),
 				),
@@ -211,7 +211,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 						&ctx.MachineConfig.KubeadmConfiguration.Init.NodeRegistration,
 						kubeadm.WithTaints(ctx.Machine.Spec.Taints),
 						kubeadm.WithNodeRegistrationName(hostnameLookup),
-						kubeadm.WithCRISocket(containerdSocket),
+						kubeadm.WithCRISocket(criSocket),
 						kubeadm.WithKubeletExtraArgs(map[string]string{"cloud-provider": cloudProvider}),
 					),
 				),
@@ -259,7 +259,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				kubeadm.SetNodeRegistration(
 					&ctx.MachineConfig.KubeadmConfiguration.Join.NodeRegistration,
 					kubeadm.WithNodeRegistrationName(hostnameLookup),
-					kubeadm.WithCRISocket(containerdSocket),
+					kubeadm.WithCRISocket(criSocket),
 					kubeadm.WithKubeletExtraArgs(map[string]string{
 						"cloud-provider": cloudProvider,
 					}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR allows a user to select the CRI socket to use. If no choice is provided then it defaults to containerd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Selectable CRI socket, defaults to containerd
```