### PR TITLE
bump csi version to the latest release

### DIFF
--- a/examples/default/cluster/cluster.yaml
+++ b/examples/default/cluster/cluster.yaml
@@ -42,10 +42,10 @@ spec:
       cloud:
         controllerImage: "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.0.0"
       storage:
-        controllerImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1"
-        nodeDriverImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1"
+        controllerImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
+        nodeDriverImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
         attacherImage: "quay.io/k8scsi/csi-attacher:v1.1.1"
         provisionerImage: "quay.io/k8scsi/csi-provisioner:v1.2.1"
-        metadataSyncerImage: "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1"
+        metadataSyncerImage: "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2"
         livenessProbeImage: "quay.io/k8scsi/livenessprobe:v1.1.0"
         registrarImage: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -32,8 +32,8 @@ import (
 // NOTE: the contents of this file are derived from https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/1.14
 
 const (
-	DefaultCSIControllerImage     = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1"
-	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1"
+	DefaultCSIControllerImage     = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2"
+	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
 	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v1.1.1"
 	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v1.2.1"
 	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1"


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR bumps the CSI version to the latest release. This should avoid breaking setups in VMC, as its SDDCs are being upgraded to vsphere 7.0 which is not compatible with the current CSI version.

**Which issue(s) this PR fixes** Fixes #

**Special notes for your reviewer**:

/assign @akutz 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
bump the vsphere csi driver to the newest release 1.0.2
```