### PR TITLE
add support for validating webhooks

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -53,6 +53,7 @@ const (
 type VirtualMachineCloneSpec struct {
 	// Template is the name or inventory path of the template used to clone
 	// the virtual machine.
+	// +kubebuilder:validation:MinLength=1
 	Template string `json:"template"`
 
 	// CloneMode specifies the type of clone operation.

--- a/api/v1alpha3/vspheremachine_webhook_test.go
+++ b/api/v1alpha3/vspheremachine_webhook_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	someProviderID = "vsphere://42305f0b-dad7-1d3d-5727-0eaffffffffc"
+)
+
+//nolint
+func TestVSphereMachine_ValidateCreate(t *testing.T) {
+
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		vsphereMachine *VSphereMachine
+		wantErr        bool
+	}{
+		{
+			name:           "preferredAPIServerCIDR set on creation ",
+			vsphereMachine: createVSphereMachine("foo.com", nil, "192.168.0.1/32", []string{}),
+			wantErr:        true,
+		},
+		{
+			name:           "ProviderID set on creation",
+			vsphereMachine: createVSphereMachine("foo.com", &someProviderID, "", []string{}),
+			wantErr:        true,
+		},
+		{
+			name:           "IPs are not in CIDR format",
+			vsphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3"}),
+			wantErr:        true,
+		},
+		{
+			name:           "successful VSphereMachine creation",
+			vsphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3/32"}),
+			wantErr:        false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vsphereMachine.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+//nolint
+func TestVSphereMachine_ValidateUpdate(t *testing.T) {
+
+	g := NewWithT(t)
+
+	tests := []struct {
+		name              string
+		oldVSphereMachine *VSphereMachine
+		vsphereMachine    *VSphereMachine
+		wantErr           bool
+	}{
+		{
+			name:              "ProviderID can be updated",
+			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"192.168.0.1/32"}),
+			wantErr:           false,
+		},
+		{
+			name:              "updating ips cannot be done",
+			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:           true,
+		},
+		{
+			name:              "updating server cannot be done",
+			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachine("bar.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:           true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vsphereMachine.ValidateUpdate(tc.oldVSphereMachine)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func createVSphereMachine(server string, providerID *string, preferredAPIServerCIDR string, ips []string) *VSphereMachine {
+	VSphereMachine := &VSphereMachine{
+		Spec: VSphereMachineSpec{
+			ProviderID: providerID,
+			VirtualMachineCloneSpec: VirtualMachineCloneSpec{
+				Server: server,
+				Network: NetworkSpec{
+					PreferredAPIServerCIDR: preferredAPIServerCIDR,
+					Devices:                []NetworkDeviceSpec{},
+				},
+			},
+		},
+	}
+	for _, ip := range ips {
+		VSphereMachine.Spec.Network.Devices = append(VSphereMachine.Spec.Network.Devices, NetworkDeviceSpec{
+			IPAddrs: []string{ip},
+		})
+	}
+	return VSphereMachine
+}

--- a/api/v1alpha3/vspheremachinetemplate_webhook.go
+++ b/api/v1alpha3/vspheremachinetemplate_webhook.go
@@ -17,11 +17,56 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 func (r *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-vspheremachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates,versions=v1alpha3,name=validation.vspheremachinetemplate.infrastructure.x-k8s.io,sideEffects=None
+
+var _ webhook.Validator = &VSphereMachineTemplate{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereMachineTemplate) ValidateCreate() error {
+	var allErrs field.ErrorList
+	spec := r.Spec.Template.Spec
+
+	if spec.Network.PreferredAPIServerCIDR != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "PreferredAPIServerCIDR"), spec.Network.PreferredAPIServerCIDR, "cannot be set, as it will be removed and is no longer used"))
+	}
+
+	if spec.ProviderID != nil {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "providerID"), "cannot be set in templates"))
+	}
+
+	for _, device := range spec.Network.Devices {
+		if len(device.IPAddrs) != 0 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "network", "devices", "ipAddrs"), "cannot be set in templates"))
+		}
+	}
+	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereMachineTemplate) ValidateUpdate(old runtime.Object) error {
+	oldVSphereMachineTemplate := old.(*VSphereMachineTemplate)
+	if !reflect.DeepEqual(r.Spec, oldVSphereMachineTemplate.Spec) {
+		return field.Forbidden(field.NewPath("spec"), "VSphereMachineTemplateSpec is immutable")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereMachineTemplate) ValidateDelete() error {
+	return nil
 }

--- a/api/v1alpha3/vspheremachinetemplate_webhooks_test.go
+++ b/api/v1alpha3/vspheremachinetemplate_webhooks_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint
+func TestVSphereMachineTemplate_ValidateCreate(t *testing.T) {
+
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		vsphereMachine *VSphereMachineTemplate
+		wantErr        bool
+	}{
+		{
+			name:           "preferredAPIServerCIDR set on creation ",
+			vsphereMachine: createVSphereMachineTemplate("foo.com", nil, "192.168.0.1/32", []string{}),
+			wantErr:        true,
+		},
+		{
+			name:           "ProviderID set on creation",
+			vsphereMachine: createVSphereMachineTemplate("foo.com", &someProviderID, "", []string{}),
+			wantErr:        true,
+		},
+		{
+			name:           "IPs are not in CIDR format",
+			vsphereMachine: createVSphereMachineTemplate("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3"}),
+			wantErr:        true,
+		},
+		{
+			name:           "successful VSphereMachine creation",
+			vsphereMachine: createVSphereMachineTemplate("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3/32"}),
+			wantErr:        true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vsphereMachine.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+//nolint
+func TestVSphereMachineTemplate_ValidateUpdate(t *testing.T) {
+
+	g := NewWithT(t)
+
+	tests := []struct {
+		name              string
+		oldVSphereMachine *VSphereMachineTemplate
+		vsphereMachine    *VSphereMachineTemplate
+		wantErr           bool
+	}{
+		{
+			name:              "ProviderID cannot be updated",
+			oldVSphereMachine: createVSphereMachineTemplate("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachineTemplate("foo.com", &someProviderID, "", []string{"192.168.0.1/32"}),
+			wantErr:           true,
+		},
+		{
+			name:              "updating ips cannot be done",
+			oldVSphereMachine: createVSphereMachineTemplate("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachineTemplate("foo.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:           true,
+		},
+		{
+			name:              "updating server cannot be done",
+			oldVSphereMachine: createVSphereMachineTemplate("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachineTemplate("baz.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:           true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vsphereMachine.ValidateUpdate(tc.oldVSphereMachine)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func createVSphereMachineTemplate(server string, providerID *string, preferredAPIServerCIDR string, ips []string) *VSphereMachineTemplate {
+	VSphereMachineTemplate := &VSphereMachineTemplate{
+		Spec: VSphereMachineTemplateSpec{
+			Template: VSphereMachineTemplateResource{
+				Spec: VSphereMachineSpec{
+					ProviderID: providerID,
+					VirtualMachineCloneSpec: VirtualMachineCloneSpec{
+						Server: server,
+						Network: NetworkSpec{
+							PreferredAPIServerCIDR: preferredAPIServerCIDR,
+							Devices:                []NetworkDeviceSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, ip := range ips {
+		VSphereMachineTemplate.Spec.Template.Spec.Network.Devices = append(VSphereMachineTemplate.Spec.Template.Spec.Network.Devices, NetworkDeviceSpec{
+			IPAddrs: []string{ip},
+		})
+	}
+	return VSphereMachineTemplate
+}

--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -17,6 +17,13 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"net"
+	"reflect"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -24,4 +31,60 @@ func (r *VSphereVM) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-vspherevm,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspherevms,versions=v1alpha3,name=validation.vspherevm.infrastructure.x-k8s.io,sideEffects=None
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereVM) ValidateCreate() error {
+	var allErrs field.ErrorList
+	spec := r.Spec
+
+	if spec.Network.PreferredAPIServerCIDR != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "PreferredAPIServerCIDR"), spec.Network.PreferredAPIServerCIDR, "cannot be set, as it will be removed and is no longer used"))
+	}
+
+	if spec.BiosUUID != "" {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "biosUUID"), "cannot be set on creation"))
+	}
+	for _, device := range spec.Network.Devices {
+		for _, ip := range device.IPAddrs {
+			if _, _, err := net.ParseCIDR(ip); err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", "devices", "ipAddrs"), ip, "ip addresses should be in the CIDR format"))
+			}
+		}
+	}
+	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereVM) ValidateUpdate(old runtime.Object) error { //nolint
+	newVSphereVM, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
+	if err != nil {
+		return apierrors.NewInternalError(errors.Wrap(err, "failed to convert new VSphereVM to unstructured object"))
+	}
+	oldVSphereVM, err := runtime.DefaultUnstructuredConverter.ToUnstructured(old)
+	if err != nil {
+		return apierrors.NewInternalError(errors.Wrap(err, "failed to convert old VSphereVM to unstructured object"))
+	}
+
+	var allErrs field.ErrorList
+
+	newVSphereVMSpec := newVSphereVM["spec"].(map[string]interface{})
+	oldVSphereVMSpec := oldVSphereVM["spec"].(map[string]interface{})
+
+	// allow changes to biosUUID
+	delete(oldVSphereVMSpec, "biosUUID")
+	delete(newVSphereVMSpec, "biosUUID")
+
+	if !reflect.DeepEqual(oldVSphereVMSpec, newVSphereVMSpec) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
+	}
+
+	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *VSphereVM) ValidateDelete() error {
+	return nil
 }

--- a/api/v1alpha3/vspherevm_webhook_test.go
+++ b/api/v1alpha3/vspherevm_webhook_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	biosUUID = "vsphere://42305f0b-dad7-1d3d-5727-0eafffffbbbfc"
+)
+
+//nolint
+func TestVSphereVM_ValidateCreate(t *testing.T) {
+
+	g := NewWithT(t)
+	tests := []struct {
+		name      string
+		vSphereVM *VSphereVM
+		wantErr   bool
+	}{
+		{
+			name:      "preferredAPIServerCIDR set on creation ",
+			vSphereVM: createVSphereVM("foo.com", "", "192.168.0.1/32", []string{}),
+			wantErr:   true,
+		},
+		{
+			name:      "ProviderID set on creation",
+			vSphereVM: createVSphereVM("foo.com", biosUUID, "", []string{}),
+			wantErr:   true,
+		},
+		{
+			name:      "IPs are not in CIDR format",
+			vSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3"}),
+			wantErr:   true,
+		},
+		{
+			name:      "successful VSphereVM creation",
+			vSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}),
+			wantErr:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vSphereVM.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+//nolint
+func TestVSphereVM_ValidateUpdate(t *testing.T) {
+
+	g := NewWithT(t)
+
+	tests := []struct {
+		name         string
+		oldVSphereVM *VSphereVM
+		vSphereVM    *VSphereVM
+		wantErr      bool
+	}{
+		{
+			name:         "ProviderID can be updated",
+			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}),
+			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32"}),
+			wantErr:      false,
+		},
+		{
+			name:         "updating ips cannot be done",
+			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}),
+			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:      true,
+		},
+		{
+			name:         "updating server cannot be done",
+			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}),
+			vSphereVM:    createVSphereVM("bar.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
+			wantErr:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vSphereVM.ValidateUpdate(tc.oldVSphereVM)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func createVSphereVM(server string, biosUUID string, preferredAPIServerCIDR string, ips []string) *VSphereVM {
+	VSphereVM := &VSphereVM{
+		Spec: VSphereVMSpec{
+			BiosUUID: biosUUID,
+			VirtualMachineCloneSpec: VirtualMachineCloneSpec{
+				Server: server,
+				Network: NetworkSpec{
+					PreferredAPIServerCIDR: preferredAPIServerCIDR,
+					Devices:                []NetworkDeviceSpec{},
+				},
+			},
+		},
+	}
+	for _, ip := range ips {
+		VSphereVM.Spec.Network.Devices = append(VSphereVM.Spec.Network.Devices, NetworkDeviceSpec{
+			IPAddrs: []string{ip},
+		})
+	}
+	return VSphereVM
+}

--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorList) error {
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		gk,
+		name,
+		allErrs,
+	)
+}

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha3
 
 import (
 	"k8s.io/api/core/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -247,6 +247,7 @@ spec:
                   template:
                     description: Template is the name or inventory path of the template
                       used to clone the virtual machine.
+                    minLength: 1
                     type: string
                 required:
                 - network

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -511,6 +511,7 @@ spec:
               template:
                 description: Template is the name or inventory path of the template
                   used to clone the virtual machine.
+                minLength: 1
                 type: string
             required:
             - network

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -571,6 +571,7 @@ spec:
                       template:
                         description: Template is the name or inventory path of the
                           template used to clone the virtual machine.
+                        minLength: 1
                         type: string
                     required:
                     - network

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -269,6 +269,7 @@ spec:
               template:
                 description: Template is the name or inventory path of the template
                   used to clone the virtual machine.
+                minLength: 1
                 type: string
             required:
             - network

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,12 +2,13 @@ namespace: capi-webhook-system
 
 resources:
 - service.yaml
+- manifests.yaml
 - ../certmanager
 - ../manager
 
 patchesStrategicMerge:
 - manager_webhook_patch.yaml
-#- webhookcainjection_patch.yaml # Disable this value if you don't have any defaulting or validation webhook. If you don't know, you can check if the manifests.yaml file in the same directory has any contents.
+- webhookcainjection_patch.yaml # Disable this value if you don't have any defaulting or validation webhook. If you don't know, you can check if the manifests.yaml file in the same directory has any contents.
 
 vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,3 +1,19 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+
 varReference:
 - kind: Deployment
   path: spec/template/spec/volumes/secret/secretName

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,68 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-vspheremachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspheremachine.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachines
+  sideEffects: None
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-vspheremachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspheremachinetemplate.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachinetemplates
+  sideEffects: None
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-vspherevm
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspherevm.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspherevms
+  sideEffects: None

--- a/config/webhook/webhookcainjection_patch.yaml
+++ b/config/webhook/webhookcainjection_patch.yaml
@@ -1,15 +1,8 @@
 # This patch add annotation to admission webhook config and
 # the variables $(NAMESPACE) and $(CERTIFICATENAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-  annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
----
-apiVersion: admissionregistration.k8s.io/v1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR adds validation logic to CAPV, this prevents any users from creating resources/updating fields that shouldn't be and checks formatting in some cases

**Which issue(s) this PR fixes** : Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/853

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
add validating webhook for VSphereMachines, VSphereVMs, VSphereMachineTemplates and VSphereClusters
```