### PR TITLE
Replace ioutil with io and os

### DIFF
--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -111,7 +110,7 @@ func (o *Options) defaults() {
 
 	if ns, ok := os.LookupEnv("POD_NAMESPACE"); ok {
 		o.PodNamespace = ns
-	} else if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	} else if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			o.PodNamespace = ns
 		}
@@ -121,7 +120,7 @@ func (o *Options) defaults() {
 }
 
 func (o *Options) getCredentials() map[string]string {
-	file, err := ioutil.ReadFile(o.CredentialsFile)
+	file, err := os.ReadFile(o.CredentialsFile)
 	if err != nil {
 		o.Logger.Error(err, "error opening credentials file")
 		return map[string]string{}

--- a/pkg/manager/options_test.go
+++ b/pkg/manager/options_test.go
@@ -18,7 +18,6 @@ package manager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -58,7 +57,7 @@ password: '%s'
 		// for linting reasons
 		test := tt
 		content := fmt.Sprintf(contentFmt, tt.username, tt.password)
-		tmpFile, err := ioutil.TempFile("", "creds")
+		tmpFile, err := os.CreateTemp("", "creds")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,5 +149,5 @@ func readPrivateKey() ([]byte, error) {
 		return nil, errors.Errorf("private key information missing. Please set %s environment variable", VSpherePrivateKeyFilePath)
 	}
 
-	return ioutil.ReadFile(privateKeyFilePath)
+	return os.ReadFile(privateKeyFilePath)
 }

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -20,7 +20,6 @@ import (
 	goctx "context"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -240,7 +239,7 @@ func (t *TestEnvironment) CreateKubeconfigSecret(ctx goctx.Context, cluster *clu
 }
 
 func getFilePathToCAPICRDs(root string) string {
-	modBits, err := ioutil.ReadFile(filepath.Join(root, "go.mod"))
+	modBits, err := os.ReadFile(filepath.Join(root, "go.mod"))
 	if err != nil {
 		return ""
 	}

--- a/test/helpers/webhook.go
+++ b/test/helpers/webhook.go
@@ -17,8 +17,8 @@ limitations under the License.
 package helpers
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"path/filepath"
 	goruntime "runtime"
@@ -82,7 +82,7 @@ func initializeWebhookInEnvironment() {
 	// Get the root of the current file to use in CRD paths.
 	_, filename, _, _ := goruntime.Caller(0) //nolint
 	root := path.Join(path.Dir(filename), "..", "..")
-	configyamlFile, err := ioutil.ReadFile(filepath.Join(root, "config", "webhook", "manifests.yaml"))
+	configyamlFile, err := os.ReadFile(filepath.Join(root, "config", "webhook", "manifests.yaml"))
 	if err != nil {
 		klog.Fatalf("Failed to read core webhook configuration file: %v ", err)
 	}


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we also need to replace all the ioutil with os and io.