### PR TITLE
Re-introduce the VM maintenance mode in v1alpha2

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -36,6 +36,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/config"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/services/govmomi"
@@ -126,6 +127,11 @@ func (r *VSphereMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, r
 		vsphereMachine)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to create machine context")
+	}
+
+	if _, ok := vsphereMachine.Annotations[constants.MaintenanceAnnotationLabel]; ok {
+		machineContext.Logger.V(6).Info("skipping operations on vsphere machine", "reason", "annotation", "annotation-key", constants.MaintenanceAnnotationLabel)
+		return reconcile.Result{RequeueAfter: config.DefaultRequeue}, nil
 	}
 
 	// Always close the context when exiting this function so we can persist any VSphereMachine changes.


### PR DESCRIPTION

**What this PR does / why we need it**:

By adding the annotation "capv.infrastructure.cluster.x-k8s.io/maintenance"
on the vsphereMachine object one can temporarily instruct the controller
to skip reconciliation of the vsphereMachine object

This feature was added in v1alpha1 previously with PR#370 but got removed
because of v1alpha2 refactoring.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #527 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```