### PR TITLE
Update OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-cluster-lifecycle-leads
   - cluster-api-admins
-  - cluster-api-vsphere-maintainers
   - cluster-api-maintainers
+  - cluster-api-vsphere-maintainers
+  - sig-cluster-lifecycle-leads
 
 reviewers:
   - cluster-api-vsphere-maintainers
-  - cluster-api-maintainers
-
-emeritus_maintainers:
-  - ncdc
+  - cluster-api-vsphere-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,25 +2,29 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
   cluster-api-admins:
-    - detiber
-    - justinsb
-    - davidewatson
+    - CecileRobertMichon
     - vincepri
   cluster-api-maintainers:
-    - justinsb
-    - detiber
+    - CecileRobertMichon
+    - fabriziopandini
     - vincepri
-    - chuckha
   cluster-api-vsphere-maintainers:
     - frapposelli
-    - yastij
+    - gab-satchi
     - randomvariable
+    - srm09
+    - yastij
+  cluster-api-vsphere-reviewers:
+    - maxrink
+    - vrabbi
   cluster-api-vsphere-emeritus-maintainers:
-    - sidharthsurana
-    - figo
     - akutz
     - andrewsykim
+    - figo
+    - frapposelli
+    - ncdc
+    - sidharthsurana


### PR DESCRIPTION
Updating the OWNERS file, and making the following proposals in the process:

* @MaxRink and @vrabbi to become reviewers
* @gab-satchi and @srm09 to become co-maintainers
* @frapposelli to move to emeritus (thanks for all the contributions!)

and then some cleanup, which is mostly making the list of Cluster API maintainers and SIG Cluster Lifecycle leads up to date.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/hold

for consensus