### PR TITLE
fix image links from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Note: These OVAs are not updated for security fixes and it is recommended to alw
 
 | Kubernetes |                                                                                               CentOS 7                                                                                               |                                                                                                Ubuntu 18.04                                                                                                |                                                                                               Photon 3                                                                                                |
 | :--------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|  v1.17.16   |   [ova](http://storage.googleapis.com/capv-images/release/v1.17.16/centos-7-kube-v1.17.16.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.17.16/centos-7-kube-v1.17.16.ova.sha256)   |   [ova](http://storage.googleapis.com/capv-images/release/v1.17.16/ubuntu-1804-kube-v1.17.16.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.17.16/ubuntu-1804-kube-v1.17.16.ova.sha256)   | [ova](http://storage.googleapis.com/capv-images/release/v1.17.16/photon-3-kube-v1.17.16.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.17.16/photon-3-1804-kube-v1.17.16.ova.sha256) |
-|  v1.18.14  | [ova](http://storage.googleapis.com/capv-images/release/v1.18.14/centos-7-kube-v1.18.14.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.18.14/centos-7-kube-v1.18.14.ova.sha256) | [ova](http://storage.googleapis.com/capv-images/release/v1.18.14/ubuntu-1804-kube-v1.18.14.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.18.14/ubuntu-1804-kube-v1.18.14.ova.sha256) | [ova](http://storage.googleapis.com/capv-images/release/v1.18.14/photon-3-kube-v1.18.14.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.18.14/photon-3-kube-v1.18.14.ova.sha256)  |
-|  v1.19.6   |   [ova](http://storage.googleapis.com/capv-images/release/v1.19.6/centos-7-kube-v1.19.6.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.19.6/centos-7-kube-v1.19.6.ova.sha256)   |   [ova](http://storage.googleapis.com/capv-images/release/v1.19.6/ubuntu-1804-kube-v1.19.6.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.19.6/ubuntu-1804-kube-v1.19.6.ova.sha256)   |   [ova](http://storage.googleapis.com/capv-images/release/v1.19.6/photon-3-kube-v1.19.6.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.19.6/photon-3-kube-v1.19.6.ova.sha256)    |
-|  v1.20.1   |   [ova](http://storage.googleapis.com/capv-images/release/v1.20.1/centos-7-kube-v1.20.1.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.20.1/centos-7-kube-v1.20.1.ova.sha256)   |   [ova](http://storage.googleapis.com/capv-images/release/v1.20.1/ubuntu-1804-kube-v1.20.1.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.20.1/ubuntu-1804-kube-v1.20.1.ova.sha256)   |   [ova](http://storage.googleapis.com/capv-images/release/v1.20.1/photon-3-kube-v1.20.1.ova), [sha256](http://storage.googleapis.com/capv-images/release/v1.20.1/photon-3-kube-v1.20.1.ova.sha256)    |
+|  v1.17.16   |   [ova](https://storage.googleapis.com/capv-images/release/v1.17.16/centos-7-kube-v1.17.16.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.17.16/centos-7-kube-v1.17.16.ova.sha256)   |   [ova](https://storage.googleapis.com/capv-images/release/v1.17.16/ubuntu-1804-kube-v1.17.16.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.17.16/ubuntu-1804-kube-v1.17.16.ova.sha256)   | [ova](https://storage.googleapis.com/capv-images/release/v1.17.16/photon-3-kube-v1.17.16.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.17.16/photon-3-1804-kube-v1.17.16.ova.sha256) |
+|  v1.18.14  | [ova](https://storage.googleapis.com/capv-images/release/v1.18.14/centos-7-kube-v1.18.14.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.18.14/centos-7-kube-v1.18.14.ova.sha256) | [ova](https://storage.googleapis.com/capv-images/release/v1.18.14/ubuntu-1804-kube-v1.18.14.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.18.14/ubuntu-1804-kube-v1.18.14.ova.sha256) | [ova](https://storage.googleapis.com/capv-images/release/v1.18.14/photon-3-kube-v1.18.14.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.18.14/photon-3-kube-v1.18.14.ova.sha256)  |
+|  v1.19.6   |   [ova](https://storage.googleapis.com/capv-images/release/v1.19.6/centos-7-kube-v1.19.6.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.19.6/centos-7-kube-v1.19.6.ova.sha256)   |   [ova](https://storage.googleapis.com/capv-images/release/v1.19.6/ubuntu-1804-kube-v1.19.6.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.19.6/ubuntu-1804-kube-v1.19.6.ova.sha256)   |   [ova](https://storage.googleapis.com/capv-images/release/v1.19.6/photon-3-kube-v1.19.6.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.19.6/photon-3-kube-v1.19.6.ova.sha256)    |
+|  v1.20.1   |   [ova](https://storage.googleapis.com/capv-images/release/v1.20.1/centos-7-kube-v1.20.1.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.20.1/centos-7-kube-v1.20.1.ova.sha256)   |   [ova](https://storage.googleapis.com/capv-images/release/v1.20.1/ubuntu-1804-kube-v1.20.1.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.20.1/ubuntu-1804-kube-v1.20.1.ova.sha256)   |   [ova](https://storage.googleapis.com/capv-images/release/v1.20.1/photon-3-kube-v1.20.1.ova), [sha256](https://storage.googleapis.com/capv-images/release/v1.20.1/photon-3-kube-v1.20.1.ova.sha256)    |
 
 A full list of the published machine images for CAPV may be obtained with the following command:
 
@@ -66,7 +66,7 @@ gsutil ls gs://capv-images/release/*
 Or, to produce a list of URLs for the same image files (and their checksums), the following command may be used:
 
 ```shell
-gsutil ls gs://capv-images/release/*/*.{ova,sha256} | sed 's~^gs://~http://storage.googleapis.com/~'
+gsutil ls gs://capv-images/release/*/*.{ova,sha256} | sed 's~^gs://~https://storage.googleapis.com/~'
 ```
 
 ## HAProxy published OVAs
@@ -75,7 +75,7 @@ Note: These OVAs are not updated for security fixes and it is recommended to alw
 
 | HAProxy Dataplane API | Photon 3 |
 |:--------------------: | :------: |
-|  v1.2.4  |  [ova](http://storage.googleapis.com/capv-images/extra/haproxy/release/v1.2.4/photon-3-haproxy-v1.2.4.ova), [sha256](http://storage.googleapis.com/capv-images/extra/haproxy/release/v1.2.4/photon-3-haproxy-v1.2.4.ova.sha256)  |
+|  v1.2.4  |  [ova](https://storage.googleapis.com/capv-images/extra/haproxy/release/v1.2.4/photon-3-haproxy-v1.2.4.ova), [sha256](https://storage.googleapis.com/capv-images/extra/haproxy/release/v1.2.4/photon-3-haproxy-v1.2.4.ova.sha256)  |
 
 A full list of the published HAProxy images for CAPV may be obtained with the following command:
 
@@ -86,7 +86,7 @@ gsutil ls gs://capv-images/extra/haproxy/release/*
 Or, to produce a list of URLs for the same image files (and their checksums), the following command may be used:
 
 ```shell
-gsutil ls gs://capv-images/extra/haproxy/release/*/*.{ova,sha256} | sed 's~^gs://~http://storage.googleapis.com/~'
+gsutil ls gs://capv-images/extra/haproxy/release/*/*.{ova,sha256} | sed 's~^gs://~https://storage.googleapis.com/~'
 ```
 
 ## Documentation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The links to OVAs are broken because the point to http when they need to point to https

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @timothysc

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```