### PR TITLE
Implement deletion logic for VSphereDeploymentZone

### DIFF
--- a/api/v1alpha3/vspheredeploymentzone_conversion.go
+++ b/api/v1alpha3/vspheredeploymentzone_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	infrav1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereDeploymentZone to the Hub version (v1beta1).
+func (src *VSphereDeploymentZone) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereDeploymentZone)
+	return Convert_v1alpha3_VSphereDeploymentZone_To_v1beta1_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this VSphereDeploymentZone.
+func (dst *VSphereDeploymentZone) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereDeploymentZone)
+	return Convert_v1beta1_VSphereDeploymentZone_To_v1alpha3_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereDeploymentZoneList to the Hub version (v1beta1).
+func (src *VSphereDeploymentZoneList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereDeploymentZoneList)
+	return Convert_v1alpha3_VSphereDeploymentZoneList_To_v1beta1_VSphereDeploymentZoneList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereDeploymentZoneList to the Hub version (v1beta1).
+func (dst *VSphereDeploymentZoneList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereDeploymentZoneList)
+	return Convert_v1beta1_VSphereDeploymentZoneList_To_v1alpha3_VSphereDeploymentZoneList(src, dst, nil)
+}

--- a/api/v1alpha3/vspherefailuredomain_conversion.go
+++ b/api/v1alpha3/vspherefailuredomain_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	infrav1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereFailureDomain to the Hub version (v1beta1).
+func (src *VSphereFailureDomain) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereFailureDomain)
+	return Convert_v1alpha3_VSphereFailureDomain_To_v1beta1_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this VSphereFailureDomain.
+func (dst *VSphereFailureDomain) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereFailureDomain)
+	return Convert_v1beta1_VSphereFailureDomain_To_v1alpha3_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereFailureDomainList to the Hub version (v1beta1).
+func (src *VSphereFailureDomainList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereFailureDomainList)
+	return Convert_v1alpha3_VSphereFailureDomainList_To_v1beta1_VSphereFailureDomainList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereFailureDomainList to the Hub version (v1beta1).
+func (dst *VSphereFailureDomainList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereFailureDomainList)
+	return Convert_v1beta1_VSphereFailureDomainList_To_v1alpha3_VSphereFailureDomainList(src, dst, nil)
+}

--- a/api/v1alpha4/vspheredeploymentzone_conversion.go
+++ b/api/v1alpha4/vspheredeploymentzone_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	infrav1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereDeploymentZone to the Hub version (v1beta1).
+func (src *VSphereDeploymentZone) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereDeploymentZone)
+	return Convert_v1alpha4_VSphereDeploymentZone_To_v1beta1_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this VSphereDeploymentZone.
+func (dst *VSphereDeploymentZone) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereDeploymentZone)
+	return Convert_v1beta1_VSphereDeploymentZone_To_v1alpha4_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereDeploymentZoneList to the Hub version (v1beta1).
+func (src *VSphereDeploymentZoneList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereDeploymentZoneList)
+	return Convert_v1alpha4_VSphereDeploymentZoneList_To_v1beta1_VSphereDeploymentZoneList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereDeploymentZoneList to the Hub version (v1beta1).
+func (dst *VSphereDeploymentZoneList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereDeploymentZoneList)
+	return Convert_v1beta1_VSphereDeploymentZoneList_To_v1alpha4_VSphereDeploymentZoneList(src, dst, nil)
+}

--- a/api/v1alpha4/vspherfailuredomain_conversion.go
+++ b/api/v1alpha4/vspherfailuredomain_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	infrav1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereFailureDomain to the Hub version (v1beta1).
+func (src *VSphereFailureDomain) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereFailureDomain)
+	return Convert_v1alpha4_VSphereFailureDomain_To_v1beta1_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this VSphereFailureDomain.
+func (dst *VSphereFailureDomain) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereFailureDomain)
+	return Convert_v1beta1_VSphereFailureDomain_To_v1alpha4_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereFailureDomainList to the Hub version (v1beta1).
+func (src *VSphereFailureDomainList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1beta1.VSphereFailureDomainList)
+	return Convert_v1alpha4_VSphereFailureDomainList_To_v1beta1_VSphereFailureDomainList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereFailureDomainList to the Hub version (v1beta1).
+func (dst *VSphereFailureDomainList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1beta1.VSphereFailureDomainList)
+	return Convert_v1beta1_VSphereFailureDomainList_To_v1alpha4_VSphereFailureDomainList(src, dst, nil)
+}

--- a/api/v1beta1/vspheredeploymentzone_conversion.go
+++ b/api/v1beta1/vspheredeploymentzone_conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// Hub marks VSphereDeploymentZone as a conversion hub.
+func (*VSphereDeploymentZone) Hub() {}
+
+// Hub marks VSphereDeploymentZoneList as a conversion hub.
+func (*VSphereDeploymentZoneList) Hub() {}

--- a/api/v1beta1/vspheredeploymentzone_types.go
+++ b/api/v1beta1/vspheredeploymentzone_types.go
@@ -21,6 +21,13 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+const (
+	// DeploymentZoneFinalizer allows ReconcileVSphereDeploymentZone to
+	// check for dependents associated with VSphereDeploymentZone
+	// before removing it from the API Server.
+	DeploymentZoneFinalizer = "vspheredeploymentzone.infrastructure.cluster.x-k8s.io"
+)
+
 // VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
 type VSphereDeploymentZoneSpec struct {
 

--- a/api/v1beta1/vspherefailuredomain_conversion.go
+++ b/api/v1beta1/vspherefailuredomain_conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// Hub marks VSphereFailureDomain as a conversion hub.
+func (*VSphereFailureDomain) Hub() {}
+
+// Hub marks VSphereFailureDomainList as a conversion hub.
+func (*VSphereFailureDomainList) Hub() {}

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -80,6 +80,9 @@ func setup() {
 	if err := AddVsphereClusterIdentityControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
+	if err := AddVSphereDeploymentZoneControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
+	}
 
 	go func() {
 		fmt.Println("Starting the manager")

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -24,14 +24,18 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheredeploymentzones,verbs=get;list;watch;create;update;patch;delete
@@ -147,6 +152,9 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx goctx.Context, request re
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileNormal(ctx *context.VSphereDeploymentZoneContext) (reconcile.Result, error) {
+
+	ctrlutil.AddFinalizer(ctx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
+
 	authSession, err := r.getVCenterSession(ctx)
 	if err != nil {
 		ctx.Logger.V(4).Error(err, "unable to create session")
@@ -170,6 +178,24 @@ func (r vsphereDeploymentZoneReconciler) reconcileNormal(ctx *context.VSphereDep
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile failure domain")
 	}
 	conditions.MarkTrue(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+
+	// Ensure the VSphereDeploymentZone is marked as an owner of the VSphereFailureDomain.
+	if !clusterutilv1.HasOwnerRef(ctx.VSphereFailureDomain.GetOwnerReferences(), metav1.OwnerReference{
+		APIVersion: infrav1.GroupVersion.String(),
+		Kind:       "VSphereDeploymentZone",
+		Name:       ctx.VSphereDeploymentZone.Name,
+	}) {
+		if err := updateOwnerReferences(ctx, ctx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
+			return append(ctx.VSphereFailureDomain.OwnerReferences, metav1.OwnerReference{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       ctx.VSphereDeploymentZone.Kind,
+				Name:       ctx.VSphereDeploymentZone.Name,
+				UID:        ctx.VSphereDeploymentZone.UID,
+			})
+		}); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 
 	ctx.VSphereDeploymentZone.Status.Ready = pointer.Bool(true)
 	return reconcile.Result{}, nil
@@ -233,7 +259,63 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx *context.VSphereD
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx *context.VSphereDeploymentZoneContext) (reconcile.Result, error) {
+	r.Logger.Info("Deleting VSphereDeploymentZone")
+
+	machines := &clusterv1.MachineList{}
+	if err := r.Client.List(ctx, machines); err != nil {
+		r.Logger.Error(err, "unable to list machines")
+		return reconcile.Result{}, errors.Wrapf(err, "unable to list machines")
+	}
+
+	machinesUsingDeploymentZone := collections.FromMachineList(machines).Filter(collections.ActiveMachines, func(machine *clusterv1.Machine) bool {
+		return *machine.Spec.FailureDomain == ctx.VSphereDeploymentZone.Name
+	})
+	if len(machinesUsingDeploymentZone) > 0 {
+		machineNamesStr := util.MachinesAsString(machinesUsingDeploymentZone.SortedByCreationTimestamp())
+		err := errors.Errorf("%s is currently in use by machines: %s", ctx.VSphereDeploymentZone.Name, machineNamesStr)
+		r.Logger.Error(err, "Error deleting VSphereDeploymentZone", "name", ctx.VSphereDeploymentZone.Name)
+		return reconcile.Result{}, err
+	}
+
+	if err := updateOwnerReferences(ctx, ctx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
+		return clusterutilv1.RemoveOwnerRef(ctx.VSphereFailureDomain.OwnerReferences, metav1.OwnerReference{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       ctx.VSphereDeploymentZone.Kind,
+			Name:       ctx.VSphereDeploymentZone.Name,
+		})
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(ctx.VSphereFailureDomain.OwnerReferences) == 0 {
+		ctx.Logger.Info("deleting vsphereFailureDomain", "name", ctx.VSphereFailureDomain.Name)
+		if err := r.Client.Delete(ctx, ctx.VSphereFailureDomain); err != nil && !apierrors.IsNotFound(err) {
+			ctx.Logger.Error(err, "failed to delete related %s %s", ctx.VSphereFailureDomain.GroupVersionKind(), ctx.VSphereFailureDomain.Name)
+		}
+	}
+
+	ctrlutil.RemoveFinalizer(ctx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
+
 	return reconcile.Result{}, nil
+}
+
+// updateOwnerReferences uses the ownerRef function to calculate the owner references
+// to be set on the object and patches the object.
+func updateOwnerReferences(ctx goctx.Context, obj client.Object, client client.Client, ownerRefFunc func() []metav1.OwnerReference) error {
+	patchHelper, err := patch.NewHelper(obj, client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to init patch helper for %s %s",
+			obj.GetObjectKind(),
+			obj.GetName())
+	}
+
+	obj.SetOwnerReferences(ownerRefFunc())
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return errors.Wrapf(err, "failed to patch object %s %s",
+			obj.GetObjectKind(),
+			obj.GetName())
+	}
+	return nil
 }
 
 func (r vsphereDeploymentZoneReconciler) failureDomainsToDeploymentZones(a client.Object) []reconcile.Request {

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -17,13 +17,20 @@ limitations under the License.
 package controllers
 
 import (
+	goctx "context"
 	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/vmware/govmomi/simulator"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
@@ -31,47 +38,67 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
 )
 
-func Success(t *testing.T) {
-	g := NewWithT(t)
+var _ = Describe("VSphereDeploymentZoneReconciler", func() {
+	var (
+		simr *helpers.Simulator
+		ctx  goctx.Context
 
-	model := simulator.VPX()
-	model.Pool = 1
+		vsphereDeploymentZone *infrav1.VSphereDeploymentZone
+		vsphereFailureDomain  *infrav1.VSphereFailureDomain
+	)
 
-	simr, err := helpers.VCSimBuilder().
-		WithModel(model).
-		WithOperations("tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
+	BeforeEach(func() {
+		model := simulator.VPX()
+		model.Pool = 1
+
+		var err error
+		simr, err = helpers.VCSimBuilder().
+			WithModel(model).
+			WithOperations().
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		operations := []string{
+			"tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
 			"tags.category.create -t Datacenter,ClusterComputeResource k8s-zone",
 			"tags.create -c k8s-region k8s-region-west",
 			"tags.create -c k8s-zone k8s-zone-west-1",
 			"tags.attach -c k8s-region k8s-region-west /DC0",
-			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0").
-		Build()
-	if err != nil {
-		t.Fatalf("unable to create simulator %s", err)
-	}
-	defer simr.Destroy()
+			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0",
+		}
+		for _, op := range operations {
+			Expect(simr.Run(op, gbytes.NewBuffer(), gbytes.NewBuffer())).To(Succeed())
+		}
 
-	mgmtContext := fake.NewControllerManagerContext()
-	mgmtContext.Username = simr.ServerURL().User.Username()
-	pass, _ := simr.ServerURL().User.Password()
-	mgmtContext.Password = pass
+		ctx = goctx.Background()
+	})
 
-	controllerCtx := fake.NewControllerContext(mgmtContext)
+	AfterEach(func() {
+		Expect(testEnv.Cleanup(ctx, vsphereDeploymentZone, vsphereFailureDomain)).To(Succeed())
+	})
 
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
-		ControllerContext: controllerCtx,
-		VSphereDeploymentZone: &infrav1.VSphereDeploymentZone{Spec: infrav1.VSphereDeploymentZoneSpec{
-			Server:        simr.ServerURL().Host,
-			FailureDomain: "blah",
-			ControlPlane:  pointer.Bool(true),
-			PlacementConstraint: infrav1.PlacementConstraint{
-				ResourcePool: "DC0_C0_RP1",
-				Folder:       "/",
-			},
-		}},
-		VSphereFailureDomain: &infrav1.VSphereFailureDomain{
+	It("should create a deployment zone & failure domain", func() {
+		dzName := "blah"
+		fdName := "blah-fd"
+
+		vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "blah",
+				Name: dzName,
+			},
+			Spec: infrav1.VSphereDeploymentZoneSpec{
+				Server:        simr.ServerURL().Host,
+				FailureDomain: fdName,
+				ControlPlane:  pointer.Bool(true),
+				PlacementConstraint: infrav1.PlacementConstraint{
+					ResourcePool: "DC0_C0_RP1",
+					Folder:       "/",
+				},
+			}}
+		Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
+
+		vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fdName,
 			},
 			Spec: infrav1.VSphereFailureDomainSpec{
 				Region: infrav1.FailureDomain{
@@ -93,91 +120,155 @@ func Success(t *testing.T) {
 					Networks:       []string{"VM Network"},
 				},
 			},
-		},
-		Logger: logr.DiscardLogger{},
-	}
+		}
+		Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
 
-	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-	_, err = reconciler.reconcileNormal(deploymentZoneCtx)
-	g.Expect(err).NotTo(HaveOccurred())
-}
+		Eventually(func() bool {
+			if err := testEnv.Get(ctx, client.ObjectKey{Name: dzName}, vsphereDeploymentZone); err != nil {
+				return false
+			}
+			return len(vsphereDeploymentZone.Finalizers) > 0
+		}, timeout).Should(BeTrue())
 
-func FailResourcePoolNotOwnedComputeCluster(t *testing.T) {
-	g := NewWithT(t)
+		Eventually(func() bool {
+			if err := testEnv.Get(ctx, client.ObjectKey{Name: dzName}, vsphereDeploymentZone); err != nil {
+				return false
+			}
+			return conditions.IsTrue(vsphereDeploymentZone, infrav1.VCenterAvailableCondition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+		}, timeout).Should(BeTrue())
 
-	model := simulator.VPX()
-	model.Cluster = 2
-	model.Pool = 2
+		By("sets the owner ref on the vsphereFailureDomain object")
+		Expect(testEnv.Get(ctx, client.ObjectKey{Name: fdName}, vsphereFailureDomain)).To(Succeed())
+		ownerRefs := vsphereFailureDomain.GetOwnerReferences()
+		Expect(ownerRefs).To(HaveLen(1))
+		Expect(ownerRefs[0].Name).To(Equal(dzName))
+		Expect(ownerRefs[0].Kind).To(Equal("VSphereDeploymentZone"))
+	})
 
-	simr, err := helpers.VCSimBuilder().
-		WithModel(model).
-		WithOperations("tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
-			"tags.category.create -t Datacenter,ClusterComputeResource k8s-zone",
-			"tags.create -c k8s-region k8s-region-west",
-			"tags.create -c k8s-zone k8s-zone-west-1",
-			"tags.attach -c k8s-region k8s-region-west /DC0",
-			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0").
-		Build()
-	if err != nil {
-		t.Fatalf("unable to create simulator %s", err)
-	}
-	defer simr.Destroy()
-
-	mgmtContext := fake.NewControllerManagerContext()
-	mgmtContext.Username = simr.ServerURL().User.Username()
-	pass, _ := simr.ServerURL().User.Password()
-	mgmtContext.Password = pass
-
-	controllerCtx := fake.NewControllerContext(mgmtContext)
-
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
-		ControllerContext: controllerCtx,
-		VSphereDeploymentZone: &infrav1.VSphereDeploymentZone{Spec: infrav1.VSphereDeploymentZoneSpec{
-			Server:        simr.ServerURL().Host,
-			FailureDomain: "blah",
-			ControlPlane:  pointer.Bool(true),
-			PlacementConstraint: infrav1.PlacementConstraint{
-				ResourcePool: "DC0_C1_RP1",
-				Folder:       "/",
-			},
-		}},
-		VSphereFailureDomain: &infrav1.VSphereFailureDomain{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "blah",
-			},
-			Spec: infrav1.VSphereFailureDomainSpec{
-				Region: infrav1.FailureDomain{
-					Name:          "k8s-region-west",
-					Type:          infrav1.DatacenterFailureDomain,
-					TagCategory:   "k8s-region",
-					AutoConfigure: pointer.Bool(false),
+	Context("With incorrect details: when resource pool is not owned by compute cluster", func() {
+		It("should fail creation of deployment zone", func() {
+			vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-two",
 				},
-				Zone: infrav1.FailureDomain{
-					Name:          "k8s-zone-west-1",
-					Type:          infrav1.ComputeClusterFailureDomain,
-					TagCategory:   "k8s-zone",
-					AutoConfigure: pointer.Bool(false),
-				},
-				Topology: infrav1.Topology{
-					Datacenter:     "DC0",
-					ComputeCluster: pointer.String("DC0_C0"),
-					Datastore:      "LocalDS_0",
-					Networks:       []string{"VM Network"},
-				},
-			},
-		},
-		Logger: logr.DiscardLogger{},
-	}
+				Spec: infrav1.VSphereDeploymentZoneSpec{
+					Server:        simr.ServerURL().Host,
+					FailureDomain: "blah-fd-two",
+					ControlPlane:  pointer.Bool(true),
+					PlacementConstraint: infrav1.PlacementConstraint{
+						ResourcePool: "DC0_C1_RP1",
+						Folder:       "/",
+					},
+				}}
+			Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
 
-	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-	_, err = reconciler.reconcileNormal(deploymentZoneCtx)
-	g.Expect(err).To(HaveOccurred())
-}
+			vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereFailureDomain",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-fd-two",
+				},
+				Spec: infrav1.VSphereFailureDomainSpec{
+					Region: infrav1.FailureDomain{
+						Name:          "k8s-region-west",
+						Type:          infrav1.DatacenterFailureDomain,
+						TagCategory:   "k8s-region",
+						AutoConfigure: pointer.Bool(false),
+					},
+					Zone: infrav1.FailureDomain{
+						Name:          "k8s-zone-west-1",
+						Type:          infrav1.ComputeClusterFailureDomain,
+						TagCategory:   "k8s-zone",
+						AutoConfigure: pointer.Bool(false),
+					},
+					Topology: infrav1.Topology{
+						Datacenter:     "DC0",
+						ComputeCluster: pointer.String("DC0_C0"),
+						Datastore:      "LocalDS_0",
+						Networks:       []string{"VM Network"},
+					},
+				},
+			}
+			Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
 
-func TestVsphereDeploymentZoneReconciler(t *testing.T) {
-	t.Run("VSphereDeploymentZone reconciliation is successful", Success)
-	t.Run("VSphereDeploymentZone reconciliation fails when resource pool is not owned by compute cluster", FailResourcePoolNotOwnedComputeCluster)
-}
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, client.ObjectKey{Name: "blah-two"}, vsphereDeploymentZone); err != nil {
+					return false
+				}
+				return conditions.IsFalse(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition)
+			}, timeout).Should(BeTrue())
+		})
+	})
+
+	Context("Delete VSphereDeploymentZone", func() {
+		It("should delete the associated failure domain", func() {
+			fdName := "blah-fd-three"
+
+			vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-three",
+				},
+				Spec: infrav1.VSphereDeploymentZoneSpec{
+					Server:        simr.ServerURL().Host,
+					FailureDomain: fdName,
+					ControlPlane:  pointer.Bool(true),
+					PlacementConstraint: infrav1.PlacementConstraint{
+						ResourcePool: "DC0_C0_RP1",
+						Folder:       "/",
+					},
+				}}
+			Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
+
+			vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fdName,
+				},
+				Spec: infrav1.VSphereFailureDomainSpec{
+					Region: infrav1.FailureDomain{
+						Name:          "k8s-region-west",
+						Type:          infrav1.DatacenterFailureDomain,
+						TagCategory:   "k8s-region",
+						AutoConfigure: pointer.Bool(false),
+					},
+					Zone: infrav1.FailureDomain{
+						Name:          "k8s-zone-west-1",
+						Type:          infrav1.ComputeClusterFailureDomain,
+						TagCategory:   "k8s-zone",
+						AutoConfigure: pointer.Bool(false),
+					},
+					Topology: infrav1.Topology{
+						Datacenter:     "DC0",
+						ComputeCluster: pointer.String("DC0_C0"),
+						Datastore:      "LocalDS_0",
+						Networks:       []string{"VM Network"},
+					},
+				},
+			}
+			Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
+
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, client.ObjectKey{Name: "blah-three"}, vsphereDeploymentZone); err != nil {
+					return false
+				}
+				return pointer.BoolDeref(vsphereDeploymentZone.Status.Ready, false) &&
+					conditions.IsTrue(vsphereDeploymentZone, clusterv1.ReadyCondition)
+			}, timeout).Should(BeTrue())
+
+			By("deleting the vsphere deployment zone")
+			Expect(testEnv.Delete(ctx, vsphereFailureDomain)).To(Succeed())
+
+			Eventually(func() bool {
+				fd := &infrav1.VSphereFailureDomain{}
+				err := testEnv.Get(ctx, client.ObjectKey{Name: fdName}, fd)
+				return apierrors.IsNotFound(err)
+			}, timeout).Should(BeTrue())
+		})
+	})
+})
 
 func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T) {
 	tests := []struct {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -477,44 +477,41 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 // generateOverrideFunc returns a function which can override the values in the VSphereVM Spec
 // with the values from the FailureDomain (if any) set on the owner CAPI machine.
 func (r machineReconciler) generateOverrideFunc(ctx *context.MachineContext) (func(vm *infrav1.VSphereVM), bool) {
-	var overrideWithFailureDomainFunc func(vm *infrav1.VSphereVM)
-	if failureDomainName := ctx.Machine.Spec.FailureDomain; failureDomainName != nil {
-		var vsphereDeploymentZoneList infrav1.VSphereDeploymentZoneList
-		if err := r.Client.List(ctx, &vsphereDeploymentZoneList); err != nil {
-			r.Logger.Error(err, "unable to fetch list of deployment zones")
-			return overrideWithFailureDomainFunc, false
-		}
+	failureDomainName := ctx.Machine.Spec.FailureDomain
+	if failureDomainName == nil {
+		return nil, false
+	}
 
-		var vsphereFailureDomain infrav1.VSphereFailureDomain
-		if err := r.Client.Get(ctx, client.ObjectKey{Name: *failureDomainName}, &vsphereFailureDomain); err != nil {
-			r.Logger.Error(err, "unable to fetch failure domain", "name", *failureDomainName)
-			return overrideWithFailureDomainFunc, false
-		}
+	// Use the failureDomain name to fetch the vSphereDeploymentZone object
+	var vsphereDeploymentZone infrav1.VSphereDeploymentZone
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: *failureDomainName}, &vsphereDeploymentZone); err != nil {
+		r.Logger.Error(err, "unable to fetch vsphere deployment zone", "name", *failureDomainName)
+		return nil, false
+	}
 
-		for index := range vsphereDeploymentZoneList.Items {
-			zone := vsphereDeploymentZoneList.Items[index]
-			if zone.Spec.FailureDomain == *failureDomainName {
-				overrideWithFailureDomainFunc = func(vm *infrav1.VSphereVM) {
-					vm.Spec.Server = zone.Spec.Server
-					vm.Spec.Datacenter = vsphereFailureDomain.Spec.Topology.Datacenter
-					if zone.Spec.PlacementConstraint.Folder != "" {
-						vm.Spec.Folder = zone.Spec.PlacementConstraint.Folder
-					}
-					if zone.Spec.PlacementConstraint.ResourcePool != "" {
-						vm.Spec.ResourcePool = zone.Spec.PlacementConstraint.ResourcePool
-					}
-					if vsphereFailureDomain.Spec.Topology.Datastore != "" {
-						vm.Spec.Datastore = vsphereFailureDomain.Spec.Topology.Datastore
-					}
-					if len(vsphereFailureDomain.Spec.Topology.Networks) > 0 {
-						vm.Spec.Network.Devices = overrideNetworkDeviceSpecs(vm.Spec.Network.Devices, vsphereFailureDomain.Spec.Topology.Networks)
-					}
-				}
-				return overrideWithFailureDomainFunc, true
-			}
+	var vsphereFailureDomain infrav1.VSphereFailureDomain
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: vsphereDeploymentZone.Spec.FailureDomain}, &vsphereFailureDomain); err != nil {
+		r.Logger.Error(err, "unable to fetch failure domain", "name", vsphereDeploymentZone.Spec.FailureDomain)
+		return nil, false
+	}
+
+	overrideWithFailureDomainFunc := func(vm *infrav1.VSphereVM) {
+		vm.Spec.Server = vsphereDeploymentZone.Spec.Server
+		vm.Spec.Datacenter = vsphereFailureDomain.Spec.Topology.Datacenter
+		if vsphereDeploymentZone.Spec.PlacementConstraint.Folder != "" {
+			vm.Spec.Folder = vsphereDeploymentZone.Spec.PlacementConstraint.Folder
+		}
+		if vsphereDeploymentZone.Spec.PlacementConstraint.ResourcePool != "" {
+			vm.Spec.ResourcePool = vsphereDeploymentZone.Spec.PlacementConstraint.ResourcePool
+		}
+		if vsphereFailureDomain.Spec.Topology.Datastore != "" {
+			vm.Spec.Datastore = vsphereFailureDomain.Spec.Topology.Datastore
+		}
+		if len(vsphereFailureDomain.Spec.Topology.Networks) > 0 {
+			vm.Spec.Network.Devices = overrideNetworkDeviceSpecs(vm.Spec.Network.Devices, vsphereFailureDomain.Spec.Topology.Networks)
 		}
 	}
-	return overrideWithFailureDomainFunc, false
+	return overrideWithFailureDomainFunc, true
 }
 
 // overrideNetworkDeviceSpecs updates the network devices with the network definitions from the PlacementConstraint.

--- a/controllers/vspheremachine_controller_unit_test.go
+++ b/controllers/vspheremachine_controller_unit_test.go
@@ -78,7 +78,7 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 
 	Context("When Failure Domain is present", func() {
 		BeforeEach(func() {
-			machineCtx.Machine.Spec.FailureDomain = pointer.String("fd-one")
+			machineCtx.Machine.Spec.FailureDomain = pointer.String("zone-one")
 		})
 
 		It("generates an override function", func() {
@@ -100,6 +100,19 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 			Expect(vm.Spec.Datastore).To(Equal("ds-one"))
 			Expect(vm.Spec.ResourcePool).To(Equal("rp-one"))
 			Expect(vm.Spec.Datacenter).To(Equal("dc-one"))
+		})
+
+		Context("for non-existent failure domain value", func() {
+			BeforeEach(func() {
+				machineCtx.Machine.Spec.FailureDomain = pointer.String("non-existent-zone")
+			})
+
+			It("fails to generate an override function", func() {
+				r := machineReconciler{controllerCtx}
+				overrideFunc, ok := r.generateOverrideFunc(machineCtx)
+				Expect(ok).To(BeFalse())
+				Expect(overrideFunc).To(BeNil())
+			})
 		})
 
 		Context("with network specified in the topology", func() {

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -176,11 +176,16 @@ func (r vmReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Res
 			return reconcile.Result{}, nil
 		}
 
-		if failureDomain := machine.Spec.FailureDomain; failureDomain != nil {
-			vsphereFailureDomain = &infrav1.VSphereFailureDomain{}
-			if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereFailureDomain); err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", *failureDomain)
-			}
+	var vsphereFailureDomain *infrav1.VSphereFailureDomain
+	if failureDomain := machine.Spec.FailureDomain; failureDomain != nil {
+		vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{}
+		if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereDeploymentZone); err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere deployment zone %s", *failureDomain)
+		}
+
+		vsphereFailureDomain = &infrav1.VSphereFailureDomain{}
+		if err := r.Client.Get(r, apitypes.NamespacedName{Name: vsphereDeploymentZone.Spec.FailureDomain}, vsphereFailureDomain); err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", vsphereDeploymentZone.Spec.FailureDomain)
 		}
 	}
 

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"regexp"
 	"text/template"
@@ -269,4 +270,26 @@ func ConvertUUIDToProviderID(uuid string) string {
 		return ""
 	}
 	return ProviderIDPrefix + uuid
+}
+
+// MachinesAsString constructs a string (with correct punctuations) to be
+// used in logging and error messages.
+func MachinesAsString(machines []*clusterv1.Machine) string {
+	var message string
+	count := 1
+	for _, m := range machines {
+		if count == 1 {
+			message = fmt.Sprintf("%s/%s", m.Namespace, m.Name)
+		} else {
+			var format string
+			if count > 1 && count != len(machines) {
+				format = "%s, %s/%s"
+			} else if count == len(machines) {
+				format = "%s and %s/%s"
+			}
+			message = fmt.Sprintf(format, message, m.Namespace, m.Name)
+		}
+		count++
+	}
+	return message
 }

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
@@ -750,6 +751,41 @@ func TestConvertUUIDtoProviderID(t *testing.T) {
 			actualProviderID := util.ConvertUUIDToProviderID(tc.uuid)
 			g.Expect(actualProviderID).To(gomega.Equal(tc.expectedProviderID))
 		})
+	}
+}
+
+func Test_MachinesAsString(t *testing.T) {
+	tests := []struct {
+		machines     []*clusterv1.Machine
+		errorMessage string
+	}{
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+			},
+			errorMessage: "m1-ns/m1",
+		},
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+			},
+			errorMessage: "m1-ns/m1 and m2-ns/m2",
+		},
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m3", Namespace: "m3-ns"}},
+			},
+			errorMessage: "m1-ns/m1, m2-ns/m2 and m3-ns/m3",
+		},
+	}
+
+	for _, tt := range tests {
+		g := gomega.NewWithT(t)
+		msg := util.MachinesAsString(tt.machines)
+		g.Expect(msg).To(gomega.Equal(tt.errorMessage))
 	}
 }
 

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -175,6 +175,13 @@ func NewTestEnvironment() *TestEnvironment {
 			return err
 		}
 
+		if err := (&infrav1.VSphereFailureDomain{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+		if err := (&infrav1.VSphereFailureDomainList{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch includes the following changes:
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1300 

**Special notes for your reviewer**:


**Release note**:
```release-note
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.
```