### PR TITLE
Add cluster-api-maintainers to OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,8 @@ approvers:
   - sig-cluster-lifecycle-leads
   - cluster-api-admins
   - cluster-api-vsphere-maintainers
+  - cluster-api-maintainers
 
 reviewers:
   - cluster-api-vsphere-maintainers
+  - cluster-api-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,12 @@ aliases:
     - davidewatson
     - detiber
     - justinsb
+  cluster-api-maintainers:
+    - justinsb
+    - detiber
+    - ncdc
+    - vincepri
+    - chuckha
   cluster-api-vsphere-maintainers:
     - frapposelli
     - sflxn


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cluster-api-maintainers as approvers and reviewers to
OWNERS_ALIASES. This is consistent with both cluster-api and
cluster-api-provider-aws.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```