### PR TITLE
Make BackEndpointsForCluster() more robust

### DIFF
--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -357,6 +357,16 @@ func (r haproxylbReconciler) BackEndpointsForCluster(ctx *context.HAProxyLoadBal
 	controlPlaneMachines := clusterutilv1.GetControlPlaneMachinesFromList(machineList)
 	endpoints := make([]corev1.EndpointAddress, 0)
 	for _, machine := range controlPlaneMachines {
+
+		// check if machine has joined the cluster before adding it to the list of backends
+		if ctx.Cluster.Status.ControlPlaneInitialized {
+			if machine.Status.NodeRef == nil ||
+				machine.Status.FailureReason != nil ||
+				machine.Status.FailureMessage != nil {
+				continue
+			}
+		}
+
 		machineEndpoints := make([]corev1.EndpointAddress, 0)
 		for i, addr := range machine.Status.Addresses {
 			if addr.Type == clusterv1.MachineExternalIP {

--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
@@ -359,6 +360,10 @@ func (r haproxylbReconciler) BackEndpointsForCluster(ctx *context.HAProxyLoadBal
 		machineEndpoints := make([]corev1.EndpointAddress, 0)
 		for i, addr := range machine.Status.Addresses {
 			if addr.Type == clusterv1.MachineExternalIP {
+				// TODO(frapposelli): Remove this check once HAproxy fully supports IPv6 - issue #859
+				if utilnet.IsIPv6String(addr.Address) {
+					continue
+				}
 				endpoint := corev1.EndpointAddress{
 					NodeName: pointer.StringPtr(fmt.Sprintf("%s-%d", machine.Name, i)),
 					IP:       addr.Address,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does two things:

1- It filters out IPv6 addresses from the backend endpoints for haproxy, this is a short-term fix that will need to be removed when #859 is addressed
2- Waits for the new control plane node to be ready before adding it to the list of backend endpoints, avoiding the case where the IP is added to HAproxy *during* the join phase and the joining node ends up talking to itself via HAproxy


```release-note
IPv6 support is disabled in HAProxyLoadBalancer
```

/assign @yastij @randomvariable 
/cc @akutz @dims @vuil 