### PR TITLE
remove deploying workers to speed CI

### DIFF
--- a/test/e2e/capv_test.go
+++ b/test/e2e/capv_test.go
@@ -55,7 +55,7 @@ var _ = Describe("CAPV", func() {
 			// The default number of control plane and worker nodes for each
 			// test is one. Tests may override these values.
 			numControlPlaneMachines = 1
-			numWorkerMachines = 1
+			numWorkerMachines = 0
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR removes deploying workers to speed up CI. it works locally but takes too much time on prow

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```