### PR TITLE
update vSphere CNS images in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -217,9 +217,9 @@ spec:
         controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.0.0
       storage:
         attacherImage: quay.io/k8scsi/csi-attacher:v1.1.1
-        controllerImage: cloudnativestorage/vsphere-block-csi-driver:latest
-        metadataSyncerImage: cloudnativestorage/volume-metadata-syncer:latest
-        nodeDriverImage: cloudnativestorage/vsphere-block-csi-driver:latest
+        controllerImage: vmware/vsphere-block-csi-driver:v1.0.0
+        metadataSyncerImage: vmware/volume-metadata-syncer:v1.0.0
+        nodeDriverImage: vmware/vsphere-block-csi-driver:v1.0.0
         provisionerImage: quay.io/k8scsi/csi-provisioner:v1.2.1
     virtualCenter:
       10.0.0.1:


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Follow-up doc fix from https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/599. CNS docker images were moved from `cloudnativestorage` -> `vmware`. The generated examples should reflect this. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```