### PR TITLE
wait for staticIP to be set in VSphereVM

### DIFF
--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -440,7 +440,9 @@ func waitForIPAddresses(
 					// spec's static IP addresses.
 					isStatic := false
 					for _, specIP := range deviceSpec.IPAddrs {
-						if discoveredIP == specIP {
+						// The static IP assigned to the VM is required in the CIDR format
+						ip, _, _ := gonet.ParseCIDR(specIP)
+						if discoveredIP == ip.String() {
 							isStatic = true
 							break
 						}
@@ -525,7 +527,8 @@ func waitForIPAddresses(
 			// If the device spec requires static IP addresses, the wait
 			// is not over if the device lacks one of those addresses.
 			for _, specIP := range deviceSpec.IPAddrs {
-				if _, ok := macToHasStaticIP[mac][specIP]; !ok {
+				ip, _, _ := gonet.ParseCIDR(specIP)
+				if _, ok := macToHasStaticIP[mac][ip.String()]; !ok {
 					ctx.Logger.Info(
 						"the VM is missing the requested IP address",
 						"addressType", "static",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
CAPV has support to assign static IP to VSphereMachine, but the static IP itself can be assigned by different means. For eg., one such implementation can be using a third party controller to modify VSphereMachine to add static IP after the object is created.
Irrespective of the implementation choice to assign static IP, if DHCP is disabled, the CAPV controllers have to wait for static IPs to be available and then continue to provision VMs.
Currently, if both DHCP4 and DHCP6 are disabled and a staticIP is set in HAProxyLB's Network.Devices.IpAddrs, the VSphereVM for HAProxyLB goes to 'Ready' without any IPAddress in the status. The HAProxyLB then never goes to 'Ready' since its indefinitely waiting for the VSphereVM's IPAddress.
This PR checks if both DHCP4 and DHCP6 are disabled for all network devices(NetworkSpec.devices) and if there is no IP provided in the IPAddrs list, then the VSphereVM controller waits for the static IP to be available/assigned.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #728 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```