### PR TITLE
Copy of PR1059 - move CPI over to CRS and refactor flavorgen

### DIFF
--- a/packaging/flavorgen/cmd/root.go
+++ b/packaging/flavorgen/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
 )
 
 const flavorFlag = "flavor"
@@ -52,11 +53,11 @@ func RunRoot(command *cobra.Command) error {
 	}
 	switch flavor {
 	case "multi-host":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithHAProxy())
+		util.PrintObjects(flavors.MultiNodeTemplateWithHAProxy())
 	case "vip":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithKubeVIP())
+		util.PrintObjects(flavors.MultiNodeTemplateWithKubeVIP())
 	case "external-loadbalancer":
-		flavors.PrintObjects(flavors.MultiNodeTemplateWithExternalLoadBalancer())
+		util.PrintObjects(flavors.MultiNodeTemplateWithExternalLoadBalancer())
 	default:
 		return errors.Errorf("invalid flavor")
 	}

--- a/packaging/flavorgen/flavors/crs/cpi.go
+++ b/packaging/flavorgen/flavors/crs/cpi.go
@@ -1,0 +1,125 @@
+package crs
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	cloudprovidersvc "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	addonsv1alpha4 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
+)
+
+// CreateCrsResourceObjectsCPI creates the api objects necessary for CSI to function. Also appends the resources to the CRS
+func CreateCrsResourceObjectsCPI(crs *addonsv1alpha4.ClusterResourceSet) []runtime.Object {
+	serviceAccount := cloudprovidersvc.CloudControllerManagerServiceAccount()
+	serviceAccount.TypeMeta = v1.TypeMeta{
+		Kind:       "ServiceAccount",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	serviceAccountSecret := newSecret(serviceAccount.Name, serviceAccount)
+	appendSecretToCrsResource(crs, serviceAccountSecret)
+
+	credentials := map[string]string{}
+	credentials[fmt.Sprintf("%s.username", env.VSphereServerVar)] = env.VSphereUsername
+	credentials[fmt.Sprintf("%s.password", env.VSphereServerVar)] = env.VSpherePassword
+	cpiSecret := cpiCredentials(credentials)
+	cpiSecretWrapper := newSecret(cpiSecret.Name, cpiSecret)
+	appendSecretToCrsResource(crs, cpiSecretWrapper)
+
+	cpiObjects := []runtime.Object{}
+	clusterRole := cloudprovider.CloudControllerManagerClusterRole()
+	clusterRole.TypeMeta = v1.TypeMeta{
+		Kind:       "ClusterRole",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, clusterRole)
+
+	clusterRoleBinding := cloudprovider.CloudControllerManagerClusterRoleBinding()
+	clusterRoleBinding.TypeMeta = v1.TypeMeta{
+		Kind:       "ClusterRoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, clusterRoleBinding)
+
+	cloudConfig, err := CPIConfigString()
+	if err != nil {
+		panic(errors.Errorf("invalid cloudConfig"))
+	}
+	// cloud config secret is wrapped in another secret so it could be injected via CRS
+	cloudConfigConfigMap := cloudprovidersvc.CloudControllerManagerConfigMap(cloudConfig)
+	cloudConfigConfigMap.TypeMeta = v1.TypeMeta{
+		Kind:       "ConfigMap",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cloudConfigConfigMap)
+
+	roleBinding := cloudprovider.CloudControllerManagerRoleBinding()
+	roleBinding.TypeMeta = v1.TypeMeta{
+		Kind:       "RoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, roleBinding)
+
+	cpiService := cloudprovider.CloudControllerManagerService()
+	cpiService.TypeMeta = v1.TypeMeta{
+		Kind:       "Service",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cpiService)
+
+	extraArgs := []string{
+		"--v=2",
+		"--cloud-provider=vsphere",
+		"--cloud-config=/etc/cloud/vsphere.conf",
+	}
+	cpiDaemonSet := cloudprovider.CloudControllerManagerDaemonSet(cloudprovider.DefaultCPIControllerImage, extraArgs)
+	cpiDaemonSet.TypeMeta = v1.TypeMeta{
+		Kind:       "DaemonSet",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	cpiObjects = append(cpiObjects, cpiDaemonSet)
+
+	manifestsCm := newConfigMapManifests("cpi-manifests", cpiObjects)
+	appendConfigMapToCrsResource(crs, manifestsCm)
+	// Define the kubeconfig secret for the target cluster.
+
+	return []runtime.Object{
+		serviceAccountSecret,
+		cpiSecretWrapper,
+		manifestsCm,
+	}
+}
+
+func CPIConfigString() (string, error) {
+	cpiConfig := newCPIConfig()
+
+	cpiConfigString, err := cpiConfig.MarshalINI()
+	if err != nil {
+		return "", err
+	}
+
+	return string(cpiConfigString), nil
+}
+
+func cpiCredentials(credentials map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceSystem,
+			Name:      "cloud-provider-vsphere-credentials",
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: credentials,
+	}
+}

--- a/packaging/flavorgen/flavors/crs/csi.go
+++ b/packaging/flavorgen/flavors/crs/csi.go
@@ -1,0 +1,125 @@
+package crs
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/cloudprovider"
+	addonsv1alpha4 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
+)
+
+// CreateCrsResourceObjectsCSI creates the api objects necessary for CSI to function. Also appends the resources to the CRS
+func CreateCrsResourceObjectsCSI(crs *addonsv1alpha4.ClusterResourceSet) []runtime.Object {
+	serviceAccount := cloudprovider.CSIControllerServiceAccount()
+	serviceAccount.TypeMeta = metav1.TypeMeta{
+		Kind:       "ServiceAccount",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	serviceAccountSecret := newSecret(serviceAccount.Name, serviceAccount)
+	appendSecretToCrsResource(crs, serviceAccountSecret)
+
+	clusterRole := cloudprovider.CSIControllerClusterRole()
+	clusterRole.TypeMeta = metav1.TypeMeta{
+		Kind:       "ClusterRole",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	clusterRoleConfigMap := newConfigMap(clusterRole.Name, clusterRole)
+	appendConfigMapToCrsResource(crs, clusterRoleConfigMap)
+
+	clusterRoleBinding := cloudprovider.CSIControllerClusterRoleBinding()
+	clusterRoleBinding.TypeMeta = metav1.TypeMeta{
+		Kind:       "ClusterRoleBinding",
+		APIVersion: rbac.SchemeGroupVersion.String(),
+	}
+	clusterRoleBindingConfigMap := newConfigMap(clusterRoleBinding.Name, clusterRoleBinding)
+	appendConfigMapToCrsResource(crs, clusterRoleBindingConfigMap)
+
+	cloudConfig, err := ConfigForCSI().MarshalINI()
+	if err != nil {
+		panic(errors.Errorf("invalid cloudConfig"))
+	}
+	// cloud config secret is wrapped in another secret so it could be injected via CRS
+	cloudConfigSecret := cloudprovider.CSICloudConfigSecret(string(cloudConfig))
+	cloudConfigSecret.TypeMeta = metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+	}
+	cloudConfigSecretWrapper := newSecret(cloudConfigSecret.Name, cloudConfigSecret)
+	appendSecretToCrsResource(crs, cloudConfigSecretWrapper)
+
+	csiDriver := cloudprovider.CSIDriver()
+	csiDriver.TypeMeta = metav1.TypeMeta{
+		Kind:       "CSIDriver",
+		APIVersion: storagev1.SchemeGroupVersion.String(),
+	}
+	csiDriverConfigMap := newConfigMap(csiDriver.Name, csiDriver)
+	appendConfigMapToCrsResource(crs, csiDriverConfigMap)
+
+	storageConfig := createStorageConfig()
+	daemonSet := cloudprovider.VSphereCSINodeDaemonSet(storageConfig)
+	daemonSet.TypeMeta = metav1.TypeMeta{
+		Kind:       "DaemonSet",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	daemonSetConfigMap := newConfigMap(daemonSet.Name, daemonSet)
+	appendConfigMapToCrsResource(crs, daemonSetConfigMap)
+
+	deployment := cloudprovider.CSIControllerDeployment(storageConfig)
+	deployment.TypeMeta = metav1.TypeMeta{
+		Kind:       "Deployment",
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+	}
+	deploymentConfigMap := newConfigMap(deployment.Name, deployment)
+	appendConfigMapToCrsResource(crs, deploymentConfigMap)
+
+	return []runtime.Object{
+		serviceAccountSecret,
+		clusterRoleConfigMap,
+		clusterRoleBindingConfigMap,
+		cloudConfigSecretWrapper,
+		csiDriverConfigMap,
+		daemonSetConfigMap,
+		deploymentConfigMap,
+	}
+}
+
+// create StorageConfig to be used by tkg template
+func createStorageConfig() *infrav1.CPIStorageConfig {
+	return &infrav1.CPIStorageConfig{
+		ControllerImage:     cloudprovider.DefaultCSIControllerImage,
+		NodeDriverImage:     cloudprovider.DefaultCSINodeDriverImage,
+		AttacherImage:       cloudprovider.DefaultCSIAttacherImage,
+		ProvisionerImage:    cloudprovider.DefaultCSIProvisionerImage,
+		MetadataSyncerImage: cloudprovider.DefaultCSIMetadataSyncerImage,
+		LivenessProbeImage:  cloudprovider.DefaultCSILivenessProbeImage,
+		RegistrarImage:      cloudprovider.DefaultCSIRegistrarImage,
+	}
+}
+
+// ConfigForCSI returns a cloudprovider.CPIConfig specific to the vSphere CSI driver until
+// it supports using Secrets for vCenter credentials
+func ConfigForCSI() *infrav1.CPIConfig {
+	config := &infrav1.CPIConfig{}
+
+	config.Global.ClusterID = fmt.Sprintf("%s/%s", env.NamespaceVar, env.ClusterNameVar)
+	config.Network.Name = env.VSphereNetworkVar
+
+	config.VCenter = map[string]infrav1.CPIVCenterConfig{
+		env.VSphereServerVar: {
+			Username:    env.VSphereUsername,
+			Password:    env.VSpherePassword,
+			Datacenters: env.VSphereDataCenterVar,
+		},
+	}
+
+	return config
+}

--- a/packaging/flavorgen/flavors/crs/util.go
+++ b/packaging/flavorgen/flavors/crs/util.go
@@ -1,0 +1,99 @@
+package crs
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/env"
+	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
+	addonsv1alpha4 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
+)
+
+func newSecret(name string, o runtime.Object) *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		StringData: map[string]string{
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
+		},
+		Type: addonsv1alpha4.ClusterResourceSetSecretType,
+	}
+}
+
+func appendSecretToCrsResource(crs *addonsv1alpha4.ClusterResourceSet, generatedSecret *v1.Secret) {
+	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha4.ResourceRef{
+		Name: generatedSecret.Name,
+		Kind: "Secret",
+	})
+}
+
+func newConfigMap(name string, o runtime.Object) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		Data: map[string]string{
+			"data": util.GenerateObjectYAML(o, []util.Replacement{}),
+		},
+	}
+}
+func newConfigMapManifests(name string, o []runtime.Object) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: env.NamespaceVar,
+		},
+		Data: map[string]string{
+			"data": util.GenerateManifestYaml(o),
+		},
+	}
+}
+
+func appendConfigMapToCrsResource(crs *addonsv1alpha4.ClusterResourceSet, generatedConfigMap *v1.ConfigMap) {
+	crs.Spec.Resources = append(crs.Spec.Resources, addonsv1alpha4.ResourceRef{
+		Name: generatedConfigMap.Name,
+		Kind: "ConfigMap",
+	})
+}
+
+func newCPIConfig() *infrav1.CPIConfig {
+	return &infrav1.CPIConfig{
+		Global: infrav1.CPIGlobalConfig{
+			SecretName:      "cloud-provider-vsphere-credentials",
+			SecretNamespace: metav1.NamespaceSystem,
+			Thumbprint:      env.VSphereThumbprint,
+		},
+		VCenter: map[string]infrav1.CPIVCenterConfig{
+			env.VSphereServerVar: {
+				Datacenters: env.VSphereDataCenterVar,
+				Thumbprint:  env.VSphereThumbprint,
+			},
+		},
+		Network: infrav1.CPINetworkConfig{
+			Name: env.VSphereNetworkVar,
+		},
+		Workspace: infrav1.CPIWorkspaceConfig{
+			Server:       env.VSphereServerVar,
+			Datacenter:   env.VSphereDataCenterVar,
+			Datastore:    env.VSphereDatastoreVar,
+			ResourcePool: env.VSphereResourcePoolVar,
+			Folder:       env.VSphereFolderVar,
+		},
+	}
+}

--- a/packaging/flavorgen/flavors/env/envsubts_consts.go
+++ b/packaging/flavorgen/flavors/env/envsubts_consts.go
@@ -1,0 +1,30 @@
+package env
+
+const (
+	ClusterNameVar               = "${CLUSTER_NAME}"
+	ControlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
+	DefaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
+	DefaultClusterCIDR           = "192.168.0.0/16"
+	DefaultDiskGiB               = 25
+	DefaultMemoryMiB             = 8192
+	DefaultNumCPUs               = 2
+	KubernetesVersionVar         = "${KUBERNETES_VERSION}"
+	MachineDeploymentNameSuffix  = "-md-0"
+	NamespaceVar                 = "${NAMESPACE}"
+	VSphereDataCenterVar         = "${VSPHERE_DATACENTER}"
+	VSphereThumbprint            = "${VSPHERE_TLS_THUMBPRINT}"
+	VSphereDatastoreVar          = "${VSPHERE_DATASTORE}"
+	VSphereFolderVar             = "${VSPHERE_FOLDER}"
+	VSphereHaproxyTemplateVar    = "${VSPHERE_HAPROXY_TEMPLATE}"
+	VSphereNetworkVar            = "${VSPHERE_NETWORK}"
+	VSphereResourcePoolVar       = "${VSPHERE_RESOURCE_POOL}"
+	VSphereServerVar             = "${VSPHERE_SERVER}"
+	VSphereSSHAuthorizedKeysVar  = "${VSPHERE_SSH_AUTHORIZED_KEY}"
+	VSphereStoragePolicyVar      = "${VSPHERE_STORAGE_POLICY}"
+	VSphereTemplateVar           = "${VSPHERE_TEMPLATE}"
+	WorkerMachineCountVar        = "${WORKER_MACHINE_COUNT}"
+	ControlPlaneEndpointVar      = "${CONTROL_PLANE_ENDPOINT_IP}"
+	VSphereUsername              = "${VSPHERE_USERNAME}"
+	VSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
+	ClusterResourceSetNameSuffix = "-crs-0"
+)

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
@@ -4,4 +4,4 @@ metadata:
   name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
   labels:
-    cni: "${CLUSTER_NAME}-crs-0"
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "cni-${CLUSTER_NAME}-crs-0"
+  name: "cni-${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha4
 kind: ClusterResourceSet
 metadata:
-  name:  "${CLUSTER_NAME}-crs-0"
+  name:  "${CLUSTER_NAME}-crs-cni"
 spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      cni: "${CLUSTER_NAME}-crs-0"
+      cni: "${CLUSTER_NAME}-crs-cni"
   resources:
-    - name: "cni-${CLUSTER_NAME}-crs-0"
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
       kind: ConfigMap


### PR DESCRIPTION
A rebased version of #1059 by @yastij 

This PR moves our templates to deploying the CPI through CRS and refactors flavorgen for better re-usability across its packages
- uses v1alpha4 types

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Release note**:
```release-note
NONE
```