### PR TITLE
check the description before using it in a condition

### DIFF
--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -141,7 +141,12 @@ func reconcileInFlightTask(ctx *context.VMContext) (bool, error) {
 
 		// NOTE: When a task fails there is not simple way to understand which operation is failing (e.g. cloning or powering on)
 		// so we are reporting failures using a dedicated reason until we find a better solution.
-		conditions.MarkFalse(ctx.VSphereVM, infrav1.VMProvisionedCondition, infrav1.TaskFailure, clusterv1.ConditionSeverityInfo, task.Info.Description.Message)
+		var description string
+
+		if task.Info.Description != nil {
+			description = task.Info.Description.Message
+		}
+		conditions.MarkFalse(ctx.VSphereVM, infrav1.VMProvisionedCondition, infrav1.TaskFailure, clusterv1.ConditionSeverityInfo, description)
 		ctx.VSphereVM.Status.TaskRef = ""
 		return false, nil
 	default:


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR fixes an NPE where we access the description before checking if `nil` or not

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

/assign @fabriziopandini 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
check the description before using it into a condition
```