### PR TITLE
bump creation timeout to avoid flakes

### DIFF
--- a/test/e2e/capv_test.go
+++ b/test/e2e/capv_test.go
@@ -43,7 +43,7 @@ var _ = Describe("CAPV", func() {
 			machineDeploymentGen   MachineDeploymentGenerator
 			controlPlaneNodeGen    ControlPlaneNodeGenerator
 			kubeadmControlPlaneGen *KubeadmControlPlaneGenerator
-			pollTimeout            = 15 * time.Minute
+			pollTimeout            = 20 * time.Minute
 			pollInterval           = 10 * time.Second
 
 			numControlPlaneMachines int32


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR bumps the creation timeout to absorb the flakes seen on e2e jobs. this should rule out the scenario where machines get stuck indefinitely 

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @akutz 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```