### PR TITLE
Failure Domain: Fixes VM Placement on Hosts

### DIFF
--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -176,7 +176,7 @@ func (r vsphereDeploymentZoneReconciler) createAndAttachMetadata(ctx *context.VS
 		logger.V(4).Info("attaching tag to object")
 		err := obj.AttachTag(ctx, failureDomain.Name)
 		if err != nil {
-			logger.V(4).Error(err, "failed to find object", obj)
+			logger.V(4).Error(err, "failed to find object")
 			errList = append(errList, errors.Wrapf(err, "failed to attach tag"))
 		}
 	}

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -335,11 +335,6 @@ func (r machineReconciler) reconcileNormal(ctx *context.MachineContext) (reconci
 		return reconcile.Result{}, nil
 	}
 
-	// Propagating the failure domain name to the VSphereMachine object
-	if failureDomain := ctx.Machine.Spec.FailureDomain; failureDomain != nil {
-		ctx.VSphereMachine.Spec.FailureDomain = failureDomain
-	}
-
 	// TODO(akutz) Determine the version of vSphere.
 	vm, err := r.reconcileNormalPre7(ctx, vsphereVM)
 	if err != nil {
@@ -517,7 +512,7 @@ func (r machineReconciler) generateOverrideFunc(ctx *context.MachineContext) (fu
 
 		for index := range vsphereDeploymentZoneList.Items {
 			zone := vsphereDeploymentZoneList.Items[index]
-			if zone.Spec.FailureDomain == *ctx.Machine.Spec.FailureDomain {
+			if zone.Spec.FailureDomain == *failureDomainName {
 				overrideWithFailureDomainFunc = func(vm *infrav1.VSphereVM) {
 					vm.Spec.Server = zone.Spec.Server
 					vm.Spec.Datacenter = vsphereFailureDomain.Spec.Topology.Datacenter

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/pkg/services/govmomi/cluster/cluster_suite_test.go
+++ b/pkg/services/govmomi/cluster/cluster_suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/find"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
@@ -40,8 +39,4 @@ type testComputeClusterCtx struct {
 
 func (t testComputeClusterCtx) GetSession() *session.Session {
 	return &session.Session{Finder: t.finder}
-}
-
-func (t testComputeClusterCtx) GetLogger() logr.Logger {
-	return logr.DiscardLogger{}
 }

--- a/pkg/services/govmomi/cluster/rule.go
+++ b/pkg/services/govmomi/cluster/rule.go
@@ -50,9 +50,6 @@ func negate(input bool) bool {
 }
 
 func VerifyAffinityRule(ctx computeClusterContext, clusterName, hostGroupName, vmGroupName string) (Rule, error) {
-	logger := ctx.GetLogger().WithValues("compute cluster", clusterName, "VM Group", vmGroupName, "Host Group", hostGroupName)
-
-	logger.V(4).Info("listing affinity rules")
 	rules, err := listRules(ctx, clusterName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to list rules for compute cluster %s", clusterName)
@@ -62,7 +59,6 @@ func VerifyAffinityRule(ctx computeClusterContext, clusterName, hostGroupName, v
 		if vmHostRuleInfo, ok := rule.(*types.ClusterVmHostRuleInfo); ok {
 			if vmHostRuleInfo.AffineHostGroupName == hostGroupName &&
 				vmHostRuleInfo.VmGroupName == vmGroupName {
-				logger.V(4).Info("found matching VM Host affinity rule")
 				return vmHostAffinityRule{vmHostRuleInfo}, nil
 			}
 		}

--- a/pkg/services/govmomi/cluster/service.go
+++ b/pkg/services/govmomi/cluster/service.go
@@ -50,17 +50,3 @@ func ListHostsFromGroup(ctx context.Context, ccr *object.ClusterComputeResource,
 	}
 	return refs, nil
 }
-
-// TODO(srm09): Consider deferring the reconciliation of the task completion to a separate loop.
-func reconfigure(ctx context.Context, ccr *object.ClusterComputeResource, spec types.BaseComputeResourceConfigSpec) error {
-	reconfigureTask, err := ccr.Reconfigure(ctx, spec, true)
-	if err != nil {
-		return err
-	}
-
-	err = reconfigureTask.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/pkg/services/govmomi/cluster/service.go
+++ b/pkg/services/govmomi/cluster/service.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -30,8 +29,6 @@ type computeClusterContext interface {
 	context.Context
 
 	GetSession() *session.Session
-
-	GetLogger() logr.Logger
 }
 
 func ListHostsFromGroup(ctx context.Context, ccr *object.ClusterComputeResource, hostGroup string) ([]object.Reference, error) {

--- a/pkg/services/govmomi/cluster/vmgroup.go
+++ b/pkg/services/govmomi/cluster/vmgroup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func AddVMToGroup(ctx computeClusterContext, clusterName, vmGroupName, vm string) error {
+func AddVMToGroup(ctx computeClusterContext, clusterName, vmGroupName string, vmObj types.ManagedObjectReference) error {
 	ccr, err := ctx.GetSession().Finder.ClusterComputeResource(ctx, clusterName)
 	if err != nil {
 		return err
@@ -34,11 +34,7 @@ func AddVMToGroup(ctx computeClusterContext, clusterName, vmGroupName, vm string
 		return err
 	}
 
-	vmObj, err := ctx.GetSession().Finder.VirtualMachine(ctx, vm)
-	if err != nil {
-		return err
-	}
-	vms = append(vms, vmObj.Reference())
+	vms = append(vms, vmObj)
 
 	info := &types.ClusterVmGroup{
 		ClusterGroupInfo: types.ClusterGroupInfo{

--- a/pkg/services/govmomi/metadata/metadata.go
+++ b/pkg/services/govmomi/metadata/metadata.go
@@ -47,24 +47,34 @@ func getCategoryAssociableType(domainType infrav1.FailureDomainType) string {
 	}
 }
 
+// CreateCategory either creates a new vSphere category or updates the associable type for an existing category.
 func CreateCategory(ctx metadataContext, name string, failureDomainType infrav1.FailureDomainType) (string, error) {
 	logger := ctx.GetLogger().WithValues("category", name)
 	manager := ctx.GetSession().TagManager
 	category, err := manager.GetCategory(ctx, name)
 	if err != nil {
 		logger.V(4).Info("failed to find existing category, creating a new category")
-		id, err := manager.CreateCategory(ctx, &tags.Category{
-			Name:            name,
-			Description:     "CAPV generated category for Failure Domain support",
-			AssociableTypes: []string{getCategoryAssociableType(failureDomainType)},
-			Cardinality:     "MULTIPLE",
-		})
+		id, err := manager.CreateCategory(ctx, getCategoryObject(name, failureDomainType))
 		if err != nil {
 			return "", err
 		}
 		return id, nil
 	}
+	category.Patch(getCategoryObject(name, failureDomainType))
+	if err := manager.UpdateCategory(ctx, category); err != nil {
+		logger.V(4).Error(err, "failed to update existing category")
+		return "", err
+	}
 	return category.ID, nil
+}
+
+func getCategoryObject(name string, failureDomainType infrav1.FailureDomainType) *tags.Category {
+	return &tags.Category{
+		Name:            name,
+		Description:     "CAPV generated category for Failure Domain support",
+		AssociableTypes: []string{getCategoryAssociableType(failureDomainType)},
+		Cardinality:     "MULTIPLE",
+	}
 }
 
 func CreateTag(ctx metadataContext, name, categoryID string) error {

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -132,11 +132,11 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 		return vm, err
 	}
 
-	if ok, err := vms.reconcilePowerState(vmCtx); err != nil || !ok {
+	if err := vms.reconcileVMGroupInfo(vmCtx); err != nil {
 		return vm, err
 	}
 
-	if err := vms.reconcileVMGroupInfo(ctx); err != nil {
+	if ok, err := vms.reconcilePowerState(vmCtx); err != nil || !ok {
 		return vm, err
 	}
 
@@ -490,14 +490,13 @@ func (vms *VMService) getBootstrapData(ctx *context.VMContext) ([]byte, error) {
 	return value, nil
 }
 
-func (vms *VMService) reconcileVMGroupInfo(ctx *context.VMContext) error {
+func (vms *VMService) reconcileVMGroupInfo(ctx *virtualMachineContext) error {
 	if ctx.VSphereFailureDomain != nil {
-		topology := ctx.VSphereFailureDomain.Spec.Topology
-		if topology.Hosts != nil {
+		if topology := ctx.VSphereFailureDomain.Spec.Topology; topology.Hosts != nil {
 			return cluster.AddVMToGroup(ctx,
 				*topology.ComputeCluster,
 				topology.Hosts.VMGroupName,
-				ctx.VSphereVM.Name)
+				ctx.Ref)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes a couple of bugs in the failure domain implementation:
1. VSphere DRS enforces host placement according to affinity rules before powering on the VM. Since the VM was being added after being powered on, the host placement wasn't being enforced. Add the VM to the VM group before powering it on, makes sure that the placement constraint is enforced.
2. Instead of re-creating the same category with a new associable type (which is not supported by Vsphere), we are now patching the category to update the associable type for a category.
3. Updating the failure domain on the VSphereMachine is not allowed, hence removed it.

**Which issue(s) this PR fixes**:
Fixes #1217 

**Special notes for your reviewer**:
None

**Release note**:
```release-note
Fixes VM placement issues in Failure Domain implementation
```