### PR TITLE
default the kubernetes version to v1.16.2 in the manifest generation

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -269,7 +269,7 @@ verify_cpu_mem_dsk VSPHERE_DISK_GIB 20
 # TODO: check if KUBERNETES_VERSION has format "v1.15.3" and
 # trim the "v" from the version. Alternatively, have CAPV or CAPI
 # handle both 1.15.3 and v1.15.3
-[[ ${KUBERNETES_VERSION-} =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+([\+\.\-](.+))?$ ]] || KUBERNETES_VERSION="1.15.3"
+[[ ${KUBERNETES_VERSION-} =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+([\+\.\-](.+))?$ ]] || KUBERNETES_VERSION="1.16.2"
 record_and_export KUBERNETES_VERSION ":-${KUBERNETES_VERSION}"
 
 # Base64 encode the credentials and unset the plain-text values.


### PR DESCRIPTION
This defaulting avoid having a kubelet with 1.16.2 and 1.15.3 control plane
which is not supported

Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR fixes a bug in the manifest generation, now If `KUBERNETES_VERSION` is not specified we default to v1.16.2 instead of v1.15.3, this avoids having a 1.16 kubelet and a 1.15 control plane which makes `kubeadm init` fail
 
**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @akutz 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```