### PR TITLE
v1a4 switches disk move type to the default: moveAllDiskBackingsAndDisallowSharing…

### DIFF
--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -273,7 +273,7 @@ func getDiskLocators(disks object.VirtualDeviceList, datastoreRef types.ManagedO
 	for _, disk := range disks {
 		dl := types.VirtualMachineRelocateSpecDiskLocator{
 			DiskId:       disk.GetVirtualDevice().Key,
-			DiskMoveType: string(types.VirtualMachineRelocateDiskMoveOptionsMoveChildMostDiskBacking),
+			DiskMoveType: string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndDisallowSharing),
 			Datastore:    datastoreRef,
 		}
 


### PR DESCRIPTION
**Release note**:

```release-note
Fix bug with fullClone of a VM while expanding the disk size
```