### PR TITLE
Use envsubst syntax

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -33,29 +33,29 @@ import (
 )
 
 const (
-	clusterNameVar               = "${ CLUSTER_NAME }"
-	controlPlaneMachineCountVar  = "${ CONTROL_PLANE_MACHINE_COUNT }"
+	clusterNameVar               = "${CLUSTER_NAME}"
+	controlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
 	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
 	defaultClusterCIDR           = "192.168.0.0/16"
 	defaultDiskGiB               = 25
 	defaultMemoryMiB             = 8192
 	defaultNumCPUs               = 2
-	kubernetesVersionVar         = "${ KUBERNETES_VERSION }"
+	kubernetesVersionVar         = "${KUBERNETES_VERSION}"
 	machineDeploymentNameSuffix  = "-md-0"
-	namespaceVar                 = "${ NAMESPACE }"
-	vSphereDataCenterVar         = "${ VSPHERE_DATACENTER }"
-	vSphereDatastoreVar          = "${ VSPHERE_DATASTORE }"
-	vSphereFolderVar             = "${ VSPHERE_FOLDER }"
-	vSphereHaproxyTemplateVar    = "${ VSPHERE_HAPROXY_TEMPLATE }"
-	vSphereNetworkVar            = "${ VSPHERE_NETWORK }"
-	vSphereResourcePoolVar       = "${ VSPHERE_RESOURCE_POOL }"
-	vSphereServerVar             = "${ VSPHERE_SERVER }"
-	vSphereSSHAuthorizedKeysVar  = "${ VSPHERE_SSH_AUTHORIZED_KEY }"
-	vSphereTemplateVar           = "${ VSPHERE_TEMPLATE }"
-	workerMachineCountVar        = "${ WORKER_MACHINE_COUNT }"
-	controlPlaneEndpointVar      = "${ CONTROL_PLANE_ENDPOINT_IP }"
-	vSphereUsername              = "${ VSPHERE_USERNAME }"
-	vSpherePassword              = "${ VSPHERE_PASSWORD }" /* #nosec */
+	namespaceVar                 = "${NAMESPACE}"
+	vSphereDataCenterVar         = "${VSPHERE_DATACENTER}"
+	vSphereDatastoreVar          = "${VSPHERE_DATASTORE}"
+	vSphereFolderVar             = "${VSPHERE_FOLDER}"
+	vSphereHaproxyTemplateVar    = "${VSPHERE_HAPROXY_TEMPLATE}"
+	vSphereNetworkVar            = "${VSPHERE_NETWORK}"
+	vSphereResourcePoolVar       = "${VSPHERE_RESOURCE_POOL}"
+	vSphereServerVar             = "${VSPHERE_SERVER}"
+	vSphereSSHAuthorizedKeysVar  = "${VSPHERE_SSH_AUTHORIZED_KEY}"
+	vSphereTemplateVar           = "${VSPHERE_TEMPLATE}"
+	workerMachineCountVar        = "${WORKER_MACHINE_COUNT}"
+	controlPlaneEndpointVar      = "${CONTROL_PLANE_ENDPOINT_IP}"
+	vSphereUsername              = "${VSPHERE_USERNAME}"
+	vSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
 	clusterResourceSetNameSuffix = "-crs-0"
 )
 
@@ -70,19 +70,19 @@ var (
 	replacements = []replacement{
 		{
 			kind:      "KubeadmControlPlane",
-			name:      "${ CLUSTER_NAME }",
+			name:      "${CLUSTER_NAME}",
 			value:     controlPlaneMachineCountVar,
 			fieldPath: []string{"spec", "replicas"},
 		},
 		{
 			kind:      "MachineDeployment",
-			name:      "${ CLUSTER_NAME }-md-0",
+			name:      "${CLUSTER_NAME}-md-0",
 			value:     workerMachineCountVar,
 			fieldPath: []string{"spec", "replicas"},
 		},
 		{
 			kind:      "MachineDeployment",
-			name:      "${ CLUSTER_NAME }-md-0",
+			name:      "${CLUSTER_NAME}-md-0",
 			value:     map[string]interface{}{},
 			fieldPath: []string{"spec", "selector", "matchLabels"},
 		},

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -2,8 +2,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   clusterNetwork:
     pods:
@@ -12,45 +12,45 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: HAProxyLoadBalancer
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   user:
     authorizedKeys:
-    - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+    - '${VSPHERE_SSH_AUTHORIZED_KEY}'
     name: capv
   virtualMachineConfiguration:
     cloneMode: linkedClone
-    datacenter: '${ VSPHERE_DATACENTER }'
-    datastore: '${ VSPHERE_DATASTORE }'
+    datacenter: '${VSPHERE_DATACENTER}'
+    datastore: '${VSPHERE_DATASTORE}'
     diskGiB: 25
-    folder: '${ VSPHERE_FOLDER }'
+    folder: '${VSPHERE_FOLDER}'
     memoryMiB: 8192
     network:
       devices:
       - dhcp4: true
-        networkName: '${ VSPHERE_NETWORK }'
+        networkName: '${VSPHERE_NETWORK}'
     numCPUs: 2
-    resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-    server: '${ VSPHERE_SERVER }'
-    template: '${ VSPHERE_HAPROXY_TEMPLATE }'
+    resourcePool: '${VSPHERE_RESOURCE_POOL}'
+    server: '${VSPHERE_SERVER}'
+    template: '${VSPHERE_HAPROXY_TEMPLATE}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   cloudProviderConfiguration:
     global:
@@ -58,7 +58,7 @@ spec:
       secretName: cloud-provider-vsphere-credentials
       secretNamespace: kube-system
     network:
-      name: '${ VSPHERE_NETWORK }'
+      name: '${VSPHERE_NETWORK}'
     providerConfig:
       cloud:
         controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1
@@ -71,53 +71,53 @@ spec:
         provisionerImage: quay.io/k8scsi/csi-provisioner:v1.4.0
         registrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
     virtualCenter:
-      ${ VSPHERE_SERVER }:
-        datacenters: '${ VSPHERE_DATACENTER }'
+      ${VSPHERE_SERVER}:
+        datacenters: '${VSPHERE_DATACENTER}'
     workspace:
-      datacenter: '${ VSPHERE_DATACENTER }'
-      datastore: '${ VSPHERE_DATASTORE }'
-      folder: '${ VSPHERE_FOLDER }'
-      resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-      server: '${ VSPHERE_SERVER }'
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
+      folder: '${VSPHERE_FOLDER}'
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
   loadBalancerRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: HAProxyLoadBalancer
-    name: '${ CLUSTER_NAME }'
-  server: '${ VSPHERE_SERVER }'
+    name: '${CLUSTER_NAME}'
+  server: '${VSPHERE_SERVER}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: '${ VSPHERE_DATACENTER }'
-      datastore: '${ VSPHERE_DATASTORE }'
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
       diskGiB: 25
-      folder: '${ VSPHERE_FOLDER }'
+      folder: '${VSPHERE_FOLDER}'
       memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: '${ VSPHERE_NETWORK }'
+          networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
-      resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-      server: '${ VSPHERE_SERVER }'
-      template: '${ VSPHERE_TEMPLATE }'
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
+      template: '${VSPHERE_TEMPLATE}'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
@@ -148,16 +148,16 @@ spec:
     users:
     - name: capv
       sshAuthorizedKeys:
-      - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+      - '${VSPHERE_SSH_AUTHORIZED_KEY}'
       sudo: ALL=(ALL) NOPASSWD:ALL
-  replicas: ${ CONTROL_PLANE_MACHINE_COUNT }
-  version: '${ KUBERNETES_VERSION }'
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: '${KUBERNETES_VERSION}'
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
-  name: '${ CLUSTER_NAME }-md-0'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}-md-0'
+  namespace: '${NAMESPACE}'
 spec:
   template:
     spec:
@@ -166,7 +166,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
-          name: '{{ ds.meta_data.hostname }}'
+          name: '{{ ds.meta_data.hostname}}'
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -176,34 +176,34 @@ spec:
       users:
       - name: capv
         sshAuthorizedKeys:
-        - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+        - '${VSPHERE_SSH_AUTHORIZED_KEY}'
         sudo: ALL=(ALL) NOPASSWD:ALL
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
-  name: '${ CLUSTER_NAME }-md-0'
-  namespace: '${ NAMESPACE }'
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}-md-0'
+  namespace: '${NAMESPACE}'
 spec:
-  clusterName: '${ CLUSTER_NAME }'
-  replicas: ${ WORKER_MACHINE_COUNT }
+  clusterName: '${CLUSTER_NAME}'
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
+        cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
-          name: '${ CLUSTER_NAME }-md-0'
-      clusterName: '${ CLUSTER_NAME }'
+          name: '${CLUSTER_NAME}-md-0'
+      clusterName: '${CLUSTER_NAME}'
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
-        name: '${ CLUSTER_NAME }'
-      version: '${ KUBERNETES_VERSION }'
+        name: '${CLUSTER_NAME}'
+      version: '${KUBERNETES_VERSION}'

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
   labels:
-    cni: "${ CLUSTER_NAME }-crs-0"
+    cni: "${CLUSTER_NAME}-crs-0"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "cni-${ CLUSTER_NAME }-crs-0"
-data: ${ CNI_RESOURCES }
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
-  name:  "${ CLUSTER_NAME }-crs-0"
+  name:  "${CLUSTER_NAME}-crs-0"
 spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      cni: "${ CLUSTER_NAME }-crs-0"
+      cni: "${CLUSTER_NAME}-crs-0"
   resources:
-    - name: "cni-${ CLUSTER_NAME }-crs-0"
+    - name: "cni-${CLUSTER_NAME}-crs-0"
       kind: ConfigMap

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-template.yaml
@@ -3,9 +3,9 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   clusterNetwork:
     pods:
@@ -14,45 +14,45 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: HAProxyLoadBalancer
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   user:
     authorizedKeys:
-    - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+    - '${VSPHERE_SSH_AUTHORIZED_KEY}'
     name: capv
   virtualMachineConfiguration:
     cloneMode: linkedClone
-    datacenter: '${ VSPHERE_DATACENTER }'
-    datastore: '${ VSPHERE_DATASTORE }'
+    datacenter: '${VSPHERE_DATACENTER}'
+    datastore: '${VSPHERE_DATASTORE}'
     diskGiB: 25
-    folder: '${ VSPHERE_FOLDER }'
+    folder: '${VSPHERE_FOLDER}'
     memoryMiB: 8192
     network:
       devices:
       - dhcp4: true
-        networkName: '${ VSPHERE_NETWORK }'
+        networkName: '${VSPHERE_NETWORK}'
     numCPUs: 2
-    resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-    server: '${ VSPHERE_SERVER }'
-    template: '${ VSPHERE_HAPROXY_TEMPLATE }'
+    resourcePool: '${VSPHERE_RESOURCE_POOL}'
+    server: '${VSPHERE_SERVER}'
+    template: '${VSPHERE_HAPROXY_TEMPLATE}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   cloudProviderConfiguration:
     global:
@@ -60,7 +60,7 @@ spec:
       secretName: cloud-provider-vsphere-credentials
       secretNamespace: kube-system
     network:
-      name: '${ VSPHERE_NETWORK }'
+      name: '${VSPHERE_NETWORK}'
     providerConfig:
       cloud:
         controllerImage: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1
@@ -73,53 +73,53 @@ spec:
         provisionerImage: quay.io/k8scsi/csi-provisioner:v1.4.0
         registrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
     virtualCenter:
-      ${ VSPHERE_SERVER }:
-        datacenters: '${ VSPHERE_DATACENTER }'
+      ${VSPHERE_SERVER}:
+        datacenters: '${VSPHERE_DATACENTER}'
     workspace:
-      datacenter: '${ VSPHERE_DATACENTER }'
-      datastore: '${ VSPHERE_DATASTORE }'
-      folder: '${ VSPHERE_FOLDER }'
-      resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-      server: '${ VSPHERE_SERVER }'
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
+      folder: '${VSPHERE_FOLDER}'
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
   loadBalancerRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: HAProxyLoadBalancer
-    name: '${ CLUSTER_NAME }'
-  server: '${ VSPHERE_SERVER }'
+    name: '${CLUSTER_NAME}'
+  server: '${VSPHERE_SERVER}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: '${ VSPHERE_DATACENTER }'
-      datastore: '${ VSPHERE_DATASTORE }'
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
       diskGiB: 25
-      folder: '${ VSPHERE_FOLDER }'
+      folder: '${VSPHERE_FOLDER}'
       memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: '${ VSPHERE_NETWORK }'
+          networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
-      resourcePool: '${ VSPHERE_RESOURCE_POOL }'
-      server: '${ VSPHERE_SERVER }'
-      template: '${ VSPHERE_TEMPLATE }'
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
+      template: '${VSPHERE_TEMPLATE}'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
-  name: '${ CLUSTER_NAME }'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: '${ CLUSTER_NAME }'
+    name: '${CLUSTER_NAME}'
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
@@ -150,16 +150,16 @@ spec:
     users:
     - name: capv
       sshAuthorizedKeys:
-      - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+      - '${VSPHERE_SSH_AUTHORIZED_KEY}'
       sudo: ALL=(ALL) NOPASSWD:ALL
-  replicas: ${ CONTROL_PLANE_MACHINE_COUNT }
-  version: '${ KUBERNETES_VERSION }'
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: '${KUBERNETES_VERSION}'
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
-  name: '${ CLUSTER_NAME }-md-0'
-  namespace: '${ NAMESPACE }'
+  name: '${CLUSTER_NAME}-md-0'
+  namespace: '${NAMESPACE}'
 spec:
   template:
     spec:
@@ -178,34 +178,34 @@ spec:
       users:
       - name: capv
         sshAuthorizedKeys:
-        - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+        - '${VSPHERE_SSH_AUTHORIZED_KEY}'
         sudo: ALL=(ALL) NOPASSWD:ALL
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
-  name: '${ CLUSTER_NAME }-md-0'
-  namespace: '${ NAMESPACE }'
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}-md-0'
+  namespace: '${NAMESPACE}'
 spec:
-  clusterName: '${ CLUSTER_NAME }'
-  replicas: ${ WORKER_MACHINE_COUNT }
+  clusterName: '${CLUSTER_NAME}'
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
+        cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
-          name: '${ CLUSTER_NAME }-md-0'
-      clusterName: '${ CLUSTER_NAME }'
+          name: '${CLUSTER_NAME}-md-0'
+      clusterName: '${CLUSTER_NAME}'
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
-        name: '${ CLUSTER_NAME }'
-      version: '${ KUBERNETES_VERSION }'
+        name: '${CLUSTER_NAME}'
+      version: '${KUBERNETES_VERSION}'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapt templates/flavor generator to the syntax of envsubst (without spaces inside ${}).
This makes it possible to use templates both with clusterctl - which tolerated spaces but not requires them - and the plain envsubst.

**Release note**:
```release-note
Change templates to use the envsubst syntax for variables (without spaces inside ${})
```