### PR TITLE
fix validating webhooks to avoid breaking clusterctl move

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable-all: true
   disable:
+    - dupl
     - funlen
     - gochecknoglobals
     - gochecknoinits

--- a/api/v1alpha3/vspheremachine_webhook.go
+++ b/api/v1alpha3/vspheremachine_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"fmt"
 	"net"
 	"reflect"
 
@@ -44,14 +45,10 @@ func (r *VSphereMachine) ValidateCreate() error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "PreferredAPIServerCIDR"), spec.Network.PreferredAPIServerCIDR, "cannot be set, as it will be removed and is no longer used"))
 	}
 
-	if spec.ProviderID != nil {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "cannot be set on creation"))
-	}
-
-	for _, device := range spec.Network.Devices {
-		for _, ip := range device.IPAddrs {
+	for i, device := range spec.Network.Devices {
+		for j, ip := range device.IPAddrs {
 			if _, _, err := net.ParseCIDR(ip); err != nil {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", "devices", "ipAddrs"), ip, "ip addresses should be in the CIDR format"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", fmt.Sprintf("devices[%d]", i), fmt.Sprintf("ipAddrs[%d]", j)), ip, "ip addresses should be in the CIDR format"))
 			}
 		}
 	}
@@ -59,7 +56,7 @@ func (r *VSphereMachine) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *VSphereMachine) ValidateUpdate(old runtime.Object) error { //nolint
+func (r *VSphereMachine) ValidateUpdate(old runtime.Object) error {
 	newVSphereMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	if err != nil {
 		return apierrors.NewInternalError(errors.Wrap(err, "failed to convert new VSphereMachine to unstructured object"))

--- a/api/v1alpha3/vspheremachine_webhook_test.go
+++ b/api/v1alpha3/vspheremachine_webhook_test.go
@@ -38,11 +38,6 @@ func TestVSphereMachine_ValidateCreate(t *testing.T) {
 			wantErr:        true,
 		},
 		{
-			name:           "ProviderID set on creation",
-			vsphereMachine: createVSphereMachine("foo.com", &someProviderID, "", []string{}),
-			wantErr:        true,
-		},
-		{
 			name:           "IPs are not in CIDR format",
 			vsphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3"}),
 			wantErr:        true,

--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"fmt"
 	"net"
 	"reflect"
 
@@ -44,13 +45,10 @@ func (r *VSphereVM) ValidateCreate() error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "PreferredAPIServerCIDR"), spec.Network.PreferredAPIServerCIDR, "cannot be set, as it will be removed and is no longer used"))
 	}
 
-	if spec.BiosUUID != "" {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "biosUUID"), "cannot be set on creation"))
-	}
-	for _, device := range spec.Network.Devices {
-		for _, ip := range device.IPAddrs {
+	for i, device := range spec.Network.Devices {
+		for j, ip := range device.IPAddrs {
 			if _, _, err := net.ParseCIDR(ip); err != nil {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", "devices", "ipAddrs"), ip, "ip addresses should be in the CIDR format"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", fmt.Sprintf("devices[%d]", i), fmt.Sprintf("ipAddrs[%d]", j)), ip, "ip addresses should be in the CIDR format"))
 			}
 		}
 	}

--- a/api/v1alpha3/vspherevm_webhook_test.go
+++ b/api/v1alpha3/vspherevm_webhook_test.go
@@ -38,11 +38,6 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "ProviderID set on creation",
-			vSphereVM: createVSphereVM("foo.com", biosUUID, "", []string{}),
-			wantErr:   true,
-		},
-		{
 			name:      "IPs are not in CIDR format",
 			vSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3"}),
 			wantErr:   true,


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: follow-up of #970 that fixes a case breaking `clusterctl move` + improves formatting

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```