### PR TITLE
Patches VsphereVM after initiating power on/off tasks

### DIFF
--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -189,6 +189,10 @@ func (vms *VMService) DestroyVM(ctx *context.VMContext) (infrav1.VirtualMachine,
 			return vm, err
 		}
 		ctx.VSphereVM.Status.TaskRef = task.Reference().Value
+		if err = ctx.Patch(); err != nil {
+			ctx.Logger.Error(err, "patch failed", "vm", ctx.String())
+			return vm, err
+		}
 		ctx.Logger.Info("wait for VM to be powered off")
 		return vm, nil
 	}
@@ -258,6 +262,10 @@ func (vms *VMService) reconcilePowerState(ctx *virtualMachineContext) (bool, err
 
 		// Update the VSphereVM.Status.TaskRef to track the power-on task.
 		ctx.VSphereVM.Status.TaskRef = task.Reference().Value
+		if err = ctx.Patch(); err != nil {
+			ctx.Logger.Error(err, "patch failed", "vm", ctx.String())
+			return false, err
+		}
 
 		// Once the VM is successfully powered on, a reconcile request should be
 		// triggered once the VM reports IP addresses are available.


### PR DESCRIPTION
**What this PR does / why we need it**:
Patches the vSphereVM object to commit the task reference after kicking off power on/off tasks. There's a race condition where a reconcile can happen before the patch is committed in the defer block and that new reconcile can send out duplicate tasks to power on/off VM.

original issue was just around power on but during testing discovered that the issue is possible for both on/off tasks. 

**Which issue(s) this PR fixes**
Fixes #1122 


**Release note**:
```release-note
NONE
```