### PR TITLE
vsphereclusteridentity returns early when secret isn't found

### DIFF
--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -118,6 +118,9 @@ const (
 	// SecretNotAvailableReason is used when the secret referenced by the VSphereClusterIdentity cannot be found
 	SecretNotAvailableReason = "SecretNotAvailable"
 
+	// SecretOwnerReferenceFailedReason is used for errors while updating the owner reference of the secret
+	SecretOwnerReferenceFailedReason = "SecretOwnerReferenceFailed"
+
 	// SecretAlreadyInUseReason is used when another VSphereClusterIdentity is using the secret
 	SecretAlreadyInUseReason = "SecretInUse"
 )

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -123,6 +123,7 @@ func (r clusterIdentityReconciler) Reconcile(req ctrl.Request) (_ reconcile.Resu
 	}
 	if err := r.Client.Get(r, secretKey, secret); err != nil {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretNotAvailableReason, clusterv1.ConditionSeverityWarning, err.Error())
+		return reconcile.Result{}, errors.Errorf("secret: %s not found in namespace: %s", secretKey.Name, secretKey.Namespace)
 	}
 
 	if !clusterutilv1.IsOwnedByObject(secret, identity) {
@@ -144,7 +145,7 @@ func (r clusterIdentityReconciler) Reconcile(req ctrl.Request) (_ reconcile.Resu
 		}
 		err = r.Client.Update(r, secret)
 		if err != nil {
-			conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretNotAvailableReason, clusterv1.ConditionSeverityWarning, err.Error())
+			conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretOwnerReferenceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 			return reconcile.Result{}, err
 		}
 	}

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -43,7 +43,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					Namespace:    controllerNamespace,
 				},
 			}
-			Expect(testEnv.Create(ctx, credentialSecret)).NotTo(HaveOccurred())
+			Expect(testEnv.Create(ctx, credentialSecret)).To(Succeed())
 
 			// create identity
 			identity := &infrav1.VSphereClusterIdentity{
@@ -54,7 +54,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					SecretName: credentialSecret.Name,
 				},
 			}
-			Expect(testEnv.Create(ctx, identity)).NotTo(HaveOccurred())
+			Expect(testEnv.Create(ctx, identity)).To(Succeed())
 
 			// wait for identity to set owner ref
 			skey := client.ObjectKey{
@@ -93,7 +93,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					},
 				},
 			}
-			Expect(testEnv.Create(ctx, credentialSecret)).NotTo(HaveOccurred())
+			Expect(testEnv.Create(ctx, credentialSecret)).To(Succeed())
 
 			// create identity
 			identity := &infrav1.VSphereClusterIdentity{
@@ -104,7 +104,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					SecretName: credentialSecret.Name,
 				},
 			}
-			Expect(testEnv.Create(ctx, identity)).NotTo(HaveOccurred())
+			Expect(testEnv.Create(ctx, identity)).To(Succeed())
 
 			Eventually(func() bool {
 				i := &infrav1.VSphereClusterIdentity{}
@@ -128,7 +128,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					SecretName: "non-existent-secret",
 				},
 			}
-			Expect(testEnv.Create(ctx, identity)).NotTo(HaveOccurred())
+			Expect(testEnv.Create(ctx, identity)).To(Succeed())
 
 			Eventually(func() bool {
 				i := &infrav1.VSphereClusterIdentity{}


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1200 


**Release note**:
```release-note
fixes issue with VSphereClusterIdentity attempting to update a secret when it's not found.
```