### PR TITLE
External Load Balaner Flavor example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ manifests:  $(STAGE)-version-check $(STAGE)-flavors $(MANIFEST_DIR) $(BUILD_DIR)
 flavors: $(FLAVOR_DIR)
 	go run ./packaging/flavorgen -f multi-host > $(FLAVOR_DIR)/cluster-template-haproxy.yaml
 	go run ./packaging/flavorgen -f vip > $(FLAVOR_DIR)/cluster-template.yaml
+	go run ./packaging/flavorgen -f external-loadbalancer > $(FLAVOR_DIR)/cluster-template-external-loadbalancer.yaml
 
 
 .PHONY: release-flavors ## Create release flavor manifests

--- a/packaging/flavorgen/cmd/root.go
+++ b/packaging/flavorgen/cmd/root.go
@@ -55,6 +55,8 @@ func RunRoot(command *cobra.Command) error {
 		flavors.PrintObjects(flavors.MultiNodeTemplateWithHAProxy())
 	case "vip":
 		flavors.PrintObjects(flavors.MultiNodeTemplateWithKubeVIP())
+	case "external-loadbalancer":
+		flavors.PrintObjects(flavors.MultiNodeTemplateWithExternalLoadBalancer())
 	default:
 		return errors.Errorf("invalid flavor")
 	}

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -56,3 +56,20 @@ func MultiNodeTemplateWithKubeVIP() []runtime.Object {
 		&machineDeployment,
 	}
 }
+
+func MultiNodeTemplateWithExternalLoadBalancer() []runtime.Object {
+	vsphereCluster := newVSphereCluster(nil)
+	machineTemplate := newVSphereMachineTemplate()
+	controlPlane := newKubeadmControlplane(444, machineTemplate, nil)
+	kubeadmJoinTemplate := newKubeadmConfigTemplate()
+	cluster := newCluster(vsphereCluster, &controlPlane)
+	machineDeployment := newMachineDeployment(cluster, machineTemplate, kubeadmJoinTemplate)
+	return []runtime.Object{
+		&cluster,
+		&vsphereCluster,
+		&machineTemplate,
+		&controlPlane,
+		&kubeadmJoinTemplate,
+		&machineDeployment,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides an example `clusterctl` `flavor` for deploying CAPV cluster with an external load balancer that fronts the control plane endpoints (kube-apiservers). This is an alternative to the HAProxy Load Balancer based deployment.

This flavor requires that the load balancer be configured out-of-band, prior to the CAPV cluster deployment.

**Which issue(s) this PR fixes** *
Fixes #904 

**Special notes for your reviewer**:
Not sure in what format or where in the repo this should best reside. Could this flavor template eventually form part of the release?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```