### PR TITLE
remove capv-webhook-system namespace from config/ directory

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,7 +1,6 @@
 namespace: capi-webhook-system
 
 resources:
-- namespace.yaml
 - service.yaml
 - ../certmanager
 - ../manager

--- a/config/webhook/namespace.yaml
+++ b/config/webhook/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: webhook-system


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR removes an extra namespace that is not used in the `config/` directory

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @randomvariable 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```