### PR TITLE
check vm existence even if machineRef is not set

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/service.go
+++ b/pkg/cloud/vsphere/services/govmomi/service.go
@@ -135,19 +135,17 @@ func (vms *VMService) DestroyVM(ctx *context.MachineContext) (infrav1.VirtualMac
 		return vm, err
 	}
 
-	// check if VM actually exists
-	if ctx.VSphereMachine.Spec.MachineRef != "" {
-		moRefID, err := findVMByInstanceUUID(ctx)
-		if err != nil {
-			return vm, err
-		}
-		if moRefID == "" {
-			// No vm exists
-			// remove the MachineRef and set the vm state to notfound
-			ctx.VSphereMachine.Spec.MachineRef = ""
-			vm.State = infrav1.VirtualMachineStateNotFound
-			return vm, nil
-		}
+	// check if the vm existts
+	moRefID, err := findVMByInstanceUUID(ctx)
+	if err != nil {
+		return vm, err
+	}
+	if moRefID == "" {
+		// No vm exists
+		// remove the MachineRef and set the vm state to notfound
+		ctx.VSphereMachine.Spec.MachineRef = ""
+		vm.State = infrav1.VirtualMachineStateNotFound
+		return vm, nil
 	}
 
 	// VM actually exists


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This fix checks vm existence even if the machineRef is not set, this covers the case where a vm delete happens fast enough through vcenter

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/622

**Special notes for your reviewer**:

/assign @andrewsykim @akutz 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```