### PR TITLE
Update vsphere-csi-driver release to v2.1.0

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -683,6 +683,11 @@ func (r clusterReconciler) reconcileStorageProvider(ctx *context.ClusterContext)
 		return err
 	}
 
+	configMap := cloudprovider.CSIFeatureStatesConfigMap()
+	if _, err := targetClusterClient.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
 	clusterRole := cloudprovider.CSIControllerClusterRole()
 	if _, err := targetClusterClient.RbacV1().ClusterRoles().Create(clusterRole); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -152,6 +152,9 @@ func createCrsResourceObjects(crs *addonsv1alpha3.ClusterResourceSet, vsphereClu
 	deploymentConfigMap := newConfigMap(deployment.Name, deployment)
 	appendConfigMapToCrsResource(crs, deploymentConfigMap)
 
+	configMap := cloudprovider.CSIFeatureStatesConfigMap()
+	featureStateConfigMap := newConfigMap(configMap.Name, configMap)
+
 	return []runtime.Object{
 		serviceAccountSecret,
 		clusterRoleConfigMap,
@@ -160,6 +163,7 @@ func createCrsResourceObjects(crs *addonsv1alpha3.ClusterResourceSet, vsphereClu
 		csiDriverConfigMap,
 		daemonSetConfigMap,
 		deploymentConfigMap,
+		featureStateConfigMap,
 	}
 }
 

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -33,15 +33,16 @@ import (
 // NOTE: the contents of this file are derived from https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/1.14
 
 const (
-	DefaultCSIControllerImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0"
-	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0"
-	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v2.0.0"
-	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v1.4.0"
-	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0"
-	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v1.1.0"
-	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	DefaultCSIControllerImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
+	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
+	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v2.2.0"
+	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v1.6.0"
+	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0"
+	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v2.0.0"
+	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v1.3.0"
 	CSINamespace                  = metav1.NamespaceSystem
 	CSIControllerName             = "vsphere-csi-controller"
+	CSIFeatureStateConfigMapName  = "internal-feature-states.csi.vsphere.vmware.com"
 )
 
 func CSIControllerServiceAccount() *corev1.ServiceAccount {
@@ -66,7 +67,7 @@ func CSIControllerClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"nodes", "pods", "secrets"},
+				Resources: []string{"nodes", "pods", "secrets", "configmaps"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
@@ -388,9 +389,6 @@ func CSIControllerDeployment(storageConfig *v1alpha3.CPIStorageConfig) *appsv1.D
 			Namespace: CSINamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-			},
 			Replicas: boolInt32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -437,10 +435,7 @@ func CSIControllerDeployment(storageConfig *v1alpha3.CPIStorageConfig) *appsv1.D
 						{
 							Name: "socket-dir",
 							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com",
-									Type: newHostPathType(string(corev1.HostPathDirectoryOrCreate)),
-								},
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -474,13 +469,6 @@ func VSphereCSIControllerContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  CSIControllerName,
 		Image: image,
-		Lifecycle: &corev1.Lifecycle{
-			PreStop: &corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"},
-				},
-			},
-		},
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "healthz",
@@ -658,6 +646,22 @@ func ConfigForCSI(vsphereCluster v1alpha3.VSphereCluster, cluster clusterv1.Clus
 	}
 
 	return config
+}
+
+func CSIFeatureStatesConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CSIFeatureStateConfigMapName,
+			Namespace: CSINamespace,
+		},
+		Data: map[string]string{
+			"csi-migration": "false",
+		},
+	}
 }
 
 func boolPtr(b bool) *bool {

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -81,6 +81,11 @@ func CSIControllerClusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "list", "watch", "update", "patch"},
 			},
 			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"volumeattachments/status"},
+				Verbs:     []string{"patch"},
+			},
+			{
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumeclaims"},
 				Verbs:     []string{"get", "list", "watch", "update"},
@@ -583,8 +588,8 @@ func CSIProvisionerContainer(image string) corev1.Container {
 			"--csi-address=$(ADDRESS)",
 			"--feature-gates=Topology=true",
 			"--strict-topology",
-			"--enable-leader-election",
-			"--leader-election-type=leases",
+			"--leader-election",
+			"--default-fstype=ext4",
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -35,11 +35,11 @@ import (
 const (
 	DefaultCSIControllerImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
 	DefaultCSINodeDriverImage     = "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
-	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v2.2.0"
-	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v1.6.0"
+	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v3.0.0"
+	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v2.0.0"
 	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0"
-	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v2.0.0"
-	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v1.3.0"
+	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v2.1.0"
+	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v2.0.1"
 	CSINamespace                  = metav1.NamespaceSystem
 	CSIControllerName             = "vsphere-csi-controller"
 	CSIFeatureStateConfigMapName  = "internal-feature-states.csi.vsphere.vmware.com"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update vsphere-csi-driver release to the latest v2.1.0 version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1078 

**Special notes for your reviewer**:
- Adds a ConfigMap that csi uses to configure feature states
- Update container images to new release

**Release note**:
```release-note
Update vsphere-csi-driver to v2.1.0
```