### PR TITLE
Bump default golang version to 1.12.10 to address CVE-2019-16276

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.12.9 as builder
+ARG GOLANG_VERSION=golang:1.12.10
+FROM $GOLANG_VERSION as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/scripts/e2e/e2e.sh
+++ b/scripts/e2e/e2e.sh
@@ -137,6 +137,15 @@ start_docker() {
    done
 }
 
+install_govc() {
+   GOVC_VERSION=v0.21.0
+   GOVC_PKG_NAME=govc_linux_amd64
+   curl -L -O https://github.com/vmware/govmomi/releases/download/"${GOVC_VERSION}"/"${GOVC_PKG_NAME}".gz
+   gunzip "${GOVC_PKG_NAME}".gz
+   mv "${GOVC_PKG_NAME}" /usr/local/bin/govc
+   chmod +x /usr/local/bin/govc
+}
+
 on_exit() {
   [ "${VM_CREATED}" ] || return 0
   get_bootstrap_vm "${CONTEXT}"
@@ -158,8 +167,7 @@ export CAPI_VERSION=v0.2.7
 echo "build vSphere controller version: ${VERSION}"
 echo "using clusterctl version: ${CAPI_VERSION}"
 
-# install_govc
-go get -u github.com/vmware/govmomi/govc
+install_govc
 
 # Push new container images
 # TODO the `-k` flag here is a workaround until we can set GCR_KEY_FILE properly


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Bump default golang version to 1.12.10 to address CVE-2019-16276

Set golang_version argument, user can always build with specific
golang version by passing --build-arg golang_version:golang:1.x.x

Signed-off-by: Hui Luo <luoh@vmware.com>

**Which issue(s) this PR fixes** 
N/A
**Special notes for your reviewer**:
N/A

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

cc @akutz @andrewsykim @jiatongw @frapposelli 