### PR TITLE
Checks for length of network statuses while generating metadata

### DIFF
--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/integer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -137,22 +138,20 @@ func IsControlPlaneMachine(machine metav1.Object) bool {
 
 // GetMachineMetadata returns the cloud-init metadata as a base-64 encoded
 // string for a given VSphereMachine.
-func GetMachineMetadata(hostname string, machine infrav1.VSphereVM, networkStatus ...infrav1.NetworkStatus) ([]byte, error) {
+func GetMachineMetadata(hostname string, vsphereVM infrav1.VSphereVM, networkStatuses ...infrav1.NetworkStatus) ([]byte, error) {
 	// Create a copy of the devices and add their MAC addresses from a network status.
-	devices := make([]infrav1.NetworkDeviceSpec, len(machine.Spec.Network.Devices))
+	devices := make([]infrav1.NetworkDeviceSpec, integer.IntMax(len(vsphereVM.Spec.Network.Devices), len(networkStatuses)))
+
 	var waitForIPv4, waitForIPv6 bool
-	for i := range machine.Spec.Network.Devices {
-		machine.Spec.Network.Devices[i].DeepCopyInto(&devices[i])
-		if len(networkStatus) > 0 {
-			devices[i].MACAddr = networkStatus[i].MACAddr
-		}
+	for i := range vsphereVM.Spec.Network.Devices {
+		vsphereVM.Spec.Network.Devices[i].DeepCopyInto(&devices[i])
 
 		if waitForIPv4 && waitForIPv6 {
 			// break early as we already wait for ipv4 and ipv6
 			continue
 		}
 		// check static IPs
-		for _, ipStr := range machine.Spec.Network.Devices[i].IPAddrs {
+		for _, ipStr := range vsphereVM.Spec.Network.Devices[i].IPAddrs {
 			ip := net.ParseIP(ipStr)
 			// check the IP family
 			if ip != nil {
@@ -164,12 +163,17 @@ func GetMachineMetadata(hostname string, machine infrav1.VSphereVM, networkStatu
 			}
 		}
 		// check if DHCP is enabled
-		if machine.Spec.Network.Devices[i].DHCP4 {
+		if vsphereVM.Spec.Network.Devices[i].DHCP4 {
 			waitForIPv4 = true
 		}
-		if machine.Spec.Network.Devices[i].DHCP6 {
+		if vsphereVM.Spec.Network.Devices[i].DHCP6 {
 			waitForIPv6 = true
 		}
+	}
+
+	// Add the MAC Address to the network device
+	for i, status := range networkStatuses {
+		devices[i].MACAddr = status.MACAddr
 	}
 
 	buf := &bytes.Buffer{}
@@ -188,14 +192,14 @@ func GetMachineMetadata(hostname string, machine infrav1.VSphereVM, networkStatu
 	}{
 		Hostname:    hostname, // note that hostname determines the Kubernetes node name
 		Devices:     devices,
-		Routes:      machine.Spec.Network.Routes,
+		Routes:      vsphereVM.Spec.Network.Routes,
 		WaitForIPv4: waitForIPv4,
 		WaitForIPv6: waitForIPv6,
 	}); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"error getting cloud init metadata for machine %s/%s/%s",
-			machine.Namespace, machine.ClusterName, machine.Name)
+			"error getting cloud init metadata for vsphereVM %s/%s/%s",
+			vsphereVM.Namespace, vsphereVM.ClusterName, vsphereVM.Name)
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -228,9 +228,10 @@ func Test_GetMachinePreferredIPAddress(t *testing.T) {
 
 func Test_GetMachineMetadata(t *testing.T) {
 	testCases := []struct {
-		name     string
-		machine  *infrav1.VSphereVM
-		expected string
+		name            string
+		machine         *infrav1.VSphereVM
+		networkStatuses []infrav1.NetworkStatus
+		expected        string
 	}{
 		{
 			name: "dhcp4",
@@ -586,12 +587,63 @@ network:
         - "vmware6.ci"
 `,
 		},
+		{
+			name: "2nets+network-statuses",
+			machine: &infrav1.VSphereVM{
+				Spec: infrav1.VSphereVMSpec{
+					VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
+						Network: infrav1.NetworkSpec{
+							Devices: []infrav1.NetworkDeviceSpec{
+								{
+									NetworkName: "network1",
+									MACAddr:     "00:00:00:00:00",
+									DHCP4:       true,
+								},
+								{
+									NetworkName: "network12",
+									MACAddr:     "00:00:00:00:01",
+									DHCP6:       true,
+								},
+							},
+						},
+					},
+				},
+			},
+			networkStatuses: []infrav1.NetworkStatus{
+				{MACAddr: "00:00:00:00:ab"},
+				{MACAddr: "00:00:00:00:cd"},
+			},
+			expected: `
+instance-id: "test-vm"
+local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:00:00:00:ab"
+      set-name: "eth0"
+      wakeonlan: true
+      dhcp4: true
+      dhcp6: false
+    id1:
+      match:
+        macaddress: "00:00:00:00:cd"
+      set-name: "eth1"
+      wakeonlan: true
+      dhcp4: false
+      dhcp6: true
+`,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tc.machine.Name = tc.name
-			actVal, err := util.GetMachineMetadata("test-vm", *tc.machine)
+			actVal, err := util.GetMachineMetadata("test-vm", *tc.machine, tc.networkStatuses...)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds a check for the length of the network status before generating the metadata string

**Which issue(s) this PR fixes**:
Fixes #1155

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/hold