### PR TITLE
📖add details about VSPHERE_STORAGE_POLICY to doc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -120,6 +120,8 @@ VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."              # The public ssh a
                                                               #   in this cluster.
                                                               #   Set to "" if you don't want to enable SSH,
                                                               #   or are using another solution.
+VSPHERE_STORAGE_POLICY: ""                                    # This is the vSphere storage policy.
+                                                              #  Set it to "" if you don't want to use a storage policy.
 ```
 
 If you are using the **DEPRECATED** `haproxy` flavour you will need to add the following variable to your `clusterctl.yaml`:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This change adds documents the `VSPHERE_STORAGE_POLICY` variable that needs to be explicitly set in `clusterctl.yaml`. 

**Which issue(s) this PR fixes**
Fixes #1183 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```