### PR TITLE
Automated cherry pick of #1306: Enqueue VSphereMachine in clusterToVSphereMachines mapper

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -665,7 +665,7 @@ func (r machineReconciler) waitReadyState(ctx *context.MachineContext, vm *unstr
 
 func (r *machineReconciler) clusterToVSphereMachines(a client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
-	machines, err := infrautilv1.GetMachinesInCluster(goctx.Background(), r.Client, a.GetNamespace(), a.GetName())
+	machines, err := infrautilv1.GetVSphereMachinesInCluster(goctx.Background(), r.Client, a.GetNamespace(), a.GetName())
 	if err != nil {
 		return requests
 	}


### PR DESCRIPTION
Cherry pick of #1306 on release-0.8.

#1306: Enqueue VSphereMachine in clusterToVSphereMachines mapper

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```