### PR TITLE
Add warning to getting started guide to carefully handle the .ova suffix

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -50,7 +50,7 @@ It is required that machines provisioned by CAPV use one of the official CAPV ma
 
 [Create a VM template](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-17BEDA21-43F6-41F4-8FB2-E01D275FE9B4.html) using the OVA URL above. The rest of the guide will assume you named the VM template `ubuntu-1804-kube-v1.15.4`.
 
-**Note:** When creating OVA template via vSphere using URL method, make sure VM template name is same as value specified for environment variable VSPHERE_TEMPLATE in envvars.txt file, taking care of .ova suffix for the template name.
+**Note:** When creating the OVA template via vSphere using the URL method, please make sure the VM template name is the same as the value specified by the environment variable `VSPHERE_TEMPLATE` in the `envvars.txt` file, taking care of the `.ova` suffix for the template name.
 
 **Note:** If you are planning to use CNS/CSI then you will need to ensure that the template is at least at VM Hardware Version 13, This is done out-of-the-box for images of K8s version `v1.15.4` and above. For versions lower than this you will need to upgrade the VMHW either [in the UI](https://kb.vmware.com/s/article/1010675) or with [`govc`](https://github.com/vmware/govmomi/tree/master/govc) as such:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -50,6 +50,8 @@ It is required that machines provisioned by CAPV use one of the official CAPV ma
 
 [Create a VM template](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-17BEDA21-43F6-41F4-8FB2-E01D275FE9B4.html) using the OVA URL above. The rest of the guide will assume you named the VM template `ubuntu-1804-kube-v1.15.4`.
 
+**Note:** When creating OVA template via vSphere using URL method, make sure VM template name is same as value specified for environment variable VSPHERE_TEMPLATE in envvars.txt file, taking care of .ova suffix for the template name.
+
 **Note:** If you are planning to use CNS/CSI then you will need to ensure that the template is at least at VM Hardware Version 13, This is done out-of-the-box for images of K8s version `v1.15.4` and above. For versions lower than this you will need to upgrade the VMHW either [in the UI](https://kb.vmware.com/s/article/1010675) or with [`govc`](https://github.com/vmware/govmomi/tree/master/govc) as such:
 
 ```sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
   Modify Getting started guide to add a warning for careful handling of .ova suffix in envvars.txt file when VM template is created using vSphere 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/671

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```