### PR TITLE
Automated cherry pick of #946: re-apply the conccurent clones fix

### DIFF
--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -332,13 +332,6 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 		return reconcile.Result{}, errors.Errorf("bios uuid is empty while VM is ready")
 	}
 
-	// patch the vsphereVM early to ensure that the task is
-	// reflected in the status right away, this avoid situations
-	// of concurrent clones
-	if err := ctx.Patch(); err != nil {
-		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
-	}
-
 	// Update the VSphereVM's network status.
 	r.reconcileNetwork(ctx, vm)
 

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -182,6 +182,12 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 
 	ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 
+	// patch the vsphereVM early to ensure that the task is
+	// reflected in the status right away, this avoid situations
+	// of concurrent clones
+	if err := ctx.Patch(); err != nil {
+		ctx.Logger.Error(err, "patch failed", "vspherevm", ctx.VSphereVM)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #946 on release-0.6.

#946: re-apply the conccurent clones fix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.