### PR TITLE
Fixes govc attach command

### DIFF
--- a/docs/proposal/20201103-failure-domain.md
+++ b/docs/proposal/20201103-failure-domain.md
@@ -399,30 +399,30 @@ the following changes are going to be introduced to vspheremachine_controller:
 
 ```shell
 #dcwest,az1
-govc tags.attach k8s-region k8s-region-west /dc-west/host/cluster-az1
-govc tags.attach k8s-zone k8s-zone-west-1 /dc-west/host/cluster-az1
+govc tags.attach -c k8s-region k8s-region-west /dc-west/host/cluster-az1
+govc tags.attach -c k8s-zone k8s-zone-west-1 /dc-west/host/cluster-az1
 
 #dcwest,az2
-govc tags.attach k8s-region k8s-region-west /dc-west/host/cluster-az2
-govc tags.attach k8s-zone k8s-zone-west-2 /dc-west/host/cluster-az2
+govc tags.attach -c k8s-region k8s-region-west /dc-west/host/cluster-az2
+govc tags.attach -c k8s-zone k8s-zone-west-2 /dc-west/host/cluster-az2
 
 #dceast,az1
-govc tags.attach k8s-region k8s-region-east /dc-east/host/cluster-az1
-govc tags.attach k8s-zone k8s-zone-east-1 /dc-east/host/cluster-az1
+govc tags.attach -c k8s-region k8s-region-east /dc-east/host/cluster-az1
+govc tags.attach -c k8s-zone k8s-zone-east-1 /dc-east/host/cluster-az1
 ```
 
 ##### Region -> Country , Zone -> DataCenter
 
 ```shell
 #dcwest
-govc tags.attach k8s-region k8s-region-us /dc-west
-govc tags.attach k8s-zone k8s-zone-us-west /dc-west
+govc tags.attach -c k8s-region k8s-region-us /dc-west
+govc tags.attach -c k8s-zone k8s-zone-us-west /dc-west
 #dceast
-govc tags.attach k8s-region k8s-region-us /dc-east
-govc tags.attach k8s-zone k8s-zone-us-east /dc-east
+govc tags.attach -c k8s-region k8s-region-us /dc-east
+govc tags.attach -c k8s-zone k8s-zone-us-east /dc-east
 #dceu
-govc tags.attach k8s-region k8s-region-eu /dc-eu
-govc tags.attach k8s-zone k8s-region-eu-all /dc-eu
+govc tags.attach -c k8s-region k8s-region-eu /dc-eu
+govc tags.attach -c k8s-zone k8s-region-eu-all /dc-eu
 ```
 
 ##### Region -> ComputeCluster, Zone -> HostGroup


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the missing category flag `-c` in the failure domain proposal.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```