### PR TITLE
move E2Es to kubernetes 1.19.1

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,7 +30,6 @@ The first step to running the e2e tests is setting up the required environment v
 | `VSPHERE_RESOURCE_POOL`    | The unique name or inventory path of the resource pool in which VMs will be created                   | `my-resource-pool` or `/my-datacenter/host/Cluster-1/Resources/my-resource-pool` |
 | `VSPHERE_DATASTORE`        | The unique name or inventory path of the datastore in which VMs will be created                       | `my-datastore` or `/my-datacenter/datstore/my-datastore`                         |
 | `VSPHERE_NETWORK`          | The unique name or inventory path of the network to which VMs will be connected                       | `my-network` or `/my-datacenter/network/my-network`                              |
-| `VSPHERE_MACHINE_TEMPLATE` | The unique name or inventory path of the template from which VMs are cloned                           | `my-machine-template` or `/my-datacenter/vm/my-machine-template`                 |
 | `VSPHERE_HAPROXY_TEMPLATE` | The unique name or inventory path of the template from which the HAProxy load balancer VMs are cloned | `my-haproxy-template` or `/my-datacenter/vm/my-haproxy-template`                 |
 
 ### Running the e2e tests

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -81,7 +81,7 @@ providers:
       - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.18.2"
+  KUBERNETES_VERSION: "v1.19.1"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   CONTROL_PLANE_MACHINE_COUNT: 1
@@ -91,9 +91,8 @@ variables:
   VSPHERE_RESOURCE_POOL: "clusterapi"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_NETWORK: "sddc-cgw-network-8"
-  VSPHERE_MACHINE_TEMPLATE: "ubuntu-1804-kube-v1.18.2"
   VSPHERE_HAPROXY_TEMPLATE: "capv-haproxy-v0.6.3"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.18.2"
+  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.19.1"
   VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCbQg7ywSD1oJAwAHhQuemrL6C9wvOIgE7wfZ0PfqolcTEQbLbv7Zxe1/TRzr4B20pb6GMryJ7O3SH9kuCubDYQ4Atw9MF/iAtsg0s3Xs4a3RAqoeaTHA0u401Um27ANDVqLswdTZ0J0Ev+XqRCEgPX+IpGgiNOyiHxfIgwdev/fG1MmMEyCKj8JNlRghFnleBcE+N3Mu0rKb88ascch2mKLY5fGDwbnC3V7d6LE6jWVT5HV391N4IWmjoBjlBt3mfzNslWqJUS+PxRbYR3i7vyVrpb/mkw1YG1jeomTAmkx4kwiV7hSzNVF6pKNIOoB1mpwULJ0VL+UkM8IPEfVJb root@9ae81f510a14"
 
 intervals:


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR moves the E2Es to test against 1.19

**Which issue(s) this PR fixes**: Fixes #

**Special notes for your reviewer**:

/assign @fabriziopandini @gab-satchi 

**Release note**:

```release-note

```