### PR TITLE
bump vSphere cloud provider  version to 1.2.0

### DIFF
--- a/examples/default/cluster/cluster.yaml
+++ b/examples/default/cluster/cluster.yaml
@@ -40,7 +40,7 @@ spec:
       folder: "${VSPHERE_FOLDER}"
     providerConfig:
       cloud:
-        controllerImage: "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0"
+        controllerImage: "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.0"
       storage:
         controllerImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
         nodeDriverImage: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -35,7 +35,7 @@ import (
 const (
 	clusterNameVar               = "${ CLUSTER_NAME }"
 	controlPlaneMachineCountVar  = "${ CONTROL_PLANE_MACHINE_COUNT }"
-	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.0.0"
+	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.0"
 	defaultClusterCIDR           = "192.168.0.0/16"
 	defaultDiskGiB               = 25
 	defaultMemoryMiB             = 8192

--- a/pkg/services/cloudprovider/cloud-controller-manager.go
+++ b/pkg/services/cloudprovider/cloud-controller-manager.go
@@ -28,7 +28,7 @@ import (
 // NOTE: the contents of this file are derived from https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager
 
 const (
-	DefaultCPIControllerImage = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0"
+	DefaultCPIControllerImage = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.0"
 )
 
 // CloudControllerManagerServiceAccount returns the ServiceAccount used for the cloud-controller-manager

--- a/test/e2e/data/infrastructure-vsphere/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/cluster-template.yaml
@@ -61,7 +61,7 @@ spec:
       name: '${ VSPHERE_NETWORK }'
     providerConfig:
       cloud:
-        controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0
+        controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.0
       storage:
         attacherImage: quay.io/k8scsi/csi-attacher:v2.0.0
         controllerImage: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR bumps vSphere cloud provider version to v1.2.0 as it has some good improvements / bug fixes. v1.2.0 should be compatible with any Kubernetes versions v1.1.0 supported.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1002 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._
This PR changes vSphere cloud provider from v1.1.0 to v1.2.0
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bump the CPI from 1.1.0 to 1.2.0
```