### PR TITLE
fix null field in SSH authorized keys due to kustomize removing double quotes

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -203,7 +203,7 @@ record_and_export VSPHERE_NETWORK       "${ENV_VAR_REQ}"
 record_and_export VSPHERE_RESOURCE_POOL ':-'
 record_and_export VSPHERE_FOLDER        ':-'
 record_and_export VSPHERE_TEMPLATE      ':-'
-record_and_export SSH_AUTHORIZED_KEY    ':-'
+record_and_export SSH_AUTHORIZED_KEY    ":-''"
 
 verify_cpu_mem_dsk() {
   eval "[[ \${${1}-} =~ [[:digit:]]+ ]] || ${1}=\"${2}\"; \


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
kustomize (for reasons I don't know yet) removes double quotes on generate yaml fields. As a result, the `sshAuthorizedKeys` field in the kubeadm config would have a null value instead of the expected string value. To work around this, we can use single quotes for the SSH key value so kustomize will keep the single quoted string value instead of a null value.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #589 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix generated null field for sshAuthorizedKeys in KubeadmConfig.  
```