### PR TITLE
✨manager: add liveness/readiness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,18 @@ spec:
         image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlsig "sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -36,6 +37,8 @@ import (
 )
 
 var (
+	setupLog = ctrllog.Log.WithName("entrypoint")
+
 	managerOpts                    manager.Options
 	defaultProfilerAddr            = os.Getenv("PROFILER_ADDR")
 	defaultSyncPeriod              = manager.DefaultSyncPeriod
@@ -48,7 +51,6 @@ var (
 func main() {
 	klog.InitFlags(nil)
 	ctrllog.SetLogger(klogr.New())
-	setupLog := ctrllog.Log.WithName("entrypoint")
 	if err := flag.Set("v", "2"); err != nil {
 		klog.Fatalf("failed to set log level: %v", err)
 	}
@@ -183,10 +185,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupChecks(mgr)
+
 	sigHandler := ctrlsig.SetupSignalHandler()
 	setupLog.Info("starting controller manager")
 	if err := mgr.Start(sigHandler); err != nil {
 		setupLog.Error(err, "problem running controller manager")
+		os.Exit(1)
+	}
+}
+
+func setupChecks(mgr ctrlmgr.Manager) {
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create ready check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create health check")
 		os.Exit(1)
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -73,6 +73,7 @@ func New(opts Options) (Manager, error) {
 		NewCache:                opts.NewCache,
 		NewClient:               newClientFunc,
 		Port:                    opts.WebhookPort,
+		HealthProbeBindAddress:  opts.HealthAddr,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create manager")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add liveness / readiness probes
similar did here: https://github.com/kubernetes-sigs/cluster-api/pull/2156

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
manager: Add liveness/readiness probes
```

/cc @vincepri 