### PR TITLE
patch early to avoid concurrent clones

### DIFF
--- a/pkg/context/fake/fake_vm_context.go
+++ b/pkg/context/fake/fake_vm_context.go
@@ -22,6 +22,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api/util/patch"
 )
 
 // NewVMContext returns a fake VMContext for unit testing
@@ -36,10 +37,16 @@ func NewVMContext(ctx *context.ControllerContext) *context.VMContext {
 		panic(err)
 	}
 
+	helper, err := patch.NewHelper(&vsphereVM, ctx.Client)
+	if err != nil {
+		panic(err)
+	}
+
 	return &context.VMContext{
 		ControllerContext: ctx,
 		VSphereVM:         &vsphereVM,
 		Logger:            ctx.Logger.WithName(vsphereVM.Name),
+		PatchHelper:       helper,
 	}
 }
 

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -182,6 +182,12 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 
 	ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 
+	// patch the vsphereVM here to ensure that the task is
+	// reflected in the status right away, this avoid situations
+	// of concurrent clones
+	if err := ctx.Patch(); err != nil {
+		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR fixes a corner case where clone tasks are done before patching a `vspherevm`'s statuts. 
Whenever a task is done, we send a notification to the vspherevm controller to reconcile the `vspherevm`, so potentially we can end up in a situation where we are reconciling with a stale status 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @randomvariable 

**Release note**:

```release-note
NONE
```