### PR TITLE
allow passing a VERSION when generating infrastructure-components.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,12 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 
 .PHONY: release-manifests
 release-manifests: ## Builds the manifests to publish with a release
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
 	@mkdir -p out
-	$(KUSTOMIZE) build config/default >out/infrastructure-components.yaml
-
+	cd config/manager/; ../../"$(KUSTOMIZE)" edit set image gcr.io/cluster-api-provider-vsphere/release/manager:"$(VERSION)"
+	"$(KUSTOMIZE)" build config/default > out/infrastructure-components.yaml
 ## --------------------------------------
 ## Cleanup / Verification
 ## --------------------------------------


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR allows us to pass a fixed version when generating `infrastructure-components.yaml`. it works using : `make release-manifests VERSION=x.y.z` 

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/609

**Special notes for your reviewer**:

/assign @andrewsykim 

**Release note**:

```release-note
NONE
```