### PR TITLE
support storage policies in CAPV

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -100,6 +100,11 @@ type VirtualMachineCloneSpec struct {
 	// +optional
 	Datastore string `json:"datastore,omitempty"`
 
+	// StoragePolicyName of the storage policy to use with this
+	// Virtual Machine
+	// +optional
+	StoragePolicyName string `json:"storagePolicyName,omitempty"`
+
 	// ResourcePool is the name or inventory path of the resource pool in which
 	// the virtual machine is created/located.
 	// +optional

--- a/api/v1alpha3/vspheremachine_webhook.go
+++ b/api/v1alpha3/vspheremachine_webhook.go
@@ -52,6 +52,10 @@ func (r *VSphereMachine) ValidateCreate() error {
 			}
 		}
 	}
+
+	if spec.Datastore != "" && spec.StoragePolicyName != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
+	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/api/v1alpha3/vspheremachinetemplate_webhook.go
+++ b/api/v1alpha3/vspheremachinetemplate_webhook.go
@@ -53,6 +53,10 @@ func (r *VSphereMachineTemplate) ValidateCreate() error {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "template", "spec", "network", "devices", "ipAddrs"), "cannot be set in templates"))
 		}
 	}
+
+	if spec.Datastore != "" && spec.StoragePolicyName != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
+	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -52,6 +52,10 @@ func (r *VSphereVM) ValidateCreate() error {
 			}
 		}
 	}
+
+	if spec.Datastore != "" && spec.StoragePolicyName != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
+	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -250,6 +250,10 @@ spec:
                       create a linked clone. This field is ignored if LinkedClone
                       is not enabled. Defaults to the source's current snapshot.
                     type: string
+                  storagePolicyName:
+                    description: StoragePolicyName of the storage policy to use with
+                      this Virtual Machine
+                    type: string
                   template:
                     description: Template is the name or inventory path of the template
                       used to clone the virtual machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -514,6 +514,10 @@ spec:
                   a linked clone. This field is ignored if LinkedClone is not enabled.
                   Defaults to the source's current snapshot.
                 type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
               template:
                 description: Template is the name or inventory path of the template
                   used to clone the virtual machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -574,6 +574,10 @@ spec:
                           to create a linked clone. This field is ignored if LinkedClone
                           is not enabled. Defaults to the source's current snapshot.
                         type: string
+                      storagePolicyName:
+                        description: StoragePolicyName of the storage policy to use
+                          with this Virtual Machine
+                        type: string
                       template:
                         description: Template is the name or inventory path of the
                           template used to clone the virtual machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -272,6 +272,10 @@ spec:
                   a linked clone. This field is ignored if LinkedClone is not enabled.
                   Defaults to the source's current snapshot.
                 type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
               template:
                 description: Template is the name or inventory path of the template
                   used to clone the virtual machine.

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -163,7 +163,6 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 			MemoryMB:          memMiB,
 		},
 		Location: types.VirtualMachineRelocateSpec{
-			//	Datastore:    types.NewReference(datastore.Reference()),
 			DiskMoveType: string(diskMoveType),
 			Folder:       types.NewReference(folder.Reference()),
 			Pool:         types.NewReference(pool.Reference()),
@@ -202,6 +201,7 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "error trigging clone op for machine %s", ctx)
 	}
+
 	ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 
 	// patch the vsphereVM early to ensure that the task is


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR introduces the support of storage policies within CAPV. The current plan is to enforce with webhooks that datastore shouldn't be set at the same time as storage policy name

**Which issue(s) this PR fixes**: Fixes #1043 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```