### PR TITLE
add liveness probe check to CSI deployments

### DIFF
--- a/pkg/cloud/vsphere/services/cloudprovider/csi.go
+++ b/pkg/cloud/vsphere/services/cloudprovider/csi.go
@@ -21,6 +21,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha2/cloudprovider"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 )
@@ -312,6 +313,25 @@ func VSphereCSINodeContainer(image string) corev1.Container {
 			},
 		},
 		Args: []string{"--v=4"},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "healthz",
+				ContainerPort: 9808,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.Parse("healthz"),
+				},
+			},
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      3,
+			PeriodSeconds:       5,
+			FailureThreshold:    3,
+		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: boolPtr(true),
 			Capabilities: &corev1.Capabilities{
@@ -464,6 +484,25 @@ func VSphereCSIControllerContainer(image string) corev1.Container {
 		},
 		Args:            []string{"--v=4"},
 		ImagePullPolicy: corev1.PullAlways,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "healthz",
+				ContainerPort: 9808,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.Parse("healthz"),
+				},
+			},
+			InitialDelaySeconds: 10,
+			TimeoutSeconds:      3,
+			PeriodSeconds:       5,
+			FailureThreshold:    3,
+		},
 		Env: []corev1.EnvVar{
 			{
 				Name:  "CSI_ENDPOINT",


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/640, adds liveness probe check to CSI spec. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```