### PR TITLE
wait for KCP nodes to be provisioned

### DIFF
--- a/test/e2e/capv_test.go
+++ b/test/e2e/capv_test.go
@@ -43,7 +43,7 @@ var _ = Describe("CAPV", func() {
 			machineDeploymentGen   MachineDeploymentGenerator
 			controlPlaneNodeGen    ControlPlaneNodeGenerator
 			kubeadmControlPlaneGen *KubeadmControlPlaneGenerator
-			pollTimeout            = 10 * time.Minute
+			pollTimeout            = 15 * time.Minute
 			pollInterval           = 10 * time.Second
 
 			numControlPlaneMachines int32

--- a/test/e2e/framework/control_plane.go
+++ b/test/e2e/framework/control_plane.go
@@ -158,13 +158,13 @@ func waitForControlPlaneInitialized(ctx context.Context, input *ControlplaneClus
 		Namespace: input.Cluster.GetNamespace(),
 		Name:      input.Cluster.GetName(),
 	}
-	Eventually(func() (bool, error) {
+	Eventually(func() (string, error) {
 		cluster := &clusterv1.Cluster{}
 		if err := mgmtClient.Get(ctx, clusterKey, cluster); err != nil {
-			return false, err
+			return "", err
 		}
-		return cluster.Status.ControlPlaneInitialized, nil
-	}, input.CreateTimeout, eventuallyInterval).Should(BeTrue())
+		return cluster.Status.Phase, nil
+	}, input.CreateTimeout, eventuallyInterval).Should(Equal(string(clusterv1.ClusterPhaseProvisioned)))
 }
 
 func logCreatingBy(obj runtime.Object) string {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR moves from waiting KCP nodes to be initialized to checking if they're provisioned 

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```