### PR TITLE
remove the vspherecluster finalizer when the secret does not exist

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -253,6 +253,7 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 		err := ctx.Client.Get(ctx, secretKey, secret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
+				ctrlutil.RemoveFinalizer(ctx.VSphereCluster, infrav1.ClusterFinalizer)
 				return reconcile.Result{}, nil
 			}
 			return reconcile.Result{}, err


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR fixes a bug in multi-tenancy. When the secret is missing, the vspherecluster controller should continue and remove the finalizer from the deleting `VSphereCluster` to unblock deletion

**Which issue(s) this PR fixes** : Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
remove the vspherecluster finalizer when the secret does not exist
```