### PR TITLE
add logic to wait for IPv4 and/or IPv6

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -19,6 +19,9 @@ package util
 const metadataFormat = `
 instance-id: "{{ .Hostname }}"
 local-hostname: "{{ .Hostname }}"
+wait-on-network:
+  ipv4: {{ .WaitForIPv4 }}
+  ipv6: {{ .WaitForIPv6 }}
 network:
   version: 2
   ethernets:

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -252,6 +252,9 @@ func Test_GetMachineMetadata(t *testing.T) {
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: false
 network:
   version: 2
   ethernets:
@@ -285,6 +288,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: false
 network:
   version: 2
   ethernets:
@@ -317,6 +323,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: false
+  ipv6: true
 network:
   version: 2
   ethernets:
@@ -350,6 +359,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
 network:
   version: 2
   ethernets:
@@ -384,6 +396,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
 network:
   version: 2
   ethernets:
@@ -428,6 +443,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
 network:
   version: 2
   ethernets:
@@ -480,6 +498,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
 network:
   version: 2
   ethernets:
@@ -534,6 +555,9 @@ network:
 			expected: `
 instance-id: "test-vm"
 local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
 network:
   version: 2
   ethernets:


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR adds the ability the set `wait-on-network` to wait for ipv4 and/or ipv6 addresses 

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:
Related to https://github.com/vmware/cloud-init-vmware-guestinfo/pull/35

/assign @akutz 
/cc @frapposelli @randomvariable 

**Release note**:

```release-note
set `wait-on-network` to wait for ipv4 and/or ipv6 addresses
```