### PR TITLE
remove manager_name in tilt-provider.json

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -11,7 +11,6 @@
       "controllers",
       "pkg"
     ],
-    "label": "CAPV",
-    "manager-name": "capv-controller-manager"
+    "label": "CAPV"
   }
 }


### PR DESCRIPTION
Yesterday CAPI made the `manager_name` field obsolete by analysing manifests. So we can remove it again, especially since I misspelled it anyway.