### PR TITLE
Fix CSI installation for non default templates

### DIFF
--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -73,6 +73,9 @@ func MultiNodeTemplateWithKubeVIP() []runtime.Object {
 	clusterResourceSet := newClusterResourceSet(cluster)
 	crsResources := createCrsResourceObjects(&clusterResourceSet, vsphereCluster, cluster)
 
+	// removing Storage config so the cluster controller is not going not install CSI (it is installed by the clusterResourceSet)
+	vsphereCluster.Spec.CloudProviderConfiguration.ProviderConfig.Storage = nil
+
 	MultiNodeTemplate := []runtime.Object{
 		&cluster,
 		&vsphereCluster,

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	cloudprovidersvc "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
@@ -143,6 +144,15 @@ func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 				ProviderConfig: infrav1.CPIProviderConfig{
 					Cloud: &infrav1.CPICloudConfig{
 						ControllerImage: defaultCloudProviderImage,
+					},
+					Storage: &infrav1.CPIStorageConfig{
+						ControllerImage:     cloudprovidersvc.DefaultCSIControllerImage,
+						NodeDriverImage:     cloudprovidersvc.DefaultCSINodeDriverImage,
+						AttacherImage:       cloudprovidersvc.DefaultCSIAttacherImage,
+						ProvisionerImage:    cloudprovidersvc.DefaultCSIProvisionerImage,
+						MetadataSyncerImage: cloudprovidersvc.DefaultCSIMetadataSyncerImage,
+						LivenessProbeImage:  cloudprovidersvc.DefaultCSILivenessProbeImage,
+						RegistrarImage:      cloudprovidersvc.DefaultCSIRegistrarImage,
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the haproxy and the external-load balancer templates to trigger CSI installation back (as it was before https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/986).

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/992

**Special notes for your reviewer**:
This PR changes release manifests

**Release note**:
```release-note
Fix a regression preventing CSI installation when using the haproxy and the external-load balancer template
```