### PR TITLE
Set network interface name with cloud-init set-name

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -94,10 +94,10 @@ type NetworkDeviceSpec struct {
 	// will be connected.
 	NetworkName string `json:"networkName"`
 
-	// setName can be used to give the device a more specific/desirable/nicer
-	// name than the default from udev’s ifnames
+	// DeviceName may be used to explicitly assign a name to the network device
+	// as it exists in the guest operating system.
 	// +optional
-	SetName string `json:"setName,omitempty"`
+	DeviceName string `json:"deviceName,omitempty"`
 
 	// DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
 	// on this device.

--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -94,6 +94,11 @@ type NetworkDeviceSpec struct {
 	// will be connected.
 	NetworkName string `json:"networkName"`
 
+	// setName can be used to give the device a more specific/desirable/nicer
+	// name than the default from udev’s ifnames
+	// +optional
+	SetName string `json:"setName,omitempty"`
+
 	// DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
 	// on this device.
 	// If true then IPAddrs should not contain any IPv4 addresses.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -62,6 +62,11 @@ spec:
                     description: NetworkDeviceSpec defines the network configuration
                       for a virtual machine's network device.
                     properties:
+                      deviceName:
+                        description: DeviceName may be used to explicitly assign a
+                          name to the network device as it exists in the guest operating
+                          system.
+                        type: string
                       dhcp4:
                         description: DHCP4 is a flag that indicates whether or not
                           to use DHCP for IPv4 on this device. If true then IPAddrs
@@ -138,10 +143,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      deviceName:
-                        description: DeviceName may be used to explicitly assign a name
-                          to the network device as it exists in the guest operating system.
-                        type: string
                     required:
                     - networkName
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -139,9 +139,8 @@ spec:
                           type: string
                         type: array
                       deviceName:
-                        description: deviceName can be used to give the device a more
-                          specific/desirable/nicer name than the default from udev’s
-                          ifnames
+                        description: DeviceName may be used to explicitly assign a name
+                          to the network device as it exists in the guest operating system.
                         type: string
                     required:
                     - networkName

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -138,8 +138,8 @@ spec:
                         items:
                           type: string
                         type: array
-                      setName:
-                        description: setName can be used to give the device a more
+                      deviceName:
+                        description: deviceName can be used to give the device a more
                           specific/desirable/nicer name than the default from udev’s
                           ifnames
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -138,6 +138,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      setName:
+                        description: setName can be used to give the device a more
+                          specific/desirable/nicer name than the default from udev’s
+                          ifnames
+                        type: string
                     required:
                     - networkName
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -255,6 +255,11 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              setName:
+                                description: setName can be used to give the device
+                                  a more specific/desirable/nicer name than the default
+                                  from udev’s ifnames
+                                type: string
                             required:
                             - networkName
                             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -255,8 +255,8 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                              setName:
-                                description: setName can be used to give the device
+                              deviceName:
+                                description: deviceName can be used to give the device
                                   a more specific/desirable/nicer name than the default
                                   from udev’s ifnames
                                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -177,6 +177,11 @@ spec:
                             description: NetworkDeviceSpec defines the network configuration
                               for a virtual machine's network device.
                             properties:
+                              deviceName:
+                                description: DeviceName may be used to explicitly
+                                  assign a name to the network device as it exists
+                                  in the guest operating system.
+                                type: string
                               dhcp4:
                                 description: DHCP4 is a flag that indicates whether
                                   or not to use DHCP for IPv4 on this device. If true
@@ -255,10 +260,6 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                              deviceName:
-                                description: DeviceName may be used to explicitly assign a name
-                                  to the network device as it exists in the guest operating system.
-                                type: string
                             required:
                             - networkName
                             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -256,9 +256,8 @@ spec:
                                   type: string
                                 type: array
                               deviceName:
-                                description: deviceName can be used to give the device
-                                  a more specific/desirable/nicer name than the default
-                                  from udev’s ifnames
+                                description: DeviceName may be used to explicitly assign a name
+                                  to the network device as it exists in the guest operating system.
                                 type: string
                             required:
                             - networkName

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -328,6 +328,21 @@ network:
 
 The above network configuratoin from a machine definition includes two network devices, both using DHCP. This likely causes two default routes to be defined on the guest, meaning it's not possible to determine the default IPv4 address that should be used by Kubernetes.
 
+#### Specifying the ethernet interface device names
+
+A bug with Cloud-Init Networking Config Version 2 prevents the use of Predicatable Device Names in CentOS and Photon [`583`](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/583). For this reason CAPV sets devices name to eth*. Should one wish to use alternate interface device names, use the setName parameter. For example:
+
+```yaml
+network:
+  devices:
+  - networkName: "sddc-cgw-network-5"
+    setName: "ens192"
+    dhcp4: true
+  - networkName: "sddc-cgw-network-6"
+    setName: "ens193"
+    dhcp4: true
+```
+
 ##### Preferring an IP address
 
 Another reason a machine with two networks can lead to failure is because the order in which IP addresses are returned externally from a VM is not guaranteed to be the same order as they are when inspected inside the guest. The solution for this is to define a preferred CIDR -- the network segment that contains the IP that the `kubeadm` bootstrap process selected for the API server. For example:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -330,16 +330,16 @@ The above network configuratoin from a machine definition includes two network d
 
 #### Specifying the ethernet interface device names
 
-A bug with Cloud-Init Networking Config Version 2 prevents the use of Predicatable Device Names in CentOS and Photon [`583`](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/583). For this reason CAPV sets devices name to eth*. Should one wish to use alternate interface device names, use the setName parameter. For example:
+A bug with Cloud-Init Networking Config Version 2 prevents the use of Predicatable Device Names in CentOS and Photon [`583`](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/583). For this reason CAPV sets devices name to eth*. Should one wish to use alternate interface device names, use the deviceName parameter. For example:
 
 ```yaml
 network:
   devices:
   - networkName: "sddc-cgw-network-5"
-    setName: "ens192"
+    deviceName: "ens192"
     dhcp4: true
   - networkName: "sddc-cgw-network-6"
-    setName: "ens193"
+    deviceName: "ens193"
     dhcp4: true
 ```
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -26,6 +26,11 @@ network:
     id{{ $i }}:
       match:
         macaddress: "{{ $net.MACAddr }}"
+      {{- if $net.SetName }}
+      set-name: "{{ $net.SetName }}"
+      {{- else }}
+      set-name: "eth{{ $i }}"
+      {{- end }}
       wakeonlan: true
       dhcp4: {{ $net.DHCP4 }}
       dhcp6: {{ $net.DHCP6 }}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -26,8 +26,8 @@ network:
     id{{ $i }}:
       match:
         macaddress: "{{ $net.MACAddr }}"
-      {{- if $net.SetName }}
-      set-name: "{{ $net.SetName }}"
+      {{- if $net.DeviceName }}
+      set-name: "{{ $net.DeviceName }}"
       {{- else }}
       set-name: "eth{{ $i }}"
       {{- end }}

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -245,6 +245,38 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
+      wakeonlan: true
+      dhcp4: true
+      dhcp6: false
+`,
+		},
+		{
+			name: "dhcp4+setName",
+			machine: &v1alpha2.VSphereMachine{
+				Spec: v1alpha2.VSphereMachineSpec{
+					Network: v1alpha2.NetworkSpec{
+						Devices: []v1alpha2.NetworkDeviceSpec{
+							{
+								NetworkName: "network1",
+								MACAddr:     "00:00:00:00:00",
+								DHCP4:       true,
+								SetName:     "ens192",
+							},
+						},
+					},
+				},
+			},
+			expected: `
+instance-id: "test-vm"
+local-hostname: "test-vm"
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:00:00:00:00"
+      set-name: "ens192"
       wakeonlan: true
       dhcp4: true
       dhcp6: false
@@ -274,6 +306,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -304,6 +337,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: true
@@ -335,6 +369,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -376,6 +411,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -425,6 +461,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: false
@@ -435,6 +472,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
+      set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -475,6 +513,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: false
@@ -489,6 +528,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
+      set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -252,7 +252,7 @@ network:
 `,
 		},
 		{
-			name: "dhcp4+setName",
+			name: "dhcp4+deviceName",
 			machine: &v1alpha2.VSphereMachine{
 				Spec: v1alpha2.VSphereMachineSpec{
 					Network: v1alpha2.NetworkSpec{
@@ -261,7 +261,7 @@ network:
 								NetworkName: "network1",
 								MACAddr:     "00:00:00:00:00",
 								DHCP4:       true,
-								SetName:     "ens192",
+								DeviceName:  "ens192",
 							},
 						},
 					},


### PR DESCRIPTION
/kind bug
/assign @akutz

**What this PR does / why we need it**:
`Cloud-Init Network Config Version 2` fails to use `Predictable Network Interface Names`. Instead it uses the `Cloud-Init Device Configuration ID` as the interface name. [Bug #1855945](https://bugs.launchpad.net/cloud-init/+bug/1855945) 

As a workaround, this PR adds `SetName` as an optional parameter to the `NetworkDeviceSpec`. When `SetName` is not specified, `cloud-init metadata` is configured with `set-name: "eth*"` where * equals the Device ID index. When `SetName` *is* specified, `cloud-init set-name` uses this value.

Summary:
- Adds `SetName` to `NetworkDeviceSpec`
- Adds `SetName` to `vspheremachines` and `vspheremachinetemplates` CRDs
- Adds templating for `set-name` to `pkg/util/constants.go` 
- Adds & updates tests in `machines_tests.go`
- Updates `troubleshooting.md` documentation


**Which issue(s) this PR fixes**
Fixes #583 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
Ability to configure Network Interface names
```