### PR TITLE
re-apply the conccurent clones fix

### DIFF
--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -332,13 +332,6 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 		return reconcile.Result{}, errors.Errorf("bios uuid is empty while VM is ready")
 	}
 
-	// patch the vsphereVM early to ensure that the task is
-	// reflected in the status right away, this avoid situations
-	// of concurrent clones
-	if err := ctx.Patch(); err != nil {
-		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
-	}
-
 	// Update the VSphereVM's network status.
 	r.reconcileNetwork(ctx, vm)
 

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -182,6 +182,12 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 
 	ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 
+	// patch the vsphereVM early to ensure that the task is
+	// reflected in the status right away, this avoid situations
+	// of concurrent clones
+	if err := ctx.Patch(); err != nil {
+		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR adds back the fix introduced in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/883 and that we removed in #926, the rational behind this was that patching in the `vspherevm_controller` was early enough. But it seems like it's not from what was reported by a user.

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
re-apply the concurrent clones fix
```