### PR TITLE
A Dockerfile with a built-in OpenVPN client for testing

### DIFF
--- a/hack/tools/openvpn/Dockerfile
+++ b/hack/tools/openvpn/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:buster-slim
+LABEL "maintainer" "Andrew Kutz <akutz@vmware.com>"
+
+RUN apt-get --assume-no  update && \
+    apt-get --assume-yes install curl openvpn iputils-ping && \
+    rm -fr /var/lib/apt/lists/*
+
+WORKDIR /vpn
+
+COPY openvpn.sh /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/openvpn.sh
+
+ENTRYPOINT ["/usr/local/bin/openvpn.sh"]

--- a/hack/tools/openvpn/Makefile
+++ b/hack/tools/openvpn/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: build
+
+VERSION ?= $(shell git describe --always --dirty)
+IMAGE_NAME ?= gcr.io/cluster-api-provider-vsphere/extra/openvpn
+IMAGE_TAG ?= $(IMAGE_NAME):$(VERSION)
+
+build:
+	docker build -t $(IMAGE_TAG) .
+	docker tag $(IMAGE_TAG) $(IMAGE_NAME):latest
+.PHONY: build
+
+push:
+	docker push $(IMAGE_TAG)
+	docker push $(IMAGE_NAME):latest
+.PHONY: push

--- a/hack/tools/openvpn/openvpn.sh
+++ b/hack/tools/openvpn/openvpn.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+run_openvpn() {
+  [ "${#}" -eq "0" ] && exec openvpn --config "$(/bin/ls ./*.ovpn)"
+  exec openvpn "${@}"
+}
+
+[ "${#}" -eq "0" ] && run_openvpn
+
+{ [ "${1}" = "/bin/bash" ] || \
+  [ "${1}" = "bash" ] || \
+  [ "${1}" = "/bin/sh" ] || \
+  [ "${1}" = "sh" ] || \
+  [ "${1}" = "shell" ]; } && exec /bin/bash
+
+run_openvpn "${@}"


### PR DESCRIPTION
/kind feature

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch introduces support for building a container image with a built-in OpenVPN client. This is useful for testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```