### PR TITLE
🐛 add vsphereStoragePolicy to stringVars slice

### DIFF
--- a/packaging/flavorgen/flavors/util/helpers.go
+++ b/packaging/flavorgen/flavors/util/helpers.go
@@ -72,6 +72,7 @@ var (
 		regexVar(env.VSphereServerVar),
 		regexVar(env.VSphereTemplateVar),
 		regexVar(env.VSphereHaproxyTemplateVar),
+		regexVar(env.VSphereStoragePolicyVar),
 	}
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds the `VSphereStoragePolicy` field from `VSphereMachineTemplate` to the `stringVars` slice. This enables the flavorgen workflow to add `""` around the `VSPHERE_STORAGE_POLICY` which in turn enables `viper`(used by clusterctl to replace env varaibles) to recognize `""` as strings and not `null`.

**Which issue(s) this PR fixes**:
Fixes #1244 

**Special notes for your reviewer**:
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```