### PR TITLE
bump kube-vip to 0.1.8 and adjust leader election params

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -361,7 +361,7 @@ func kubeVIPPod() string {
 			Containers: []v1.Container{
 				{
 					Name:  "kube-vip",
-					Image: "plndr/kube-vip:0.1.7",
+					Image: "plndr/kube-vip:0.1.8",
 					Args: []string{
 						"start",
 					},
@@ -397,6 +397,18 @@ func kubeVIPPod() string {
 							// this is hardcoded since we use eth0 as a network interface for all of our machines in this template
 							Name:  "vip_interface",
 							Value: "eth0",
+						},
+						{
+							Name:  "vip_leaseduration",
+							Value: "15",
+						},
+						{
+							Name:  "vip_renewdeadline",
+							Value: "10",
+						},
+						{
+							Name:  "vip_retryperiod",
+							Value: "2",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR bumps kube-vip to `0.1.8` and sets the leader election params to the default values

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
bump kube-vip to v0.1.8 and adjust leader election params
```