### PR TITLE
remove csi ImagePullPolicy for air-gapped environments

### DIFF
--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -287,9 +287,8 @@ func NodeDriverRegistrarContainer(image string) corev1.Container {
 
 func VSphereCSINodeContainer(image string) corev1.Container {
 	return corev1.Container{
-		Name:            "vsphere-csi-node",
-		Image:           image,
-		ImagePullPolicy: corev1.PullAlways,
+		Name:  "vsphere-csi-node",
+		Image: image,
 		Env: []corev1.EnvVar{
 			{
 				Name:  "CSI_ENDPOINT",
@@ -486,8 +485,7 @@ func VSphereCSIControllerContainer(image string) corev1.Container {
 				},
 			},
 		},
-		Args:            []string{"--v=4"},
-		ImagePullPolicy: corev1.PullAlways,
+		Args: []string{"--v=4"},
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "healthz",
@@ -557,10 +555,9 @@ func LivenessProbeForCSIControllerContainer(image string) corev1.Container {
 
 func VSphereSyncerContainer(image string) corev1.Container {
 	return corev1.Container{
-		Name:            "vsphere-syncer",
-		Image:           image,
-		Args:            []string{"--v=4"},
-		ImagePullPolicy: corev1.PullAlways,
+		Name:  "vsphere-syncer",
+		Image: image,
+		Args:  []string{"--v=4"},
 		Env: []corev1.EnvVar{
 			{
 				Name:  "X_CSI_FULL_SYNC_INTERVAL_MINUTES",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR removes `ImagePullPolicy: Always` for csi images.
If `ImagePullPolicy: Always` forced, some csi images can't be pulled in an air-gapped environment.

```
$ kubectl get po -n kube-system
NAME                                               READY   STATUS             RESTARTS   AGE
coredns-76d6dbd6f6-7h6xs                           1/1     Running            0          10m
coredns-76d6dbd6f6-vd2wm                           1/1     Running            0          10m
etcd-vsphere-quickstart-vh6cr                      1/1     Running            0          9m39s
kube-apiserver-vsphere-quickstart-vh6cr            1/1     Running            0          9m38s
kube-controller-manager-vsphere-quickstart-vh6cr   1/1     Running            0          9m34s
kube-proxy-dfqg8                                   1/1     Running            0          8m9s
kube-proxy-p4cm9                                   1/1     Running            0          10m
kube-proxy-skx9l                                   1/1     Running            0          8m9s
kube-scheduler-vsphere-quickstart-vh6cr            1/1     Running            0          9m28s
vsphere-cloud-controller-manager-zrw8t             1/1     Running            0          10m
vsphere-csi-controller-0                           3/5     ImagePullBackOff   0          10m
vsphere-csi-node-5dvcx                             2/3     ImagePullBackOff   0          15s
vsphere-csi-node-krzht                             2/3     ImagePullBackOff   0          7s
vsphere-csi-node-w9sqs                             2/3     ImagePullBackOff   0          8s
weave-net-5cqp2                                    2/2     Running            0          20s
weave-net-dvfht                                    2/2     Running            0          20s
weave-net-x5czm                                    2/2     Running            0          20s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```