### PR TITLE
Updates golang version to 1.15.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GOLANG_VERSION=golang:1.13.5
+ARG GOLANG_VERSION=golang:1.15.8
 FROM $GOLANG_VERSION as builder
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-vsphere
 
-go 1.12
+go 1.15
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api/hack/tools
 
-go 1.12
+go 1.15
 
 require (
 	github.com/golangci/golangci-lint v1.23.8


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch updates the golang version to `1.15.8`

**Which issue(s) this PR fixes**:
Fixes #1140

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Update underlying golang version to 1.15.8
```