### PR TITLE
avoid LLA with default dhcp settings in haproxy

### DIFF
--- a/hack/tools/haproxy/ansible/roles/sysprep/tasks/main.yml
+++ b/hack/tools/haproxy/ansible/roles/sysprep/tasks/main.yml
@@ -17,6 +17,11 @@
     last_log_mode:   "0644"
     machine_id_mode: "0444"
 
+- name: Set LinkLocalAddressing to no
+  lineinfile:
+    path: /etc/systemd/network/99-dhcp-en.network
+    line: LinkLocalAddressing=no
+
 - name: Set hostname
   command: hostnamectl set-hostname localhost.local
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes when HAproxy starts, the `network-online` unit will go online before an ipv4 is successfully acquired. This will lead the certificate generation process to use an ipv6 LLA `fe80:` as it's the only IP available at the time, this will fail the script as it doesn't know how to parse an ipv6 address.
