### PR TITLE
Enqueue VSphereMachine in clusterToVSphereMachines mapper

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -665,7 +665,7 @@ func (r machineReconciler) waitReadyState(ctx *context.MachineContext, vm *unstr
 
 func (r *machineReconciler) clusterToVSphereMachines(a client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
-	machines, err := infrautilv1.GetMachinesInCluster(goctx.Background(), r.Client, a.GetNamespace(), a.GetName())
+	machines, err := infrautilv1.GetVSphereMachinesInCluster(goctx.Background(), r.Client, a.GetNamespace(), a.GetName())
 	if err != nil {
 		return requests
 	}


### PR DESCRIPTION
The clusterToVSphereMachines mapper gets a list of machines in a cluster
and enqueues objects using the Machine's name instead of the corresponding
VSphereMachine's name. If the VSphereMachine and Machine object are named differently,
the controller can't reconcile the VSphereMachine object since it tries
to find it by the wrong name. This commit changes the mapper to get and enqueue VSphereMachine objects

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1307

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```