### PR TITLE
CSI Thumbprint Support and Version Bump

### DIFF
--- a/api/v1alpha3/cloudprovider_types.go
+++ b/api/v1alpha3/cloudprovider_types.go
@@ -80,6 +80,7 @@ type CPIStorageConfig struct {
 	MetadataSyncerImage string `json:"metadataSyncerImage,omitempty"`
 	LivenessProbeImage  string `json:"livenessProbeImage,omitempty"`
 	RegistrarImage      string `json:"registrarImage,omitempty"`
+	ResizerImage        string `json:"resizerImage,omitempty"`
 }
 
 // unmarshallableConfig is used to unmarshal the INI data using the gcfg

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -782,6 +782,7 @@ func autoConvert_v1alpha3_CPIStorageConfig_To_v1alpha4_CPIStorageConfig(in *CPIS
 	out.MetadataSyncerImage = in.MetadataSyncerImage
 	out.LivenessProbeImage = in.LivenessProbeImage
 	out.RegistrarImage = in.RegistrarImage
+	out.ResizerImage = in.ResizerImage
 	return nil
 }
 
@@ -798,6 +799,7 @@ func autoConvert_v1alpha4_CPIStorageConfig_To_v1alpha3_CPIStorageConfig(in *v1al
 	out.MetadataSyncerImage = in.MetadataSyncerImage
 	out.LivenessProbeImage = in.LivenessProbeImage
 	out.RegistrarImage = in.RegistrarImage
+	out.ResizerImage = in.ResizerImage
 	return nil
 }
 

--- a/api/v1alpha4/cloudprovider_types.go
+++ b/api/v1alpha4/cloudprovider_types.go
@@ -80,6 +80,7 @@ type CPIStorageConfig struct {
 	MetadataSyncerImage string `json:"metadataSyncerImage,omitempty"`
 	LivenessProbeImage  string `json:"livenessProbeImage,omitempty"`
 	RegistrarImage      string `json:"registrarImage,omitempty"`
+	ResizerImage        string `json:"resizerImage,omitempty"`
 }
 
 // unmarshallableConfig is used to unmarshal the INI data using the gcfg

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -167,6 +167,8 @@ spec:
                             type: string
                           registrarImage:
                             type: string
+                          resizerImage:
+                            type: string
                         type: object
                     type: object
                   virtualCenter:
@@ -518,6 +520,8 @@ spec:
                           provisionerImage:
                             type: string
                           registrarImage:
+                            type: string
+                          resizerImage:
                             type: string
                         type: object
                     type: object

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -629,7 +629,7 @@ func (r clusterReconciler) reconcileCloudProvider(ctx *context.ClusterContext) e
 	return nil
 }
 
-// nolint:gocognit
+// nolint:gocognit,gocyclo
 func (r clusterReconciler) reconcileStorageProvider(ctx *context.ClusterContext) error {
 	// if storage config is not defined, assume we don't want CSI installed
 	storageConfig := ctx.VSphereCluster.Spec.CloudProviderConfiguration.ProviderConfig.Storage
@@ -669,6 +669,10 @@ func (r clusterReconciler) reconcileStorageProvider(ctx *context.ClusterContext)
 
 	if storageConfig.RegistrarImage == "" {
 		storageConfig.RegistrarImage = cloudprovider.DefaultCSIRegistrarImage
+	}
+
+	if storageConfig.ResizerImage == "" {
+		storageConfig.ResizerImage = cloudprovider.DefaultCSIResizerImage
 	}
 
 	ctx.VSphereCluster.Spec.CloudProviderConfiguration.ProviderConfig.Storage = storageConfig

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -41,6 +41,7 @@ func createStorageConfig() *infrav1.CPIStorageConfig {
 		MetadataSyncerImage: cloudprovider.DefaultCSIMetadataSyncerImage,
 		LivenessProbeImage:  cloudprovider.DefaultCSILivenessProbeImage,
 		RegistrarImage:      cloudprovider.DefaultCSIRegistrarImage,
+		ResizerImage:        cloudprovider.DefaultCSIResizerImage,
 	}
 }
 func MultiNodeTemplateWithHAProxy() []runtime.Object {

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -157,6 +157,7 @@ func newVSphereCluster(lb *infrav1.HAProxyLoadBalancer) infrav1.VSphereCluster {
 						MetadataSyncerImage: cloudprovidersvc.DefaultCSIMetadataSyncerImage,
 						LivenessProbeImage:  cloudprovidersvc.DefaultCSILivenessProbeImage,
 						RegistrarImage:      cloudprovidersvc.DefaultCSIRegistrarImage,
+						ResizerImage:        cloudprovidersvc.DefaultCSIResizerImage,
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Currently, API spec for CSI Thumbprint does not get applied to CSIConfig

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1162

**Special notes for your reviewer**: N/A

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vsphereCluster.Spec.CloudProviderConfiguration.Global.Thumbprint now applies to CSIConfig ConfigMap object.
```