### PR TITLE
inject CAPV credentials as a file

### DIFF
--- a/config/default/credentials.yaml
+++ b/config/default/credentials.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: system
 type: Opaque
 stringData:
-  username: ${VSPHERE_USERNAME}
-  password: ${VSPHERE_PASSWORD}
+  credentials.yaml: |-
+    username: ${VSPHERE_USERNAME}
+    password: ${VSPHERE_PASSWORD}

--- a/config/default/manager_credentials_patch.yaml
+++ b/config/default/manager_credentials_patch.yaml
@@ -8,15 +8,11 @@ spec:
     spec:
       containers:
       - name: manager
-        env:
-        - name: VSPHERE_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: manager-bootstrap-credentials
-              key: username
-        - name: VSPHERE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: manager-bootstrap-credentials
-              key: password
-
+        volumeMounts:
+        - name: manager-bootstrap-credentials
+          mountPath: "/etc/capv"
+          readOnly: true
+      volumes:
+        - name: manager-bootstrap-credentials
+          secret:
+            secretName: manager-bootstrap-credentials

--- a/main.go
+++ b/main.go
@@ -107,6 +107,12 @@ func main() {
 		":9440",
 		"The address the health endpoint binds to.",
 	)
+	flag.StringVar(
+		&managerOpts.CredentialsFile,
+		"credentials-file",
+		"/etc/capv/credentials.yaml",
+		"path to CAPV's credentials file",
+	)
 
 	flag.Parse()
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,7 +49,9 @@ type Manager interface {
 func New(opts Options) (Manager, error) {
 
 	// Ensure the default options are set.
-	opts.defaults()
+	if err := opts.defaults(); err != nil {
+		return nil, err
+	}
 
 	_ = clientgoscheme.AddToScheme(opts.Scheme)
 	_ = clusterv1.AddToScheme(opts.Scheme)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR moves `capv-controller-manager` to file-based secret injection

**Which issue(s) this PR fixes** : Fixes #776

**Special notes for your reviewer**:

/assign @randomvariable 

**Release note**:

```release-note
capv-controller-manager now reads credentials from a file. default path is /etc/capv/credentials.yaml
```