### PR TITLE
update CAPI and CABPK dependencies

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -30,8 +30,8 @@ OVERWRITE=
 CLUSTER_NAME="${CLUSTER_NAME:-capv-mgmt-example}"
 ENV_VAR_REQ=':?required'
 
-CABPK_MANAGER_IMAGE="${CABPK_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/capi-kubeadm/cluster-api-kubeadm-controller:v0.1.5}"
-CAPI_MANAGER_IMAGE="${CAPI_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.2.8}"
+CABPK_MANAGER_IMAGE="${CABPK_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/capi-kubeadm/cluster-api-kubeadm-controller:v0.1.6}"
+CAPI_MANAGER_IMAGE="${CAPI_MANAGER_IMAGE:-us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.2.10}"
 CAPV_MANAGER_IMAGE="${CAPV_MANAGER_IMAGE:-gcr.io/cluster-api-provider-vsphere/release/manager:latest}"
 K8S_IMAGE_REPOSITORY="${K8S_IMAGE_REPOSITORY:-k8s.gcr.io}"
 
@@ -327,11 +327,11 @@ kustomize build "${SRC_DIR}/machinedeployment" | envsubst >"${MACHINEDEPLOYMENT_
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=v0.2.8" >"${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=v0.2.10" >"${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-kustomize build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/config/default/?ref=v0.1.5" >"${COMPONENTS_KUBEADM_GENERATED_FILE}"
+kustomize build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/config/default/?ref=v0.1.6" >"${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate VSphere Infrastructure Provider components file.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
 	k8s.io/klog v0.4.0
-	sigs.k8s.io/cluster-api v0.2.8
-	sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.5
+	sigs.k8s.io/cluster-api v0.2.10
+	sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.6
 	sigs.k8s.io/controller-runtime v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -349,10 +349,10 @@ modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/cluster-api v0.2.5/go.mod h1:Agc72Ra5LMOkQQ2v/Ywv1KUemaYAwvkQ+G59Ym5H8e4=
-sigs.k8s.io/cluster-api v0.2.8 h1:sDxjJaRbdaqs8ELyswkvyyJ0RLvMMDwfAJ9Jsumy3Dc=
-sigs.k8s.io/cluster-api v0.2.8/go.mod h1:Agc72Ra5LMOkQQ2v/Ywv1KUemaYAwvkQ+G59Ym5H8e4=
-sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.5 h1:NC5z0GfiarpEiOwLp+kgpTiUHG9Hp422YklHDPnzYds=
-sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.5/go.mod h1:916zreHrHzA66A3yzL0M0HCW8JeddmJa6Nzjnrfop4U=
+sigs.k8s.io/cluster-api v0.2.10 h1:0vhn1Uy6/j98TM+ihmWRb+lenkmd2VvdbHzrttsClIk=
+sigs.k8s.io/cluster-api v0.2.10/go.mod h1:BCw+Pqy1sc8mQ/3d2NZM/f5BApKFCMPsnGvKolvDcA0=
+sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.6 h1:VSbJstRYt/CU2e0BXkOcE/Ux5a4TnbuO2x7Ln2AynmQ=
+sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.6/go.mod h1:916zreHrHzA66A3yzL0M0HCW8JeddmJa6Nzjnrfop4U=
 sigs.k8s.io/controller-runtime v0.3.0 h1:ZtdgqJXVHsIytjdmDuk0QjagnzyLq9FjojXRqIp+dU4=
 sigs.k8s.io/controller-runtime v0.3.0/go.mod h1:Cw6PkEg0Sa7dAYovGT4R0tRkGhHXpYijwNxYhAnAZZk=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR updates CAPI and CABPK. This change is required to be able to upgrade to v1alpha3

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @randomvariable 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
update CAPI to v0.2.10 and CABPK v0.1.6
```