### PR TITLE
add variable for dataplane and guestinfo urls to enable air gap builds

### DIFF
--- a/hack/tools/haproxy/ansible/roles/cloudinit/tasks/main.yml
+++ b/hack/tools/haproxy/ansible/roles/cloudinit/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Download cloud-init datasource for VMware Guestinfo
   get_url:
-    url:  https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo/master/install.sh
+    url:  '{{ guestinfo_datasource_script }}'
     dest: /tmp/cloud-init-vmware.sh
 
 - name: Execute cloud-init-vmware.sh

--- a/hack/tools/haproxy/ansible/roles/haproxy/tasks/main.yml
+++ b/hack/tools/haproxy/ansible/roles/haproxy/tasks/main.yml
@@ -14,7 +14,7 @@
 ---
 - name: Download dataplaneapi
   get_url:
-    url: https://github.com/haproxytech/dataplaneapi/releases/download/v{{ dataplaneapi_version }}/dataplaneapi
+    url: '{{ dataplane_url }}'
     dest: /usr/local/bin/dataplaneapi
     mode: 0755
 

--- a/hack/tools/haproxy/packer.json
+++ b/hack/tools/haproxy/packer.json
@@ -3,10 +3,12 @@
     "build_timestamp": "{{timestamp}}",
     "version": "v1alpha3",
     "dataplaneapi_version": "1.2.4",
+    "dataplane_url": "https://github.com/haproxytech/dataplaneapi/releases/download/v{{user `dataplaneapi_version`}}/dataplaneapi",
     "disk_type_id": "0",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "guestinfo_datasource_slug": "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo",
     "guestinfo_datasource_ref": "master",
+    "guestinfo_datasource_script": "{{user `guestinfo_datasource_slug`}}/{{user `guestinfo_datasource_ref`}}/install.sh",
     "headless": "true",
     "iso_url": "http://dl.bintray.com/vmware/photon/3.0/Rev2/iso/photon-minimal-3.0-58f9c74.iso",
     "iso_checksum": "ae28558e57f5d8aefb8b479c9fac7473079156e1",
@@ -67,7 +69,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "dataplaneapi_version={{user `dataplaneapi_version`}} guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}}"
+        "guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}} guestinfo_datasource_script={{user `guestinfo_datasource_script`}} dataplane_url={{user `dataplane_url`}}"
       ]
     }
   ],


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR adds variables for the dataplane and guestinfo URLs to enable air gap build

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:

/assign @ncdc @figo @dims 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```