### PR TITLE
drop capv-manager-bootstrap-credentials from infrastructure-components.yaml

### DIFF
--- a/config/default/manager_credentials_patch.yaml
+++ b/config/default/manager_credentials_patch.yaml
@@ -12,11 +12,11 @@ spec:
         - name: VSPHERE_USERNAME
           valueFrom:
             secretKeyRef:
-              name: manager-bootstrap-credentials
+              name: capv-manager-bootstrap-credentials
               key: username
         - name: VSPHERE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: manager-bootstrap-credentials
+              name: capv-manager-bootstrap-credentials
               key: password
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - manager.yaml
-- credentials.yaml

--- a/examples/default/provider-components/capv_manager_bootstrap_credentials.yaml
+++ b/examples/default/provider-components/capv_manager_bootstrap_credentials.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: manager-bootstrap-credentials
-  namespace: system
+  name: capv-manager-bootstrap-credentials
+  namespace: capv-system
 type: Opaque
 data:
   username: ${VSPHERE_B64ENCODED_USERNAME}

--- a/examples/default/provider-components/kustomization.yaml
+++ b/examples/default/provider-components/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - provider-components-kubeadm.yaml
 - provider-components-cluster-api.yaml
 - provider-components-vsphere.yaml
+- capv_manager_bootstrap_credentials.yaml
 patchesStrategicMerge:
 - cabpk_manager_patches.yaml
 - capi_manager_patches.yaml

--- a/examples/pre-67u3/provider-components/capv_manager_bootstrap_credentials.yaml
+++ b/examples/pre-67u3/provider-components/capv_manager_bootstrap_credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capv-manager-bootstrap-credentials
+  namespace: capv-system
+type: Opaque
+data:
+  username: ${VSPHERE_B64ENCODED_USERNAME}
+  password: ${VSPHERE_B64ENCODED_PASSWORD}

--- a/examples/pre-67u3/provider-components/kustomization.yaml
+++ b/examples/pre-67u3/provider-components/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - provider-components-kubeadm.yaml
 - provider-components-cluster-api.yaml
 - provider-components-vsphere.yaml
+- capv_manager_bootstrap_credentials.yaml
 patchesStrategicMerge:
 - cabpk_manager_patches.yaml
 - capi_manager_patches.yaml


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This  PR drops the bootstrap credentials from the infrastructure-components. This should make `infrastructure-components.yaml` non-specific to an environment. 

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/608

**Special notes for your reviewer**:

/assign @andrewsykim 

**Release note**:

```release-note

```