### PR TITLE
update calico addons to use apps/v1 instead of extensions/v1beta1

### DIFF
--- a/examples/default/addons.yaml
+++ b/examples/default/addons.yaml
@@ -467,7 +467,7 @@ subjects:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -695,7 +695,7 @@ metadata:
 # Source: calico/templates/calico-kube-controllers.yaml
 # This manifest deploys the Calico node controller.
 # See https://github.com/projectcalico/kube-controllers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers

--- a/examples/pre-67u3/addons.yaml
+++ b/examples/pre-67u3/addons.yaml
@@ -467,7 +467,7 @@ subjects:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -695,7 +695,7 @@ metadata:
 # Source: calico/templates/calico-kube-controllers.yaml
 # This manifest deploys the Calico node controller.
 # See https://github.com/projectcalico/kube-controllers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
In v1.16, the extensions/v1beta1 API group is removed and the calico addons still referencing that API group should also be removed. Thanks for catching this @figo 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default Calico addons should use API group apps/v1 instead of extensions/v1beta1
```