### PR TITLE
let deletion go through when the folder of a VSphereVM doesn't exist

### DIFF
--- a/pkg/services/govmomi/errors.go
+++ b/pkg/services/govmomi/errors.go
@@ -44,6 +44,15 @@ func isNotFound(err error) bool {
 	}
 }
 
+func isFolderNotFound(err error) bool {
+	switch err.(type) {
+	case *find.NotFoundError:
+		return true
+	default:
+		return false
+	}
+}
+
 func isVirtualMachineNotFound(err error) bool {
 	switch err.(type) {
 	case *find.NotFoundError:

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -159,7 +159,7 @@ func (vms *VMService) DestroyVM(ctx *context.VMContext) (infrav1.VirtualMachine,
 	if err != nil {
 		// If the VM's MoRef could not be found then the VM no longer exists. This
 		// is the desired state.
-		if isNotFound(err) {
+		if isNotFound(err) || isFolderNotFound(err) {
 			vm.State = infrav1.VirtualMachineStateNotFound
 			return vm, nil
 		}

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -78,7 +78,7 @@ func findVM(ctx *context.VMContext) (types.ManagedObjectReference, error) {
 		// fallback to use inventory paths
 		folder, err := ctx.Session.Finder.FolderOrDefault(ctx, ctx.VSphereVM.Spec.Folder)
 		if err != nil {
-			return types.ManagedObjectReference{}, errors.Wrapf(err, "unable to get folder for %s/%s", ctx.VSphereVM.Namespace, ctx.VSphereVM.Name)
+			return types.ManagedObjectReference{}, err
 		}
 		inventoryPath := path.Join(folder.InventoryPath, ctx.VSphereVM.Name)
 		ctx.Logger.Info("using inventory path to find vm", "path", inventoryPath)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR fixes a bug where the deletion flow of a `VSphereVM` is blocked if its folder doesn't exist.

**Which issue(s) this PR fixes**: Fixes #1000 

**Special notes for your reviewer**:

/assign @vincepri @fabriziopandini 

**Release note**:

```release-note
let deletion go through when the folder of a VSphereVM doesn't exist
```