### PR TITLE
add checks for network validation on update in vSphereMachine #1192 of a3

### DIFF
--- a/api/v1alpha3/vspheremachine_webhook.go
+++ b/api/v1alpha3/vspheremachine_webhook.go
@@ -83,6 +83,16 @@ func (r *VSphereMachine) ValidateUpdate(old runtime.Object) error {
 	delete(oldVSphereMachineNetwork, "devices")
 	delete(newVSphereMachineNetwork, "devices")
 
+	// validate that IPAddrs in updaterequest are valid
+	spec := r.Spec
+	for i, device := range spec.Network.Devices {
+		for j, ip := range device.IPAddrs {
+			if _, _, err := net.ParseCIDR(ip); err != nil {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "network", fmt.Sprintf("devices[%d]", i), fmt.Sprintf("ipAddrs[%d]", j)), ip, "ip addresses should be in the CIDR format"))
+			}
+		}
+	}
+
 	if !reflect.DeepEqual(oldVSphereMachineSpec, newVSphereMachineSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
 	}

--- a/api/v1alpha3/vspheremachine_webhook_test.go
+++ b/api/v1alpha3/vspheremachine_webhook_test.go
@@ -46,6 +46,11 @@ func TestVSphereMachine_ValidateCreate(t *testing.T) {
 			wantErr:        true,
 		},
 		{
+			name:           "IPs are not valid IPs in CIDR format",
+			vsphereMachine: createVSphereMachine("foo.com", nil, "", []string{"<nil>/32", "192.168.0.644/33"}),
+			wantErr:        true,
+		},
+		{
 			name:           "successful VSphereMachine creation",
 			vsphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32", "192.168.0.3/32"}),
 			wantErr:        false,
@@ -85,6 +90,18 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
 			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}),
 			wantErr:           false,
+		},
+		{
+			name:              "updating non-existing IP with invalid ips can not be done",
+			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", nil),
+			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"<nil>/32", "192.168.0.10/33"}),
+			wantErr:           true,
+		},
+		{
+			name:              "updating existing IP with invalid ips can not be done",
+			oldVSphereMachine: createVSphereMachine("foo.com", nil, "", []string{"192.168.0.1/32"}),
+			vsphereMachine:    createVSphereMachine("foo.com", &someProviderID, "", []string{"<nil>/32", "192.168.0.10/33"}),
+			wantErr:           true,
 		},
 		{
 			name:              "updating server cannot be done",


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1192 into alpha 3
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

none
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate vSphereMachine Network assignment also upon update, not just on create

```