### PR TITLE
Enable log collection for E2E tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,9 @@ run:
 issue:
   max-same-issues: 0
   max-per-linter: 0
+issues:
+  exclude-rules:
+    - path: "test/e2e/*"
+      linters:
+        - gosec
+      text: "G106:"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/vmware/govmomi v0.23.1
+	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/warnings.v0 v0.1.2 // indirect
@@ -22,5 +23,6 @@ require (
 	k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
 	sigs.k8s.io/cluster-api v0.3.11
 	sigs.k8s.io/controller-runtime v0.5.11
+	sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -31,6 +31,8 @@ trap on_exit EXIT
 export VSPHERE_SERVER="${GOVC_URL}"
 export VSPHERE_USERNAME="${GOVC_USERNAME}"
 export VSPHERE_PASSWORD="${GOVC_PASSWORD}"
+export VSPHERE_SSH_AUTHORIZED_KEY="${VM_SSH_PUB_KEY}"
+export VSPHERE_SSH_PRIVATE_KEY="/root/ssh/.private-key/private-key"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/vsphere-ci.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -22,15 +22,17 @@ The first step to running the e2e tests is setting up the required environment v
 
 | Environment variable       | Description                                                                                           | Example                                                                          |
 | -------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `VSPHERE_SERVER`           | The IP address or FQDN of a vCenter 6.7u3 server                                                      | `my.vcenter.com`                                                                 |
-| `VSPHERE_USERNAME`         | The username used to access the vSphere server                                                        | `my-username`                                                                    |
-| `VSPHERE_PASSWORD`         | The password used to access the vSphere server                                                        | `my-password`                                                                    |
-| `VSPHERE_DATACENTER`       | The unique name or inventory path of the datacenter in which VMs will be created                      | `my-datacenter` or `/my-datacenter`                                              |
-| `VSPHERE_FOLDER`           | The unique name or inventory path of the folder in which VMs will be created                          | `my-folder` or `/my-datacenter/vm/my-folder`                                     |
-| `VSPHERE_RESOURCE_POOL`    | The unique name or inventory path of the resource pool in which VMs will be created                   | `my-resource-pool` or `/my-datacenter/host/Cluster-1/Resources/my-resource-pool` |
-| `VSPHERE_DATASTORE`        | The unique name or inventory path of the datastore in which VMs will be created                       | `my-datastore` or `/my-datacenter/datstore/my-datastore`                         |
-| `VSPHERE_NETWORK`          | The unique name or inventory path of the network to which VMs will be connected                       | `my-network` or `/my-datacenter/network/my-network`                              |
-| `VSPHERE_HAPROXY_TEMPLATE` | The unique name or inventory path of the template from which the HAProxy load balancer VMs are cloned | `my-haproxy-template` or `/my-datacenter/vm/my-haproxy-template`                 |
+| `VSPHERE_SERVER`              | The IP address or FQDN of a vCenter 6.7u3 server                                                      | `my.vcenter.com`                                                                 |
+| `VSPHERE_USERNAME`            | The username used to access the vSphere server                                                        | `my-username`                                                                    |
+| `VSPHERE_PASSWORD`            | The password used to access the vSphere server                                                        | `my-password`                                                                    |
+| `VSPHERE_DATACENTER`          | The unique name or inventory path of the datacenter in which VMs will be created                      | `my-datacenter` or `/my-datacenter`                                              |
+| `VSPHERE_FOLDER`              | The unique name or inventory path of the folder in which VMs will be created                          | `my-folder` or `/my-datacenter/vm/my-folder`                                     |
+| `VSPHERE_RESOURCE_POOL`       | The unique name or inventory path of the resource pool in which VMs will be created                   | `my-resource-pool` or `/my-datacenter/host/Cluster-1/Resources/my-resource-pool` |
+| `VSPHERE_DATASTORE`           | The unique name or inventory path of the datastore in which VMs will be created                       | `my-datastore` or `/my-datacenter/datstore/my-datastore`                         |
+| `VSPHERE_NETWORK`             | The unique name or inventory path of the network to which VMs will be connected                       | `my-network` or `/my-datacenter/network/my-network`                              |
+| `VSPHERE_HAPROXY_TEMPLATE`    | The unique name or inventory path of the template from which the HAProxy load balancer VMs are cloned | `my-haproxy-template` or `/my-datacenter/vm/my-haproxy-template`                 |
+| `VSPHERE_SSH_PRIVATE_KEY`     | The file path of the private key used to ssh into the CAPV VMs                                        | `/home/foo/bar-ssh.key`                                                          |
+| `VSPHERE_SSH_AUTHORIZED_KEY`  | The public key that is added to the CAPV VMs                                                          | `ss-rsa ABCDEF...XYZ=`                                                          |
 
 ### Running the e2e tests
 

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -94,7 +94,6 @@ variables:
   VSPHERE_NETWORK: "sddc-cgw-network-8"
   VSPHERE_HAPROXY_TEMPLATE: "capv-haproxy-v0.6.3"
   VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.19.1"
-  VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCbQg7ywSD1oJAwAHhQuemrL6C9wvOIgE7wfZ0PfqolcTEQbLbv7Zxe1/TRzr4B20pb6GMryJ7O3SH9kuCubDYQ4Atw9MF/iAtsg0s3Xs4a3RAqoeaTHA0u401Um27ANDVqLswdTZ0J0Ev+XqRCEgPX+IpGgiNOyiHxfIgwdev/fG1MmMEyCKj8JNlRghFnleBcE+N3Mu0rKb88ascch2mKLY5fGDwbnC3V7d6LE6jWVT5HV391N4IWmjoBjlBt3mfzNslWqJUS+PxRbYR3i7vyVrpb/mkw1YG1jeomTAmkx4kwiV7hSzNVF6pKNIOoB1mpwULJ0VL+UkM8IPEfVJb root@9ae81f510a14"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -133,7 +133,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	kubeconfigPath := parts[3]
 
 	e2eConfig = loadE2EConfig(configPath)
-	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme())
+	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme(), framework.WithMachineLogCollector(LogCollector{}))
 })
 
 // Using a SynchronizedAfterSuite for controlling how to delete resources shared across ParallelNodes (~ginkgo threads).

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/pkg/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kinderrors "sigs.k8s.io/kind/pkg/errors"
+)
+
+const (
+	DefaultUserName           = "capv"
+	VSpherePrivateKeyFilePath = "VSPHERE_SSH_PRIVATE_KEY"
+)
+
+type LogCollector struct{}
+
+func (collector LogCollector) CollectMachineLog(_ context.Context, _ client.Client, m *clusterv1.Machine, outputPath string) error {
+	var hostIPAddr string
+	for _, address := range m.Status.Addresses {
+		if address.Type != clusterv1.MachineExternalIP {
+			continue
+		}
+		hostIPAddr = address.Address
+		break
+	}
+
+	captureLogs := func(hostFileName, command string, args ...string) func() error {
+		return func() error {
+			f, err := createOutputFile(filepath.Join(outputPath, hostFileName))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return executeRemoteCommand(f, hostIPAddr, command, args...)
+		}
+	}
+
+	return kinderrors.AggregateConcurrent([]func() error{
+		captureLogs("kubelet.log",
+			"sudo journalctl", "--no-pager", "--output=short-precise", "-u", "kubelet.service"),
+		captureLogs("containerd.log",
+			"sudo journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service"),
+		captureLogs("cloud-init.log",
+			"cat", "/var/log/cloud-init.log"),
+		captureLogs("cloud-init-output.log",
+			"cat", "/var/log/cloud-init-output.log"),
+	})
+}
+
+func createOutputFile(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return nil, err
+	}
+	return os.Create(path)
+}
+
+func executeRemoteCommand(f io.StringWriter, hostIPAddr, command string, args ...string) error {
+	config, err := newSSHConfig()
+	if err != nil {
+		return err
+	}
+	port := "22"
+
+	hostClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", hostIPAddr, port), config)
+	if err != nil {
+		return errors.Wrapf(err, "dialing host IP address at %s", hostIPAddr)
+	}
+	defer hostClient.Close()
+
+	session, err := hostClient.NewSession()
+	if err != nil {
+		return errors.Wrap(err, "opening SSH session")
+	}
+	defer session.Close()
+
+	// Run the command and write the captured stdout to the file
+	var stdoutBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+	if len(args) > 0 {
+		command += " " + strings.Join(args, " ")
+	}
+	if err = session.Run(command); err != nil {
+		return errors.Wrapf(err, "running command \"%s\"", command)
+	}
+	if _, err = f.WriteString(stdoutBuf.String()); err != nil {
+		return errors.Wrap(err, "writing output to file")
+	}
+
+	return nil
+}
+
+// newSSHConfig returns a configuration to use for SSH connections to remote machines
+func newSSHConfig() (*ssh.ClientConfig, error) {
+	sshPrivateKeyContent, err := readPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := ssh.ParsePrivateKey(sshPrivateKeyContent)
+	if err != nil {
+		return nil, errors.Wrapf(err, fmt.Sprintf("error parsing private key: %s", sshPrivateKeyContent))
+	}
+
+	config := &ssh.ClientConfig{
+		User:            DefaultUserName,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+	}
+
+	return config, nil
+}
+
+func readPrivateKey() ([]byte, error) {
+	privateKeyFilePath := os.Getenv(VSpherePrivateKeyFilePath)
+	if len(privateKeyFilePath) == 0 {
+		return nil, errors.Errorf("private key information missing. Please set %s environment variable", VSpherePrivateKeyFilePath)
+	}
+
+	return ioutil.ReadFile(privateKeyFilePath)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch enables log collection for E2E tests

**Which issue(s) this PR fixes**:
Fixes #734

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Enables log collection for E2E tests
```