### PR TITLE
Remove clusterctl build instructions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,22 +26,6 @@ This is a guide on how to get started with CAPV (Cluster API Provider vSphere). 
 
 Please download the latest `clusterctl` from the Cluster API (CAPI), GitHub [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
 
-**Note:** CAPI v1alpha2 may not yet have published a `clusterctl` binary. Docker may be used to build `clusterctl` from source using the `master` branch of the CAPI repository:
-
-```shell
-docker run --rm \
-  -v "$(pwd)":/out \
-  -e CGO_ENABLED=0 \
-  -e GOOS="$(uname -s | tr '[:upper:]' '[:lower:]')" \
-  -e GOARCH=amd64 \
-  -e GOFLAGS="-ldflags=-extldflags=-static" \
-  -e GOPROXY="https://proxy.golang.org" \
-  -w /build \
-  golang:1.12 \
-  /bin/bash -c 'git clone https://github.com/kubernetes-sigs/cluster-api.git . && \
-                go build -o /out/clusterctl.${GOOS}_${GOARCH} ./cmd/clusterctl'
-```
-
 #### Docker
 
 Docker is required for the bootstrap cluster using `clusterctl`. See the [docker documentation](https://docs.docker.com/glossary/?term=install) for install instructions.


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes instructions for building `clusterctl` from getting started as v1a2 bin is built on `ClusterAPI` main repo.

**Which issue(s) this PR fixes**
As discussed in PR #613 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
Removes clusterctl build instructions
```