### PR TITLE
update controller-gen to v0.2.6-0.20200226180227-d6efdcdd90e2

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6-0.20200226180227-d6efdcdd90e2
   creationTimestamp: null
   name: haproxyloadbalancers.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6-0.20200226180227-d6efdcdd90e2
   creationTimestamp: null
   name: vsphereclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6-0.20200226180227-d6efdcdd90e2
   creationTimestamp: null
   name: vspheremachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6-0.20200226180227-d6efdcdd90e2
   creationTimestamp: null
   name: vspheremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6-0.20200226180227-d6efdcdd90e2
   creationTimestamp: null
   name: vspherevms.infrastructure.cluster.x-k8s.io
 spec:

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/golangci/golangci-lint v1.23.6
 	k8s.io/code-generator v0.17.0
-	sigs.k8s.io/controller-tools v0.2.5
+	sigs.k8s.io/controller-tools v0.2.6-0.20200226180227-d6efdcdd90e2
 	sigs.k8s.io/kustomize/kustomize/v3 v3.5.1
 	sigs.k8s.io/testing_frameworks v0.1.1
 )

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -691,6 +691,8 @@ mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f h1:Cq7MalBHYACRd6EesksG1Q8Eo
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 sigs.k8s.io/controller-tools v0.2.5 h1:kH7HKWed9XO42OTxyhUtqyImiefdZV2Q9Jbrytvhf18=
 sigs.k8s.io/controller-tools v0.2.5/go.mod h1:+t0Hz6tOhJQCdd7IYO0mNzimmiM9sqMU0021u6UCF2o=
+sigs.k8s.io/controller-tools v0.2.6-0.20200226180227-d6efdcdd90e2 h1:emZ+AFmD8mTciBRbEj2Qfk/RDI8uApvizRrFpmHf7IQ=
+sigs.k8s.io/controller-tools v0.2.6-0.20200226180227-d6efdcdd90e2/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/kustomize/api v0.2.0 h1:e++6JpysnnlUbHmFrv6jvfF5rFlgQ103bS1DO7r5bWA=
 sigs.k8s.io/kustomize/api v0.2.0/go.mod h1:zVtMg179jW1gr74jo9fc2Ac9dLYLTZZThc3DDb9lDW4=
 sigs.k8s.io/kustomize/kustomize/v3 v3.5.1 h1:FWUkkV0fzFmIfcQE3isklPsPPXyE/BQeGZI/mhZoegU=


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR updates controller-gen to `v0.2.6-0.20200226180227-d6efdcdd90e2` and unblocks CI failures seen after moving to the rc-3 and uncovered by #812

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```