### PR TITLE
Add the vendor directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ config/default/vsphere_tmp
 # Tooling
 .bin/
 bin/
+vendor/
 
 # Ignore the temporary .gopath directory
 .gopath/


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**:
This PR adds the `vendor` folder to `.gitignore` to prevent people from accidentally adding `vendor` to the Git index.

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:

/assign @akutz 

**Release note**:

```release-note
NONE
```