### PR TITLE
/etc/hosts update fixes cloudinit vmware reconcile

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -241,7 +241,8 @@ spec:
   preKubeadmCommands:
   - hostname "{{ ds.meta_data.hostname }}"
   - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-  - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+  - echo "127.0.0.1   localhost" >>/etc/hosts
+  - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
   - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
   users:
   - name: capv
@@ -312,7 +313,8 @@ spec:
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: capv

--- a/examples/default/controlplane/controlplane.yaml
+++ b/examples/default/controlplane/controlplane.yaml
@@ -65,5 +65,6 @@ spec:
   preKubeadmCommands:
   - hostname "{{ ds.meta_data.hostname }}"
   - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-  - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+  - echo "127.0.0.1   localhost" >>/etc/hosts
+  - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
   - echo "{{ ds.meta_data.hostname }}" >/etc/hostname

--- a/examples/default/machinedeployment/machinedeployment.yaml
+++ b/examples/default/machinedeployment/machinedeployment.yaml
@@ -64,5 +64,6 @@ spec:
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname

--- a/examples/pre-67u3/controlplane/controlplane.yaml
+++ b/examples/pre-67u3/controlplane/controlplane.yaml
@@ -86,5 +86,6 @@ spec:
   preKubeadmCommands:
   - hostname "{{ ds.meta_data.hostname }}"
   - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-  - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+  - echo "127.0.0.1   localhost" >>/etc/hosts
+  - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
   - echo "{{ ds.meta_data.hostname }}" >/etc/hostname

--- a/examples/pre-67u3/machinedeployment/machinedeployment.yaml
+++ b/examples/pre-67u3/machinedeployment/machinedeployment.yaml
@@ -64,5 +64,6 @@ spec:
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname


### PR DESCRIPTION
**What this PR does / why we need it**:
Subsequent runs of cloud-init, post the initial start-up, sometimes cause the machine hostname to be renamed to `localhost`. This is due to the way `cloud-init` `DataSourceVMwareGuestInfo.py` reconciles the hostname from multi-line entries within `/etc/hosts`.

```python
>>> socket.getaddrinfo('generic-cluster-1-controlplane-0', None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME)
[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_DGRAM: 2>, 17, 'localhost', ('127.0.0.1', 0))]
```

https://github.com/vmware/cloud-init-vmware-guestinfo/blob/9e69060170b5b4210ec60ba2f09caf644617d91b/DataSourceVMwareGuestInfo.py#L544-L545

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #577

**Special notes for your reviewer**:
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```

/assign @akutz
/cc andrewsykim 