### PR TITLE
Adds metadata.yaml for clusterctl contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ endif
 .PHONY: release-manifests
 release-manifests:
 	$(MAKE) manifests STAGE=release MANIFEST_DIR=$(RELEASE_DIR) PULL_POLICY=IfNotPresent IMAGE=$(RELEASE_CONTROLLER_IMG):$(VERSION)
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: release-overrides
 release-overrides:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,20 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 0
+    minor: 4
+    contract: v1alpha2
+  - major: 0
+    minor: 5
+    contract: v1alpha2
+  - major: 0
+    minor: 6
+    contract: v1alpha3
+  - major: 0
+    minor: 7
+    contract: v1alpha3


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a metadata.yaml outlined by the [docs](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#metadata-yaml) so users aren't forced to update clusterctl in order to use a new CAPV release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #999 

**Release note**:
```release-note
NONE
```