### PR TITLE
update mdlint to v0.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ lint-go-full: lint-go ## Run slower linters to detect possible issues
 
 .PHONY: lint-markdown
 lint-markdown: ## Lint the project's markdown
-	docker run --rm -v "$$(pwd)":/build$(DOCKER_VOL_OPTS) gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0 -- /md/lint -i vendor -i contrib/haproxy/openapi .
+	docker run --rm -v "$$(pwd)":/build$(DOCKER_VOL_OPTS) gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 -- /md/lint -i vendor -i contrib/haproxy/openapi .
 
 .PHONY: lint-shell
 lint-shell: ## Lint the project's shell scripts

--- a/README.md
+++ b/README.md
@@ -153,3 +153,5 @@ We also use the issue tracker to track features. If you have an idea for a featu
 [slack_info]: https://github.com/kubernetes/community/tree/master/communication#communication
 [troubleshooting]: ./docs/troubleshooting.md
 [zoom_meeting]: https://zoom.us/j/875399243
+
+<!-- markdownlint-disable-file MD033 -->

--- a/hack/tools/mdlint/Dockerfile
+++ b/hack/tools/mdlint/Dockerfile
@@ -16,7 +16,7 @@
 ##                             INSTALL MDLINT                                 ##
 ################################################################################
 FROM node:12.6.0-slim as build
-ARG MDLINT_CLI_VERSION=0.17.0
+ARG MDLINT_CLI_VERSION=0.23.2
 ENV MDLINT_CLI_VERSION=${MDLINT_CLI_VERSION}
 RUN npm install -g --prefix=/md markdownlint-cli@${MDLINT_CLI_VERSION} && \
     ln -s /md/lib/node_modules/markdownlint-cli/markdownlint.js /md/lint

--- a/hack/tools/mdlint/Makefile
+++ b/hack/tools/mdlint/Makefile
@@ -14,7 +14,7 @@
 
 all: build
 
-MDLINT_CLI_VERSION ?= 0.17.0
+MDLINT_CLI_VERSION ?= 0.23.2
 IMAGE_NAME ?= gcr.io/cluster-api-provider-vsphere/extra/mdlint
 IMAGE_TAG ?= $(IMAGE_NAME):$(MDLINT_CLI_VERSION)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
I happened to be messign with the markdownlint container in another
project, and decided it was a good opportunity to update this. The
exception added to the README is due to a change in the linter not
allowing raw HTML by default, but I felt like that it was okay to have
in the README.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I've already pushed v0.23.2 of this container to gcr.io, so local `make` commands will work and pull the right version. Once this is merged, I will make the change in `test-infra` to use the new container as well. I've also verified that running this iwth the old version (v0.17.0) works with these changes, so the prow job isn't going to break on us with this PR.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @yastij 