### PR TITLE
Automated cherry pick of #926: Fix race condition that leads to dropping the biosuuid

### DIFF
--- a/controllers/haproxyloadbalancer_controller.go
+++ b/controllers/haproxyloadbalancer_controller.go
@@ -555,6 +555,19 @@ func (r haproxylbReconciler) reconcileVMPre7(ctx *context.HAProxyLoadBalancerCon
 		// Copy the HAProxyLoadBalancer's VM clone spec into the VSphereVM's
 		// clone spec.
 		ctx.HAProxyLoadBalancer.Spec.VirtualMachineConfiguration.DeepCopyInto(&vm.Spec.VirtualMachineCloneSpec)
+
+		objectKey, err := ctrlclient.ObjectKeyFromObject(vm)
+		if err != nil {
+			return err
+		}
+		existingVM := &infrav1.VSphereVM{}
+		if err := r.Client.Get(ctx, objectKey, existingVM); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		vm.Spec.BiosUUID = existingVM.Spec.BiosUUID
 		return nil
 	}
 	if _, err := ctrlutil.CreateOrUpdate(ctx, ctx.Client, vm, mutateFn); err != nil {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -315,7 +315,7 @@ func (r machineReconciler) reconcileNormal(ctx *context.MachineContext) (reconci
 	}
 
 	// TODO(akutz) Determine the version of vSphere.
-	vm, err := r.reconcileNormalPre7(ctx)
+	vm, err := r.reconcileNormalPre7(ctx, vsphereVM)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return reconcile.Result{}, nil
@@ -368,7 +368,7 @@ func (r machineReconciler) reconcileNormal(ctx *context.MachineContext) (reconci
 	return reconcile.Result{}, nil
 }
 
-func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext) (runtime.Object, error) {
+func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsphereVM *infrav1.VSphereVM) (runtime.Object, error) {
 	// Create or update the VSphereVM resource.
 	vm := &infrav1.VSphereVM{
 		ObjectMeta: metav1.ObjectMeta{
@@ -432,6 +432,9 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext) (run
 		}
 		if vm.Spec.ResourcePool == "" {
 			vm.Spec.ResourcePool = vsphereCloudConfig.ResourcePool
+		}
+		if vsphereVM != nil {
+			vm.Spec.BiosUUID = vsphereVM.Spec.BiosUUID
 		}
 		return nil
 	}

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -182,12 +182,6 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 
 	ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 
-	// patch the vsphereVM here to ensure that the task is
-	// reflected in the status right away, this avoid situations
-	// of concurrent clones
-	if err := ctx.Patch(); err != nil {
-		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #926 on release-0.6.

#926: Fix race condition that leads to dropping the biosuuid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.