### PR TITLE
Automated cherry pick of #925: Use DataSecretName to get Bootstrap data

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -389,6 +389,7 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 
 		// Instruct the VSphereVM to use the CAPI bootstrap data resource.
 		vm.Spec.BootstrapRef = ctx.Machine.Spec.Bootstrap.ConfigRef
+		vm.Spec.BootstrapRef.Name = ctx.Machine.Spec.Bootstrap.DataSecretName
 
 		// Initialize the VSphereVM's labels map if it is nil.
 		if vm.Labels == nil {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -389,8 +390,10 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 
 		// Instruct the VSphereVM to use the CAPI bootstrap data resource.
 		// TODO: BootstrapRef field should be replaced with BootstrapSecret of type string
-		vm.Spec.BootstrapRef = ctx.Machine.Spec.Bootstrap.ConfigRef
-		vm.Spec.BootstrapRef.Name = *ctx.Machine.Spec.Bootstrap.DataSecretName
+		vm.Spec.BootstrapRef = &corev1.ObjectReference{
+			Name:      *ctx.Machine.Spec.Bootstrap.DataSecretName,
+			Namespace: ctx.Machine.ObjectMeta.Namespace,
+		}
 
 		// Initialize the VSphereVM's labels map if it is nil.
 		if vm.Labels == nil {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -388,8 +388,9 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 			}))
 
 		// Instruct the VSphereVM to use the CAPI bootstrap data resource.
+		// TODO: BootstrapRef field should be replaced with BootstrapSecret of type string
 		vm.Spec.BootstrapRef = ctx.Machine.Spec.Bootstrap.ConfigRef
-		vm.Spec.BootstrapRef.Name = ctx.Machine.Spec.Bootstrap.DataSecretName
+		vm.Spec.BootstrapRef.Name = *ctx.Machine.Spec.Bootstrap.DataSecretName
 
 		// Initialize the VSphereVM's labels map if it is nil.
 		if vm.Labels == nil {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -391,8 +391,10 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 		// Instruct the VSphereVM to use the CAPI bootstrap data resource.
 		// TODO: BootstrapRef field should be replaced with BootstrapSecret of type string
 		vm.Spec.BootstrapRef = &corev1.ObjectReference{
-			Name:      *ctx.Machine.Spec.Bootstrap.DataSecretName,
-			Namespace: ctx.Machine.ObjectMeta.Namespace,
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       *ctx.Machine.Spec.Bootstrap.DataSecretName,
+			Namespace:  ctx.Machine.ObjectMeta.Namespace,
 		}
 
 		// Initialize the VSphereVM's labels map if it is nil.


### PR DESCRIPTION
Cherry pick of #925 on release-0.6.

#925: Use DataSecretName to get Bootstrap data

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.