### PR TITLE
[cherry-pick into master] Add ability to alter vSphereVM thumbprints and tests for it 

### DIFF
--- a/api/v1alpha3/vspherevm_webhook.go
+++ b/api/v1alpha3/vspherevm_webhook.go
@@ -80,6 +80,10 @@ func (r *VSphereVM) ValidateUpdate(old runtime.Object) error { //nolint
 	delete(oldVSphereVMSpec, "bootstrapRef")
 	delete(newVSphereVMSpec, "bootstrapRef")
 
+	// allow changes to thumbprint
+	delete(oldVSphereVMSpec, "thumbprint")
+	delete(newVSphereVMSpec, "thumbprint")
+
 	newVSphereVMNetwork := newVSphereVMSpec["network"].(map[string]interface{})
 	oldVSphereVMNetwork := oldVSphereVMSpec["network"].(map[string]interface{})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the ability to alter vSphereVM thumbprints 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1134

**Special notes for your reviewer**:


**Release note**:
```release-note
allow changing of thumbprints of exing clusters without redepolying
```