### PR TITLE
Adds new reason for VMProvisionedCondition

### DIFF
--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -78,6 +78,10 @@ const (
 	// NOTE: This reason does not apply to VSphereVM (this state happens before the VSphereVM is actually created).
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
 
+	// WaitingForStaticIPAllocationReason (Severity=Info) documents a VSphereVM waiting for the allocation of
+	// a static IP address.
+	WaitingForStaticIPAllocationReason = "WaitingForStaticIPAllocation"
+
 	// CloningReason documents (Severity=Info) a VSphereMachine/VSphereVM currently executing the clone operation.
 	CloningReason = "Cloning"
 

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -1,0 +1,153 @@
+package controllers
+
+import (
+	goctx "context"
+	"crypto/tls"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/simulator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apirecord "k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
+)
+
+func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
+	// initializing a fake server to replace the vSphere endpoint
+	model := simulator.VPX()
+	model.Host = 0
+	defer model.Remove()
+
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+	model.Service.TLS = new(tls.Config)
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	vSphereVM := &infrav1.VSphereVM{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "VSphereVM",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-vm",
+			Namespace: "test",
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: "valid-cluster",
+			},
+			// To make sure PatchHelper does not error out
+			ResourceVersion: "1234",
+		},
+		Spec: infrav1.VSphereVMSpec{
+			VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
+				Server: s.URL.Host,
+				Network: infrav1.NetworkSpec{
+					Devices: []infrav1.NetworkDeviceSpec{
+						{NetworkName: "nw-1"},
+						{NetworkName: "nw-2"},
+					},
+				},
+			},
+		},
+		Status: infrav1.VSphereVMStatus{},
+	}
+
+	controllerMgrContext := fake.NewControllerManagerContext(vSphereVM)
+	password, _ := s.URL.User.Password()
+	controllerMgrContext.Password = password
+	controllerMgrContext.Username = s.URL.User.Username()
+
+	controllerContext := &context.ControllerContext{
+		ControllerManagerContext: controllerMgrContext,
+		Recorder:                 record.New(apirecord.NewFakeRecorder(100)),
+		Logger:                   log.Log,
+	}
+	r := vmReconciler{ControllerContext: controllerContext}
+
+	_, err = r.Reconcile(ctrl.Request{NamespacedName: util.ObjectKey(vSphereVM)})
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	vm := &infrav1.VSphereVM{}
+	vmKey := util.ObjectKey(vSphereVM)
+	g.Expect(r.Client.Get(goctx.Background(), vmKey, vm)).NotTo(HaveOccurred())
+
+	g.Expect(conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
+	vmProvisionCondition := conditions.Get(vm, infrav1.VMProvisionedCondition)
+	g.Expect(vmProvisionCondition.Status).To(Equal(corev1.ConditionFalse))
+	g.Expect(vmProvisionCondition.Reason).To(Equal(infrav1.WaitingForStaticIPAllocationReason))
+}
+
+func TestVmReconciler_WaitingForStaticIPAllocation(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		devices    []infrav1.NetworkDeviceSpec
+		shouldWait bool
+	}{
+		{
+			name:       "for one n/w device with DHCP set to true",
+			devices:    []infrav1.NetworkDeviceSpec{{DHCP4: true, NetworkName: "nw-1"}},
+			shouldWait: false,
+		},
+		{
+			name: "for multiple n/w devices with DHCP set and unset",
+			devices: []infrav1.NetworkDeviceSpec{
+				{DHCP4: true, NetworkName: "nw-1"},
+				{NetworkName: "nw-2"},
+			},
+			shouldWait: true,
+		},
+		{
+			name: "for multiple n/w devices with static IP address specified",
+			devices: []infrav1.NetworkDeviceSpec{
+				{NetworkName: "nw-1", IPAddrs: []string{"192.168.1.2/32"}},
+				{NetworkName: "nw-2"},
+			},
+			shouldWait: true,
+		},
+		{
+			name: "for single n/w devices with DHCP4, DHCP6 & IP address unset",
+			devices: []infrav1.NetworkDeviceSpec{
+				{NetworkName: "nw-1"},
+			},
+			shouldWait: true,
+		},
+		{
+			name: "for multiple n/w devices with DHCP4, DHCP6 & IP address unset",
+			devices: []infrav1.NetworkDeviceSpec{
+				{NetworkName: "nw-1"},
+				{NetworkName: "nw-2"},
+			},
+			shouldWait: true,
+		},
+	}
+
+	controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext())
+	vmContext := fake.NewVMContext(controllerCtx)
+	r := vmReconciler{controllerCtx}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			vmContext.VSphereVM.Spec.Network = infrav1.NetworkSpec{Devices: tt.devices}
+			isWaiting := r.isWaitingForStaticIPAllocation(vmContext)
+			g := NewWithT(t)
+			g.Expect(isWaiting).To(Equal(tt.shouldWait))
+		})
+	}
+
+}

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientrecord "k8s.io/client-go/tools/record"
-	clusterv1a2 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -38,7 +38,7 @@ func NewControllerManagerContext(initObjects ...runtime.Object) *context.Control
 
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = clusterv1a2.AddToScheme(scheme)
+	_ = clusterv1.AddToScheme(scheme)
 	_ = infrav1.AddToScheme(scheme)
 
 	return &context.ControllerManagerContext{


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch introduces a new reason to indicate that the `VMProvisionedCondition` is halted because of static IP Address allocation.

**Which issue(s) this PR fixes**:
Fixes #1116 

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Adds a new reason for VMProvisionedCondition
```