### PR TITLE
Automated cherry pick of #1277: move datacenter defaulting to resource defaults

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -89,6 +89,7 @@ type VirtualMachineCloneSpec struct {
 
 	// Datacenter is the name or inventory path of the datacenter in which the
 	// virtual machine is created/located.
+	// Defaults to * which selects the default datacenter.
 	// +optional
 	Datacenter string `json:"datacenter,omitempty"`
 

--- a/api/v1alpha4/vspherefailuredomain_types.go
+++ b/api/v1alpha4/vspherefailuredomain_types.go
@@ -57,8 +57,7 @@ type FailureDomain struct {
 }
 
 type Topology struct {
-	// The underlying infrastructure for this failure domain
-	// Datacenter as the failure domain
+	// Datacenter as the failure domain.
 	// +kubebuilder:validation:Required
 	Datacenter string `json:"datacenter"`
 

--- a/api/v1alpha4/vspherefailuredomain_webhook_test.go
+++ b/api/v1alpha4/vspherefailuredomain_webhook_test.go
@@ -24,6 +24,18 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+//nolint
+func TestVsphereFailureDomain_Default(t *testing.T) {
+	g := NewWithT(t)
+	m := &VSphereFailureDomain{
+		Spec: VSphereFailureDomainSpec{},
+	}
+	m.Default()
+
+	g.Expect(*m.Spec.Zone.AutoConfigure).To(BeFalse())
+	g.Expect(*m.Spec.Region.AutoConfigure).To(BeFalse())
+}
+
 func TestVSphereFailureDomain_ValidateCreate(t *testing.T) {
 	g := NewWithT(t)
 

--- a/api/v1alpha4/vspheremachine_webhook.go
+++ b/api/v1alpha4/vspheremachine_webhook.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 func (m *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -35,6 +36,16 @@ func (m *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1alpha4,name=validation.vspheremachine.infrastructure.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1alpha4,name=default.vspheremachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var _ webhook.Validator = &VSphereMachine{}
+var _ webhook.Defaulter = &VSphereMachine{}
+
+func (m *VSphereMachine) Default() {
+	if m.Spec.Datacenter == "" {
+		m.Spec.Datacenter = "*"
+	}
+}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (m *VSphereMachine) ValidateCreate() error {

--- a/api/v1alpha4/vspheremachine_webhook_test.go
+++ b/api/v1alpha4/vspheremachine_webhook_test.go
@@ -27,6 +27,17 @@ var (
 )
 
 //nolint
+func TestVsphereMachine_Default(t *testing.T) {
+	g := NewWithT(t)
+	m := &VSphereMachine{
+		Spec: VSphereMachineSpec{},
+	}
+	m.Default()
+
+	g.Expect(m.Spec.Datacenter).To(Equal("*"))
+}
+
+//nolint
 func TestVSphereMachine_ValidateCreate(t *testing.T) {
 
 	g := NewWithT(t)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -75,7 +75,8 @@ spec:
                     type: object
                   datacenter:
                     description: Datacenter is the name or inventory path of the datacenter
-                      in which the virtual machine is created/located.
+                      in which the virtual machine is created/located. Defaults to
+                      * which selects the default datacenter.
                     type: string
                   datastore:
                     description: Datastore is the name or inventory path of the datastore

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -195,8 +195,7 @@ spec:
                     description: ComputeCluster as the failure domain
                     type: string
                   datacenter:
-                    description: The underlying infrastructure for this failure domain
-                      Datacenter as the failure domain
+                    description: Datacenter as the failure domain.
                     type: string
                   datastore:
                     description: Datastore is the name or inventory path of the datastore

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -55,7 +55,8 @@ spec:
                 type: object
               datacenter:
                 description: Datacenter is the name or inventory path of the datacenter
-                  in which the virtual machine is created/located.
+                  in which the virtual machine is created/located. Defaults to * which
+                  selects the default datacenter.
                 type: string
               datastore:
                 description: Datastore is the name or inventory path of the datastore

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -172,6 +172,7 @@ spec:
                       datacenter:
                         description: Datacenter is the name or inventory path of the
                           datacenter in which the virtual machine is created/located.
+                          Defaults to * which selects the default datacenter.
                         type: string
                       datastore:
                         description: Datastore is the name or inventory path of the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -97,7 +97,8 @@ spec:
                 type: object
               datacenter:
                 description: Datacenter is the name or inventory path of the datacenter
-                  in which the virtual machine is created/located.
+                  in which the virtual machine is created/located. Defaults to * which
+                  selects the default datacenter.
                 type: string
               datastore:
                 description: Datastore is the name or inventory path of the datastore

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -50,6 +50,28 @@ webhooks:
     resources:
     - vspherefailuredomains
   sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.vspheremachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachines
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -66,7 +66,8 @@ func ForComputeClusterZone(t *testing.T) {
 
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
-		WithUserInfo(simr.Username(), simr.Password())
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithDatacenter("*")
 	authSession, err := session.GetOrCreate(controllerCtx, params)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -146,7 +147,8 @@ func ForHostGroupZone(t *testing.T) {
 
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
-		WithUserInfo(simr.Username(), simr.Password())
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithDatacenter("*")
 	authSession, err := session.GetOrCreate(controllerCtx, params)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -217,7 +219,8 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 	controllerCtx := fake.NewControllerContext(mgmtContext)
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
-		WithUserInfo(simr.Username(), simr.Password())
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithDatacenter("*")
 	authSession, err := session.GetOrCreate(controllerCtx, params)
 	NewWithT(t).Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -45,7 +45,8 @@ func TestCreate(t *testing.T) {
 		vmContext.Context,
 		session.NewParams().
 			WithServer(vmContext.VSphereVM.Spec.Server).
-			WithUserInfo(simr.Username(), simr.Password()))
+			WithUserInfo(simr.Username(), simr.Password()).
+			WithDatacenter("*"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -149,7 +149,8 @@ func initSimulator(t *testing.T) (*simulator.Model, *session.Session, *simulator
 		ctx.TODO(),
 		session.NewParams().
 			WithServer(server.URL.Host).
-			WithUserInfo(server.URL.User.Username(), pass))
+			WithUserInfo(server.URL.User.Username(), pass).
+			WithDatacenter("*"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -150,13 +150,14 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	session.TagManager = manager
 
 	// Assign the datacenter if one was specified.
-	dc, err := session.Finder.DatacenterOrDefault(ctx, params.datacenter)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to find datacenter %q", params.datacenter)
+	if params.datacenter != "" {
+		dc, err := session.Finder.Datacenter(ctx, params.datacenter)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to find datacenter %q", params.datacenter)
+		}
+		session.datacenter = dc
+		session.Finder.SetDatacenter(dc)
 	}
-	session.datacenter = dc
-	session.Finder.SetDatacenter(dc)
-
 	// Cache the session.
 	sessionCache[sessionKey] = session
 


### PR DESCRIPTION
Cherry pick of #1277 on release-0.8.

#1277: move datacenter defaulting to resource defaults

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.