### PR TITLE
strip clonespec from logs

### DIFF
--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -175,7 +175,7 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 		Snapshot: snapshotRef,
 	}
 
-	ctx.Logger.Info("cloning machine", "cloneType", ctx.VSphereVM.Status.CloneMode, "cloneSpec", spec)
+	ctx.Logger.Info("cloning machine", "namespace", ctx.VSphereVM.Namespace, "name", ctx.VSphereVM.Name, "cloneType", ctx.VSphereVM.Status.CloneMode)
 	task, err := tpl.Clone(ctx, folder, ctx.VSphereVM.Name, spec)
 	if err != nil {
 		return errors.Wrapf(err, "error trigging clone op for machine %s", ctx)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR removes clonespec from the logs as contains some sensitive information

**Which issue(s) this PR fixes** : Fixes #809 

**Special notes for your reviewer**:

/assign @randomvariable 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```