### PR TITLE
Set network interface name with cloud-init set-name

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -89,6 +89,11 @@ type NetworkDeviceSpec struct {
 	// will be connected.
 	NetworkName string `json:"networkName"`
 
+	// DeviceName may be used to explicitly assign a name to the network device
+	// as it exists in the guest operating system.
+	// +optional
+	DeviceName string `json:"deviceName,omitempty"`
+
 	// DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
 	// on this device.
 	// If true then IPAddrs should not contain any IPv4 addresses.

--- a/api/v1alpha2/vspheremachine_conversion.go
+++ b/api/v1alpha2/vspheremachine_conversion.go
@@ -73,7 +73,15 @@ func Convert_v1alpha2_VSphereMachineSpec_To_v1alpha3_VSphereMachineSpec(in *VSph
 	if err := autoConvert_v1alpha2_VSphereMachineSpec_To_v1alpha3_VSphereMachineSpec(in, out, s); err != nil {
 		return err
 	}
-
+	out.Template = in.Template
+	out.Datacenter = in.Datacenter
+	if err := autoConvert_v1alpha2_NetworkSpec_To_v1alpha3_NetworkSpec(&in.Network, &out.Network, s); err != nil {
+		return err
+	}
+	out.NumCPUs = in.NumCPUs
+	out.NumCoresPerSocket = in.NumCoresPerSocket
+	out.MemoryMiB = in.MemoryMiB
+	out.DiskGiB = in.DiskGiB
 	return nil
 }
 
@@ -82,7 +90,15 @@ func Convert_v1alpha3_VSphereMachineSpec_To_v1alpha2_VSphereMachineSpec(in *infr
 	if err := autoConvert_v1alpha3_VSphereMachineSpec_To_v1alpha2_VSphereMachineSpec(in, out, s); err != nil {
 		return err
 	}
-
+	out.Template = in.Template
+	out.Datacenter = in.Datacenter
+	if err := autoConvert_v1alpha3_NetworkSpec_To_v1alpha2_NetworkSpec(&in.Network, &out.Network, s); err != nil {
+		return err
+	}
+	out.NumCPUs = in.NumCPUs
+	out.NumCoresPerSocket = in.NumCoresPerSocket
+	out.MemoryMiB = in.MemoryMiB
+	out.DiskGiB = in.DiskGiB
 	return nil
 }
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -652,6 +652,7 @@ func Convert_v1alpha3_CPIWorkspaceConfig_To_v1alpha2_CPIWorkspaceConfig(in *v1al
 
 func autoConvert_v1alpha2_NetworkDeviceSpec_To_v1alpha3_NetworkDeviceSpec(in *NetworkDeviceSpec, out *v1alpha3.NetworkDeviceSpec, s conversion.Scope) error {
 	out.NetworkName = in.NetworkName
+	out.DeviceName = in.DeviceName
 	out.DHCP4 = in.DHCP4
 	out.DHCP6 = in.DHCP6
 	out.Gateway4 = in.Gateway4
@@ -672,7 +673,7 @@ func Convert_v1alpha2_NetworkDeviceSpec_To_v1alpha3_NetworkDeviceSpec(in *Networ
 
 func autoConvert_v1alpha3_NetworkDeviceSpec_To_v1alpha2_NetworkDeviceSpec(in *v1alpha3.NetworkDeviceSpec, out *NetworkDeviceSpec, s conversion.Scope) error {
 	out.NetworkName = in.NetworkName
-	// WARNING: in.DeviceName requires manual conversion: does not exist in peer-type
+	out.DeviceName = in.DeviceName
 	out.DHCP4 = in.DHCP4
 	out.DHCP6 = in.DHCP6
 	out.Gateway4 = in.Gateway4
@@ -716,17 +717,7 @@ func Convert_v1alpha3_NetworkRouteSpec_To_v1alpha2_NetworkRouteSpec(in *v1alpha3
 }
 
 func autoConvert_v1alpha2_NetworkSpec_To_v1alpha3_NetworkSpec(in *NetworkSpec, out *v1alpha3.NetworkSpec, s conversion.Scope) error {
-	if in.Devices != nil {
-		in, out := &in.Devices, &out.Devices
-		*out = make([]v1alpha3.NetworkDeviceSpec, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha2_NetworkDeviceSpec_To_v1alpha3_NetworkDeviceSpec(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Devices = nil
-	}
+	out.Devices = *(*[]v1alpha3.NetworkDeviceSpec)(unsafe.Pointer(&in.Devices))
 	out.Routes = *(*[]v1alpha3.NetworkRouteSpec)(unsafe.Pointer(&in.Routes))
 	out.PreferredAPIServerCIDR = in.PreferredAPIServerCIDR
 	return nil
@@ -738,17 +729,7 @@ func Convert_v1alpha2_NetworkSpec_To_v1alpha3_NetworkSpec(in *NetworkSpec, out *
 }
 
 func autoConvert_v1alpha3_NetworkSpec_To_v1alpha2_NetworkSpec(in *v1alpha3.NetworkSpec, out *NetworkSpec, s conversion.Scope) error {
-	if in.Devices != nil {
-		in, out := &in.Devices, &out.Devices
-		*out = make([]NetworkDeviceSpec, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha3_NetworkDeviceSpec_To_v1alpha2_NetworkDeviceSpec(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Devices = nil
-	}
+	out.Devices = *(*[]NetworkDeviceSpec)(unsafe.Pointer(&in.Devices))
 	out.Routes = *(*[]NetworkRouteSpec)(unsafe.Pointer(&in.Routes))
 	out.PreferredAPIServerCIDR = in.PreferredAPIServerCIDR
 	return nil

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -672,6 +672,7 @@ func Convert_v1alpha2_NetworkDeviceSpec_To_v1alpha3_NetworkDeviceSpec(in *Networ
 
 func autoConvert_v1alpha3_NetworkDeviceSpec_To_v1alpha2_NetworkDeviceSpec(in *v1alpha3.NetworkDeviceSpec, out *NetworkDeviceSpec, s conversion.Scope) error {
 	out.NetworkName = in.NetworkName
+	// WARNING: in.DeviceName requires manual conversion: does not exist in peer-type
 	out.DHCP4 = in.DHCP4
 	out.DHCP6 = in.DHCP6
 	out.Gateway4 = in.Gateway4
@@ -715,7 +716,17 @@ func Convert_v1alpha3_NetworkRouteSpec_To_v1alpha2_NetworkRouteSpec(in *v1alpha3
 }
 
 func autoConvert_v1alpha2_NetworkSpec_To_v1alpha3_NetworkSpec(in *NetworkSpec, out *v1alpha3.NetworkSpec, s conversion.Scope) error {
-	out.Devices = *(*[]v1alpha3.NetworkDeviceSpec)(unsafe.Pointer(&in.Devices))
+	if in.Devices != nil {
+		in, out := &in.Devices, &out.Devices
+		*out = make([]v1alpha3.NetworkDeviceSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_NetworkDeviceSpec_To_v1alpha3_NetworkDeviceSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Devices = nil
+	}
 	out.Routes = *(*[]v1alpha3.NetworkRouteSpec)(unsafe.Pointer(&in.Routes))
 	out.PreferredAPIServerCIDR = in.PreferredAPIServerCIDR
 	return nil
@@ -727,7 +738,17 @@ func Convert_v1alpha2_NetworkSpec_To_v1alpha3_NetworkSpec(in *NetworkSpec, out *
 }
 
 func autoConvert_v1alpha3_NetworkSpec_To_v1alpha2_NetworkSpec(in *v1alpha3.NetworkSpec, out *NetworkSpec, s conversion.Scope) error {
-	out.Devices = *(*[]NetworkDeviceSpec)(unsafe.Pointer(&in.Devices))
+	if in.Devices != nil {
+		in, out := &in.Devices, &out.Devices
+		*out = make([]NetworkDeviceSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_NetworkDeviceSpec_To_v1alpha2_NetworkDeviceSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Devices = nil
+	}
 	out.Routes = *(*[]NetworkRouteSpec)(unsafe.Pointer(&in.Routes))
 	out.PreferredAPIServerCIDR = in.PreferredAPIServerCIDR
 	return nil

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -183,6 +183,11 @@ type NetworkDeviceSpec struct {
 	// will be connected.
 	NetworkName string `json:"networkName"`
 
+	// DeviceName may be used to explicitly assign a name to the network device
+	// as it exists in the guest operating system.
+	// +optional
+	DeviceName string `json:"deviceName,omitempty"`
+
 	// DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
 	// on this device.
 	// If true then IPAddrs should not contain any IPv4 addresses.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -103,6 +103,11 @@ spec:
                           description: NetworkDeviceSpec defines the network configuration
                             for a virtual machine's network device.
                           properties:
+                            deviceName:
+                              description: DeviceName may be used to explicitly assign
+                                a name to the network device as it exists in the guest
+                                operating system.
+                              type: string
                             dhcp4:
                               description: DHCP4 is a flag that indicates whether
                                 or not to use DHCP for IPv4 on this device. If true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -358,6 +358,11 @@ spec:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
                       properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
                         dhcp4:
                           description: DHCP4 is a flag that indicates whether or not
                             to use DHCP for IPv4 on this device. If true then IPAddrs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -66,6 +66,11 @@ spec:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
                       properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
                         dhcp4:
                           description: DHCP4 is a flag that indicates whether or not
                             to use DHCP for IPv4 on this device. If true then IPAddrs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -186,6 +186,11 @@ spec:
                               description: NetworkDeviceSpec defines the network configuration
                                 for a virtual machine's network device.
                               properties:
+                                deviceName:
+                                  description: DeviceName may be used to explicitly
+                                    assign a name to the network device as it exists
+                                    in the guest operating system.
+                                  type: string
                                 dhcp4:
                                   description: DHCP4 is a flag that indicates whether
                                     or not to use DHCP for IPv4 on this device. If

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -412,6 +412,11 @@ spec:
                               description: NetworkDeviceSpec defines the network configuration
                                 for a virtual machine's network device.
                               properties:
+                                deviceName:
+                                  description: DeviceName may be used to explicitly
+                                    assign a name to the network device as it exists
+                                    in the guest operating system.
+                                  type: string
                                 dhcp4:
                                   description: DHCP4 is a flag that indicates whether
                                     or not to use DHCP for IPv4 on this device. If

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -125,6 +125,11 @@ spec:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
                       properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
                         dhcp4:
                           description: DHCP4 is a flag that indicates whether or not
                             to use DHCP for IPv4 on this device. If true then IPAddrs

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -26,6 +26,11 @@ network:
     id{{ $i }}:
       match:
         macaddress: "{{ $net.MACAddr }}"
+      {{- if $net.DeviceName }}
+      set-name: "{{ $net.DeviceName }}"
+      {{- else }}
+      set-name: "eth{{ $i }}"
+      {{- end }}
       wakeonlan: true
       dhcp4: {{ $net.DHCP4 }}
       dhcp6: {{ $net.DHCP6 }}

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -257,7 +257,7 @@ network:
   ethernets:
     id0:
       match:
-				macaddress: "00:00:00:00:00"
+        macaddress: "00:00:00:00:00"
       set-name: "eth0"
       wakeonlan: true
       dhcp4: true
@@ -322,8 +322,8 @@ network:
   ethernets:
     id0:
       match:
-				macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+        macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -355,8 +355,8 @@ network:
   ethernets:
     id0:
       match:
-				macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+        macaddress: "00:00:00:00:00"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: true
@@ -390,7 +390,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -434,7 +434,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -486,7 +486,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: false
@@ -497,7 +497,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
-			set-name: "eth1"
+      set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -540,7 +540,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
-			set-name: "eth0"
+      set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: false
@@ -555,7 +555,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
-			set-name: "eth1"
+      set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -257,7 +257,41 @@ network:
   ethernets:
     id0:
       match:
+				macaddress: "00:00:00:00:00"
+      set-name: "eth0"
+      wakeonlan: true
+      dhcp4: true
+      dhcp6: false
+`,
+		},
+		{
+			name: "dhcp4+deviceName",
+			machine: &v1alpha3.VSphereVM{
+				Spec: v1alpha3.VSphereVMSpec{
+					VirtualMachineCloneSpec: v1alpha3.VirtualMachineCloneSpec{
+						Network: v1alpha3.NetworkSpec{
+							Devices: []v1alpha3.NetworkDeviceSpec{
+								{
+									NetworkName: "network1",
+									MACAddr:     "00:00:00:00:00",
+									DHCP4:       true,
+									DeviceName:  "ens192",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+instance-id: "test-vm"
+local-hostname: "test-vm"
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
         macaddress: "00:00:00:00:00"
+      set-name: "ens192"
       wakeonlan: true
       dhcp4: true
       dhcp6: false
@@ -288,7 +322,8 @@ network:
   ethernets:
     id0:
       match:
-        macaddress: "00:00:00:00:00"
+				macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -320,7 +355,8 @@ network:
   ethernets:
     id0:
       match:
-        macaddress: "00:00:00:00:00"
+				macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: true
@@ -354,6 +390,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -397,6 +434,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -448,6 +486,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: true
       dhcp6: false
@@ -458,6 +497,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
+			set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true
@@ -500,6 +540,7 @@ network:
     id0:
       match:
         macaddress: "00:00:00:00:00"
+			set-name: "eth0"
       wakeonlan: true
       dhcp4: false
       dhcp6: false
@@ -514,6 +555,7 @@ network:
     id1:
       match:
         macaddress: "00:00:00:00:01"
+			set-name: "eth1"
       wakeonlan: true
       dhcp4: false
       dhcp6: true


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

Co-authored-by: Greg May <mrgregmay@gmail.com>


**What this PR does / why we need it**: This PR moves bits of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/707 to v1alpha3

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/834

**Special notes for your reviewer**:

/cc @akutz @randomvariable 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
re-introduce support for static ip assignment that existed previously in v1alpha2 to avoid regression
```