### PR TITLE
Updating “Getting Started” and “Troubleshooting” docs with image pull…

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,19 +2,19 @@
 
 This is a guide on how to get started with CAPV (Cluster API Provider vSphere). To learn more about cluster API in more depth, check out the the [cluster api docs page](https://cluster-api.sigs.k8s.io/).
 
-* [Getting Started](#getting-started)
-  * [Bootstrapping a Management Cluster with clusterctl](#bootstrapping-a-management-cluster-with-clusterctl)
-    * [Install Requirements](#install-requirements)
-      * [clusterctl](#clusterctl)
-      * [Docker](#docker)
-      * [Kind](#kind)
-      * [kubectl](#kubectl)
-    * [vSphere Requirements](#vsphere-requirements)
-      * [vCenter Credentials](#vcenter-credentials)
-      * [Uploading the CAPV Machine Image](#uploading-the-capv-machine-image)
-    * [Generating YAML for the Bootstrap Cluster](#generating-yaml-for-the-bootstrap-cluster)
-    * [Using clusterctl](#using-clusterctl)
-  * [Managing Workload Clusters using the Management Cluster](#managing-workload-clusters-using-the-management-cluster)
+- [Getting Started](#getting-started)
+  - [Bootstrapping a Management Cluster with clusterctl](#bootstrapping-a-management-cluster-with-clusterctl)
+    - [Install Requirements](#install-requirements)
+      - [clusterctl](#clusterctl)
+      - [Docker](#docker)
+      - [Kind](#kind)
+      - [kubectl](#kubectl)
+    - [vSphere Requirements](#vsphere-requirements)
+      - [vCenter Credentials](#vcenter-credentials)
+      - [Uploading the CAPV Machine Image](#uploading-the-capv-machine-image)
+    - [Generating YAML for the Bootstrap Cluster](#generating-yaml-for-the-bootstrap-cluster)
+    - [Using clusterctl](#using-clusterctl)
+  - [Managing Workload Clusters using the Management Cluster](#managing-workload-clusters-using-the-management-cluster)
 
 ## Bootstrapping a Management Cluster with clusterctl
 
@@ -111,7 +111,11 @@ export SERVICE_DOMAIN='cluster.local'     # (optional) The k8s service domain of
 EOF
 ```
 
-With the above environment variable file it is now possible to generate the manifests needed to bootstrap the management cluster. The following command uses Docker to run an image that has all of the necessary templates and tools to generate the YAML manifests. Additionally, the `envvars.txt` file created above is mounted inside the the image in order to provide the generation routine with its default values:
+With the above environment variable file it is now possible to generate the manifests needed to bootstrap the management cluster. The following command uses Docker to run an image that has all of the necessary templates and tools to generate the YAML manifests. Additionally, the `envvars.txt` file created above is mounted inside the the image in order to provide the generation routine with its default values.
+
+**Note** It's important to ensure you are leveraging an up to date version of the manifests container image below. Problems with this typically manifest themselves on workstations that have tested previous versions of CAPV. You can delete your existing manifest image by using ```docker rmi gcr.io/cluster-api-provider-vsphere/release/manifests``` or change the below command to use a specific manifest image version (i.e. release/manifests:0.5.2-alpha.1)
+
+You can issue the below command to generate the required manifest files.
 
 ```shell
 $ docker run --rm \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,7 @@ This is a guide on how to troubleshoot issues related to the Cluster API provide
           - [The scheduler](#the-scheduler)
   - [Common issues](#common-issues)
     - [Ensure prerequisites are up to date](#ensure-prerequisites-are-up-to-date)
+    - [Missing manifest files during bootstrap phase](#missing-manifest-files-during-bootstrap-phase)
     - [`envvars.txt` is a directory](#envvarstxt-is-a-directory)
     - [Failed to retrieve kubeconfig secret](#failed-to-retrieve-kubeconfig-secret)
     - [Timed out while failing to retrieve kubeconfig secret](#timed-out-while-failing-to-retrieve-kubeconfig-secret)
@@ -187,6 +188,20 @@ This section contains issues commonly encountered by people using CAPV.
 ### Ensure prerequisites are up to date
 
 The [Getting Started](getting_started.md) guide lists the prerequisites for deploying clusters with CAPV. Make sure those prerequisites, such as `clusterctl`, `kubectl`, `kind`, etc. are up to date.
+
+### Missing manifest files during bootstrap phase
+
+If you are using CAPV from a previously tested CAPV on, you may be using an out of date manifest docker image. You can remedy this by removing your existing CAPV manifest image by using ```docker rmi gcr.io/cluster-api-provider-vsphere/release/manifests:latest``` or by updating the command to specify a specific manifest image, for example:
+
+```shell
+$ docker run --rm \
+>   -v "$(pwd)":/out \
+>   -v "$(pwd)/envvars.txt":/envvars.txt:ro \
+>   gcr.io/cluster-api-provider-vsphere/release/manifests:0.5.2-alpha.1 \
+>   -c management-cluster
+```
+
+This will ensure that the desired image is being used.
 
 ### `envvars.txt` is a directory
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates to the getting_started and troubleshooting docs to support issues that have been observed with cached images during the bootstrap phase. These were resovled by removing the existing cached images and allowing them to download a new "latest" tag, or by using a specific image tag.

Added clarity to troubleshooting doc for this fix as well

**Which issue(s) this PR fixes**:

Documentation updates for consuming the provider. 
**Release note**:
```release-note
None
```