### PR TITLE
haproxy: set PhotonOS password expiry to never

### DIFF
--- a/hack/tools/haproxy/kickstart.json
+++ b/hack/tools/haproxy/kickstart.json
@@ -1,8 +1,9 @@
 {
   "hostname": "localhost",
   "password": {
-    "crypted": false,
-    "text": "photon"
+    "crypted": true,
+    "text": "*",
+    "age": -1
   },
   "disk": "/dev/sda",
   "packages": [


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch sets the default password expiry to -1, which makes it be equivalent to never. The default in PhotonOS is 90 days, which would lead to long-term issues with both the root account and any accounts created by cloud-init. Even though passwords are not used to access the image, an expired password means that admins logging in (even via SSH keypair, the only way) are prompted to change a password.

We also set the PhotonOS root account back to its [default](https://github.com/vmware/photon/blob/7b2f140e6496c7baaae4c99df9c1c9fdadabb9d3/installer/ks_config.txt#L156-L175). Though it's kind of a funny "default" -- if you don't set text or crypted fields in the kickstart, the installer aborts as they are required fields. 🤷‍♂
There is no reason to set an actual password for the root account here since it is never used - it was already locked.

Note that setting age: -1 also [changes the default value](https://github.com/vmware/photon/blob/3.0/installer/modules/m_updaterootpassword.py#L36-L38) in /etc/login.defs, meaning that it applies to any user when it is created during initial boot via cloud-init.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a copy of https://github.com/kubernetes-sigs/image-builder/pull/192 in image-builder.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```