### PR TITLE
Clarifying CRD schema documentation for `ipAddrs` param that CIDR notation is required.

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -129,7 +129,7 @@ spec:
                             ipAddrs:
                               description: IPAddrs is a list of one or more IPv4 and/or
                                 IPv6 addresses to assign to this device. Required
-                                when DHCP4 and DHCP6 are both false.
+                                when DHCP4 and DHCP6 are both false. Written in CIDR notation.
                               items:
                                 type: string
                               type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -92,7 +92,7 @@ spec:
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
                             IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            DHCP4 and DHCP6 are both false. Written in CIDR notation.
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -215,6 +215,7 @@ spec:
                                   description: IPAddrs is a list of one or more IPv4
                                     and/or IPv6 addresses to assign to this device.
                                     Required when DHCP4 and DHCP6 are both false.
+                                    Written in CIDR notation.
                                   items:
                                     type: string
                                   type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -151,7 +151,7 @@ spec:
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
                             IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            DHCP4 and DHCP6 are both false. Written in CIDR notation.
                           items:
                             type: string
                           type: array


### PR DESCRIPTION
**What this PR does / why we need it**: Clarifies CRD schema documentation for the `ipAddrs` parameter to state that the format must be in CIDR notation as this is not stated anywhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```