### PR TITLE
support cluster-id in cloud config which is required by vSphere CSI driver

### DIFF
--- a/api/v1alpha2/cloudprovider/encoding_test.go
+++ b/api/v1alpha2/cloudprovider/encoding_test.go
@@ -49,6 +49,7 @@ func TestMarshalINI(t *testing.T) {
 user = user
 password = password
 datacenters = us-west
+cluster-id = cluster-namespace/cluster-name
 
 [VirtualCenter "0.0.0.0"]
 
@@ -64,6 +65,7 @@ default-datastore = default
 					Username:    "user",
 					Password:    "password",
 					Datacenters: "us-west",
+					ClusterID:   "cluster-namespace/cluster-name",
 				},
 				VCenter: map[string]cloudprovider.VCenterConfig{
 					"0.0.0.0": {},
@@ -357,6 +359,7 @@ func TestUnmarshalINI(t *testing.T) {
 		user = user
 		password = password
 		datacenters = us-west
+		cluster-id = cluster-namespace/cluster-name
 
 		[VirtualCenter "0.0.0.0"]
 
@@ -371,6 +374,7 @@ func TestUnmarshalINI(t *testing.T) {
 					Username:    "user",
 					Password:    "password",
 					Datacenters: "us-west",
+					ClusterID:   "cluster-namespace/cluster-name",
 				},
 				VCenter: map[string]cloudprovider.VCenterConfig{
 					"0.0.0.0": {},

--- a/api/v1alpha2/cloudprovider/types.go
+++ b/api/v1alpha2/cloudprovider/types.go
@@ -151,6 +151,10 @@ type GlobalConfig struct {
 	// Defaults to 43001.
 	// +optional
 	APIBindPort string `gcfg:"api-binding,omitempty" json:"apiBindPort,omitempty"`
+
+	// ClusterID is a unique identifier for a cluster used by the vSphere CSI driver (CNS)
+	// NOTE: This field is set internally by CAPV and should not be set by any other consumer of this API
+	ClusterID string `gcfg:"cluster-id,omitempty" json:"-"`
 }
 
 // VCenterConfig is a vSphere cloud provider's vCenter configuration.

--- a/pkg/cloud/vsphere/services/cloudprovider/csi.go
+++ b/pkg/cloud/vsphere/services/cloudprovider/csi.go
@@ -14,6 +14,8 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -562,6 +564,7 @@ func CSICloudConfigSecret(data string) *corev1.Secret {
 func ConfigForCSI(ctx *context.ClusterContext) *cloudprovider.Config {
 	config := &cloudprovider.Config{}
 
+	config.Global.ClusterID = fmt.Sprintf("%s/%s", ctx.Cluster.Namespace, ctx.Cluster.Name)
 	config.Global.Insecure = false
 	config.Network.Name = ctx.VSphereCluster.Spec.CloudProviderConfiguration.Network.Name
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Supports adding the `cluster-id` field in the cloud config which is required by vSphere CSI driver. Uses the format "<cluster-namespace>/<cluster-name>" which is guaranteed to be unique on the management cluster. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Supports adding the `cluster-id` field in the cloud config which is required by vSphere CSI driver.
```