### PR TITLE
Fix VSphereCluster VCenterAvailable condition

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -301,14 +301,12 @@ func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconci
 		return reconcile.Result{}, err
 	}
 
-	if cloudProviderConfigurationAvailable(ctx) {
-		if err := r.reconcileVCenterConnectivity(ctx); err != nil {
-			conditions.MarkFalse(ctx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
-			return reconcile.Result{}, errors.Wrapf(err,
-				"unexpected error while probing vcenter for %s", ctx)
-		}
-		conditions.MarkTrue(ctx.VSphereCluster, infrav1.VCenterAvailableCondition)
+	if err := r.reconcileVCenterConnectivity(ctx); err != nil {
+		conditions.MarkFalse(ctx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
+		return reconcile.Result{}, errors.Wrapf(err,
+			"unexpected error while probing vcenter for %s", ctx)
 	}
+	conditions.MarkTrue(ctx.VSphereCluster, infrav1.VCenterAvailableCondition)
 
 	// Reconcile the VSphereCluster's load balancer.
 	if ok, err := r.reconcileLoadBalancer(ctx); !ok {


### PR DESCRIPTION
We now check the connectivity regardless of whether CloudProviderConfiguration is set on the spec.

That property has been deprecated and it is valuable to check this connectivity early and surface this on the VSphereCluster status rather than just on VSphereVMs.

This also fixes a bug where the status could be set to "False" if the secret was not found and then never properly set to "True" once the secret becomes present.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This fixes #1209 for the `release-0.7` branch. 


**Special notes for your reviewer**:

This fix was originally proposed against the `master` branch via PR #1214. However, it was noted in that PR that  #1095 already includes a fix for this issue on master so that is likely to be merged instead, at which point #1214 may be closed or just slimmed down to add test coverage.

While `reconcileVCenterConnectivity` accesses the Datacenter value on the deprecated, (but still present) CloudProviderConfiguration spec property, we believe it is always initialized to an empty string and is so is safe to call unconditionally as [it calls](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/7e1a78f2035d64321604a45195572fdc5f72f637/pkg/session/session.go#L96) the [`DatacenterOrDefault` func](https://github.com/vmware/govmomi/blob/cfbe1d59b449be9b5378251bc6e52c65bc5e1cbd/find/finder.go#L394) which handles being called with an empty string.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VSphereCluster VCenterAvailable condition
```

cc @tylerschultz