### PR TITLE
Updates path of calico images for E2E tests

### DIFF
--- a/test/e2e/data/cni/calico/calico.yaml
+++ b/test/e2e/data/cni/calico/calico.yaml
@@ -518,7 +518,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.13.2
+          image: quay.io/calico/cni:v3.13.2
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -540,7 +540,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.13.2
+          image: quay.io/calico/cni:v3.13.2
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -576,7 +576,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.13.2
+          image: quay.io/calico/pod2daemon-flexvol:v3.13.2
           volumeMounts:
             - name: flexvol-driver-host
               mountPath: /host/driver
@@ -587,7 +587,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.13.2
+          image: quay.io/calico/node:v3.13.2
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -762,7 +762,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.13.2
+          image: quay.io/calico/kube-controllers:v3.13.2
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch updates the image paths used to deploy Calico while running the e2e tests.

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```