### PR TITLE
Support multiple disks on OVA for full clone mode

### DIFF
--- a/apis/v1alpha3/vspheremachine_conversion.go
+++ b/apis/v1alpha3/vspheremachine_conversion.go
@@ -37,6 +37,7 @@ func (src *VSphereMachine) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
+	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
 	dst.Spec.TagIDs = restored.Spec.TagIDs
 
 	return nil

--- a/apis/v1alpha3/vspheremachinetemplate_conversion.go
+++ b/apis/v1alpha3/vspheremachinetemplate_conversion.go
@@ -40,6 +40,7 @@ func (src *VSphereMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.Template.Spec.TagIDs = restored.Spec.Template.Spec.TagIDs
+	dst.Spec.Template.Spec.AdditionalDisksGiB = restored.Spec.Template.Spec.AdditionalDisksGiB
 
 	return nil
 }

--- a/apis/v1alpha3/vspherevm_conversion.go
+++ b/apis/v1alpha3/vspherevm_conversion.go
@@ -37,6 +37,7 @@ func (src *VSphereVM) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.TagIDs = restored.Spec.TagIDs
+	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
 
 	return nil
 }

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1675,6 +1675,7 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha3_VirtualMachineClone
 	out.NumCoresPerSocket = in.NumCoresPerSocket
 	out.MemoryMiB = in.MemoryMiB
 	out.DiskGiB = in.DiskGiB
+	// WARNING: in.AdditionalDisksGiB requires manual conversion: does not exist in peer-type
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	return nil

--- a/apis/v1alpha4/vspheremachine_conversion.go
+++ b/apis/v1alpha4/vspheremachine_conversion.go
@@ -37,6 +37,7 @@ func (src *VSphereMachine) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
+	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
 	dst.Spec.TagIDs = restored.Spec.TagIDs
 
 	return nil

--- a/apis/v1alpha4/vspheremachinetemplate_conversion.go
+++ b/apis/v1alpha4/vspheremachinetemplate_conversion.go
@@ -40,6 +40,7 @@ func (src *VSphereMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.Template.Spec.TagIDs = restored.Spec.Template.Spec.TagIDs
+	dst.Spec.Template.Spec.AdditionalDisksGiB = restored.Spec.Template.Spec.AdditionalDisksGiB
 
 	return nil
 }

--- a/apis/v1alpha4/vspherevm_conversion.go
+++ b/apis/v1alpha4/vspherevm_conversion.go
@@ -37,6 +37,7 @@ func (src *VSphereVM) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.TagIDs = restored.Spec.TagIDs
+	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
 
 	return nil
 }

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1793,6 +1793,7 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha4_VirtualMachineClone
 	out.NumCoresPerSocket = in.NumCoresPerSocket
 	out.MemoryMiB = in.MemoryMiB
 	out.DiskGiB = in.DiskGiB
+	// WARNING: in.AdditionalDisksGiB requires manual conversion: does not exist in peer-type
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	return nil

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -138,6 +138,11 @@ type VirtualMachineCloneSpec struct {
 	// virtual machine is cloned.
 	// +optional
 	DiskGiB int32 `json:"diskGiB,omitempty"`
+	// AdditionalDisksGiB holds the sizes of additional disks of the virtual machine, in GiB
+	// Defaults to the eponymous property value in the template from which the
+	// virtual machine is cloned.
+	// +optional
+	AdditionalDisksGiB []int32 `json:"additionalDisksGiB,omitempty"`
 	// CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
 	// Defaults to empty map
 	// +optional

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -1154,6 +1154,11 @@ func (in *VirtualMachine) DeepCopy() *VirtualMachine {
 func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 	*out = *in
 	in.Network.DeepCopyInto(&out.Network)
+	if in.AdditionalDisksGiB != nil {
+		in, out := &in.AdditionalDisksGiB, &out.AdditionalDisksGiB
+		*out = make([]int32, len(*in))
+		copy(*out, *in)
+	}
 	if in.CustomVMXKeys != nil {
 		in, out := &in.CustomVMXKeys, &out.CustomVMXKeys
 		*out = make(map[string]string, len(*in))

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -838,6 +838,14 @@ spec:
           spec:
             description: VSphereMachineSpec defines the desired state of VSphereMachine
             properties:
+              additionalDisksGiB:
+                description: AdditionalDisksGiB holds the sizes of additional disks
+                  of the virtual machine, in GiB Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                items:
+                  format: int32
+                  type: integer
+                type: array
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -729,6 +729,15 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
+                      additionalDisksGiB:
+                        description: AdditionalDisksGiB holds the sizes of additional
+                          disks of the virtual machine, in GiB Defaults to the eponymous
+                          property value in the template from which the virtual machine
+                          is cloned.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
                       cloneMode:
                         description: CloneMode specifies the type of clone operation.
                           The LinkedClone mode is only support for templates that

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -856,6 +856,14 @@ spec:
           spec:
             description: VSphereVMSpec defines the desired state of VSphereVM.
             properties:
+              additionalDisksGiB:
+                description: AdditionalDisksGiB holds the sizes of additional disks
+                  of the virtual machine, in GiB Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                items:
+                  format: int32
+                  type: integer
+                type: array
               biosUUID:
                 description: BiosUUID is the the VM's BIOS UUID that is assigned at
                   runtime after the VM has been created. This field is required at


### PR DESCRIPTION
**What this PR does / why we need it**:
The VirtualMachineCloneSpec only allow 1 disk on the vm when cloning. This restricts using certain OSes that ship with more than 1 disk by default, like Bottlerocket or Ceph. This change to spec allows to specify more than 1 disk and its sizes, so that capv can clone and create multi-disk vms.
* Adds API changes to specify more than 1 disk on the `VirtualMachineCloneSpec`. 
* New field `AdditionalDisksGiB` is an array of type `int32` to represent additional disks on the vm

CAPV will ignore any additionalDisks specified on spec, but not part of template. That is, CAPV will not spin up any additional disks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1196 
Fixes #1166 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._
Does not change any image versions.

**Release note**:
```release-note
Added AdditionalDisksGiB field to VirtualMachineCloneSpec. 
```