### PR TITLE
use Machine.Name for VM name instead of VSphereMachine.Name

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/service.go
+++ b/pkg/cloud/vsphere/services/govmomi/service.go
@@ -44,7 +44,7 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (infrav1.VirtualM
 
 	// Create a VM object
 	vm := infrav1.VirtualMachine{
-		Name:  ctx.VSphereMachine.Name,
+		Name:  ctx.Machine.Name,
 		State: infrav1.VirtualMachineStatePending,
 	}
 
@@ -56,7 +56,7 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (infrav1.VirtualM
 		}
 
 		if ref != "" {
-			return vm, errors.Errorf("vm with the same Instance UUID already exists %q", ctx.VSphereMachine.Name)
+			return vm, errors.Errorf("vm with the same Instance UUID already exists %q", ctx.Machine.Name)
 		}
 
 		// no VM exits, goahead and create a VM
@@ -120,7 +120,7 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (infrav1.VirtualM
 func (vms *VMService) DestroyVM(ctx *context.MachineContext) (infrav1.VirtualMachine, error) {
 
 	vm := infrav1.VirtualMachine{
-		Name:  ctx.VSphereMachine.Name,
+		Name:  ctx.Machine.Name,
 		State: infrav1.VirtualMachineStatePending,
 	}
 
@@ -197,7 +197,7 @@ func (vms *VMService) reconcileMetadata(ctx *context.MachineContext, vm infrav1.
 		return false, err
 	}
 
-	newMetadata, err := util.GetMachineMetadata(*ctx.VSphereMachine, vm.Network...)
+	newMetadata, err := util.GetMachineMetadata(ctx.Machine.Name, *ctx.VSphereMachine, vm.Network...)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cloud/vsphere/util/machines.go
+++ b/pkg/cloud/vsphere/util/machines.go
@@ -146,7 +146,7 @@ func IsControlPlaneMachine(machine *clusterv1.Machine) bool {
 
 // GetMachineMetadata returns the cloud-init metadata as a base-64 encoded
 // string for a given VSphereMachine.
-func GetMachineMetadata(machine infrav1.VSphereMachine, networkStatus ...infrav1.NetworkStatus) ([]byte, error) {
+func GetMachineMetadata(hostname string, machine infrav1.VSphereMachine, networkStatus ...infrav1.NetworkStatus) ([]byte, error) {
 	// Create a copy of the devices and add their MAC addresses from a network status.
 	devices := make([]infrav1.NetworkDeviceSpec, len(machine.Spec.Network.Devices))
 	for i := range machine.Spec.Network.Devices {
@@ -168,7 +168,7 @@ func GetMachineMetadata(machine infrav1.VSphereMachine, networkStatus ...infrav1
 		Devices  []infrav1.NetworkDeviceSpec
 		Routes   []infrav1.NetworkRouteSpec
 	}{
-		Hostname: machine.Name,
+		Hostname: hostname, // note that hostname determines the Kubernetes node name
 		Devices:  devices,
 		Routes:   machine.Spec.Network.Routes,
 	}); err != nil {


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Use `Machine.Name` instead of `VSphereMachine.Name` for VM names in vSphere. That way the hostname and name of the VM are matching. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #623 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use Machine.Name for VM name instead of VSphereMachine.Name
```