### PR TITLE
fix file-based credentials injection

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,9 +49,7 @@ type Manager interface {
 func New(opts Options) (Manager, error) {
 
 	// Ensure the default options are set.
-	if err := opts.defaults(); err != nil {
-		return nil, err
-	}
+	opts.defaults()
 
 	_ = clientgoscheme.AddToScheme(opts.Scheme)
 	_ = clusterv1.AddToScheme(opts.Scheme)

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -115,7 +115,7 @@ type Options struct {
 	AddToManager AddToManagerFunc
 }
 
-func (o *Options) defaults() error {
+func (o *Options) defaults() {
 	if o.Logger == nil {
 		o.Logger = ctrllog.Log
 	}
@@ -141,10 +141,7 @@ func (o *Options) defaults() error {
 	}
 
 	if o.Username == "" || o.Password == "" {
-		credentials, err := o.getCredentials()
-		if err != nil {
-			return err
-		}
+		credentials := o.getCredentials()
 		o.Username = credentials["username"]
 		o.Password = credentials["password"]
 	}
@@ -158,19 +155,20 @@ func (o *Options) defaults() error {
 	} else {
 		o.PodNamespace = DefaultPodNamespace
 	}
-	return nil
 }
 
-func (o *Options) getCredentials() (map[string]string, error) {
+func (o *Options) getCredentials() map[string]string {
 	file, err := ioutil.ReadFile(o.CredentialsFile)
 	if err != nil {
 		o.Logger.Error(err, "error opening credentials file")
-		return map[string]string{}, err
+		return map[string]string{}
 	}
+
 	credentials := map[string]string{}
-	if err := yaml.Unmarshal(file, credentials); err != nil {
-		o.Logger.Error(err, "error unmarshaling credentials file")
-		return map[string]string{}, err
+	if err := yaml.Unmarshal(file, &credentials); err != nil {
+		o.Logger.Error(err, "error unmarshaling credentials to yaml")
+		return map[string]string{}
 	}
-	return credentials, nil
+
+	return credentials
 }


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR fixes an unmarshaling issues and adds errors swallowing so that the `capv-controller-manager` can start in a webhook mode without credentials

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @randomvariable 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```