### PR TITLE
Updates image to use nonroot user for CAPV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nobody
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying PSPs
+USER 65532
 ENTRYPOINT ["/manager"]

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses nonroot user for CAPV

**Which issue(s) this PR fixes**:
Fixes #1089

**Special notes for your reviewer**:
Porting a similar PR from CAPI

**Release note**:
```release-note
Uses nonroot user for CAPV for successful deployment when PSPs are enabled 
```