### PR TITLE
switch e2e to use a centOS-based OVA

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -113,7 +113,7 @@ export VSPHERE_FOLDER="clusterapi"
 export VSPHERE_RESOURCE_POOL="clusterapi"
 export VSPHERE_DATASTORE="WorkloadDatastore"
 export VSPHERE_NETWORK="sddc-cgw-network-5"
-export VSPHERE_MACHINE_TEMPLATE="ubuntu-1804-kube-v1.16.2"
+export VSPHERE_MACHINE_TEMPLATE="centos-7-kube-v1.16.2"
 export VSPHERE_HAPROXY_TEMPLATE="capv-haproxy-v0.5.3-77-g224e0ef6"
 
 export CAPI_IMAGE="gcr.io/k8s-staging-cluster-api/cluster-api-controller:v20200103-v0.2.5-497-gdbe789259"


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**:
This PR switch the e2e to use a centOS-based OVA. it's an attempt to remove flakes seen in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/730 and https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/725
Probably caused by https://github.com/kubernetes-sigs/image-builder/issues/90#issuecomment-579296188

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:


**Release note**:

```release-note

```