### PR TITLE
Reconcile storage policy after cloning the VM

### DIFF
--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -326,12 +326,12 @@ func (vms *VMService) reconcileStoragePolicy(ctx *virtualMachineContext) error {
 	for _, d := range disks {
 		disk := d.(*types.VirtualDisk)
 		found := false
+		// entities associated with storage policy has key in the form <vm-ID>:<disk>
+		diskID := fmt.Sprintf("%s:%d", ctx.Obj.Reference().Value, disk.Key)
 		for _, e := range entities {
-			// entities associated with storage policy has key in the form <vm-ID>:<disk>
-			diskID := fmt.Sprintf("%s:%d", ctx.Obj.Reference().Value, disk.Key)
-
 			if e.Key == diskID {
 				found = true
+				break
 			}
 		}
 
@@ -358,7 +358,6 @@ func (vms *VMService) reconcileStoragePolicy(ctx *virtualMachineContext) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to set storagePolicy on vm %s", ctx)
 		}
-
 		ctx.VSphereVM.Status.TaskRef = task.Reference().Value
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where host based storage policies couldn't be applied to VMs during the clone process. With these changes, the storage policy is reconciled separately after the clone VM, reconcile network and reconcile metadata completes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1146 

**Special notes for your reviewer**:
The reconcile function returns early if the VM is powered on. This is to avoid the scenario where the storage policies have already been reconciled and the VM is in a running state but the user either attaches extra disks or uses CSI to provision new disks with a different storage policy. The capv controller should not overwrite the storage policy on any disks other than the first 'root' one. 

**Release note**:
```release-note
NONE
```