### PR TITLE
requeue when we are waiting and not returning an error

### DIFF
--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -315,7 +315,7 @@ func (r haproxylbReconciler) reconcileNormal(ctx *context.HAProxyLoadBalancerCon
 					"unexpected error while reconciling network for %s", ctx)
 			}
 			ctx.Logger.Info("network is not reconciled")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
 		// Create the HAProxyLoadBalancer's API config secret.

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -228,7 +228,7 @@ func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconci
 				"unexpected error while reconciling load balancer for %s", ctx)
 		}
 		ctx.Logger.Info("load balancer is not reconciled")
-		return reconcile.Result{}, nil
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Reconcile the VSphereCluster resource's ready state.


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: when we are trying to reconcile network or load balancer, some times we are waiting for some fields to read, when they're not set we return withtout errors or requeue. This PR add requeues for these cases 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @frapposelli @vincepri 

**Release note**:

```release-note

```