### PR TITLE
add quotes around username/password

### DIFF
--- a/config/default/credentials.yaml
+++ b/config/default/credentials.yaml
@@ -6,5 +6,5 @@ metadata:
 type: Opaque
 stringData:
   credentials.yaml: |-
-    username: ${VSPHERE_USERNAME}
-    password: ${VSPHERE_PASSWORD}
+    username: "${VSPHERE_USERNAME}"
+    password: "${VSPHERE_PASSWORD}"


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR adds quotes are the username and password in our credentials yaml file, this avoids issues with entries that starts with special chars like "@"

**Which issue(s) this PR fixes** : Fixes #980 

**Special notes for your reviewer**:

/assign @vincepri  

**Release note**:

```release-note

```