### PR TITLE
Updates the dev-manifests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ release-overrides:
 .PHONY: dev-manifests
 dev-manifests:
 	$(MAKE) manifests STAGE=dev MANIFEST_DIR=$(OVERRIDES_DIR) PULL_POLICY=Always IMAGE=$(DEV_CONTROLLER_IMG):$(DEV_TAG)
+	cp metadata.yaml $(OVERRIDES_DIR)/metadata.yaml
 
 .PHONY: manifests
 manifests:  $(STAGE)-version-check $(STAGE)-flavors $(MANIFEST_DIR) $(BUILD_DIR) $(KUSTOMIZE)

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,8 @@ Running the following generates these overrides for you:
 make dev-manifests
 ```
 
+For development purposes, if you are using a `major.minor.x` version (see env variable VERSION) which is not present in the `metadata.yml`, include this version entry along with the API contract in the file.
+
 ### Using dev manifests
 
 After publishing your test image and generating the manifests, you can use


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes copying the `metadata.yml` over to the overrides directory when running this target. Updates the documentation to include dev semver if not present in the file.

**Which issue(s) this PR fixes**:
Fixes #1075

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```