### PR TITLE
relax storage policy constrains and enable datastore too

### DIFF
--- a/api/v1alpha3/vspheremachine_webhook.go
+++ b/api/v1alpha3/vspheremachine_webhook.go
@@ -53,9 +53,6 @@ func (r *VSphereMachine) ValidateCreate() error {
 		}
 	}
 
-	if spec.Datastore != "" && spec.StoragePolicyName != "" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
-	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/api/v1alpha3/vspheremachinetemplate_webhook.go
+++ b/api/v1alpha3/vspheremachinetemplate_webhook.go
@@ -54,9 +54,6 @@ func (r *VSphereMachineTemplate) ValidateCreate() error {
 		}
 	}
 
-	if spec.Datastore != "" && spec.StoragePolicyName != "" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
-	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -53,9 +53,6 @@ func (r *VSphereVM) ValidateCreate() error {
 		}
 	}
 
-	if spec.Datastore != "" && spec.StoragePolicyName != "" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "Datastore"), spec.Datastore, "cannot be set when spec.StoragePolicyName is also set"))
-	}
 	return aggregateObjErrors(r.GroupVersionKind().GroupKind(), r.Name, allErrs)
 }
 

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -188,7 +188,8 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 		spec.Location.Profile = []types.BaseVirtualMachineProfileSpec{
 			&types.VirtualMachineDefinedProfileSpec{ProfileId: storageProfileID},
 		}
-	} else {
+	}
+	if ctx.VSphereVM.Spec.Datastore != "" {
 		datastore, err := ctx.Session.Finder.DatastoreOrDefault(ctx, ctx.VSphereVM.Spec.Datastore)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get datastore for %q", ctx)


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR relaxes storage policy setting, as users might want to target a specific datastore within a given storage policy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```