### PR TITLE
Add TLS thumbprint to the CAPV cluster template

### DIFF
--- a/packaging/flavorgen/flavors/crs/csi.go
+++ b/packaging/flavorgen/flavors/crs/csi.go
@@ -111,6 +111,7 @@ func ConfigForCSI() *infrav1.CPIConfig {
 	config := &infrav1.CPIConfig{}
 
 	config.Global.ClusterID = fmt.Sprintf("%s/%s", env.NamespaceVar, env.ClusterNameVar)
+	config.Global.Thumbprint = env.VSphereThumbprint
 	config.Network.Name = env.VSphereNetworkVar
 
 	config.VCenter = map[string]infrav1.CPIVCenterConfig{

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -637,6 +637,7 @@ func ConfigForCSI(vsphereCluster infrav1.VSphereCluster, cluster clusterv1.Clust
 
 	config.Global.ClusterID = fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)
 	config.Global.Insecure = vsphereCluster.Spec.CloudProviderConfiguration.Global.Insecure
+	config.Global.Thumbprint = vsphereCluster.Spec.CloudProviderConfiguration.Global.Thumbprint
 	config.Network.Name = vsphereCluster.Spec.CloudProviderConfiguration.Network.Name
 
 	config.VCenter = map[string]infrav1.CPIVCenterConfig{}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds the tls thumprint to the vsphere-csi.conf, fixing x509 error in the provisionned vsphere-csi-controller pod

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1162 