### PR TITLE
Fixes error when using -P flag with generator

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -62,7 +62,7 @@ FLAGS
 EOF
 }
 
-while getopts ':b:B:c:dfhi:m:M:r:o:p:P' opt; do
+while getopts ':b:B:c:dfhi:m:M:r:o:p:P:' opt; do
   case "${opt}" in
   b)
     CABPK_MANAGER_IMAGE="${OPTARG}"


### PR DESCRIPTION
/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes an error when using the `-P` flag with the generator to set the CAPI manager's log level. The getopts string was missing a `:` character after the `P`, and so the shell was saying `OPTARG` was an unbound variable since the `-P` flag didn't pick up its value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
/assign @yastij 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Fixes bug when using the -P flag with the manifest generator image
```