### PR TITLE
add dhcp4 and dhcp6 flags in cloud-init metadata only when either of them is set to true

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -35,8 +35,10 @@ network:
       set-name: "eth{{ $i }}"
       {{- end }}
       wakeonlan: true
+      {{- if or $net.DHCP4 $net.DHCP6 }}
       dhcp4: {{ $net.DHCP4 }}
       dhcp6: {{ $net.DHCP6 }}
+      {{- end }}
       {{- if $net.IPAddrs }}
       addresses:
       {{- range $net.IPAddrs }}

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -566,8 +566,6 @@ network:
         macaddress: "00:00:00:00:00"
       set-name: "eth0"
       wakeonlan: true
-      dhcp4: false
-      dhcp6: false
       addresses:
       - "192.168.4.21"
       gateway4: "192.168.4.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR selectively adds dhcp flags in the machine's cloud-init metadata, only when either of them is set to true. This is to handle the centos 7 cloud-init issue where dhcp is not disabled in static IP mode, resulting in an additional DHCP IP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #996 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```