### PR TITLE
check that vsphereMachines are deleted before deleting the vsphereCluster

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -194,6 +194,16 @@ func (r clusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr er
 func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconcile.Result, error) {
 	ctx.Logger.Info("Reconciling VSphereCluster delete")
 
+	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(ctx, ctx.Client, ctx.VSphereCluster.Namespace, ctx.VSphereCluster.Name)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err,
+			"unable to list VSphereMachines part of VSphereCluster %s/%s", ctx.VSphereCluster.Namespace, ctx.VSphereCluster.Name)
+	}
+
+	if len(vsphereMachines) > 0 {
+		return reconcile.Result{}, errors.Errorf("unable to delete VSphereCluster %s/%s: %v VSphereMachines left", ctx.VSphereCluster.Namespace, ctx.VSphereCluster.Name, len(vsphereMachines))
+	}
+
 	// Cluster is deleted so remove the finalizer.
 	ctrlutil.RemoveFinalizer(ctx.VSphereCluster, infrav1.ClusterFinalizer)
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR checks that all VSphereMachines are gone before deleting the VsphereCluster. This avoids dead-locking [here](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/controllers/vspheremachine_controller.go#L142)

**Which issue(s) this PR fixes** : Fixes #761 

**Special notes for your reviewer**:

/assign @randomvariable @ncdc 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
Before deleting a VSphereCluster check if all the corresponding VSphereMachines are gone
```