### PR TITLE
Bumps kube-vip to v0.3.5 and update templates

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -251,7 +251,7 @@ func kubeVIPPod() string {
 			Containers: []corev1.Container{
 				{
 					Name:  "kube-vip",
-					Image: "plndr/kube-vip:0.3.2",
+					Image: "ghcr.io/kube-vip/kube-vip:v0.3.5",
 					Args: []string{
 						"start",
 					},

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
@@ -125,7 +125,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: projects-stg.registry.vmware.com/tkg/kube-vip:v0.3.3_vmware.1
+            image: ghcr.io/kube-vip/kube-vip:v0.3.5
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
@@ -101,7 +101,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: projects-stg.registry.vmware.com/tkg/kube-vip:v0.3.3_vmware.1
+            image: ghcr.io/kube-vip/kube-vip:v0.3.5
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the `kube-vip` image path for cluster templates

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```