### PR TITLE
increase haproxy health-check thresholds

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -85,7 +85,7 @@ frontend kube_api_frontend
 backend kube_api_backend
   mode tcp
   balance leastconn
-  default-server inter 15s downinter 15s rise 2 fall 2 slowstart 60s maxconn 1000 maxqueue 256 weight 100
+  default-server inter 10s downinter 10s rise 5 fall 3 slowstart 120s maxconn 1000 maxqueue 256 weight 100
   option httpchk GET /healthz
   http-check expect status 200
   {{range .Addresses}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns HA proxy health-check thresholds to the one used in CAPA https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/9913ac8dbb96ed9bcffa6eba75b886cd4ef8c20b/pkg/cloud/services/elb/loadbalancer.go#L263-L269

**Release note**:
```release-note
Align HA proxy health-check thresholds to the one used in CAPA for a better consistency across providers
```

/assign @yastij 
/assign @randomvariable 