### PR TITLE
Refactor manager and options to use controller-runtime structs

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -60,19 +60,7 @@ func New(opts Options) (Manager, error) {
 	}
 
 	// Build the controller manager.
-	mgr, err := ctrl.NewManager(opts.KubeConfig, ctrl.Options{
-		Scheme:                  opts.Scheme,
-		MetricsBindAddress:      opts.MetricsAddr,
-		LeaderElection:          opts.LeaderElectionEnabled,
-		LeaderElectionID:        opts.LeaderElectionID,
-		LeaderElectionNamespace: opts.LeaderElectionNamespace,
-		SyncPeriod:              &opts.SyncPeriod,
-		Namespace:               opts.WatchNamespace,
-		NewCache:                opts.NewCache,
-		Port:                    opts.WebhookPort,
-		HealthProbeBindAddress:  opts.HealthAddr,
-		CertDir:                 opts.CertDir,
-	})
+	mgr, err := ctrl.NewManager(opts.KubeConfig, opts.Options)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create manager")
 	}
@@ -80,7 +68,7 @@ func New(opts Options) (Manager, error) {
 	// Build the controller manager context.
 	controllerManagerContext := &context.ControllerManagerContext{
 		Context:                 goctx.Background(),
-		WatchNamespace:          opts.WatchNamespace,
+		WatchNamespace:          opts.Namespace,
 		Namespace:               opts.PodNamespace,
 		Name:                    opts.PodName,
 		LeaderElectionID:        opts.LeaderElectionID,

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -22,19 +22,15 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/yaml"
-
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
-
-	// +kubebuilder:scaffold:imports
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	// +kubebuilder:scaffold:imports
 )
 
 // AddToManagerFunc is a function that can be optionally specified with
@@ -44,38 +40,17 @@ type AddToManagerFunc func(*context.ControllerManagerContext, ctrlmgr.Manager) e
 
 // Options describes the options used to create a new CAPV manager.
 type Options struct {
-	// LeaderElectionEnabled is a flag that enables leader election.
-	LeaderElectionEnabled bool
+	ctrlmgr.Options
 
 	// EnableKeepAlive is a session feature to enable keep alive handler
 	// for better load management on vSphere api server
 	EnableKeepAlive bool
-
-	// LeaderElectionID is the name of the config map to use as the
-	// locking resource when configuring leader election.
-	LeaderElectionID string
-
-	// SyncPeriod is the amount of time to wait between syncing the local
-	// object cache with the API server.
-	SyncPeriod time.Duration
 
 	// MaxConcurrentReconciles the maximum number of allowed, concurrent
 	// reconciles.
 	//
 	// Defaults to the eponymous constant in this package.
 	MaxConcurrentReconciles int
-
-	// MetricsAddr is the net.Addr string for the metrics server.
-	MetricsAddr string
-
-	// HealthAddr is the net.Addr string for the healthcheck server
-	HealthAddr string
-
-	// LeaderElectionNamespace is the namespace in which the pod running the
-	// controller maintains a leader election lock
-	//
-	// Defaults to ""
-	LeaderElectionNamespace string
 
 	// LeaderElectionNamespace is the namespace in which the pod running the
 	// controller maintains a leader election lock
@@ -87,12 +62,6 @@ type Options struct {
 	//
 	// Defaults to the eponymous constant in this package.
 	PodName string
-
-	// WatchNamespace is the namespace the controllers watch for changes. If
-	// no value is specified then all namespaces are watched.
-	//
-	// Defaults to the eponymous constant in this package.
-	WatchNamespace string
 
 	// Username is the username for the account used to access remote vSphere
 	// endpoints.
@@ -106,20 +75,10 @@ type Options struct {
 	// in keepalive handler
 	KeepAliveDuration time.Duration
 
-	// WebhookPort is the port that the webhook server serves at.
-	WebhookPort int
-
-	// CertDir is the directory that contains the server key and certificate.
-	// TODO (srm09): Use CertDir from controller-runtime instead
-	CertDir string
-
 	// CredentialsFile is the file that contains credentials of CAPV
 	CredentialsFile string
 
-	Logger     logr.Logger
 	KubeConfig *rest.Config
-	Scheme     *runtime.Scheme
-	NewCache   cache.NewCacheFunc
 
 	// AddToManager is a function that can be optionally specified with
 	// the manager's Options in order to explicitly decide what controllers
@@ -134,10 +93,6 @@ func (o *Options) defaults() {
 
 	if o.PodName == "" {
 		o.PodName = DefaultPodName
-	}
-
-	if o.SyncPeriod == 0 {
-		o.SyncPeriod = DefaultSyncPeriod
 	}
 
 	if o.KubeConfig == nil {

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -121,11 +121,13 @@ func NewTestEnvironment() *TestEnvironment {
 	}
 
 	managerOpts := manager.Options{
-		Scheme:      scheme,
-		MetricsAddr: "0",
-		WebhookPort: env.WebhookInstallOptions.LocalServingPort,
-		CertDir:     env.WebhookInstallOptions.LocalServingCertDir,
-		KubeConfig:  env.Config,
+		Options: ctrl.Options{
+			Scheme:             scheme,
+			Port:               env.WebhookInstallOptions.LocalServingPort,
+			CertDir:            env.WebhookInstallOptions.LocalServingCertDir,
+			MetricsBindAddress: "0",
+		},
+		KubeConfig: env.Config,
 		// TODO (srm09): might need to supply some mock for
 		// 		vCenter interactions
 		Username: "blah",


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch removes duplicates code and reuses types from controller-runtime

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
n/a 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```