### PR TITLE
Add rng-tools as default entropy gatherer to HAProxy

### DIFF
--- a/hack/tools/haproxy/kickstart.json
+++ b/hack/tools/haproxy/kickstart.json
@@ -23,6 +23,7 @@
     "openssh-server",
     "open-vm-tools",
     "psmisc",
+    "rng-tools",
     "sed",
     "shadow",
     "sudo",
@@ -31,7 +32,7 @@
   ],
   "postinstall": [
     "#!/bin/bash",
-    "tdnf install -y bash ca-certificates curl gzip haproxy jq lsof lvm2 ntp openssh-server open-vm-tools psmisc sed shadow sudo tar vim",
+    "tdnf install -y bash ca-certificates curl gzip haproxy jq lsof lvm2 ntp openssh-server open-vm-tools psmisc rng-tools sed shadow sudo tar vim",
     "useradd --create-home --home-dir=/home/photon --groups=wheel --user-group photon",
     "echo 'photon:photon' | chpasswd",
     "echo 'photon ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/photon",


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Use of hardware entropy sources is less contentious than using haveged in #879 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Enable rngd for entropy gathering
```