### PR TITLE
deprecate API fields in v1alpha3 for future removal

### DIFF
--- a/api/v1alpha3/cloudprovider_types.go
+++ b/api/v1alpha3/cloudprovider_types.go
@@ -26,6 +26,7 @@ limitations under the License.
 package v1alpha3
 
 // CPIConfig is the vSphere cloud provider's configuration.
+// DEPRECATED: will be removed in v1alpha4
 type CPIConfig struct {
 	// Global is the vSphere cloud provider's global configuration.
 	// +optional

--- a/api/v1alpha3/haproxyloadbalancer_types.go
+++ b/api/v1alpha3/haproxyloadbalancer_types.go
@@ -66,6 +66,7 @@ type HAProxyLoadBalancerStatus struct {
 // +kubebuilder:subresource:status
 
 // HAProxyLoadBalancer is the Schema for the haproxyloadbalancers API
+// DEPRECATED: will be removed in v1alpha4
 type HAProxyLoadBalancer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/vspherecluster_types.go
+++ b/api/v1alpha3/vspherecluster_types.go
@@ -36,6 +36,7 @@ type VSphereClusterSpec struct {
 
 	// Insecure is a flag that controls whether or not to validate the
 	// vSphere server's certificate.
+	// DEPRECATED: will be removed in v1alpha4
 	// +optional
 	Insecure *bool `json:"insecure,omitempty"`
 
@@ -45,6 +46,7 @@ type VSphereClusterSpec struct {
 	Thumbprint string `json:"thumbprint,omitempty"`
 
 	// CloudProviderConfiguration holds the cluster-wide configuration for the
+	// DEPRECATED: will be removed in v1alpha4
 	// vSphere cloud provider.
 	CloudProviderConfiguration CPIConfig `json:"cloudProviderConfiguration,omitempty"`
 
@@ -57,6 +59,7 @@ type VSphereClusterSpec struct {
 	// When a LoadBalancerRef is provided, the VSphereCluster.Status.Ready field
 	// will not be true until the referenced resource is Status.Ready and has a
 	// non-empty Status.Address value.
+	// DEPRECATED: will be removed in v1alpha4
 	// +optional
 	LoadBalancerRef *corev1.ObjectReference `json:"loadBalancerRef,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -19,8 +19,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: HAProxyLoadBalancer is the Schema for the haproxyloadbalancers
-          API
+        description: 'HAProxyLoadBalancer is the Schema for the haproxyloadbalancers
+          API DEPRECATED: will be removed in v1alpha4'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -278,8 +278,8 @@ spec:
             description: VSphereClusterSpec defines the desired state of VSphereCluster
             properties:
               cloudProviderConfiguration:
-                description: CloudProviderConfiguration holds the cluster-wide configuration
-                  for the vSphere cloud provider.
+                description: 'CloudProviderConfiguration holds the cluster-wide configuration
+                  for the DEPRECATED: will be removed in v1alpha4 vSphere cloud provider.'
                 properties:
                   disk:
                     description: Disk is the vSphere cloud provider's disk configuration.
@@ -481,15 +481,16 @@ spec:
                 - port
                 type: object
               insecure:
-                description: Insecure is a flag that controls whether or not to validate
-                  the vSphere server's certificate.
+                description: 'Insecure is a flag that controls whether or not to validate
+                  the vSphere server''s certificate. DEPRECATED: will be removed in
+                  v1alpha4'
                 type: boolean
               loadBalancerRef:
-                description: LoadBalancerRef may be used to enable a control plane
+                description: 'LoadBalancerRef may be used to enable a control plane
                   load balancer for this cluster. When a LoadBalancerRef is provided,
                   the VSphereCluster.Status.Ready field will not be true until the
                   referenced resource is Status.Ready and has a non-empty Status.Address
-                  value.
+                  value. DEPRECATED: will be removed in v1alpha4'
                 properties:
                   apiVersion:
                     description: API version of the referent.


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR is a followup to #1045 to kickoff deprecation of fields

**Which issue(s) this PR fixes**:  Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
Deprecate CPI/CSI, HAProxyLoadBalancer and the insecure mode from v1alpha3. Removal planned in v1alpha4
```