### PR TITLE
do not swallow errors reconcileNetworkStatus

### DIFF
--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -107,7 +107,7 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 	vms.reconcileUUID(vmCtx)
 
 	if err := vms.reconcileNetworkStatus(vmCtx); err != nil {
-		return vm, nil
+		return vm, err
 	}
 
 	if ok, err := vms.reconcileMetadata(vmCtx); err != nil || !ok {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR does not swallow errors for reconcileNetworkStatus 

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:


**Release note**:

```release-note

```