### PR TITLE
bump kube-vip to 0.1.7

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -356,7 +356,7 @@ func kubeVIPPod() string {
 			Containers: []v1.Container{
 				{
 					Name:  "kube-vip",
-					Image: "plndr/kube-vip:0.1.6",
+					Image: "plndr/kube-vip:0.1.7",
 					Args: []string{
 						"start",
 					},
@@ -389,28 +389,8 @@ func kubeVIPPod() string {
 							Value: controlPlaneEndpointVar,
 						},
 						{
-							Name:  "lb_backendport",
-							Value: "6443",
-						},
-						{
-							Name:  "vip_addpeerstolb",
-							Value: "true",
-						},
-						{
-							Name:  "lb_name",
-							Value: "kcpEndpoint",
-						},
-						{
-							Name:  "lb_bindtovip",
-							Value: "true",
-						},
-						{
 							Name:  "vip_interface",
 							Value: vipNetworkInterfaceVar,
-						},
-						{
-							Name:  "lb_type",
-							Value: "tcp",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR bumps kube-vip to 0.1.7 and cleans up some unused variables

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @gab-satchi 

**Release note**:

```release-note
bump kube-vip to 0.1.7
```