### PR TITLE
add label to be able to list vspheremachines that are part of cluster

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -21,6 +21,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: VSphereMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-0
+  labels:
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
 spec:
   datacenter: "${VSPHERE_DATACENTER}"
   network:


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR adds the following labels:

```
  labels:
    cluster.x-k8s.io/control-plane: "true"
    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
```

to be able to list vspheremachines that are part of a cluster through the function `GetVSphereMachinesInCluster()`.
Without this change, in #538 the loadbalancer_controller is not able to list vspheremachines  which result in the creation of a load balancer without a corresponding pool of machines/ips attached to it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @akutz 

**Release note**:

```release-note
NONE
```