### PR TITLE
add label and manager-name to tilt-provider.json

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -10,6 +10,8 @@
       "contrib",
       "controllers",
       "pkg"
-    ]
+    ],
+    "label": "CAPV",
+    "manager-name": "capv-controller-manager"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `CAPV` as a label and `capv-controller-manager` as the `manager-name` to the `tilt-provider.json` config so they are shown properly with the CAPI Tiltfile.

![image](https://user-images.githubusercontent.com/1710904/138903120-5809a622-d36e-490d-a2c7-9b8364af6deb.png)
