### PR TITLE
Adds new reason to vspheremachine condition

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -324,6 +324,11 @@ func (r machineReconciler) reconcileNormal(ctx *context.MachineContext) (reconci
 
 	// Make sure bootstrap data is available and populated.
 	if ctx.Machine.Spec.Bootstrap.DataSecretName == nil {
+		if !infrautilv1.IsControlPlaneMachine(ctx.VSphereMachine) && !ctx.Cluster.Status.ControlPlaneInitialized {
+			ctx.Logger.Info("Waiting for the control plane to be initialized")
+			conditions.MarkFalse(ctx.VSphereMachine, infrav1.VMProvisionedCondition, clusterv1.WaitingForControlPlaneAvailableReason, clusterv1.ConditionSeverityInfo, "")
+			return ctrl.Result{}, nil
+		}
 		ctx.Logger.Info("Waiting for bootstrap data to be available")
 		conditions.MarkFalse(ctx.VSphereMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForBootstrapDataReason, clusterv1.ConditionSeverityInfo, "")
 		return reconcile.Result{}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the vSphereMachine controller logic to use the WaitingForCPAvailableReason if the machine is waiting for bootstrap data because the CP is not yet functional. 
This is a **backport of the PR** #1102 to the 0.7 branch.

**Which issue(s) this PR fixes**:
Fixes #1037

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Updates vSphereMachine condition status to report for Control Plane to be ready
```