### PR TITLE
Make conversion-gen output location explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ KIND := $(TOOLS_BIN_DIR)/kind
 KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE)
 
+# Set --output-base for conversion-gen if we are not within GOPATH
+ifneq ($(abspath $(ROOT_DIR)),$(shell go env GOPATH)/src/sigs.k8s.io/cluster-api-provider-vsphere)
+	OUTPUT_BASE := --output-base=$(ROOT_DIR)
+endif
+
 # Allow overriding manifest generation destination directory
 MANIFEST_ROOT ?= ./config
 CRD_ROOT ?= $(MANIFEST_ROOT)/crd/bases
@@ -203,7 +208,7 @@ generate-go: $(CONTROLLER_GEN) $(CONVERSION_GEN) ## Runs Go related generate tar
 
 	$(CONVERSION_GEN) \
 		--input-dirs=./api/v1alpha3 \
-		--output-file-base=zz_generated.conversion \
+		--output-file-base=zz_generated.conversion $(OUTPUT_BASE) \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-manifests


### PR DESCRIPTION
**What this PR does / why we need it**:

The conversion-gen command has an --output-base argument to control
where generated files are placed. The default value for this argument
can vary depending on whether or not $GOPATH is set or not. This results
in our generated files being created in the wrong place for some people
in a subtle and non-obvious way.

For those running `make generate` with GOPATH set, the files are created
in `$GOPATH/src/[file path]`. For those without GOPATH set, files are
created where we expect them to be within the repo at `./[file path]`.

To make sure files are always generated to the location where we expect
them to be, this updates our calls to conversion-gen to always be
explicit and set `--output-base=./`.

**Which issue(s) this PR fixes**:
Fixes #1152
