### PR TITLE
fix panic and randomize chosen datastore when using storage policies

### DIFF
--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -18,6 +18,8 @@ package vcenter
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
@@ -227,8 +229,9 @@ func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 				return errors.New(fmt.Sprintf("couldn't find specified datastore: %s in compatible list of datastores for storage policy", ctx.VSphereVM.Spec.Datastore))
 			}
 		} else {
-			firstDSRef := fmt.Sprintf("%s:%s", result.CompatibleDatastores()[0].HubType, result.CompatibleDatastores()[0].HubId)
-			datastoreRef.FromString(firstDSRef)
+			rand.Seed(time.Now().UnixNano())
+			ds := result.CompatibleDatastores()[rand.Intn(len(result.CompatibleDatastores()))]
+			datastoreRef = &types.ManagedObjectReference{Type: ds.HubType, Value: ds.HubId}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR fixes a panic where datastoreRef was nil that was introduced in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1118, it also randomize the picking of the compatible datastore, to avoid blocking when the first compatible datastore is full

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```