### PR TITLE
Allow user to set kubeadm clusterConfiguration imageRepository

### DIFF
--- a/examples/default/controlplane/controlplane.yaml
+++ b/examples/default/controlplane/controlplane.yaml
@@ -50,6 +50,7 @@ spec:
       kubeletExtraArgs:
         cloud-provider: external
   clusterConfiguration:
+    imageRepository: ${K8S_IMAGE_REPOSITORY}
     apiServer:
       extraArgs:
         cloud-provider: external

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -33,6 +33,7 @@ ENV_VAR_REQ=':?required'
 CABPK_MANAGER_IMAGE="${CABPK_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/capi-kubeadm/cluster-api-kubeadm-controller:v0.1.0}"
 CAPI_MANAGER_IMAGE="${CAPI_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.2.1}"
 CAPV_MANAGER_IMAGE="${CAPV_MANAGER_IMAGE:-gcr.io/cluster-api-provider-vsphere/release/manager:latest}"
+K8S_IMAGE_REPOSITORY="${K8S_IMAGE_REPOSITORY:-k8s.gcr.io}"
 
 # Set the default log levels for the manager containers.
 CABPK_MANAGER_LOG_LEVEL="${CABPK_MANAGER_LOG_LEVEL:-4}"
@@ -56,6 +57,7 @@ FLAGS
   -i    input directory (default ${SRC_DIR})
   -m    capv manager image (default "${CAPV_MANAGER_IMAGE}")
   -M    capv manager log level (default "${CAPV_MANAGER_LOG_LEVEL}")
+  -r    kubernetes container image repository (default "${K8S_IMAGE_REPOSITORY}")
   -o    output directory (default ${OUT_DIR})
   -p    capi manager image (default "${CAPI_MANAGER_IMAGE}")
   -P    capi manager log level (default "${CAPI_MANAGER_LOG_LEVEL}")
@@ -63,7 +65,7 @@ FLAGS
 EOF
 }
 
-while getopts ':b:B:c:dfhi:m:M:o:p:P:u' opt; do
+while getopts ':b:B:c:dfhi:m:M:r:o:p:P:u' opt; do
   case "${opt}" in
   b)
     CABPK_MANAGER_IMAGE="${OPTARG}"
@@ -91,6 +93,9 @@ while getopts ':b:B:c:dfhi:m:M:o:p:P:u' opt; do
     ;;
   M)
     CAPV_MANAGER_LOG_LEVEL="${OPTARG}"
+    ;;
+  r)
+    K8S_IMAGE_REPOSITORY="${OPTARG}"
     ;;
   o)
     OUT_DIR="${OPTARG}"
@@ -188,6 +193,7 @@ record_and_export CLUSTER_CIDR          ':-100.96.0.0/11'
 record_and_export SERVICE_DOMAIN        ':-cluster.local'
 record_and_export CABPK_MANAGER_IMAGE   ':-'
 record_and_export CAPV_MANAGER_IMAGE    ':-'
+record_and_export K8S_IMAGE_REPOSITORY  ':-'
 record_and_export VSPHERE_USERNAME      "${ENV_VAR_REQ}"
 record_and_export VSPHERE_PASSWORD      "${ENV_VAR_REQ}"
 record_and_export VSPHERE_SERVER        "${ENV_VAR_REQ}"

--- a/examples/pre-67u3/controlplane/controlplane.yaml
+++ b/examples/pre-67u3/controlplane/controlplane.yaml
@@ -50,6 +50,7 @@ spec:
       kubeletExtraArgs:
         cloud-provider: vsphere
   clusterConfiguration:
+    imageRepository: ${K8S_IMAGE_REPOSITORY}
     apiServer:
       extraArgs:
         cloud-provider: vsphere


### PR DESCRIPTION
kubeadm using "k8s.gcr.io" by default, we default it to same
default value, although this change allow user to set it to different value.

Signed-off-by: Hui Luo <luoh@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Allow specification of a custom, default image repository
```