### PR TITLE
fix aggressive reconciliation on task failures

### DIFF
--- a/api/v1alpha3/vspherevm_types.go
+++ b/api/v1alpha3/vspherevm_types.go
@@ -74,6 +74,10 @@ type VSphereVMStatus struct {
 	// +optional
 	Snapshot string `json:"snapshot,omitempty"`
 
+	// RetryAfter tracks the time we can retry queueing a task
+	// +optional
+	RetryAfter metav1.Time `json:"retryAfter,omitempty"`
+
 	// TaskRef is a managed object reference to a Task related to the machine.
 	// This value is set automatically at runtime and should not be set or
 	// modified by users.

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -1267,6 +1267,7 @@ func (in *VSphereVMStatus) DeepCopyInto(out *VSphereVMStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	in.RetryAfter.DeepCopyInto(&out.RetryAfter)
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network
 		*out = make([]NetworkStatus, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -407,6 +407,10 @@ spec:
                   field is required at runtime for other controllers that read this
                   CRD as unstructured data.
                 type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
               snapshot:
                 description: Snapshot is the name of the snapshot from which the VM
                   was cloned if LinkedMode is enabled.

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -23,12 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -224,74 +221,6 @@ func (r vmReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) 
 			vmContext.Logger.Error(err, "patch failed", "vm", vmContext.String())
 		}
 
-		// localObj is a deep copy of the VSphereVM resource that was
-		// fetched at the top of this Reconcile function.
-		localObj := vmContext.VSphereVM.DeepCopy()
-
-		// Fetch the up-to-date VSphereVM resource into remoteObj until the
-		// fetched resource has a a different ResourceVersion than the local
-		// object.
-		//
-		// FYI - resource versions are opaque, numeric strings and should not
-		// be compared with < or >, only for equality -
-		// https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions.
-		//
-		// Since CAPV is currently deployed with a single replica, and this
-		// controller has a max concurrency of one, the only agent updating the
-		// VSphereVM resource should be this controller.
-		//
-		// So if the remote resource's ResourceVersion is different than the
-		// ResourceVersion of the resource fetched at the beginning of this
-		// reconcile request, then that means the remote resource should be
-		// newer than the local resource.
-		// nolint:errcheck
-		wait.PollImmediateInfinite(time.Second*1, func() (bool, error) {
-			// remoteObj references the same VSphereVM resource as it exists
-			// on the API server post the patch operation above. In a perfect world,
-			// the Status for localObj and remoteObj should be the same.
-			remoteObj := &infrav1.VSphereVM{}
-			if err := vmContext.Client.Get(vmContext, req.NamespacedName, remoteObj); err != nil {
-				if apierrors.IsNotFound(err) {
-					// It's possible that the remote resource cannot be found
-					// because it has been removed. Do not error, just exit.
-					return true, nil
-				}
-
-				// There was an issue getting the remote resource. Sleep for a
-				// second and try again.
-				vmContext.Logger.Error(err, "failed to get VSphereVM while exiting reconcile")
-				return false, nil
-			}
-			// If the remote resource version is not the same as the local
-			// resource version, then it means we were able to get a resource
-			// newer than the one we already had.
-			if localObj.ResourceVersion != remoteObj.ResourceVersion {
-				vmContext.Logger.Info(
-					"resource is patched",
-					"local-resource-version", localObj.ResourceVersion,
-					"remote-resource-version", remoteObj.ResourceVersion)
-				return true, nil
-			}
-
-			// If the resources are the same resource version, then a previous
-			// patch may not have resulted in any changes. Check to see if the
-			// remote status is the same as the local status.
-			if cmp.Equal(localObj.Status, remoteObj.Status, cmpopts.EquateEmpty()) {
-				vmContext.Logger.Info(
-					"resource patch was not required",
-					"local-resource-version", localObj.ResourceVersion,
-					"remote-resource-version", remoteObj.ResourceVersion)
-				return true, nil
-			}
-
-			// The remote resource version is the same as the local resource
-			// version, which means the local cache is not yet up-to-date.
-			vmContext.Logger.Info(
-				"resource is not patched",
-				"local-resource-version", localObj.ResourceVersion,
-				"remote-resource-version", remoteObj.ResourceVersion)
-			return false, nil
-		})
 	}()
 
 	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, vsphereVM.ObjectMeta)

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -19,12 +19,15 @@ package govmomi
 import (
 	gonet "net"
 	"path"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -122,6 +125,12 @@ func reconcileInFlightTask(ctx *context.VMContext) (bool, error) {
 		return false, nil
 	}
 
+	// Since RetryAfter is set, the last task failed. Wait for the RetryAfter time duration to expire
+	// before checking/resetting the task.
+	if !ctx.VSphereVM.Status.RetryAfter.IsZero() && time.Now().Before(ctx.VSphereVM.Status.RetryAfter.Time) {
+		return false, errors.Errorf("last task failed retry after %v", ctx.VSphereVM.Status.RetryAfter)
+	}
+
 	// Otherwise the course of action is determined by the state of the task.
 	logger := ctx.Logger.WithName(task.Reference().Value)
 	logger.Info("task found", "state", task.Info.State, "description-id", task.Info.DescriptionId)
@@ -147,8 +156,16 @@ func reconcileInFlightTask(ctx *context.VMContext) (bool, error) {
 			description = task.Info.Description.Message
 		}
 		conditions.MarkFalse(ctx.VSphereVM, infrav1.VMProvisionedCondition, infrav1.TaskFailure, clusterv1.ConditionSeverityInfo, description)
-		ctx.VSphereVM.Status.TaskRef = ""
-		return false, nil
+
+		// Instead of directly requeuing the failed task, wait for the RetryAfter duration to pass
+		// before resetting the taskRef from the VSphereVM status.
+		if ctx.VSphereVM.Status.RetryAfter.IsZero() {
+			ctx.VSphereVM.Status.RetryAfter = metav1.Time{Time: time.Now().Add(1 * time.Minute)}
+		} else {
+			ctx.VSphereVM.Status.TaskRef = ""
+			ctx.VSphereVM.Status.RetryAfter = metav1.Time{}
+		}
+		return true, nil
 	default:
 		return false, errors.Errorf("unknown task state %q for %q", task.Info.State, ctx)
 	}
@@ -233,6 +250,12 @@ func reconcileVSphereVMOnTaskCompletion(ctx *context.VMContext) {
 		// failed, *not* if the task itself failed.
 		if err != nil && taskInfo == nil {
 			return nil, err
+		}
+		// do not queue in the event channel when task fails as we don't
+		// want to retry right away
+		if taskInfo.State == types.TaskInfoStateError {
+			ctx.Logger.Info("async task wait failed")
+			return nil, errors.Errorf("task failed")
 		}
 
 		return []interface{}{


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR fixes issues where reconciliation is being aggressive when a task fails consistently (e.g. a host is being disconnected) 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/assign @gab-satchi @srm09 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note

```