### PR TITLE
[0.7] Move ncdc to emeritus status

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,6 @@ approvers:
 reviewers:
   - cluster-api-vsphere-maintainers
   - cluster-api-maintainers
+
+emeritus_maintainers:
+  - ncdc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,7 +13,6 @@ aliases:
   cluster-api-maintainers:
     - justinsb
     - detiber
-    - ncdc
     - vincepri
     - chuckha
   cluster-api-vsphere-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Move ncdc to emeritus status
(cherry picked from commit de3aa74797fd152b3a6d6b81c10552a9929f4f0c)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```