### PR TITLE
bump cloud-provider-vsphere to v1.18.1

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -35,7 +35,6 @@ import (
 const (
 	clusterNameVar               = "${CLUSTER_NAME}"
 	controlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
-	defaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
 	defaultClusterCIDR           = "192.168.0.0/16"
 	defaultDiskGiB               = 25
 	defaultMemoryMiB             = 8192
@@ -148,7 +147,7 @@ func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 				},
 				ProviderConfig: infrav1.CPIProviderConfig{
 					Cloud: &infrav1.CPICloudConfig{
-						ControllerImage: defaultCloudProviderImage,
+						ControllerImage: cloudprovidersvc.DefaultCPIControllerImage,
 					},
 					Storage: &infrav1.CPIStorageConfig{
 						ControllerImage:     cloudprovidersvc.DefaultCSIControllerImage,

--- a/pkg/services/cloudprovider/cloud-controller-manager.go
+++ b/pkg/services/cloudprovider/cloud-controller-manager.go
@@ -28,7 +28,7 @@ import (
 // NOTE: the contents of this file are derived from https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager
 
 const (
-	DefaultCPIControllerImage = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
+	DefaultCPIControllerImage = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.18.1"
 )
 
 // CloudControllerManagerServiceAccount returns the ServiceAccount used for the cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps our manifest generation to the latest cloud-provider-vsphere version

**Which issue(s) this PR fixes**:
Fixes #1130 

**Special notes for your reviewer**:
Cherry-pick of #1128

**Release note**:
```release-note
Bumps CPI version in the manifest generation to v1.18.1
```