### PR TITLE
Fix idempotency convention link

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -74,7 +74,7 @@ spec:
                         with Reason ServerTimeout indicating a unique name could not
                         be found in the time allotted, and the client should retry
                         (optionally after the time indicated in the Retry-After header).
-                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                       type: string
                     labels:
                       additionalProperties:


### PR DESCRIPTION


**What this PR does / why we need it**: The CRD test was failing because the generated CRDs have an updated link
to idempotency conventions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @andrewsykim 