### PR TITLE
Refactor multi-node, control plane e2e test to use KubeadmControlPlane

### DIFF
--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -131,7 +131,8 @@ func GetMachinePreferredIPAddress(machine *infrav1.VSphereMachine) (string, erro
 // IsControlPlaneMachine returns true if the provided resource is
 // a member of the control plane.
 func IsControlPlaneMachine(machine metav1.Object) bool {
-	return machine.GetLabels()[clusterv1.MachineControlPlaneLabelName] != ""
+	_, ok := machine.GetLabels()[clusterv1.MachineControlPlaneLabelName]
+	return ok
 }
 
 // GetMachineMetadata returns the cloud-init metadata as a base-64 encoded

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -58,6 +58,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(config).ShouldNot(BeNil())
 
+	By("applying e2e config defaults")
+	config.Defaults()
+
 	By("cleaning up previous kind cluster")
 	kindx.TeardownIfExists(ctx, config.ManagementClusterName)
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: 
This PR updates the e2e test that validates CAPV can deploy a multi-node, control plane to use the `KubeadmControlPlane` model.

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @akutz 

**note**: This still keeps the single-node control plane test

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```