### PR TITLE
fix cloudinit network in haproxy ova

### DIFF
--- a/hack/tools/haproxy/ansible/roles/cloudinit/tasks/main.yml
+++ b/hack/tools/haproxy/ansible/roles/cloudinit/tasks/main.yml
@@ -31,3 +31,8 @@
     path:  /tmp/cloud-init-vmware.sh
     state: absent
 
+- name: Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+    state: absent
+  when: ansible_os_family == "VMware Photon OS"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds an ansible task to remove a canary file for cloud-init that prevents network from being configured by data passed to cloud-init.
