### PR TITLE
add missing printcolumn to v1alpha3 `VSphereMachine` and `VSphereCluster`

### DIFF
--- a/api/v1alpha3/vspherecluster_types.go
+++ b/api/v1alpha3/vspherecluster_types.go
@@ -85,6 +85,9 @@ type VSphereClusterStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=vsphereclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
+// +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint"
+// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint[0]",description="API Endpoint",priority=1
 
 // VSphereCluster is the Schema for the vsphereclusters API
 type VSphereCluster struct {

--- a/api/v1alpha3/vspheremachine_types.go
+++ b/api/v1alpha3/vspheremachine_types.go
@@ -103,6 +103,10 @@ type VSphereMachineStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=vspheremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this VSphereMachine belongs"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="VSphereMachine instance ID"
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns this VSphereMachine",priority=1
 
 // VSphereMachine is the Schema for the vspheremachines API
 type VSphereMachine struct {

--- a/api/v1alpha4/vspherecluster_types.go
+++ b/api/v1alpha4/vspherecluster_types.go
@@ -65,7 +65,7 @@ type VSphereClusterStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
-// +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint."
+// +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint"
 // +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint[0]",description="API Endpoint",priority=1
 
 // VSphereCluster is the Schema for the vsphereclusters API

--- a/api/v1alpha4/vspheremachine_types.go
+++ b/api/v1alpha4/vspheremachine_types.go
@@ -107,7 +107,7 @@ type VSphereMachineStatus struct {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this VSphereMachine belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="VSphereMachine instance ID"
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this VSphereMachine",priority=1
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns this VSphereMachine",priority=1
 
 // VSphereMachine is the Schema for the vspheremachines API
 type VSphereMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -18,7 +18,21 @@ spec:
     singular: vspherecluster
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready for VSphereMachine
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Server is the address of the vSphere endpoint
+      jsonPath: .spec.server
+      name: Server
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint[0]
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         description: VSphereCluster is the Schema for the vsphereclusters API
@@ -394,7 +408,7 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: string
-    - description: Server is the address of the vSphere endpoint.
+    - description: Server is the address of the vSphere endpoint
       jsonPath: .spec.server
       name: Server
       type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -18,7 +18,25 @@ spec:
     singular: vspheremachine
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - additionalPrinterColumns:
+    - description: Cluster to which this VSphereMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: VSphereMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns this VSphereMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         description: VSphereMachine is the Schema for the vspheremachines API
@@ -404,7 +422,7 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
-    - description: Machine object which owns with this VSphereMachine
+    - description: Machine object which owns this VSphereMachine
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       priority: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds printcolumn to the v1alpha3 `VSphereCluster` and `VSphereMachine` for better UX. The print column fields are the same as those being used in v1alpha4. 

**Which issue(s) this PR fixes**:
Fixes #1259 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```