### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,6 @@ aliases:
     - yastij
     - randomvariable
   cluster-api-vsphere-emeritus-maintainers:
-    - sflxn
     - sidharthsurana
     - figo
     - akutz


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes sflxn from the capv emeritus
alias.

/kind cleanup


**Release note**:

```release-note
NONE
```