### PR TITLE
Automated cherry pick of #1291: Updates the kube-vip image path in templates

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -378,7 +378,7 @@ func kubeVIPPod() string {
 			Containers: []v1.Container{
 				{
 					Name:  "kube-vip",
-					Image: "plndr/kube-vip:0.3.2",
+					Image: "ghcr.io/kube-vip/kube-vip:v0.3.5",
 					Args: []string{
 						"start",
 					},


### PR DESCRIPTION
Cherry pick of #1291 on release-0.7.

#1291: Updates the kube-vip image path in templates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```