### PR TITLE
WIP: deploy CPI in same minor version as Kubernetes

### DIFF
--- a/api/v1alpha3/cloudprovider_types.go
+++ b/api/v1alpha3/cloudprovider_types.go
@@ -54,6 +54,8 @@ type CPIConfig struct {
 	// CPIProviderConfig contains extra information used to configure the
 	// vSphere cloud provider.
 	ProviderConfig CPIProviderConfig `json:"providerConfig,omitempty"`
+
+	// Maybe add a k8s version to pass down the info to VSphere Cluster
 }
 
 // CPIProviderConfig defines any extra information used to configure

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -55,6 +55,9 @@ var (
 	clusterControlledType     = &infrav1.VSphereCluster{}
 	clusterControlledTypeName = reflect.TypeOf(clusterControlledType).Elem().Name()
 	clusterControlledTypeGVK  = infrav1.GroupVersion.WithKind(clusterControlledTypeName)
+	k8sVersionToCPIVersion = map[string]string{
+		"v1.18.6":"gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1",
+	}
 )
 
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch
@@ -557,7 +560,10 @@ func (r clusterReconciler) reconcileCloudProvider(ctx *context.ClusterContext) e
 	}
 
 	if cloudproviderConfig.ControllerImage == "" {
-		cloudproviderConfig.ControllerImage = cloudprovider.DefaultCPIControllerImage
+		// get k8s version info
+		k8sVersion := ctx.Cluster.ObjectMeta.ResourceVersion
+		//deploy the right CPI version
+		cloudproviderConfig.ControllerImage = k8sVersionToCPIVersion[k8sVersion]
 	}
 
 	ctx.VSphereCluster.Spec.CloudProviderConfiguration.ProviderConfig.Cloud = cloudproviderConfig

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -35,7 +35,6 @@ import (
 const (
 	clusterNameVar               = "${CLUSTER_NAME}"
 	controlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
-	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
 	defaultClusterCIDR           = "192.168.0.0/16"
 	defaultDiskGiB               = 25
 	defaultMemoryMiB             = 8192
@@ -104,6 +103,9 @@ var (
 		regexVar(vSphereTemplateVar),
 		regexVar(vSphereHaproxyTemplateVar),
 	}
+	k8sVersionToCPIVersion = map[string]string{
+		"v1.18.6":"gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1",
+	}
 )
 
 func regexVar(str string) string {
@@ -143,7 +145,7 @@ func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 				},
 				ProviderConfig: infrav1.CPIProviderConfig{
 					Cloud: &infrav1.CPICloudConfig{
-						ControllerImage: defaultCloudProviderImage,
+						ControllerImage: k8sVersionToCPIVersion[kubernetesVersionVar],
 					},
 					Storage: &infrav1.CPIStorageConfig{
 						ControllerImage:     cloudprovidersvc.DefaultCSIControllerImage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR aims to solve the problem of deploying the CPI version to the minor version of K8s
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```