### PR TITLE
remove StorageClass from addons file

### DIFF
--- a/examples/default/addons.yaml
+++ b/examples/default/addons.yaml
@@ -1,13 +1,3 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  datastore: ""
-
 # Calico Version v3.6
 # https://docs.projectcalico.org/v3.6/release-notes/
 ---

--- a/examples/pre-67u3/addons.yaml
+++ b/examples/pre-67u3/addons.yaml
@@ -1,13 +1,3 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  datastore: ""
-
 # Calico Version v3.6
 # https://docs.projectcalico.org/v3.6/release-notes/
 ---


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Removes StorageClass from addons.yaml, which removes any confusion from users thinking that CAPV is responsible for managing StorageClasses. StorageClasses should be created by the user or some operator that runs on top of the cluster. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #360 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove StorageClass from addons file, users should manage their own StorageClasses based on the CSI documentation. 
```