### PR TITLE
wire max-concurrent-reconciles with higher default

### DIFF
--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -116,8 +116,8 @@ func AddHAProxyLoadBalancerControllerToManager(ctx *context.ControllerManagerCon
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
-	Build(reconciler)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Build(reconciler)
 	if err != nil {
 		return err
 	}

--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -115,7 +116,8 @@ func AddHAProxyLoadBalancerControllerToManager(ctx *context.ControllerManagerCon
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		Build(reconciler)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
+	Build(reconciler)
 	if err != nil {
 		return err
 	}

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -121,7 +122,8 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		Complete(reconciler)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
+	Complete(reconciler)
 }
 
 type clusterReconciler struct {

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -122,8 +122,8 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
-	Complete(reconciler)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Complete(reconciler)
 }
 
 type clusterReconciler struct {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -102,7 +103,8 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		Build(r)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
+	Build(r)
 	if err != nil {
 		return err
 	}

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -103,8 +103,8 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
-	Build(r)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Build(r)
 	if err != nil {
 		return err
 	}

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -87,8 +87,8 @@ func AddVMControllerToManager(ctx *context.ControllerManagerContext, mgr manager
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
-	Build(r)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Build(r)
 
 	if err != nil {
 		return err

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -86,7 +87,8 @@ func AddVMControllerToManager(ctx *context.ControllerManagerContext, mgr manager
 			&source.Channel{Source: ctx.GetGenericEventChannelFor(controlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		Build(r)
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
+	Build(r)
 
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 	flag.IntVar(
 		&managerOpts.MaxConcurrentReconciles,
 		"max-concurrent-reconciles",
-		defaultMaxConcurrentReconciles,
+		10,
 		"The maximum number of allowed, concurrent reconciles.")
 	flag.StringVar(
 		&managerOpts.PodName,

--- a/main.go
+++ b/main.go
@@ -40,13 +40,12 @@ import (
 var (
 	setupLog = ctrllog.Log.WithName("entrypoint")
 
-	managerOpts                    manager.Options
-	defaultProfilerAddr            = os.Getenv("PROFILER_ADDR")
-	defaultSyncPeriod              = manager.DefaultSyncPeriod
-	defaultMaxConcurrentReconciles = manager.DefaultMaxConcurrentReconciles
-	defaultLeaderElectionID        = manager.DefaultLeaderElectionID
-	defaultPodName                 = manager.DefaultPodName
-	defaultWebhookPort             = manager.DefaultWebhookServiceContainerPort
+	managerOpts             manager.Options
+	defaultProfilerAddr     = os.Getenv("PROFILER_ADDR")
+	defaultSyncPeriod       = manager.DefaultSyncPeriod
+	defaultLeaderElectionID = manager.DefaultLeaderElectionID
+	defaultPodName          = manager.DefaultPodName
+	defaultWebhookPort      = manager.DefaultWebhookServiceContainerPort
 )
 
 // nolint:gocognit

--- a/pkg/manager/constants.go
+++ b/pkg/manager/constants.go
@@ -29,10 +29,6 @@ const (
 	// manager option.
 	DefaultSyncPeriod = time.Minute * 10
 
-	// DefaultMaxConcurrentReconciles is the default value for the eponymous
-	// manager option.
-	DefaultMaxConcurrentReconciles = 1
-
 	// DefaultPodName is the default value for the eponymous manager option.
 	DefaultPodName = defaultPrefix + "controller-manager"
 

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -136,10 +136,6 @@ func (o *Options) defaults() {
 		o.Scheme = runtime.NewScheme()
 	}
 
-	if o.MaxConcurrentReconciles == 0 {
-		o.MaxConcurrentReconciles = DefaultMaxConcurrentReconciles
-	}
-
 	if o.Username == "" || o.Password == "" {
 		credentials := o.getCredentials()
 		o.Username = credentials["username"]


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR wires the controllers with `--max-concurrent-reconciles` flag and bumps its default value.

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @vincepri 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
wire --max-concurrent-reconciles with the controllers and bump its default value
```