### PR TITLE
Add service domain to the cluster config

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -107,6 +107,7 @@ export SSH_AUTHORIZED_KEY='ssh-rsa AAAAB3N...'      # (optional) The public ssh 
 export KUBERNETES_VERSION='1.13.6'        # (optional) The Kubernetes version to use, defaults to 1.13.6
 export SERVICE_CIDR='100.64.0.0/13'       # (optional) The service CIDR of the management cluster, defaults to "100.64.0.0/13"
 export CLUSTER_CIDR='100.96.0.0/11'       # (optional) The cluster CIDR of the management cluster, defaults to "100.96.0.0/11"
+export SERVICE_DOMAIN='cluster.local'     # (optional) The k8s service domain of the management cluster, defaults to "cluster.local"
 EOF
 ```
 

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -9,6 +9,7 @@ spec:
       cidrBlocks: ["${SERVICE_CIDR}"]
     pods:
       cidrBlocks: ["${CLUSTER_CIDR}"]
+    serviceDomain: ${DNS_DOMAIN}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: VSphereCluster

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -9,7 +9,7 @@ spec:
       cidrBlocks: ["${SERVICE_CIDR}"]
     pods:
       cidrBlocks: ["${CLUSTER_CIDR}"]
-    serviceDomain: ${DNS_DOMAIN}
+    serviceDomain: ${SERVICE_DOMAIN}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: VSphereCluster

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -173,7 +173,7 @@ record_and_export() {
 record_and_export CLUSTER_NAME          ':-capv-mgmt-example'
 record_and_export SERVICE_CIDR          ':-100.64.0.0/13'
 record_and_export CLUSTER_CIDR          ':-100.96.0.0/11'
-record_and_export DNS_DOMAIN            ':-cluster.local'
+record_and_export SERVICE_DOMAIN        ':-cluster.local'
 record_and_export CABPK_MANAGER_IMAGE   ':-'
 record_and_export CAPV_MANAGER_IMAGE    ':-'
 record_and_export VSPHERE_USERNAME      "${ENV_VAR_REQ}"

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -173,6 +173,7 @@ record_and_export() {
 record_and_export CLUSTER_NAME          ':-capv-mgmt-example'
 record_and_export SERVICE_CIDR          ':-100.64.0.0/13'
 record_and_export CLUSTER_CIDR          ':-100.96.0.0/11'
+record_and_export DNS_DOMAIN            ':-cluster.local'
 record_and_export CABPK_MANAGER_IMAGE   ':-'
 record_and_export CAPV_MANAGER_IMAGE    ':-'
 record_and_export VSPHERE_USERNAME      "${ENV_VAR_REQ}"


### PR DESCRIPTION

**What this PR does / why we need it**:
When kubeadconfig controller reconciles. It needs dnsDomain field. 
This documents in https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/blob/master/README.md

![image](https://user-images.githubusercontent.com/1630796/64499335-2df11f80-d27e-11e9-8d37-8ce7c980d7b0.png)

The current manifest generation does not provide that field, which caused below error on cabpk

```validation failure list:\nspec.clusterConfiguration.networking.dnsDomain in body is required"  "controller"="kubeadmconfig" "request"={"Namespace":"default","Name":"management-cluster-controlplane-0”}```

This pull request will add that field and fix ^^ issue 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

This PR does not change any image... 
But gcr.io/cluster-api-provider-vsphere/release/manifests:latest should be updated upon this change

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
the manifest generator will add Cluster.spec.clusterNetwork.serviceDomain field
```