### PR TITLE
Fix VSphereCluster VCenterAvailable condition

### DIFF
--- a/controllers/vspherecluster_controller_test.go
+++ b/controllers/vspherecluster_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/simulator"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,8 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
 )
 
 const (
@@ -49,11 +52,20 @@ var _ = Describe("ClusterReconciler", func() {
 
 	Context("Reconcile an VSphereCluster", func() {
 		It("should create a cluster", func() {
+			fakeVCenter := startVcenter()
+			vcURL := fakeVCenter.ServerURL()
+			defer fakeVCenter.Destroy()
+
 			// Create the secret containing the credentials
+			password, _ := vcURL.User.Password()
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "secret-",
 					Namespace:    "default",
+				},
+				Data: map[string][]byte{
+					identity.UsernameKey: []byte(vcURL.User.Username()),
+					identity.PasswordKey: []byte(password),
 				},
 			}
 			Expect(testEnv.Create(ctx, secret)).To(Succeed())
@@ -69,6 +81,7 @@ var _ = Describe("ClusterReconciler", func() {
 						Kind: infrav1.SecretKind,
 						Name: secret.Name,
 					},
+					Server: fmt.Sprintf("%s://%s", vcURL.Scheme, vcURL.Host),
 				},
 			}
 			Expect(testEnv.Create(ctx, instance)).To(Succeed())
@@ -128,6 +141,14 @@ var _ = Describe("ClusterReconciler", func() {
 					return false
 				}
 				return len(secret.OwnerReferences) > 0
+			}, timeout).Should(BeTrue())
+
+			By("setting the VSphereCluster's VCenterAvailableCondition to true")
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, key, instance); err != nil {
+					return false
+				}
+				return conditions.IsTrue(instance, infrav1.VCenterAvailableCondition)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -452,4 +473,16 @@ func deploymentZone(server, fdName string, cp, ready *bool) *infrav1.VSphereDepl
 		},
 		Status: infrav1.VSphereDeploymentZoneStatus{Ready: ready},
 	}
+}
+
+func startVcenter() *helpers.Simulator {
+	model := simulator.VPX()
+	model.Pool = 1
+
+	simr, err := helpers.VCSimBuilder().WithModel(model).Build()
+	if err != nil {
+		panic(fmt.Sprintf("unable to create simulator %s", err))
+	}
+
+	return simr
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We now check the connectivity regardless of whether
CloudProviderConfiguration is set on the spec.

That property has been deprecated and it is valuable to check this
connectivity early and surface this on the VSphereCluster status rather
than just on VSphereVMs.

This also fixes a bug where the status could be set to "False" if the
secret was not found and then never properly set to "True" once the secret
becomes present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1209

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```