### PR TITLE
Add ignition config support

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -138,6 +138,12 @@ type VirtualMachineCloneSpec struct {
 	// Defaults to empty map
 	// +optional
 	CustomVMXKeys map[string]string `json:"customVMXKeys,omitempty"`
+	// ProvisionerType is the name of provisioner type to use. Can be either cloud-init or
+	// ignition. Defaults to cloud-init.
+	// +optional
+	// +kubebuilder:validation:Enum:=cloud-init;ignition
+	// +kubebuilder:default=cloud-init
+	ProvisionerType string `json:"provisionerType,omitempty"`
 }
 
 // VSphereMachineTemplateResource describes the data needed to create a VSphereMachine from a template

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -237,6 +237,14 @@ spec:
                       value in the template from which the virtual machine is cloned.
                     format: int32
                     type: integer
+                  provisionerType:
+                    default: cloud-init
+                    description: ProvisionerType is the name of provisioner type to
+                      use. Can be either cloud-init or ignition. Defaults to cloud-init.
+                    enum:
+                    - cloud-init
+                    - ignition
+                    type: string
                   resourcePool:
                     description: ResourcePool is the name or inventory path of the
                       resource pool in which the virtual machine is created/located.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -501,6 +501,14 @@ spec:
                 description: ProviderID is the virtual machine's BIOS UUID formated
                   as vsphere://12345678-1234-1234-1234-123456789abc
                 type: string
+              provisionerType:
+                default: cloud-init
+                description: ProvisionerType is the name of provisioner type to use.
+                  Can be either cloud-init or ignition. Defaults to cloud-init.
+                enum:
+                - cloud-init
+                - ignition
+                type: string
               resourcePool:
                 description: ResourcePool is the name or inventory path of the resource
                   pool in which the virtual machine is created/located.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -561,6 +561,15 @@ spec:
                         description: ProviderID is the virtual machine's BIOS UUID
                           formated as vsphere://12345678-1234-1234-1234-123456789abc
                         type: string
+                      provisionerType:
+                        default: cloud-init
+                        description: ProvisionerType is the name of provisioner type
+                          to use. Can be either cloud-init or ignition. Defaults to
+                          cloud-init.
+                        enum:
+                        - cloud-init
+                        - ignition
+                        type: string
                       resourcePool:
                         description: ResourcePool is the name or inventory path of
                           the resource pool in which the virtual machine is created/located.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -259,6 +259,14 @@ spec:
                   value in the template from which the virtual machine is cloned.
                 format: int32
                 type: integer
+              provisionerType:
+                default: cloud-init
+                description: ProvisionerType is the name of provisioner type to use.
+                  Can be either cloud-init or ignition. Defaults to cloud-init.
+                enum:
+                - cloud-init
+                - ignition
+                type: string
               resourcePool:
                 description: ResourcePool is the name or inventory path of the resource
                   pool in which the virtual machine is created/located.

--- a/pkg/services/govmomi/extra/config.go
+++ b/pkg/services/govmomi/extra/config.go
@@ -25,6 +25,13 @@ import (
 // Config is data used with a VM's guestInfo RPC interface.
 type Config []types.BaseOptionValue
 
+const (
+	guestInfoIgnitionData      = "guestinfo.ignition.config.data"
+	guestInfoIgnitionEncoding  = "guestinfo.ignition.config.data.encoding"
+	guestInfoCloudInitData     = "guestinfo.userdata"
+	guestInfoCloudInitEncoding = "guestinfo.userdata.encoding"
+)
+
 // SetCustomVMXKeys sets the custom VMX keys as
 // OptionValues in extraConfig
 func (e *Config) SetCustomVMXKeys(customKeys map[string]string) error {
@@ -39,21 +46,11 @@ func (e *Config) SetCustomVMXKeys(customKeys map[string]string) error {
 
 // SetCloudInitUserData sets the cloud init user data at the key
 // "guestinfo.userdata" as a base64-encoded string.
-func (e *Config) SetCloudInitUserData(data []byte) error {
-	*e = append(*e,
-		&types.OptionValue{
-			Key:   "guestinfo.userdata",
-			Value: e.encode(data),
-		},
-		&types.OptionValue{
-			Key:   "guestinfo.userdata.encoding",
-			Value: "base64",
-		},
-	)
-	return nil
+func (e *Config) SetCloudInitUserData(data []byte) {
+	e.setUserData(guestInfoCloudInitData, guestInfoCloudInitEncoding, data)
 }
 
-// SetCloudInitMetadata sets the cloud init user data at the key
+// SetCloudInitMetadata sets the cloud init metadata at the key
 // "guestinfo.metadata" as a base64-encoded string.
 func (e *Config) SetCloudInitMetadata(data []byte) error {
 	*e = append(*e,
@@ -68,6 +65,27 @@ func (e *Config) SetCloudInitMetadata(data []byte) error {
 	)
 
 	return nil
+}
+
+// SetIgnitionUserData sets the ignition user data at the key
+// "guestinfo.ignition.config.data" as a base64-encoded string.
+func (e *Config) SetIgnitionUserData(data []byte) {
+	e.setUserData(guestInfoIgnitionData, guestInfoIgnitionEncoding, data)
+}
+
+// setUserData sets the user data at the provided key
+// as a base64-encoded string.
+func (e *Config) setUserData(userdataKey, encodingKey string, data []byte) {
+	*e = append(*e,
+		&types.OptionValue{
+			Key:   userdataKey,
+			Value: e.encode(data),
+		},
+		&types.OptionValue{
+			Key:   encodingKey,
+			Value: "base64",
+		},
+	)
 }
 
 // encode first attempts to decode the data as many times as necessary

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -49,8 +49,11 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 	var extraConfig extra.Config
 	if len(bootstrapData) > 0 {
 		ctx.Logger.Info("applied bootstrap data to VM clone spec")
-		if err := extraConfig.SetCloudInitUserData(bootstrapData); err != nil {
-			return err
+		switch ctx.VSphereVM.Spec.ProvisionerType {
+		case "cloud-init":
+			extraConfig.SetCloudInitUserData(bootstrapData)
+		case "ignition":
+			extraConfig.SetIgnitionUserData(bootstrapData)
 		}
 	}
 	if ctx.VSphereVM.Spec.CustomVMXKeys != nil {


### PR DESCRIPTION
This PR adds ProvisionerType field that indicates the provisioner type to use. ProvisionerType can be either cloud-init or ignition and the default value is cloud-init because I think cloud-init is more common for VM provisioning.

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1006

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ignition config support
```