### PR TITLE
🐛 Support running alongside other Cluster API pods in the same namespace with leader election enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-capv",
 		SyncPeriod:         syncPeriod,
 		Namespace:          *watchNamespace,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `LeaderElectionID` is set to the default `controller-leader-election-helper`. This causes an issue when several Cluster API pods are deployed in the same namespace. Adding a unique ID per service should resolve this. 
**Which issue(s) this PR fixes** :
Fixes #606 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Action required
The default leader election ID has been updated in this release. When upgrading from a previous release you will need to:
1.	Scale down the old controllers: kubectl -n capv-system scale deployment/controller-manager --replicas=0.
2.	Deploy the updated manifests with the newer image.
3.	Scale up the new controllers: kubectl -n capv-system scale deployment/controller-manager --replicas=1.
Failure to scale down the Deployment prior to updating to this version will result in multiple controllers running concurrently during the roll out of the updated controller-manager image.
``````