### PR TITLE
Add missing coordination.k8s.io to ClusterRole for CCM

### DIFF
--- a/pkg/services/cloudprovider/cloud-controller-manager.go
+++ b/pkg/services/cloudprovider/cloud-controller-manager.go
@@ -213,6 +213,11 @@ func CloudControllerManagerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{"secrets"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "watch", "list", "delete", "update", "create"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the necassesary rights to the ClusterRole for the CCM lock to function

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1113 


**Release note**:
```release-note
Fixes ClusterRole for CCM
```