### PR TITLE
🐛 relax constraints on the validating webhooks to update ips and enable IPAM use cases

### DIFF
--- a/api/v1alpha3/vspheremachine_webhook.go
+++ b/api/v1alpha3/vspheremachine_webhook.go
@@ -75,6 +75,13 @@ func (r *VSphereMachine) ValidateUpdate(old runtime.Object) error {
 	delete(oldVSphereMachineSpec, "providerID")
 	delete(newVSphereMachineSpec, "providerID")
 
+	newVSphereMachineNetwork := newVSphereMachineSpec["network"].(map[string]interface{})
+	oldVSphereMachineNetwork := oldVSphereMachineSpec["network"].(map[string]interface{})
+
+	// allow changes to the devices
+	delete(oldVSphereMachineNetwork, "devices")
+	delete(newVSphereMachineNetwork, "devices")
+
 	if !reflect.DeepEqual(oldVSphereMachineSpec, newVSphereMachineSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
 	}

--- a/api/v1alpha3/vspheremachine_webhook_test.go
+++ b/api/v1alpha3/vspheremachine_webhook_test.go
@@ -81,10 +81,10 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 			wantErr:           false,
 		},
 		{
-			name:              "updating ips cannot be done",
+			name:              "updating ips can be done",
 			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
 			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
-			wantErr:           true,
+			wantErr:           false,
 		},
 		{
 			name:              "updating server cannot be done",

--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -75,6 +75,13 @@ func (r *VSphereVM) ValidateUpdate(old runtime.Object) error { //nolint
 	delete(oldVSphereVMSpec, "biosUUID")
 	delete(newVSphereVMSpec, "biosUUID")
 
+	newVSphereVMNetwork := newVSphereVMSpec["network"].(map[string]interface{})
+	oldVSphereVMNetwork := oldVSphereVMSpec["network"].(map[string]interface{})
+
+	// allow changes to the network devices
+	delete(oldVSphereVMNetwork, "devices")
+	delete(newVSphereVMNetwork, "devices")
+
 	if !reflect.DeepEqual(oldVSphereVMSpec, newVSphereVMSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
 	}

--- a/api/v1alpha3/vspherevm_webhook_test.go
+++ b/api/v1alpha3/vspherevm_webhook_test.go
@@ -81,10 +81,10 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:         "updating ips cannot be done",
+			name:         "updating ips can be done",
 			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}),
 			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
-			wantErr:      true,
+			wantErr:      false,
 		},
 		{
 			name:         "updating server cannot be done",


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR relaxes the validating webhooks to be able to update the devices, this avoids breaking IPAM use cases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```