### PR TITLE
bump DefaultCSIMetadataSyncerImage to right patch version

### DIFF
--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -37,7 +37,7 @@ const (
 	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
 	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v1.1.1"
 	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v1.2.1"
-	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1"
+	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2"
 	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v1.1.0"
 	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 )


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>



**What this PR does / why we need it**: This aligns the DefaultCSIMetadataSyncerImage with other versions. This needs to be cherrypicked

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @randomvariable @detiber 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```