### PR TITLE
fix e2e: broken link to download clusterctl

### DIFF
--- a/scripts/e2e/bootstrap_job.template
+++ b/scripts/e2e/bootstrap_job.template
@@ -14,7 +14,7 @@ spec:
         image: gcr.io/cluster-api-provider-vsphere/pr/ci:${VERSION}
         env:
           - name: CLUSTERCTL_VERSION
-            value: ${VERSION}
+            value: ${CAPI_VERSION}
           - name: TARGET_VM_SSH
             valueFrom:
               secretKeyRef:

--- a/scripts/e2e/bootstrap_job/clusterctl.sh
+++ b/scripts/e2e/bootstrap_job/clusterctl.sh
@@ -55,17 +55,16 @@ wget https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux
 chmod +x /usr/local/bin/kubectl
 
 # download clusterctl binary
-wget https://storage.googleapis.com/capv-pr/"${CLUSTERCTL_VERSION}"/bin/linux/amd64/clusterctl \
+wget https://github.com/kubernetes-sigs/cluster-api/releases/download/"${CLUSTERCTL_VERSION}"/clusterctl-linux-amd64 \
     --no-verbose -O /usr/local/bin/clusterctl
 chmod +x /usr/local/bin/clusterctl
 
 # run clusterctl
 echo "test ${PROVIDER_COMPONENT_SPEC}"
 clusterctl create cluster -e ~/.kube/config -c ./spec/cluster.yaml \
-    -m ./spec/machines.yaml \
+    -m ./spec/controlplane.yaml \
     -p ./spec/"${PROVIDER_COMPONENT_SPEC}" \
     -a ./spec/addons.yaml \
-    --provider vsphere \
     -v 6
 
 ret=$?

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -154,7 +154,9 @@ fi
 
 VERSION=$(git describe --dirty --always 2>/dev/null)
 export VERSION
+export CAPI_VERSION=v0.2.1
 echo "build vSphere controller version: ${VERSION}"
+echo "using clusterctl version: ${CAPI_VERSION}"
 
 # install_govc
 go get -u github.com/vmware/govmomi/govc

--- a/scripts/e2e/generate-e2e-spec.sh
+++ b/scripts/e2e/generate-e2e-spec.sh
@@ -36,6 +36,7 @@ docker run --rm \
     -e VSPHERE_RESOURCE_POOL="clusterapi" \
     -e VSPHERE_FOLDER="clusterapi" \
     -e VSPHERE_TEMPLATE="ubuntu-1804-kube-v1.13.6" \
+    -e SSH_AUTHORIZED_KEY="N/A" \
     "${MANIFESTS_IMAGE}" \
     -c "${CLUSTER_NAME}" \
     -m "${VSPHERE_CONTROLLER_VERSION}" \


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: As we do not build clusterctl anymore this PR updates the link to download the one released for CAPI

**Which issue(s) this PR fixes**: Fixes #562

**Special notes for your reviewer**:

/assign @akutz @figo 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```