### PR TITLE
hardcode network interface to eth0 in the cluster-template.yaml

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -53,7 +53,6 @@ const (
 	vSphereTemplateVar           = "${ VSPHERE_TEMPLATE }"
 	workerMachineCountVar        = "${ WORKER_MACHINE_COUNT }"
 	controlPlaneEndpointVar      = "${ CONTROL_PLANE_ENDPOINT_IP }"
-	vipNetworkInterfaceVar       = "${ VIP_NETWORK_INTERFACE }"
 	vSphereUsername              = "${ VSPHERE_USERNAME }"
 	vSpherePassword              = "${ VSPHERE_PASSWORD }" /* #nosec */
 	clusterResourceSetNameSuffix = "-crs-0"
@@ -385,8 +384,9 @@ func kubeVIPPod() string {
 							Value: controlPlaneEndpointVar,
 						},
 						{
+							// this is hardcoded since we use eth0 as a network interface for all of our machines in this template
 							Name:  "vip_interface",
-							Value: vipNetworkInterfaceVar,
+							Value: "eth0",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR fixes a bug in our templating, where if you supplied a custom network interface name to kube-vip, it wouldn't start (we weren't setting `DeviceName` into the `VSphereMachineTemplate`).
After giving more thoughts for a quickstart template we don't need to template that kind of things.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @gab-satchi 

**Release note**:

```release-note

```