### PR TITLE
[WIP] Fix E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test: generate lint-go ## Run tests
 
 .PHONY: e2e-image
 e2e-image: ## Build the e2e manager image
-	docker build --build-arg ldflags="$(LDFLAGS)" --tag="capv-manager:e2e" .
+	docker build --build-arg ldflags="$(LDFLAGS)" --tag="gcr.io/k8s-staging-cluster-api/capv-manager:e2e" .
 
 .PHONY: e2e
 e2e: e2e-image

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -14,7 +14,7 @@ images:
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v0.3.7
     loadBehavior: tryLoad
-  - name: capv-manager:e2e
+  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v0.11.0
     loadBehavior: tryLoad
@@ -72,7 +72,7 @@ providers:
         value: ../../../../cluster-api-provider-vsphere/config
         replacements:
           - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
-            new: capv-manager:e2e
+            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
 

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -17,7 +17,7 @@ images:
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v0.3.7
     loadBehavior: tryLoad
-  - name: capv-manager:e2e
+  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v0.11.0
     loadBehavior: tryLoad
@@ -75,7 +75,7 @@ providers:
         value: ../../../../cluster-api-provider-vsphere/config
         replacements:
           - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
-            new: capv-manager:e2e
+            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CAPI v0.3.9 apparently introduced stricter validation on image names, requiring canonical names to be used.

**Release note**:
```release-note
NONE
```