### PR TITLE
add SKIP_NODE_DELETION to skip node deletion on node startup

### DIFF
--- a/pkg/services/cloudprovider/cloud-controller-manager.go
+++ b/pkg/services/cloudprovider/cloud-controller-manager.go
@@ -19,6 +19,7 @@ package cloudprovider
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,6 +134,13 @@ func CloudControllerManagerDaemonSet(image string, args []string) *appsv1.Daemon
 							Name:  "vsphere-cloud-controller-manager",
 							Image: image,
 							Args:  args,
+							Env: []v1.EnvVar{
+								{
+									// skips node deletion, remove when kubernetes/cloud-provider-vsphere#381 is resolved
+									Name:  "SKIP_NODE_DELETION",
+									Value: "true",
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vsphere-config-volume",


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: after merging #1005 we noticed consistent flakes where the cluster couldn't finish the bootstrapping because of the controllers of the CCM was deleting the node object, due to behaviour change added in 1.2, more details here kubernetes/cloud-provider-vsphere#381
This PR adds the `SKIP_NODE_DELETION` Env var to restore the old behaviour until kubernetes/cloud-provider-vsphere#381 is solved

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @randomvariable @fabriziopandini 

**Release note**:

```release-note

```