### PR TITLE
let delete go through if we are not able to find the vspherevm

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -250,9 +250,11 @@ func (r machineReconciler) reconcileDeleteVMPre7(ctx *context.MachineContext) er
 	vm, err := r.findVMPre7(ctx)
 	// Attempt to find the associated VSphereVM resource.
 	if err != nil {
-		return err
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
-	if vm.GetDeletionTimestamp().IsZero() {
+	if vm != nil && vm.GetDeletionTimestamp().IsZero() {
 		// If the VSphereVM was found and it's not already enqueued for
 		// deletion, go ahead and attempt to delete it.
 		if err := ctx.Client.Delete(ctx, vm); err != nil {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR let delete go through for vsphereMachine if we don't find a vsphereVM

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #836 835 

**Special notes for your reviewer**:

/assign @randomvariable @frapposelli 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
let vsphereMachine delete go through if we are not able to find a corresponding vspherevm
```