### PR TITLE
single quote resource pool in manifest generation since it can begin with special characters like *

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -205,6 +205,10 @@ record_and_export VSPHERE_FOLDER        ':-'
 record_and_export VSPHERE_TEMPLATE      ':-'
 record_and_export SSH_AUTHORIZED_KEY    ":-''"
 
+# single quote string variables that can start with special characters like "*"
+# otherwise invalid yaml will be generated
+export VSPHERE_RESOURCE_POOL="'${VSPHERE_RESOURCE_POOL}'"
+
 verify_cpu_mem_dsk() {
   eval "[[ \${${1}-} =~ [[:digit:]]+ ]] || ${1}=\"${2}\"; \
         [ \"\${${1}}\" -ge \"${2}\" ] || { echo \"${1} must be >= ${2}\" 1>&2; exit 1; }; \


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Kustomize removes double quotes from generated manifests so we have to intentionally add single quotes for variables that may could generate invalid yaml. For our case, the resource pool variable can start with "*" which would result in invalid yaml unless we quote it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
manifests: single quote resource pool in manifest generation since it can begin with special characters like *
```