### PR TITLE
move CPI over to CRS and refactor flavorgen

### DIFF
--- a/packaging/flavorgen/cmd/root.go
+++ b/packaging/flavorgen/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
 )
 
 const flavorFlag = "flavor"
@@ -52,11 +53,11 @@ func RunRoot(command *cobra.Command) error {
 	}
 	switch flavor {
 	case "multi-host":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithHAProxy())
+		util.PrintObjects(flavors.MultiNodeTemplateWithHAProxy())
 	case "vip":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithKubeVIP())
+		util.PrintObjects(flavors.MultiNodeTemplateWithKubeVIP())
 	case "external-loadbalancer":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithExternalLoadBalancer())
+		util.PrintObjects(flavors.MultiNodeTemplateWithExternalLoadBalancer())
 	default:
 		return errors.Errorf("invalid flavor")
 	}

--- a/packaging/flavorgen/flavors/crs/cpi.go
+++ b/packaging/flavorgen/flavors/crs/cpi.go
@@ -1,0 +1,125 @@
+package crs
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	cloudprovidersvc "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+)
+
+// CreateCrsResourceObjectsCPI creates the api objects necessary for CSI to function. Also appends the resources to the CRS
+func CreateCrsResourceObjectsCPI(crs *addonsv1alpha3.ClusterResourceSet) []runtime.Object {
+	serviceAccount := cloudprovidersvc.CloudControllerManagerServiceAccount()
+	serviceAccount.TypeMeta = v1.TypeMeta{
+		Kind:       "ServiceAccount",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	serviceAccountSecret := newSecret(serviceAccount.Name, serviceAccount)
+	appendSecretToCrsResource(crs, serviceAccountSecret)
+
+	credentials := map[string]string{}
+	credentials[fmt.Sprintf("%s.username", env.VSphereServerVar)] = env.VSphereUsername
+	credentials[fmt.Sprintf("%s.password", env.VSphereServerVar)] = env.VSpherePassword
+	cpiSecret := cpiCredentials(credentials)
+	cpiSecretWrapper := newSecret(cpiSecret.Name, cpiSecret)
+	appendSecretToCrsResource(crs, cpiSecretWrapper)
+
+	cpiObjects := []runtime.Object{}
+	clusterRole := cloudprovider.CloudControllerManagerClusterRole()
+	clusterRole.TypeMeta = v1.TypeMeta{
+		Kind:       "ClusterRole",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, clusterRole)
+
+	clusterRoleBinding := cloudprovider.CloudControllerManagerClusterRoleBinding()
+	clusterRoleBinding.TypeMeta = v1.TypeMeta{
+		Kind:       "ClusterRoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, clusterRoleBinding)
+
+	cloudConfig, err := CPIConfigString()
+	if err != nil {
+		panic(errors.Errorf("invalid cloudConfig"))
+	}
+	// cloud config secret is wrapped in another secret so it could be injected via CRS
+	cloudConfigConfigMap := cloudprovidersvc.CloudControllerManagerConfigMap(cloudConfig)
+	cloudConfigConfigMap.TypeMeta = v1.TypeMeta{
+		Kind:       "ConfigMap",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cloudConfigConfigMap)
+
+	roleBinding := cloudprovider.CloudControllerManagerRoleBinding()
+	roleBinding.TypeMeta = v1.TypeMeta{
+		Kind:       "RoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, roleBinding)
+
+	cpiService := cloudprovider.CloudControllerManagerService()
+	cpiService.TypeMeta = v1.TypeMeta{
+		Kind:       "Service",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cpiService)
+
+	extraArgs := []string{
+		"--v=2",
+		"--cloud-provider=vsphere",
+		"--cloud-config=/etc/cloud/vsphere.conf",
+	}
+	cpiDaemonSet := cloudprovider.CloudControllerManagerDaemonSet(cloudprovider.DefaultCPIControllerImage, extraArgs)
+	cpiDaemonSet.TypeMeta = v1.TypeMeta{
+		Kind:       "DaemonSet",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cpiDaemonSet)
+
+	manifestsCm := newConfigMapManifests("cpi-manifests", cpiObjects)
+	appendConfigMapToCrsResource(crs, manifestsCm)
+	// Define the kubeconfig secret for the target cluster.
+
+	return []runtime.Object{
+		serviceAccountSecret,
+		cpiSecretWrapper,
+		manifestsCm,
+	}
+}
+
+func CPIConfigString() (string, error) {
+	cpiConfig := newCPIConfig()
+
+	cpiConfigString, err := cpiConfig.MarshalINI()
+	if err != nil {
+		return "", err
+	}
+
+	return string(cpiConfigString), nil
+}
+
+func cpiCredentials(credentials map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceSystem,
+			Name:      "cloud-provider-vsphere-credentials",
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: credentials,
+	}
+}

--- a/packaging/flavorgen/flavors/crs/csi.go
+++ b/packaging/flavorgen/flavors/crs/csi.go
@@ -114,7 +114,7 @@ func ConfigForCSI() *infrav1.CPIConfig {
 	config.Network.Name = env.VSphereNetworkVar
 
 	config.VCenter = map[string]infrav1.CPIVCenterConfig{
-		env.VSphereServerVar: infrav1.CPIVCenterConfig{
+		env.VSphereServerVar: {
 			Username:    env.VSphereUsername,
 			Password:    env.VSpherePassword,
 			Datacenters: env.VSphereDataCenterVar,

--- a/packaging/flavorgen/flavors/crs/csi.go
+++ b/packaging/flavorgen/flavors/crs/csi.go
@@ -1,0 +1,125 @@
+package crs
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+)
+
+// CreateCrsResourceObjectsCSI creates the api objects necessary for CSI to function. Also appends the resources to the CRS
+func CreateCrsResourceObjectsCSI(crs *addonsv1alpha3.ClusterResourceSet) []runtime.Object {
+	serviceAccount := cloudprovider.CSIControllerServiceAccount()
+	serviceAccount.TypeMeta = metav1.TypeMeta{
+		Kind:       "ServiceAccount",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	serviceAccountSecret := newSecret(serviceAccount.Name, serviceAccount)
+	appendSecretToCrsResource(crs, serviceAccountSecret)
+
+	clusterRole := cloudprovider.CSIControllerClusterRole()
+	clusterRole.TypeMeta = metav1.TypeMeta{
+		Kind:       "ClusterRole",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	clusterRoleConfigMap := newConfigMap(clusterRole.Name, clusterRole)
+	appendConfigMapToCrsResource(crs, clusterRoleConfigMap)
+
+	clusterRoleBinding := cloudprovider.CSIControllerClusterRoleBinding()
+	clusterRoleBinding.TypeMeta = metav1.TypeMeta{
+		Kind:       "ClusterRoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	clusterRoleBindingConfigMap := newConfigMap(clusterRoleBinding.Name, clusterRoleBinding)
+	appendConfigMapToCrsResource(crs, clusterRoleBindingConfigMap)
+
+	cloudConfig, err := ConfigForCSI().MarshalINI()
+	if err != nil {
+		panic(errors.Errorf("invalid cloudConfig"))
+	}
+	// cloud config secret is wrapped in another secret so it could be injected via CRS
+	cloudConfigSecret := cloudprovider.CSICloudConfigSecret(string(cloudConfig))
+	cloudConfigSecret.TypeMeta = metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cloudConfigSecretWrapper := newSecret(cloudConfigSecret.Name, cloudConfigSecret)
+	appendSecretToCrsResource(crs, cloudConfigSecretWrapper)
+
+	csiDriver := cloudprovider.CSIDriver()
+	csiDriver.TypeMeta = metav1.TypeMeta{
+		Kind:       "CSIDriver",
+		APIVersion: storagev1.SchemeGroupVersion.String(),
+	}
+	csiDriverConfigMap := newConfigMap(csiDriver.Name, csiDriver)
+	appendConfigMapToCrsResource(crs, csiDriverConfigMap)
+
+	storageConfig := createStorageConfig()
+	daemonSet := cloudprovider.VSphereCSINodeDaemonSet(storageConfig)
+	daemonSet.TypeMeta = metav1.TypeMeta{
+		Kind:       "DaemonSet",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	daemonSetConfigMap := newConfigMap(daemonSet.Name, daemonSet)
+	appendConfigMapToCrsResource(crs, daemonSetConfigMap)
+
+	deployment := cloudprovider.CSIControllerDeployment(storageConfig)
+	deployment.TypeMeta = metav1.TypeMeta{
+		Kind:       "Deployment",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	deploymentConfigMap := newConfigMap(deployment.Name, deployment)
+	appendConfigMapToCrsResource(crs, deploymentConfigMap)
+
+	return []runtime.Object{
+		serviceAccountSecret,
+		clusterRoleConfigMap,
+		clusterRoleBindingConfigMap,
+		cloudConfigSecretWrapper,
+		csiDriverConfigMap,
+		daemonSetConfigMap,
+		deploymentConfigMap,
+	}
+}
+
+// create StorageConfig to be used by tkg template
+func createStorageConfig() *infrav1.CPIStorageConfig {
+	return &infrav1.CPIStorageConfig{
+		ControllerImage:     cloudprovider.DefaultCSIControllerImage,
+		NodeDriverImage:     cloudprovider.DefaultCSINodeDriverImage,
+		AttacherImage:       cloudprovider.DefaultCSIAttacherImage,
+		ProvisionerImage:    cloudprovider.DefaultCSIProvisionerImage,
+		MetadataSyncerImage: cloudprovider.DefaultCSIMetadataSyncerImage,
+		LivenessProbeImage:  cloudprovider.DefaultCSILivenessProbeImage,
+		RegistrarImage:      cloudprovider.DefaultCSIRegistrarImage,
+	}
+}
+
+// ConfigForCSI returns a cloudprovider.CPIConfig specific to the vSphere CSI driver until
+// it supports using Secrets for vCenter credentials
+func ConfigForCSI() *infrav1.CPIConfig {
+	config := &infrav1.CPIConfig{}
+
+	config.Global.ClusterID = fmt.Sprintf("%s/%s", env.NamespaceVar, env.ClusterNameVar)
+	config.Network.Name = env.VSphereNetworkVar
+
+	config.VCenter = map[string]infrav1.CPIVCenterConfig{
+		env.VSphereServerVar: infrav1.CPIVCenterConfig{
+			Username:    env.VSphereUsername,
+			Password:    env.VSpherePassword,
+			Datacenters: env.VSphereDataCenterVar,
+		},
+	}
+
+	return config
+}

--- a/packaging/flavorgen/flavors/crs/util.go
+++ b/packaging/flavorgen/flavors/crs/util.go
@@ -1,0 +1,99 @@
+package crs
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
+	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+)
+
+func newSecret(name string, o runtime.Object) *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		StringData: map[string]string{
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
+		},
+		Type: addonsv1alpha3.ClusterResourceSetSecretType,
+	}
+}
+
+func appendSecretToCrsResource(crs *addonsv1alpha3.ClusterResourceSet, generatedSecret *v1.Secret) {
+	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha3.ResourceRef{
+		Name: generatedSecret.Name,
+		Kind: "Secret",
+	})
+}
+
+func newConfigMap(name string, o runtime.Object) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		Data: map[string]string{
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
+		},
+	}
+}
+func newConfigMapManifests(name string, o []runtime.Object) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		Data: map[string]string{
+			"data": util.GenerateManifestYaml(o),
+		},
+	}
+}
+
+func appendConfigMapToCrsResource(crs *addonsv1alpha3.ClusterResourceSet, generatedConfigMap *v1.ConfigMap) {
+	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha3.ResourceRef{
+		Name: generatedConfigMap.Name,
+		Kind: "ConfigMap",
+	})
+}
+
+func newCPIConfig() *infrav1.CPIConfig {
+	return &infrav1.CPIConfig{
+		Global: infrav1.CPIGlobalConfig{
+			SecretName:      "cloud-provider-vsphere-credentials",
+			SecretNamespace: metav1.NamespaceSystem,
+			Thumbprint:      env.VSphereThumbprint,
+		},
+		VCenter: map[string]infrav1.CPIVCenterConfig{
+			env.VSphereServerVar: {
+				Datacenters: env.VSphereDataCenterVar,
+				Thumbprint:  env.VSphereThumbprint,
+			},
+		},
+		Network: infrav1.CPINetworkConfig{
+			Name: env.VSphereNetworkVar,
+		},
+		Workspace: infrav1.CPIWorkspaceConfig{
+			Server:       env.VSphereServerVar,
+			Datacenter:   env.VSphereDataCenterVar,
+			Datastore:    env.VSphereDatastoreVar,
+			ResourcePool: env.VSphereResourcePoolVar,
+			Folder:       env.VSphereFolderVar,
+		},
+	}
+}

--- a/packaging/flavorgen/flavors/env/envsubts_consts.go
+++ b/packaging/flavorgen/flavors/env/envsubts_consts.go
@@ -1,0 +1,29 @@
+package env
+
+const (
+	ClusterNameVar               = "${CLUSTER_NAME}"
+	ControlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
+	DefaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
+	DefaultClusterCIDR           = "192.168.0.0/16"
+	DefaultDiskGiB               = 25
+	DefaultMemoryMiB             = 8192
+	DefaultNumCPUs               = 2
+	KubernetesVersionVar         = "${KUBERNETES_VERSION}"
+	MachineDeploymentNameSuffix  = "-md-0"
+	NamespaceVar                 = "${NAMESPACE}"
+	VSphereDataCenterVar         = "${VSPHERE_DATACENTER}"
+	VSphereThumbprint            = "${VSPHERE_TLS_THUMBPRINT}"
+	VSphereDatastoreVar          = "${VSPHERE_DATASTORE}"
+	VSphereFolderVar             = "${VSPHERE_FOLDER}"
+	VSphereHaproxyTemplateVar    = "${VSPHERE_HAPROXY_TEMPLATE}"
+	VSphereNetworkVar            = "${VSPHERE_NETWORK}"
+	VSphereResourcePoolVar       = "${VSPHERE_RESOURCE_POOL}"
+	VSphereServerVar             = "${VSPHERE_SERVER}"
+	VSphereSSHAuthorizedKeysVar  = "${VSPHERE_SSH_AUTHORIZED_KEY}"
+	VSphereTemplateVar           = "${VSPHERE_TEMPLATE}"
+	WorkerMachineCountVar        = "${WORKER_MACHINE_COUNT}"
+	ControlPlaneEndpointVar      = "${CONTROL_PLANE_ENDPOINT_IP}"
+	VSphereUsername              = "${VSPHERE_USERNAME}"
+	VSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
+	ClusterResourceSetNameSuffix = "-crs-0"
+)

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -17,33 +17,11 @@ limitations under the License.
 package flavors
 
 import (
-	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
-	cloudprovidersvc "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/crs"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
-	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 )
 
-// create StorageConfig to be used by tkg template
-func createStorageConfig() *infrav1.CPIStorageConfig {
-	return &infrav1.CPIStorageConfig{
-		ControllerImage:     cloudprovidersvc.DefaultCSIControllerImage,
-		NodeDriverImage:     cloudprovidersvc.DefaultCSINodeDriverImage,
-		AttacherImage:       cloudprovidersvc.DefaultCSIAttacherImage,
-		ProvisionerImage:    cloudprovidersvc.DefaultCSIProvisionerImage,
-		MetadataSyncerImage: cloudprovidersvc.DefaultCSIMetadataSyncerImage,
-		LivenessProbeImage:  cloudprovidersvc.DefaultCSILivenessProbeImage,
-		RegistrarImage:      cloudprovidersvc.DefaultCSIRegistrarImage,
-	}
-}
 func MultiNodeTemplateWithHAProxy() []runtime.Object {
 	lb := newHAProxyLoadBalancer()
 	vsphereCluster := newVSphereCluster(&lb)
@@ -52,7 +30,11 @@ func MultiNodeTemplateWithHAProxy() []runtime.Object {
 	kubeadmJoinTemplate := newKubeadmConfigTemplate()
 	cluster := newCluster(vsphereCluster, &controlPlane)
 	machineDeployment := newMachineDeployment(cluster, machineTemplate, kubeadmJoinTemplate)
-	return []runtime.Object{
+	clusterResourceSet := newClusterResourceSet(cluster)
+	crsResourcesCSI := crs.CreateCrsResourceObjectsCSI(&clusterResourceSet)
+	crsResourcesCPI := crs.CreateCrsResourceObjectsCPI(&clusterResourceSet)
+
+	MultiNodeTemplate := []runtime.Object{
 		&cluster,
 		&lb,
 		&vsphereCluster,
@@ -60,7 +42,13 @@ func MultiNodeTemplateWithHAProxy() []runtime.Object {
 		&controlPlane,
 		&kubeadmJoinTemplate,
 		&machineDeployment,
+		&clusterResourceSet,
 	}
+
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCSI...)
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCPI...)
+
+	return MultiNodeTemplate
 }
 
 func MultiNodeTemplateWithKubeVIP() []runtime.Object {
@@ -71,10 +59,8 @@ func MultiNodeTemplateWithKubeVIP() []runtime.Object {
 	cluster := newCluster(vsphereCluster, &controlPlane)
 	machineDeployment := newMachineDeployment(cluster, machineTemplate, kubeadmJoinTemplate)
 	clusterResourceSet := newClusterResourceSet(cluster)
-	crsResources := createCrsResourceObjects(&clusterResourceSet, vsphereCluster, cluster)
-
-	// removing Storage config so the cluster controller is not going not install CSI (it is installed by the clusterResourceSet)
-	vsphereCluster.Spec.CloudProviderConfiguration.ProviderConfig.Storage = nil
+	crsResourcesCSI := crs.CreateCrsResourceObjectsCSI(&clusterResourceSet)
+	crsResourcesCPI := crs.CreateCrsResourceObjectsCPI(&clusterResourceSet)
 
 	MultiNodeTemplate := []runtime.Object{
 		&cluster,
@@ -85,82 +71,11 @@ func MultiNodeTemplateWithKubeVIP() []runtime.Object {
 		&machineDeployment,
 		&clusterResourceSet,
 	}
-	return append(MultiNodeTemplate, crsResources...)
-}
 
-// createCrsResourceObjects creates the api objects necessary for CSI to function. Also appends the resources to the CRS
-func createCrsResourceObjects(crs *addonsv1alpha3.ClusterResourceSet, vsphereCluster infrav1.VSphereCluster, cluster v1alpha3.Cluster) []runtime.Object {
-	serviceAccount := cloudprovidersvc.CSIControllerServiceAccount()
-	serviceAccount.TypeMeta = v1.TypeMeta{
-		Kind:       "ServiceAccount",
-		APIVersion: corev1.SchemeGroupVersion.String(),
-	}
-	serviceAccountSecret := newSecret(serviceAccount.Name, serviceAccount)
-	appendSecretToCrsResource(crs, serviceAccountSecret)
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCSI...)
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCPI...)
 
-	clusterRole := cloudprovider.CSIControllerClusterRole()
-	clusterRole.TypeMeta = v1.TypeMeta{
-		Kind:       "ClusterRole",
-		APIVersion: rbac.SchemeGroupVersion.String(),
-	}
-	clusterRoleConfigMap := newConfigMap(clusterRole.Name, clusterRole)
-	appendConfigMapToCrsResource(crs, clusterRoleConfigMap)
-
-	clusterRoleBinding := cloudprovider.CSIControllerClusterRoleBinding()
-	clusterRoleBinding.TypeMeta = v1.TypeMeta{
-		Kind:       "ClusterRoleBinding",
-		APIVersion: rbac.SchemeGroupVersion.String(),
-	}
-	clusterRoleBindingConfigMap := newConfigMap(clusterRoleBinding.Name, clusterRoleBinding)
-	appendConfigMapToCrsResource(crs, clusterRoleBindingConfigMap)
-
-	cloudConfig, err := cloudprovidersvc.ConfigForCSI(vsphereCluster, cluster, vSphereUsername, vSpherePassword).MarshalINI()
-	if err != nil {
-		panic(errors.Errorf("invalid cloudConfig"))
-	}
-	// cloud config secret is wrapped in another secret so it could be injected via CRS
-	cloudConfigSecret := cloudprovidersvc.CSICloudConfigSecret(string(cloudConfig))
-	cloudConfigSecret.TypeMeta = v1.TypeMeta{
-		Kind:       "Secret",
-		APIVersion: corev1.SchemeGroupVersion.String(),
-	}
-	cloudConfigSecretWrapper := newSecret(cloudConfigSecret.Name, cloudConfigSecret)
-	appendSecretToCrsResource(crs, cloudConfigSecretWrapper)
-
-	csiDriver := cloudprovider.CSIDriver()
-	csiDriver.TypeMeta = v1.TypeMeta{
-		Kind:       "CSIDriver",
-		APIVersion: storagev1.SchemeGroupVersion.String(),
-	}
-	csiDriverConfigMap := newConfigMap(csiDriver.Name, csiDriver)
-	appendConfigMapToCrsResource(crs, csiDriverConfigMap)
-
-	storageConfig := createStorageConfig()
-	daemonSet := cloudprovidersvc.VSphereCSINodeDaemonSet(storageConfig)
-	daemonSet.TypeMeta = v1.TypeMeta{
-		Kind:       "DaemonSet",
-		APIVersion: appsv1.SchemeGroupVersion.String(),
-	}
-	daemonSetConfigMap := newConfigMap(daemonSet.Name, daemonSet)
-	appendConfigMapToCrsResource(crs, daemonSetConfigMap)
-
-	deployment := cloudprovider.CSIControllerDeployment(storageConfig)
-	deployment.TypeMeta = v1.TypeMeta{
-		Kind:       "Deployment",
-		APIVersion: appsv1.SchemeGroupVersion.String(),
-	}
-	deploymentConfigMap := newConfigMap(deployment.Name, deployment)
-	appendConfigMapToCrsResource(crs, deploymentConfigMap)
-
-	return []runtime.Object{
-		serviceAccountSecret,
-		clusterRoleConfigMap,
-		clusterRoleBindingConfigMap,
-		cloudConfigSecretWrapper,
-		csiDriverConfigMap,
-		daemonSetConfigMap,
-		deploymentConfigMap,
-	}
+	return MultiNodeTemplate
 }
 
 func MultiNodeTemplateWithExternalLoadBalancer() []runtime.Object {
@@ -170,12 +85,21 @@ func MultiNodeTemplateWithExternalLoadBalancer() []runtime.Object {
 	kubeadmJoinTemplate := newKubeadmConfigTemplate()
 	cluster := newCluster(vsphereCluster, &controlPlane)
 	machineDeployment := newMachineDeployment(cluster, machineTemplate, kubeadmJoinTemplate)
-	return []runtime.Object{
+	clusterResourceSet := newClusterResourceSet(cluster)
+	crsResourcesCSI := crs.CreateCrsResourceObjectsCSI(&clusterResourceSet)
+	crsResourcesCPI := crs.CreateCrsResourceObjectsCPI(&clusterResourceSet)
+
+	MultiNodeTemplate := []runtime.Object{
 		&cluster,
 		&vsphereCluster,
 		&machineTemplate,
 		&controlPlane,
 		&kubeadmJoinTemplate,
 		&machineDeployment,
+		&clusterResourceSet,
 	}
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCSI...)
+	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCPI...)
+
+	return MultiNodeTemplate
 }

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -23,7 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	cloudprovidersvc "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
@@ -32,135 +33,19 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const (
-	clusterNameVar               = "${CLUSTER_NAME}"
-	controlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
-	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
-	defaultClusterCIDR           = "192.168.0.0/16"
-	defaultDiskGiB               = 25
-	defaultMemoryMiB             = 8192
-	defaultNumCPUs               = 2
-	kubernetesVersionVar         = "${KUBERNETES_VERSION}"
-	machineDeploymentNameSuffix  = "-md-0"
-	namespaceVar                 = "${NAMESPACE}"
-	vSphereDataCenterVar         = "${VSPHERE_DATACENTER}"
-	vSphereThumbprint            = "${VSPHERE_TLS_THUMBPRINT}"
-	vSphereDatastoreVar          = "${VSPHERE_DATASTORE}"
-	vSphereFolderVar             = "${VSPHERE_FOLDER}"
-	vSphereHaproxyTemplateVar    = "${VSPHERE_HAPROXY_TEMPLATE}"
-	vSphereNetworkVar            = "${VSPHERE_NETWORK}"
-	vSphereResourcePoolVar       = "${VSPHERE_RESOURCE_POOL}"
-	vSphereServerVar             = "${VSPHERE_SERVER}"
-	vSphereSSHAuthorizedKeysVar  = "${VSPHERE_SSH_AUTHORIZED_KEY}"
-	vSphereTemplateVar           = "${VSPHERE_TEMPLATE}"
-	workerMachineCountVar        = "${WORKER_MACHINE_COUNT}"
-	controlPlaneEndpointVar      = "${CONTROL_PLANE_ENDPOINT_IP}"
-	vSphereUsername              = "${VSPHERE_USERNAME}"
-	vSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
-	clusterResourceSetNameSuffix = "-crs-0"
-)
-
-type replacement struct {
-	kind      string
-	name      string
-	value     interface{}
-	fieldPath []string
-}
-
-var (
-	replacements = []replacement{
-		{
-			kind:      "KubeadmControlPlane",
-			name:      "${CLUSTER_NAME}",
-			value:     controlPlaneMachineCountVar,
-			fieldPath: []string{"spec", "replicas"},
-		},
-		{
-			kind:      "MachineDeployment",
-			name:      "${CLUSTER_NAME}-md-0",
-			value:     workerMachineCountVar,
-			fieldPath: []string{"spec", "replicas"},
-		},
-		{
-			kind:      "MachineDeployment",
-			name:      "${CLUSTER_NAME}-md-0",
-			value:     map[string]interface{}{},
-			fieldPath: []string{"spec", "selector", "matchLabels"},
-		},
-	}
-
-	stringVars = []string{
-		regexVar(clusterNameVar),
-		regexVar(clusterNameVar + machineDeploymentNameSuffix),
-		regexVar(namespaceVar),
-		regexVar(kubernetesVersionVar),
-		regexVar(vSphereFolderVar),
-		regexVar(vSphereHaproxyTemplateVar),
-		regexVar(vSphereResourcePoolVar),
-		regexVar(vSphereSSHAuthorizedKeysVar),
-		regexVar(vSphereDataCenterVar),
-		regexVar(vSphereDatastoreVar),
-		regexVar(vSphereNetworkVar),
-		regexVar(vSphereServerVar),
-		regexVar(vSphereTemplateVar),
-		regexVar(vSphereHaproxyTemplateVar),
-	}
-)
-
-func regexVar(str string) string {
-	return "((?m:\\" + str + "$))"
-}
-
 func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 	vsphereCluster := infrav1.VSphereCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       typeToKind(&infrav1.VSphereCluster{}),
+			Kind:       util.TypeToKind(&infrav1.VSphereCluster{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar,
-			Namespace: namespaceVar,
+			Name:      env.ClusterNameVar,
+			Namespace: env.NamespaceVar,
 		},
 		Spec: infrav1.VSphereClusterSpec{
-			Server:     vSphereServerVar,
-			Thumbprint: vSphereThumbprint,
-			CloudProviderConfiguration: infrav1.CPIConfig{
-				Global: infrav1.CPIGlobalConfig{
-					SecretName:      "cloud-provider-vsphere-credentials",
-					SecretNamespace: metav1.NamespaceSystem,
-					Thumbprint:      vSphereThumbprint,
-				},
-				VCenter: map[string]infrav1.CPIVCenterConfig{
-					vSphereServerVar: {
-						Datacenters: vSphereDataCenterVar,
-						Thumbprint:  vSphereThumbprint,
-					},
-				},
-				Network: infrav1.CPINetworkConfig{
-					Name: vSphereNetworkVar,
-				},
-				Workspace: infrav1.CPIWorkspaceConfig{
-					Server:       vSphereServerVar,
-					Datacenter:   vSphereDataCenterVar,
-					Datastore:    vSphereDatastoreVar,
-					ResourcePool: vSphereResourcePoolVar,
-					Folder:       vSphereFolderVar,
-				},
-				ProviderConfig: infrav1.CPIProviderConfig{
-					Cloud: &infrav1.CPICloudConfig{
-						ControllerImage: defaultCloudProviderImage,
-					},
-					Storage: &infrav1.CPIStorageConfig{
-						ControllerImage:     cloudprovidersvc.DefaultCSIControllerImage,
-						NodeDriverImage:     cloudprovidersvc.DefaultCSINodeDriverImage,
-						AttacherImage:       cloudprovidersvc.DefaultCSIAttacherImage,
-						ProvisionerImage:    cloudprovidersvc.DefaultCSIProvisionerImage,
-						MetadataSyncerImage: cloudprovidersvc.DefaultCSIMetadataSyncerImage,
-						LivenessProbeImage:  cloudprovidersvc.DefaultCSILivenessProbeImage,
-						RegistrarImage:      cloudprovidersvc.DefaultCSIRegistrarImage,
-					},
-				},
-			},
+			Server:     env.VSphereServerVar,
+			Thumbprint: env.VSphereThumbprint,
 		},
 	}
 	if lb != nil {
@@ -171,7 +56,7 @@ func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 		}
 	} else {
 		vsphereCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
-			Host: controlPlaneEndpointVar,
+			Host: env.ControlPlaneEndpointVar,
 			Port: 6443,
 		}
 	}
@@ -182,17 +67,17 @@ func newCluster(vsphereCluster infrav1.VSphereCluster, controlPlane *controlplan
 	cluster := clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterv1.GroupVersion.String(),
-			Kind:       typeToKind(&clusterv1.Cluster{}),
+			Kind:       util.TypeToKind(&clusterv1.Cluster{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar,
-			Namespace: namespaceVar,
+			Name:      env.ClusterNameVar,
+			Namespace: env.NamespaceVar,
 			Labels:    clusterLabels(),
 		},
 		Spec: clusterv1.ClusterSpec{
 			ClusterNetwork: &clusterv1.ClusterNetwork{
 				Pods: &clusterv1.NetworkRanges{
-					CIDRBlocks: []string{defaultClusterCIDR},
+					CIDRBlocks: []string{env.DefaultClusterCIDR},
 				},
 			},
 			InfrastructureRef: &corev1.ObjectReference{
@@ -213,18 +98,18 @@ func newCluster(vsphereCluster infrav1.VSphereCluster, controlPlane *controlplan
 }
 
 func clusterLabels() map[string]string {
-	return map[string]string{"cluster.x-k8s.io/cluster-name": clusterNameVar}
+	return map[string]string{"cluster.x-k8s.io/cluster-name": env.ClusterNameVar}
 }
 
 func newVSphereMachineTemplate() infrav1.VSphereMachineTemplate {
 	return infrav1.VSphereMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar,
-			Namespace: namespaceVar,
+			Name:      env.ClusterNameVar,
+			Namespace: env.NamespaceVar,
 		},
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       typeToKind(&infrav1.VSphereMachineTemplate{}),
+			Kind:       util.TypeToKind(&infrav1.VSphereMachineTemplate{}),
 		},
 		Spec: infrav1.VSphereMachineTemplateSpec{
 			Template: infrav1.VSphereMachineTemplateResource{
@@ -242,11 +127,11 @@ func defaultVirtualMachineSpec() infrav1.VSphereMachineSpec {
 
 func defaultVirtualMachineCloneSpec() infrav1.VirtualMachineCloneSpec {
 	return infrav1.VirtualMachineCloneSpec{
-		Datacenter: vSphereDataCenterVar,
+		Datacenter: env.VSphereDataCenterVar,
 		Network: infrav1.NetworkSpec{
 			Devices: []infrav1.NetworkDeviceSpec{
 				{
-					NetworkName: vSphereNetworkVar,
+					NetworkName: env.VSphereNetworkVar,
 					DHCP4:       true,
 					DHCP6:       false,
 				},
@@ -254,15 +139,15 @@ func defaultVirtualMachineCloneSpec() infrav1.VirtualMachineCloneSpec {
 		},
 		CustomVMXKeys: defaultCustomVMXKeys(),
 		CloneMode:     infrav1.LinkedClone,
-		NumCPUs:       defaultNumCPUs,
-		DiskGiB:       defaultDiskGiB,
-		MemoryMiB:     defaultMemoryMiB,
-		Template:      vSphereTemplateVar,
-		Server:        vSphereServerVar,
-		Thumbprint:    vSphereThumbprint,
-		ResourcePool:  vSphereResourcePoolVar,
-		Datastore:     vSphereDatastoreVar,
-		Folder:        vSphereFolderVar,
+		NumCPUs:       env.DefaultNumCPUs,
+		DiskGiB:       env.DefaultDiskGiB,
+		MemoryMiB:     env.DefaultMemoryMiB,
+		Template:      env.VSphereTemplateVar,
+		Server:        env.VSphereServerVar,
+		Thumbprint:    env.VSphereThumbprint,
+		ResourcePool:  env.VSphereResourcePoolVar,
+		Datastore:     env.VSphereDatastoreVar,
+		Folder:        env.VSphereFolderVar,
 	}
 }
 
@@ -290,12 +175,12 @@ func defaultKubeadmInitSpec(files []bootstrapv1.File) bootstrapv1.KubeadmConfigS
 func newKubeadmConfigTemplate() bootstrapv1.KubeadmConfigTemplate {
 	return bootstrapv1.KubeadmConfigTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar + machineDeploymentNameSuffix,
-			Namespace: namespaceVar,
+			Name:      env.ClusterNameVar + env.MachineDeploymentNameSuffix,
+			Namespace: env.NamespaceVar,
 		},
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: bootstrapv1.GroupVersion.String(),
-			Kind:       typeToKind(&bootstrapv1.KubeadmConfigTemplate{}),
+			Kind:       util.TypeToKind(&bootstrapv1.KubeadmConfigTemplate{}),
 		},
 		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
 			Template: bootstrapv1.KubeadmConfigTemplateResource{
@@ -325,7 +210,7 @@ func defaultUsers() []bootstrapv1.User {
 			Name: "capv",
 			Sudo: pointer.StringPtr("ALL=(ALL) NOPASSWD:ALL"),
 			SSHAuthorizedKeys: []string{
-				vSphereSSHAuthorizedKeysVar,
+				env.VSphereSSHAuthorizedKeysVar,
 			},
 		},
 	}
@@ -362,7 +247,7 @@ func kubeVIPPod() string {
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
-			Kind:       typeToKind(&v1.Pod{}),
+			Kind:       util.TypeToKind(&v1.Pod{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-vip",
@@ -402,7 +287,7 @@ func kubeVIPPod() string {
 						},
 						{
 							Name:  "vip_address",
-							Value: controlPlaneEndpointVar,
+							Value: env.ControlPlaneEndpointVar,
 						},
 						{
 							// this is hardcoded since we use eth0 as a network interface for all of our machines in this template
@@ -447,11 +332,11 @@ func kubeVIPPod() string {
 func newClusterResourceSet(cluster clusterv1.Cluster) addonsv1alpha3.ClusterResourceSet {
 	crs := addonsv1alpha3.ClusterResourceSet{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       typeToKind(&addonsv1alpha3.ClusterResourceSet{}),
+			Kind:       util.TypeToKind(&addonsv1alpha3.ClusterResourceSet{}),
 			APIVersion: addonsv1alpha3.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name + clusterResourceSetNameSuffix,
+			Name:      cluster.Name + env.ClusterResourceSetNameSuffix,
 			Labels:    clusterLabels(),
 			Namespace: cluster.Namespace,
 		},
@@ -481,22 +366,22 @@ func newMachineDeployment(cluster clusterv1.Cluster, machineTemplate infrav1.VSp
 	return clusterv1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterv1.GroupVersion.String(),
-			Kind:       typeToKind(&clusterv1.MachineDeployment{}),
+			Kind:       util.TypeToKind(&clusterv1.MachineDeployment{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar + machineDeploymentNameSuffix,
+			Name:      env.ClusterNameVar + env.MachineDeploymentNameSuffix,
 			Labels:    clusterLabels(),
-			Namespace: namespaceVar,
+			Namespace: env.NamespaceVar,
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
-			ClusterName: clusterNameVar,
+			ClusterName: env.ClusterNameVar,
 			Replicas:    pointer.Int32Ptr(int32(555)),
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels: clusterLabels(),
 				},
 				Spec: clusterv1.MachineSpec{
-					Version:     pointer.StringPtr(kubernetesVersionVar),
+					Version:     pointer.StringPtr(env.KubernetesVersionVar),
 					ClusterName: cluster.Name,
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
@@ -518,23 +403,23 @@ func newMachineDeployment(cluster clusterv1.Cluster, machineTemplate infrav1.VSp
 
 func newHAProxyLoadBalancer() infrav1.HAProxyLoadBalancer {
 	cloneSpec := defaultVirtualMachineCloneSpec()
-	cloneSpec.Template = vSphereHaproxyTemplateVar
+	cloneSpec.Template = env.VSphereHaproxyTemplateVar
 	return infrav1.HAProxyLoadBalancer{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       typeToKind(&infrav1.HAProxyLoadBalancer{}),
+			Kind:       util.TypeToKind(&infrav1.HAProxyLoadBalancer{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar,
+			Name:      env.ClusterNameVar,
 			Labels:    clusterLabels(),
-			Namespace: namespaceVar,
+			Namespace: env.NamespaceVar,
 		},
 		Spec: infrav1.HAProxyLoadBalancerSpec{
 			VirtualMachineConfiguration: cloneSpec,
 			User: &infrav1.SSHUser{
 				Name: "capv",
 				AuthorizedKeys: []string{
-					vSphereSSHAuthorizedKeysVar,
+					env.VSphereSSHAuthorizedKeysVar,
 				},
 			},
 		},
@@ -556,15 +441,15 @@ func newKubeadmControlplane(replicas int, infraTemplate infrav1.VSphereMachineTe
 	return controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: controlplanev1.GroupVersion.String(),
-			Kind:       typeToKind(&controlplanev1.KubeadmControlPlane{}),
+			Kind:       util.TypeToKind(&controlplanev1.KubeadmControlPlane{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterNameVar,
-			Namespace: namespaceVar,
+			Name:      env.ClusterNameVar,
+			Namespace: env.NamespaceVar,
 		},
 		Spec: controlplanev1.KubeadmControlPlaneSpec{
 			Replicas: pointer.Int32Ptr(int32(replicas)),
-			Version:  kubernetesVersionVar,
+			Version:  env.KubernetesVersionVar,
 			InfrastructureTemplate: corev1.ObjectReference{
 				APIVersion: infraTemplate.GroupVersionKind().GroupVersion().String(),
 				Kind:       infraTemplate.Kind,
@@ -583,10 +468,10 @@ func newConfigMap(name string, o runtime.Object) *v1.ConfigMap {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespaceVar,
+			Namespace: env.NamespaceVar,
 		},
 		Data: map[string]string{
-			"data": generateObjectYAML(o, []replacement{}),
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
 		},
 	}
 }
@@ -599,10 +484,10 @@ func newSecret(name string, o runtime.Object) *v1.Secret {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespaceVar,
+			Namespace: env.NamespaceVar,
 		},
 		StringData: map[string]string{
-			"data": generateObjectYAML(o, []replacement{}),
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
 		},
 		Type: addonsv1alpha3.ClusterResourceSetSecretType,
 	}

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
@@ -348,19 +347,6 @@ func newClusterResourceSet(cluster clusterv1.Cluster) addonsv1alpha3.ClusterReso
 
 	return crs
 }
-func appendSecretToCrsResource(crs *addonsv1alpha3.ClusterResourceSet, generatedSecret *v1.Secret) {
-	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha3.ResourceRef{
-		Name: generatedSecret.Name,
-		Kind: "Secret",
-	})
-}
-
-func appendConfigMapToCrsResource(crs *addonsv1alpha3.ClusterResourceSet, generatedConfigMap *v1.ConfigMap) {
-	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha3.ResourceRef{
-		Name: generatedConfigMap.Name,
-		Kind: "ConfigMap",
-	})
-}
 
 func newMachineDeployment(cluster clusterv1.Cluster, machineTemplate infrav1.VSphereMachineTemplate, bootstrapTemplate bootstrapv1.KubeadmConfigTemplate) clusterv1.MachineDeployment {
 	return clusterv1.MachineDeployment{
@@ -457,38 +443,5 @@ func newKubeadmControlplane(replicas int, infraTemplate infrav1.VSphereMachineTe
 			},
 			KubeadmConfigSpec: defaultKubeadmInitSpec(files),
 		},
-	}
-}
-
-func newConfigMap(name string, o runtime.Object) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: env.NamespaceVar,
-		},
-		Data: map[string]string{
-			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
-		},
-	}
-}
-
-func newSecret(name string, o runtime.Object) *v1.Secret {
-	return &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: env.NamespaceVar,
-		},
-		StringData: map[string]string{
-			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
-		},
-		Type: addonsv1alpha3.ClusterResourceSetSecretType,
 	}
 }

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
@@ -4,4 +4,4 @@ metadata:
   name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
   labels:
-    cni: "${CLUSTER_NAME}-crs-0"
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "cni-${CLUSTER_NAME}-crs-0"
+  name: "cni-${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
-  name:  "${CLUSTER_NAME}-crs-0"
+  name:  "${CLUSTER_NAME}-crs-cni"
 spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      cni: "${CLUSTER_NAME}-crs-0"
+      cni: "${CLUSTER_NAME}-crs-cni"
   resources:
-    - name: "cni-${CLUSTER_NAME}-crs-0"
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
       kind: ConfigMap


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR moves our templates to deploying the CPI through CRS and refactors flavorgen for better re-usability across its packages

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
deploy CPI through CRS instead of using the built-in APIs
```