### PR TITLE
wait to have IP addresses reported before making a VSphereVM as ready

### DIFF
--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -348,6 +348,11 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 	// Update the VSphereVM's network status.
 	r.reconcileNetwork(ctx, vm)
 
+	// we didn't get any addresses, requeue
+	if len(ctx.VSphereVM.Status.Addresses) == 0 {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	// Once the network is online the VM is considered ready.
 	ctx.VSphereVM.Status.Ready = true
 	conditions.MarkTrue(ctx.VSphereVM, infrav1.VMProvisionedCondition)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR waits for the `VSphereVM` to report Addresses before marking it as Ready

**Which issue(s) this PR fixes**  Fixes #938 

**Special notes for your reviewer**:

/assign @vincepri 


**Release note**:

```release-note
wait to report Addresses on the VSphereVM before marking it as ready
```