### PR TITLE
rename errorreason/message fields in vsphereMachine status

### DIFF
--- a/api/v1alpha3/vspheremachine_types.go
+++ b/api/v1alpha3/vspheremachine_types.go
@@ -53,7 +53,7 @@ type VSphereMachineStatus struct {
 	// +optional
 	Network []NetworkStatus `json:"network,omitempty"`
 
-	// ErrorReason will be set in the event that there is a terminal problem
+	// FailureReason will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a succinct value suitable
 	// for machine interpretation.
 	//
@@ -70,9 +70,9 @@ type VSphereMachineStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	ErrorReason *errors.MachineStatusError `json:"errorReason,omitempty"`
+	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
-	// ErrorMessage will be set in the event that there is a terminal problem
+	// FailureMessage will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a more verbose string suitable
 	// for logging and human consumption.
 	//
@@ -89,7 +89,7 @@ type VSphereMachineStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	ErrorMessage *string `json:"errorMessage,omitempty"`
+	FailureMessage *string `json:"failureMessage,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -455,13 +455,13 @@ func (in *VSphereMachineStatus) DeepCopyInto(out *VSphereMachineStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ErrorReason != nil {
-		in, out := &in.ErrorReason, &out.ErrorReason
+	if in.FailureReason != nil {
+		in, out := &in.FailureReason, &out.FailureReason
 		*out = new(errors.MachineStatusError)
 		**out = **in
 	}
-	if in.ErrorMessage != nil {
-		in, out := &in.ErrorMessage, &out.ErrorMessage
+	if in.FailureMessage != nil {
+		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -528,8 +528,8 @@ spec:
                   - type
                   type: object
                 type: array
-              errorMessage:
-                description: "ErrorMessage will be set in the event that there is
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
                   a terminal problem reconciling the Machine and will contain a more
                   verbose string suitable for logging and human consumption. \n This
                   field should not be set for transitive errors that a controller
@@ -543,9 +543,9 @@ spec:
                   occur during the reconciliation of Machines can be added as events
                   to the Machine object and/or logged in the controller's output."
                 type: string
-              errorReason:
-                description: "ErrorReason will be set in the event that there is a
-                  terminal problem reconciling the Machine and will contain a succinct
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
                   value suitable for machine interpretation. \n This field should
                   not be set for transitive errors that a controller faces that are
                   expected to be fixed automatically over time (like service outages),

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -239,7 +239,7 @@ func (r machineReconciler) reconcileDeleteVMPre7(ctx *context.MachineContext) er
 
 func (r machineReconciler) reconcileNormal(ctx *context.MachineContext) (reconcile.Result, error) {
 	// If the VSphereMachine is in an error state, return early.
-	if ctx.VSphereMachine.Status.ErrorReason != nil || ctx.VSphereMachine.Status.ErrorMessage != nil {
+	if ctx.VSphereMachine.Status.FailureReason != nil || ctx.VSphereMachine.Status.FailureMessage != nil {
 		ctx.Logger.Info("Error state detected, skipping reconciliation")
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR renames status fields related to errors reason and messages to match CAPI's expectation

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @akutz 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```