### PR TITLE
use govmomi types.VirtualEthernetCardMacType for NIC address type

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
+++ b/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
@@ -195,7 +195,7 @@ func getNetworkSpecs(
 			nic.MacAddress = netSpec.MACAddr
 			// Please see https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.vm.device.VirtualEthernetCard.html#addressType
 			// for the valid values for this field.
-			nic.AddressType = "Manual"
+			nic.AddressType = string(types.VirtualEthernetCardMacTypeManual)
 			ctx.Logger.V(6).Info("configured manual mac address", "mac-addr", nic.MacAddress)
 		}
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Use the VirtualEthernetCardMacTypeManual constant for setting the NIC address type. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```