### PR TITLE
Add watch on cluster.status.infrastructureReady to reconcile vsphereMachine when cluster infrastructure is ready

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -34,14 +34,13 @@ import (
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -143,19 +142,7 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		err = c.Watch(
 			&source.Kind{Type: &clusterv1.Cluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.clusterToVSphereMachines),
-			predicate.Funcs{
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					oldCluster := e.ObjectOld.(*clusterv1.Cluster)
-					newCluster := e.ObjectNew.(*clusterv1.Cluster)
-					return oldCluster.Spec.Paused && !newCluster.Spec.Paused
-				},
-				CreateFunc: func(e event.CreateEvent) bool {
-					if _, ok := e.Object.GetAnnotations()[clusterv1.PausedAnnotation]; !ok {
-						return false
-					}
-					return true
-				},
-			})
+			predicates.ClusterUnpausedAndInfrastructureReady(r.Logger))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
After `clusterctl move` for self-managed CAPV clusters, worker machines take around 10-15 minutes to go to "Running" phase. 
It could be due to the following reasons:
1. During `clusterctl move`, the Status fields are removed. So none of the CAPI objects retain the status fields, including the Cluster object. Once the Cluster.Spec.Paused field is unset after move, controllers begin to reconcile and the status fields get set again.
2. The [capv vsphereMachine controller](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/controllers/vspheremachine_controller.go#L316) while reconciling the VsphereMachine object checks for the `Cluster.Status.InfrastructureReady` field before proceeding, which will be `false` immediately after the move until the cluster controller has reconciled & updated it.
3. The vsphereMachine controller gets the Cluster object at the start of every Reconcile, and it's possible that the CAPI cluster controller updates the Cluster object after it has already been picked up by the vsphereMachine controller. It's also possible that CAPV could be hitting [this bug](https://github.com/kubernetes-sigs/controller-runtime/issues/1464) where controller-runtime GET is reading stale data. And from the comments on that bug the recommended way is to keep retrying.
4. CAPV syncs with CAPI objects eventually after the sync period which is by default set to 10 minutes. Because of which, after around 10 minutes the vsphereMachine controller gets the latest copy of the Cluster object and reconciles VsphereMachine successfully because by then the Cluster.Status.InfrastructureReady field has been set to true.
5. So the solution is either reducing the sync period time so that CAPV gets the latest Cluster object sooner or requeuing VsphereMachine until Cluster.Status.InfrastructureReady is true. It is recommended to requeue the object instead of reducing the sync period in this case as per [these comments in the controller-runtime code](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.9.1/pkg/manager/manager.go#L108-L133).
4. This PR modifies the watch on Cluster object, to receive update events when cluster.status.infrastructureReady field becomes true. This way it enqueues the vsphereMachine for reconcilation once infrastructure is ready post clusterctl move

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1211

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```