### PR TITLE
Parameterized livenessProbe image and registrar image

### DIFF
--- a/api/v1alpha2/cloudprovider/types.go
+++ b/api/v1alpha2/cloudprovider/types.go
@@ -65,6 +65,8 @@ type StorageConfig struct {
 	AttacherImage       string `json:"attacherImage,omitempty"`
 	ProvisionerImage    string `json:"provisionerImage,omitempty"`
 	MetadataSyncerImage string `json:"metadataSyncerImage,omitempty"`
+	LivenessProbeImage  string `json:"livenessProbeImage,omitempty"`
+	RegistrarImage      string `json:"registrarImage,omitempty"`
 }
 
 // unmarshallableConfig is used to unmarshal the INI data using the gcfg

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -145,11 +145,15 @@ spec:
                           type: string
                         controllerImage:
                           type: string
+                        livenessProbeImage:
+                          type: string
                         metadataSyncerImage:
                           type: string
                         nodeDriverImage:
                           type: string
                         provisionerImage:
+                          type: string
+                        registrarImage:
                           type: string
                       type: object
                   type: object

--- a/examples/default/cluster/cluster.yaml
+++ b/examples/default/cluster/cluster.yaml
@@ -47,3 +47,5 @@ spec:
         attacherImage: "quay.io/k8scsi/csi-attacher:v1.1.1"
         provisionerImage: "quay.io/k8scsi/csi-provisioner:v1.2.1"
         metadataSyncerImage: "vmware/volume-metadata-syncer:v1.0.0"
+        livenessProbeImage: "quay.io/k8scsi/livenessprobe:v1.1.0"
+        registrarImage: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"

--- a/pkg/cloud/vsphere/services/cloudprovider/csi.go
+++ b/pkg/cloud/vsphere/services/cloudprovider/csi.go
@@ -163,9 +163,9 @@ func VSphereCSINodeDaemonSet(storageConfig cloudprovider.StorageConfig) *appsv1.
 				Spec: corev1.PodSpec{
 					HostNetwork: true,
 					Containers: []corev1.Container{
-						NodeDriverRegistrarContainer(),
+						NodeDriverRegistrarContainer(storageConfig.RegistrarImage),
 						VSphereCSINodeContainer(storageConfig.NodeDriverImage),
-						LivenessProbeForNodeContainer(),
+						LivenessProbeForNodeContainer(storageConfig.LivenessProbeImage),
 					},
 					Tolerations: []corev1.Toleration{
 						{
@@ -224,10 +224,10 @@ func VSphereCSINodeDaemonSet(storageConfig cloudprovider.StorageConfig) *appsv1.
 	}
 }
 
-func NodeDriverRegistrarContainer() corev1.Container {
+func NodeDriverRegistrarContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  "node-driver-registrar",
-		Image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+		Image: image,
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.Handler{
 				Exec: &corev1.ExecAction{
@@ -323,10 +323,10 @@ func VSphereCSINodeContainer(image string) corev1.Container {
 	}
 }
 
-func LivenessProbeForNodeContainer() corev1.Container {
+func LivenessProbeForNodeContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  "liveness-probe",
-		Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+		Image: image,
 		Args:  []string{"--csi-address=$(ADDRESS)", "--health-port=9808"},
 		Env: []corev1.EnvVar{
 			{
@@ -384,7 +384,7 @@ func CSIControllerStatefulSet(storageConfig cloudprovider.StorageConfig) *appsv1
 					Containers: []corev1.Container{
 						CSIAttacherContainer(storageConfig.AttacherImage),
 						VSphereCSIControllerContainer(storageConfig.ControllerImage),
-						LivenessProbeForCSIControllerContainer(),
+						LivenessProbeForCSIControllerContainer(storageConfig.LivenessProbeImage),
 						VSphereSyncerContainer(storageConfig.MetadataSyncerImage),
 						CSIProvisionerContainer(storageConfig.ProvisionerImage),
 					},
@@ -474,10 +474,10 @@ func VSphereCSIControllerContainer(image string) corev1.Container {
 	}
 }
 
-func LivenessProbeForCSIControllerContainer() corev1.Container {
+func LivenessProbeForCSIControllerContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  "liveness-probe",
-		Image: "quay.io/k8scsi/livenessprobe:v1.1.0",
+		Image: image,
 		Args:  []string{"--csi-address=$(ADDRESS)", "--health-port=9809"},
 		Env: []corev1.EnvVar{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:

There are two image repos that hard coded in `csi.go`: `livenessprobe` and `csi-node-driver-registrar`. This PR parameterized those two image repos so that we could pass them as a parameter in `cluster.yaml`. 

**Special notes for your reviewer**:
Tested by deploying a 3 worker nodes cluster, replaced `livenessProbeImage` and `registrarImage` fields to point to my personal image repo in `cluster.yaml` and it is working. Please double check