### PR TITLE
add keepalive roundtripper to vimClient

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"time"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
-
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -33,7 +31,9 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlsig "sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-vsphere/controllers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/version"
@@ -42,12 +42,14 @@ import (
 var (
 	setupLog = ctrllog.Log.WithName("entrypoint")
 
-	managerOpts             manager.Options
-	defaultProfilerAddr     = os.Getenv("PROFILER_ADDR")
-	defaultSyncPeriod       = manager.DefaultSyncPeriod
-	defaultLeaderElectionID = manager.DefaultLeaderElectionID
-	defaultPodName          = manager.DefaultPodName
-	defaultWebhookPort      = manager.DefaultWebhookServiceContainerPort
+	managerOpts              manager.Options
+	defaultProfilerAddr      = os.Getenv("PROFILER_ADDR")
+	defaultSyncPeriod        = manager.DefaultSyncPeriod
+	defaultLeaderElectionID  = manager.DefaultLeaderElectionID
+	defaultPodName           = manager.DefaultPodName
+	defaultWebhookPort       = manager.DefaultWebhookServiceContainerPort
+	defaultEnableKeepAlive   = constants.DefaultEnableKeepAlive
+	defaultKeepAliveDuration = constants.DefaultKeepAliveDuration
 )
 
 // nolint:gocognit
@@ -116,6 +118,15 @@ func main() {
 		"/etc/capv/credentials.yaml",
 		"path to CAPV's credentials file",
 	)
+	flag.BoolVar(&managerOpts.EnableKeepAlive,
+		"enable-keep-alive",
+		defaultEnableKeepAlive,
+		"feature to enable keep alive handler in vsphere sessions")
+
+	flag.DurationVar(&managerOpts.KeepAliveDuration,
+		"keep-alive-duration",
+		defaultKeepAliveDuration,
+		"idle time interval(minutes) in between send() requests in keepalive handler")
 
 	flag.Parse()
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -17,6 +17,8 @@ limitations under the License.
 package constants
 
 import (
+	"time"
+
 	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 )
 
@@ -48,4 +50,10 @@ const (
 	// MaintenanceAnnotationLabel is the annotation used to indicate a machine and/or
 	// cluster are in maintenance mode.
 	MaintenanceAnnotationLabel = "capv." + v1alpha3.GroupName + "/maintenance"
+
+	// DefaultEnableKeepAlive is false by default
+	DefaultEnableKeepAlive = false
+
+	// KeepaliveDuration unit minutes
+	DefaultKeepAliveDuration = time.Minute * 5
 )

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -19,6 +19,7 @@ package context
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,14 @@ type ControllerManagerContext struct {
 	// Password is the password for the account used to access remote vSphere
 	// endpoints.
 	Password string
+
+	// EnableKeepAlive is a session feature to enable keep alive handler
+	// for better load management on vSphere api server
+	EnableKeepAlive bool
+
+	// KeepAliveDuration is the idle time interval in between send() requests
+	// in keepalive handler
+	KeepAliveDuration time.Duration
 
 	genericEventCache sync.Map
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -92,6 +92,8 @@ func New(opts Options) (Manager, error) {
 		Scheme:                  opts.Scheme,
 		Username:                opts.Username,
 		Password:                opts.Password,
+		EnableKeepAlive:         opts.EnableKeepAlive,
+		KeepAliveDuration:       opts.KeepAliveDuration,
 	}
 
 	// Add the requested items to the manager.

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -47,6 +47,10 @@ type Options struct {
 	// LeaderElectionEnabled is a flag that enables leader election.
 	LeaderElectionEnabled bool
 
+	// EnableKeepAlive is a session feature to enable keep alive handler
+	// for better load management on vSphere api server
+	EnableKeepAlive bool
+
 	// LeaderElectionID is the name of the config map to use as the
 	// locking resource when configuring leader election.
 	LeaderElectionID string
@@ -97,6 +101,10 @@ type Options struct {
 	// Password is the password for the account used to access remote vSphere
 	// endpoints.
 	Password string
+
+	// KeepAliveDuration is the idle time interval in between send() requests
+	// in keepalive handler
+	KeepAliveDuration time.Duration
 
 	// WebhookPort is the port that the webhook server serves at.
 	WebhookPort int

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -47,9 +47,10 @@ func TestCreate(t *testing.T) {
 	vmContext.VSphereVM.Spec.Server = s.URL.Host
 
 	authSession, err := session.GetOrCreate(
-		vmContext,
-		vmContext.VSphereVM.Spec.Server, "",
-		s.URL.User.Username(), pass, "")
+		vmContext.Context,
+		session.NewParams().
+			WithServer(vmContext.VSphereVM.Spec.Server).
+			WithUserInfo(s.URL.User.Username(), pass))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -143,8 +143,9 @@ func initSimulator(t *testing.T) (*simulator.Model, *session.Session, *simulator
 
 	authSession, err := session.GetOrCreate(
 		ctx.TODO(),
-		server.URL.Host, "",
-		server.URL.User.Username(), pass, "")
+		session.NewParams().
+			WithServer(server.URL.Host).
+			WithUserInfo(server.URL.User.Username(), pass))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds session.Keepalive to vimclient 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Special notes for your reviewer**:
Ref PR https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1072 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```