### PR TITLE
Fixes to CAPV Docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -228,7 +228,7 @@ spec:
       datacenter: SDDC-Datacenter
       datastore: DefaultDatastore
       folder: vm
-      resourcePool: Resources
+      resourcePool: 'Resources'
       server: 10.0.0.1
   server: 10.0.0.1
 ```
@@ -245,36 +245,16 @@ spec:
   clusterConfiguration:
     apiServer:
       extraArgs:
-        cloud-config: /etc/kubernetes/vsphere.conf
-        cloud-provider: vsphere
-      extraVolumes:
-      - hostPath: /etc/kubernetes/vsphere.conf
-        mountPath: /etc/kubernetes/vsphere.conf
-        name: cloud-config
-        pathType: File
-        readOnly: true
+        cloud-provider: external
     controllerManager:
       extraArgs:
-        cloud-config: /etc/kubernetes/vsphere.conf
-        cloud-provider: vsphere
-      extraVolumes:
-      - hostPath: /etc/kubernetes/vsphere.conf
-        mountPath: /etc/kubernetes/vsphere.conf
-        name: cloud-config
-        pathType: File
-        readOnly: true
-  files:
-  - content: |
-      W0dsb2JhbF0Kc2VjcmV0LW5hbWUgPSAiY2xvdWQtcHJvdmlkZXItdnNwaGVyZS1jcmVkZW50aWFscyIKc2VjcmV0LW5hbWVzcGFjZSA9ICJrdWJlLXN5c3RlbSIKZGF0YWNlbnRlcnMgPSAiU0REQy1EYXRhY2VudGVyIgppbnNlY3VyZS1mbGFnID0gIjEiCgpbVmlydHVhbENlbnRlciAiMTAuMC4wLjFdCgpbV29ya3NwYWNlXQpzZXJ2ZXIgPSAiMTAuMC4wLjEiCmRhdGFjZW50ZXIgPSAiU0REQy1EYXRhY2VudGVyIgpmb2xkZXIgPSAidm0iCmRlZmF1bHQtZGF0YXN0b3JlID0gIkRlZmF1bHREYXRhc3RvcmUiCnJlc291cmNlcG9vbC1wYXRoID0gIlJlc291cmNlcyIKCltEaXNrXQpzY3NpY29udHJvbGxlcnR5cGUgPSBwdnNjc2kKCltOZXR3b3JrXQpwdWJsaWMtbmV0d29yayA9ICJ2bS1uZXR3b3JrLTEiCg==
-    encoding: base64
-    owner: root:root
-    path: /etc/kubernetes/vsphere.conf
-    permissions: "0600"
+        cloud-provider: external
+    imageRepository: k8s.gcr.io
   initConfiguration:
     nodeRegistration:
       criSocket: /var/run/containerd/containerd.sock
       kubeletExtraArgs:
-        cloud-provider: vsphere
+        cloud-provider: external
       name: '{{ ds.meta_data.hostname }}'
   preKubeadmCommands:
   - hostname "{{ ds.meta_data.hostname }}"
@@ -312,6 +292,9 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: VSphereMachine
 metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: workload-cluster-1
+    cluster.x-k8s.io/control-plane: "true"
   name: workload-cluster-1-controlplane-0
   namespace: default
 spec:
@@ -342,7 +325,7 @@ spec:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            cloud-provider: vsphere
+            cloud-provider: external
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -95,7 +95,7 @@ export VSPHERE_PASSWORD='some-secure-password'  # (required) The password used t
 export VSPHERE_DATACENTER='SDDC-Datacenter'         # (required) The vSphere datacenter to deploy the management cluster on
 export VSPHERE_DATASTORE='DefaultDatastore'         # (required) The vSphere datastore to deploy the management cluster on
 export VSPHERE_NETWORK='vm-network-1'               # (required) The VM network to deploy the management cluster on
-export VSPHERE_RESOURCE_POOL='Resources'            # (required) The vSphere resource pool for your VMs
+export VSPHERE_RESOURCE_POOL='*/Resources'            # (required) The vSphere resource pool for your VMs
 export VSPHERE_FOLDER='vm'                          # (optional) The VM folder for your VMs, defaults to the root vSphere folder if not set.
 export VSPHERE_TEMPLATE='ubuntu-1804-kube-v1.15.3'  # (required) The VM template to use for your management cluster.
 export VSPHERE_DISK_GIB='50'                        # (optional) The VM Disk size in GB, defaults to 20 if not set
@@ -228,7 +228,7 @@ spec:
       datacenter: SDDC-Datacenter
       datastore: DefaultDatastore
       folder: vm
-      resourcePool: 'Resources'
+      resourcePool: '*/Resources'
       server: 10.0.0.1
   server: 10.0.0.1
 ```

--- a/examples/default/machinedeployment/machinedeployment.yaml
+++ b/examples/default/machinedeployment/machinedeployment.yaml
@@ -55,7 +55,7 @@ spec:
           name: "{{ ds.meta_data.hostname }}"
           criSocket: "/var/run/containerd/containerd.sock"
           kubeletExtraArgs:
-            cloud-provider: vsphere
+            cloud-provider: external
       users:
       - name: capv
         sudo: "ALL=(ALL) NOPASSWD:ALL"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes to CAPV docs:
* fixes the existing getting started guide to use the correct KubeadmConfig
* fix a bug in the manifest generator where the kubelet still set `--cloud-provider=vsphere` as the default. 
* fix invalid resource pool in examples

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CAPV docs to:
* use updated KubeadmConfig with --cloud-provider=external 
* fix invalid resource pool in examples
```