### PR TITLE
dump the bootstrap cluster logs into the artifacts directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ MANIFEST_ROOT ?= config
 CRD_ROOT ?= $(MANIFEST_ROOT)/crd/bases
 WEBHOOK_ROOT ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
+GC_KIND ?= true
 
 ## --------------------------------------
 ## Help
@@ -72,7 +73,7 @@ e2e-image: ## Build the e2e manager image
 .PHONY: e2e
 e2e: e2e-image
 e2e: ## Run e2e tests
-	time ginkgo -v ./test/e2e -- --e2e.config="$(abspath test/e2e/e2e.conf)"
+	time ginkgo -v ./test/e2e -- --e2e.config="$(abspath test/e2e/e2e.conf)" --e2e.teardownKind=$(GC_KIND)
 
 ## --------------------------------------
 ## Binaries

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -34,15 +34,17 @@ import (
 )
 
 var (
-	mgmt       framework.ManagementCluster
-	mgmtClient client.Client
-	configPath string
-	config     *framework.Config
-	ctx        = context.Background()
+	mgmt         framework.ManagementCluster
+	mgmtClient   client.Client
+	configPath   string
+	teardownKind bool
+	config       *framework.Config
+	ctx          = context.Background()
 )
 
 func init() {
 	flag.StringVar(&configPath, "e2e.config", "e2e.conf", "path to the e2e config file")
+	flag.BoolVar(&teardownKind, "e2e.teardownKind", true, "should we teardown the kind cluster or not")
 }
 
 func TestCAPV(t *testing.T) {
@@ -82,6 +84,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the management cluster")
-	mgmt.Teardown(ctx)
+	if teardownKind {
+		By("tearing down the management cluster")
+		mgmt.Teardown(ctx)
+	}
 })


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR dump logs and other info of the bootstrap cluster into the artifacts directory

**Which issue(s) this PR fixes**: part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/734

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```