### PR TITLE
Supervisor based integration tests. RBAC fixes for capv-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 test/e2e/data/infrastructure-vsphere/kustomization/base/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml
+_artifacts/
 
 # env vars file used in getting-started.md and manifests generation
 envvars.txt

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -1,0 +1,64 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: contentlibraryproviders.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: ContentLibraryProvider
+    listKind: ContentLibraryProviderList
+    plural: contentlibraryproviders
+    singular: contentlibraryprovider
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: UUID of the vSphere content library
+      jsonPath: .spec.uuid
+      name: Content Library UUID
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContentLibraryProvider is the Schema for the contentlibraryproviders
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContentLibraryProviderSpec defines the desired state of ContentLibraryProvider
+            properties:
+              uuid:
+                description: UUID describes the UUID of a vSphere content library.
+                  It is the unique identifier for a vSphere content library.
+                type: string
+            type: object
+          status:
+            description: ContentLibraryProviderStatus defines the observed state of
+              ContentLibraryProvider Can include fields indicating when was the last
+              time VM images were updated from a library
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
@@ -1,0 +1,60 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: contentsourcebindings.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: ContentSourceBinding
+    listKind: ContentSourceBindingList
+    plural: contentsourcebindings
+    singular: contentsourcebinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContentSourceBinding is an object that represents a ContentSource
+          to Namespace mapping.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          contentSourceRef:
+            description: ContentSourceRef is a reference to a ContentSource object.
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              kind:
+                description: Kind is the type of resource being referenced.
+                type: string
+              name:
+                description: Name is the name of resource being referenced.
+                type: string
+            required:
+            - name
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
@@ -1,0 +1,74 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: contentsources.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: ContentSource
+    listKind: ContentSourceList
+    plural: contentsources
+    singular: contentsource
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContentSource is the Schema for the contentsources API. A ContentSource
+          represents the desired specification and the observed status of a ContentSource
+          instance.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContentSourceSpec defines the desired state of ContentSource
+            properties:
+              providerRef:
+                description: ProviderRef is a reference to a content provider object
+                  that describes a provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced.
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced.
+                    type: string
+                  namespace:
+                    description: Namespace of the resource being referenced. If empty,
+                      cluster scoped resource is assumed.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: ContentSourceStatus defines the observed state of ContentSource
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -1,0 +1,67 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachineclassbindings.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineClassBinding
+    listKind: VirtualMachineClassBindingList
+    plural: virtualmachineclassbindings
+    shortNames:
+    - vmclassbinding
+    singular: virtualmachineclassbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineClassBinding is a binding object responsible for
+          defining a VirtualMachineClass and a Namespace associated with it
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          classRef:
+            description: ClassReference is a reference to a VirtualMachineClass object
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              kind:
+                description: Kind is the type of resource being referenced.
+                type: string
+              name:
+                description: Name is the name of resource being referenced.
+                type: string
+            required:
+            - name
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -1,0 +1,210 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachineclasses.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineClass
+    listKind: VirtualMachineClassList
+    plural: virtualmachineclasses
+    shortNames:
+    - vmclass
+    singular: virtualmachineclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.hardware.devices.vgpuDevices[*].profileName
+      name: VGPUDevicesProfileNames
+      priority: 1
+      type: string
+    - jsonPath: .spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID
+      name: PassthroughDeviceIDs
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineClass is the Schema for the virtualmachineclasses
+          API. A VirtualMachineClass represents the desired specification and the
+          observed status of a VirtualMachineClass instance.  A VirtualMachineClass
+          represents a policy and configuration resource which defines a set of attributes
+          to be used in the configuration of a VirtualMachine instance.  A VirtualMachine
+          resource references a VirtualMachineClass as a required input.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass
+            properties:
+              description:
+                description: Description describes the configuration of the VirtualMachineClass
+                  which is not related to virtual hardware or infrastructure policy.
+                  This field is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware.  The configuration specified
+                  in this field is used to customize the virtual hardware characteristics
+                  of any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: VirtualDevices contains information about the virtual
+                      devices associated with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: DynamicDirectPathIODevice contains the configuration
+                            corresponding to a Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              type: integer
+                            vendorID:
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                    type: object
+                  instanceStorage:
+                    description: InstanceStorage provides information used to configure
+                      instance storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: StorageClass refers to the name of a StorageClass
+                          resource used to provide the storage for the configured
+                          instance storage volumes. The value of this field has no
+                          relationship to or bearing on the field virtualMachine.spec.storageClass.
+                          Please note the referred StorageClass must be available
+                          in the same namespace as the VirtualMachineClass that uses
+                          it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: Volumes describes instance storage volumes created
+                          for a VirtualMachine instance that use this VirtualMachineClass.
+                        items:
+                          description: InstanceStorageVolume contains information
+                            required to create an instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy.  The configuration
+                  specified in this field is used to customize various policies related
+                  to infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: VirtualMachineClassResources describes the virtual
+                      hardware resource reservations and limits configuration to be
+                      used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.  VirtualMachineClasses
+              are immutable, non-dynamic resources, so this status is currently unused.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -1,0 +1,245 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachineimages.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineImage
+    listKind: VirtualMachineImageList
+    plural: virtualmachineimages
+    shortNames:
+    - vmimage
+    singular: virtualmachineimage
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.providerRef.name
+      name: ContentSourceName
+      type: string
+    - jsonPath: .spec.productInfo.version
+      name: Version
+      type: string
+    - jsonPath: .spec.osInfo.type
+      name: OsType
+      type: string
+    - jsonPath: .spec.type
+      name: Format
+      type: string
+    - jsonPath: .status.imageSupported
+      name: ImageSupported
+      priority: 1
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineImage is the Schema for the virtualmachineimages
+          API A VirtualMachineImage represents a VirtualMachine image (e.g. VM template)
+          that can be used as the base image for creating a VirtualMachine instance.  The
+          VirtualMachineImage is a required field of the VirtualMachine spec.  Currently,
+          VirtualMachineImages are immutable to end users.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage
+            properties:
+              hwVersion:
+                description: HardwareVersion describes the virtual hardware version
+                  of the image
+                format: int32
+                type: integer
+              imageID:
+                description: ImageID is a unique identifier exposed by the provider
+                  of this VirtualMachineImage.
+                type: string
+              imageSourceType:
+                description: ImageSourceType describes the type of content source
+                  of the VirtualMachineImage.  The only Content Source supported currently
+                  is the vSphere Content Library.
+                type: string
+              osInfo:
+                description: OSInfo describes the attributes of the VirtualMachineImage
+                  relating to the Operating System contained in the image.
+                properties:
+                  type:
+                    description: Type typically describes the type of the guest operating
+                      system.
+                    type: string
+                  version:
+                    description: Version typically describes the version of the guest
+                      operating system.
+                    type: string
+                type: object
+              ovfEnv:
+                additionalProperties:
+                  description: OvfProperty describes information related to a user
+                    configurable property element that is supported by VirtualMachineImage
+                    and can be customized during VirtualMachine creation.
+                  properties:
+                    default:
+                      description: Default describes the default value of the ovf
+                        key.
+                      type: string
+                    key:
+                      description: Key describes the key of the ovf property.
+                      type: string
+                    type:
+                      description: Type describes the type of the ovf property.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                description: OVFEnv describes the user configurable customization
+                  parameters of the VirtualMachineImage.
+                type: object
+              productInfo:
+                description: ProductInfo describes the attributes of the VirtualMachineImage
+                  relating to the product contained in the image.
+                properties:
+                  fullVersion:
+                    description: FullVersion typically describes a long-form version
+                      of the image.
+                    type: string
+                  product:
+                    description: Product typically describes the type of product contained
+                      in the image.
+                    type: string
+                  vendor:
+                    description: Vendor typically describes the name of the vendor
+                      that is producing the image.
+                    type: string
+                  version:
+                    description: Version typically describes a short-form version
+                      of the image.
+                    type: string
+                type: object
+              providerRef:
+                description: ProviderRef is a reference to a content provider object
+                  that describes a provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced.
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced.
+                    type: string
+                  namespace:
+                    description: Namespace of the resource being referenced. If empty,
+                      cluster scoped resource is assumed.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              type:
+                description: Type describes the type of the VirtualMachineImage. Currently,
+                  the only supported image is "OVF"
+                type: string
+            required:
+            - imageID
+            - providerRef
+            - type
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage
+            properties:
+              conditions:
+                description: Conditions describes the current condition information
+                  of the VirtualMachineImage object. e.g. if the OS type is supported
+                  or image is supported by VMService
+                items:
+                  description: Condition defines an observation of a VM Operator API
+                    resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: ImageName describes the display name of this VirtualMachineImage.
+                type: string
+              imageSupported:
+                description: 'ImageSupported indicates whether the VirtualMachineImage
+                  is supported by VMService. A VirtualMachineImage is supported by
+                  VMService if the following conditions are true: - VirtualMachineImageV1Alpha1CompatibleCondition'
+                type: boolean
+              internalId:
+                description: Deprecated
+                type: string
+              powerState:
+                description: Deprecated
+                type: string
+              uuid:
+                description: Deprecated
+                type: string
+            required:
+            - internalId
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
@@ -1,0 +1,530 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachines.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachine
+    listKind: VirtualMachineList
+    plural: virtualmachines
+    shortNames:
+    - vm
+    singular: virtualmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.powerState
+      name: PowerState
+      type: string
+    - jsonPath: .spec.className
+      name: Class
+      priority: 1
+      type: string
+    - jsonPath: .spec.imageName
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.vmIp
+      name: Primary-IP
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachine is the Schema for the virtualmachines API. A VirtualMachine
+          represents the desired specification and the observed status of a VirtualMachine
+          instance.  A VirtualMachine is realized by the VirtualMachine controller
+          on a backing Virtual Infrastructure provider such as vSphere.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine
+            properties:
+              advancedOptions:
+                description: AdvancedOptions describes a set of optional, advanced
+                  options for configuring a VirtualMachine
+                properties:
+                  changeBlockTracking:
+                    description: ChangeBlockTracking specifies the enablement of incremental
+                      backup support for this VirtualMachine, which can be utilized
+                      by external backup systems such as VMware Data Recovery.
+                    type: boolean
+                  defaultVolumeProvisioningOptions:
+                    description: DefaultProvisioningOptions specifies the provisioning
+                      type to be used by default for VirtualMachine volumes exclusively
+                      owned by this VirtualMachine. This does not apply to PersistentVolumeClaim
+                      volumes that are created and managed externally.
+                    properties:
+                      eagerZeroed:
+                        description: EagerZeroed specifies whether to use eager zero
+                          provisioning for the VirtualMachineVolume. An eager zeroed
+                          thick disk has all space allocated and wiped clean of any
+                          previous contents on the physical media at creation time.
+                          Such disks may take longer time during creation compared
+                          to other disk formats. EagerZeroed is only applicable if
+                          ThinProvisioned is false. This is validated by the webhook.
+                        type: boolean
+                      thinProvisioned:
+                        description: ThinProvisioned specifies whether to use thin
+                          provisioning for the VirtualMachineVolume. This means a
+                          sparse (allocate on demand) format with additional space
+                          optimizations.
+                        type: boolean
+                    type: object
+                type: object
+              className:
+                description: ClassName describes the name of a VirtualMachineClass
+                  that is to be used as the overlaid resource configuration of VirtualMachine.  A
+                  VirtualMachineClass is used to further customize the attributes
+                  of the VirtualMachine instance.  See VirtualMachineClass for more
+                  description.
+                type: string
+              imageName:
+                description: ImageName describes the name of a VirtualMachineImage
+                  that is to be used as the base Operating System image of the desired
+                  VirtualMachine instances.  The VirtualMachineImage resources can
+                  be introspected to discover identifying attributes that may help
+                  users to identify the desired image to use.
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces describes a list of VirtualMachineNetworkInterfaces
+                  to be configured on the VirtualMachine instance. Each of these VirtualMachineNetworkInterfaces
+                  describes external network integration configurations that are to
+                  be used by the VirtualMachine controller when integrating the VirtualMachine
+                  into one or more external networks.
+                items:
+                  description: VirtualMachineNetworkInterface defines the properties
+                    of a network interface to attach to a VirtualMachine instance.  A
+                    VirtualMachineNetworkInterface describes network interface configuration
+                    that is used by the VirtualMachine controller when integrating
+                    the VirtualMachine into a VirtualNetwork.  Currently, only NSX-T
+                    and vSphere Distributed Switch (VDS) type network integrations
+                    are supported using this VirtualMachineNetworkInterface structure.
+                  properties:
+                    ethernetCardType:
+                      description: EthernetCardType describes an optional ethernet
+                        card that should be used by the VirtualNetworkInterface (vNIC)
+                        associated with this network integration.  The default is
+                        "vmxnet3".
+                      type: string
+                    networkName:
+                      description: NetworkName describes the name of an existing virtual
+                        network that this interface should be added to. For "nsx-t"
+                        NetworkType, this is the name of a pre-existing NSX-T VirtualNetwork.
+                        If unspecified, the default network for the namespace will
+                        be used. For "vsphere-distributed" NetworkType, the NetworkName
+                        must be specified.
+                      type: string
+                    networkType:
+                      description: NetworkType describes the type of VirtualNetwork
+                        that is referenced by the NetworkName.  Currently, the only
+                        supported NetworkTypes are "nsx-t" and "vsphere-distributed".
+                      type: string
+                    providerRef:
+                      description: ProviderRef is reference to a network interface
+                        provider object that specifies the network interface configuration.
+                        If unset, default configuration is assumed.
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced.
+                          type: string
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - apiGroup
+                      - kind
+                      - name
+                      type: object
+                  type: object
+                type: array
+              ports:
+                description: Ports is currently unused and can be considered deprecated.
+                items:
+                  description: VirtualMachinePort is unused and can be considered
+                    deprecated.
+                  properties:
+                    ip:
+                      type: string
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      default: TCP
+                      type: string
+                  required:
+                  - ip
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              powerState:
+                description: PowerState describes the desired power state of a VirtualMachine.  Valid
+                  power states are "poweredOff" and "poweredOn".
+                enum:
+                - poweredOff
+                - poweredOn
+                type: string
+              readinessProbe:
+                description: ReadinessProbe describes a network probe that can be
+                  used to determine if the VirtualMachine is available and responding
+                  to the probe.
+                properties:
+                  guestHeartbeat:
+                    description: GuestHeartbeat specifies an action involving the
+                      guest heartbeat status.
+                    properties:
+                      thresholdStatus:
+                        default: green
+                        description: ThresholdStatus is the value that the guest heartbeat
+                          status must be at or above to be considered successful.
+                        enum:
+                        - yellow
+                        - green
+                        type: string
+                    type: object
+                  periodSeconds:
+                    description: PeriodSeconds specifics how often (in seconds) to
+                      perform the probe. Defaults to 10 seconds. Minimum value is
+                      1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
+                    properties:
+                      host:
+                        description: Host is an optional host name to connect to.  Host
+                          defaults to the VirtualMachine IP.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Port specifies a number or name of the port to
+                          access on the VirtualMachine. If the format of port is a
+                          number, it must be in the range 1 to 65535. If the format
+                          of name is a string, it must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: TimeoutSeconds specifies a number of seconds after
+                      which the probe times out. Defaults to 10 seconds. Minimum value
+                      is 1.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
+                type: object
+              resourcePolicyName:
+                description: ResourcePolicyName describes the name of a VirtualMachineSetResourcePolicy
+                  to be used when creating the VirtualMachine instance.
+                type: string
+              storageClass:
+                description: StorageClass describes the name of a StorageClass that
+                  should be used to configure storage-related attributes of the VirtualMachine
+                  instance.
+                type: string
+              vmMetadata:
+                description: VmMetadata describes any optional metadata that should
+                  be passed to the Guest OS.
+                properties:
+                  configMapName:
+                    description: ConfigMapName describes the name of the ConfigMap,
+                      in the same Namespace as the VirtualMachine, that should be
+                      used for VirtualMachine metadata.  The contents of the Data
+                      field of the ConfigMap is used as the VM Metadata. The format
+                      of the contents of the VM Metadata are not parsed or interpreted
+                      by the VirtualMachine controller. Please note, this field and
+                      SecretName are mutually exclusive.
+                    type: string
+                  secretName:
+                    description: SecretName describes the name of the Secret, in the
+                      same Namespace as the VirtualMachine, that should be used for
+                      VirtualMachine metadata. The contents of the Data field of the
+                      Secret is used as the VM Metadata. The format of the contents
+                      of the VM Metadata are not parsed or interpreted by the VirtualMachine
+                      controller. Please note, this field and ConfigMapName are mutually
+                      exclusive.
+                    type: string
+                  transport:
+                    description: Transport describes the name of a supported VirtualMachineMetadata
+                      transport protocol.  Currently, the only supported transport
+                      protocols are "ExtraConfig", "OvfEnv" and "CloudInit".
+                    enum:
+                    - ExtraConfig
+                    - OvfEnv
+                    - CloudInit
+                    type: string
+                type: object
+              volumes:
+                description: Volumes describes the list of VirtualMachineVolumes that
+                  are desired to be attached to the VirtualMachine.  Each of these
+                  volumes specifies a volume identity that the VirtualMachine controller
+                  will attempt to satisfy, potentially with an external Volume Management
+                  service.
+                items:
+                  description: VirtualMachineVolume describes a Volume that should
+                    be attached to a specific VirtualMachine. Only one of PersistentVolumeClaim,
+                    VsphereVolume should be specified.
+                  properties:
+                    name:
+                      description: Name specifies the name of the VirtualMachineVolume.  Each
+                        volume within the scope of a VirtualMachine must have a unique
+                        name.
+                      type: string
+                    persistentVolumeClaim:
+                      description: "PersistentVolumeClaim represents a reference to
+                        a PersistentVolumeClaim in the same namespace. The PersistentVolumeClaim
+                        must match one of the following: \n   * A volume provisioned
+                        (either statically or dynamically) by the     cluster's CSI
+                        provider. \n   * An instance volume with a lifecycle coupled
+                        to the VM."
+                      properties:
+                        claimName:
+                          description: 'ClaimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        instanceVolumeClaim:
+                          description: InstanceVolumeClaim is set if the PVC is backed
+                            by instance storage.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Size is the size of the requested instance
+                                storage volume.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageClass:
+                              description: StorageClass is the name of the Kubernetes
+                                StorageClass that provides the backing storage for
+                                this instance storage volume.
+                              type: string
+                          required:
+                          - size
+                          - storageClass
+                          type: object
+                        readOnly:
+                          description: Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    vSphereVolume:
+                      description: VsphereVolume represents a reference to a VsphereVolumeSource
+                        in the same namespace. Only one of PersistentVolumeClaim or
+                        VsphereVolume can be specified. This is enforced via a webhook
+                      properties:
+                        capacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: A description of the virtual volume's resources
+                            and capacity
+                          type: object
+                        deviceKey:
+                          description: Device key of vSphere disk.
+                          type: integer
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - className
+            - imageName
+            - powerState
+            type: object
+          status:
+            description: VirtualMachineStatus defines the observed state of a VirtualMachine
+              instance.
+            properties:
+              biosUUID:
+                description: BiosUUID describes a unique identifier provided by the
+                  underlying infrastructure provider that is exposed to the Guest
+                  OS BIOS as a unique hardware identifier.
+                type: string
+              changeBlockTracking:
+                description: ChangeBlockTracking describes the CBT enablement status
+                  on the VirtualMachine.
+                type: boolean
+              conditions:
+                description: Conditions describes the current condition information
+                  of the VirtualMachine.
+                items:
+                  description: Condition defines an observation of a VM Operator API
+                    resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              host:
+                description: Host describes the hostname or IP address of the infrastructure
+                  host that the VirtualMachine is executing on.
+                type: string
+              instanceUUID:
+                description: InstanceUUID describes the unique instance UUID provided
+                  by the underlying infrastructure provider, such as vSphere.
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces describes a list of current status
+                  information for each network interface that is desired to be attached
+                  to the VirtualMachine.
+                items:
+                  description: NetworkInterfaceStatus defines the observed state of
+                    network interfaces attached to the VirtualMachine as seen by the
+                    Guest OS and VMware tools
+                  properties:
+                    connected:
+                      description: Connected represents whether the network interface
+                        is connected or not.
+                      type: boolean
+                    ipAddresses:
+                      description: IpAddresses represents zero, one or more IP addresses
+                        assigned to the network interface in CIDR notation. For eg,
+                        "192.0.2.1/16".
+                      items:
+                        type: string
+                      type: array
+                    macAddress:
+                      description: MAC address of the network adapter
+                      type: string
+                  required:
+                  - connected
+                  type: object
+                type: array
+              phase:
+                description: Phase describes the current phase information of the
+                  VirtualMachine.
+                type: string
+              powerState:
+                description: PowerState describes the current power state of the VirtualMachine.
+                enum:
+                - poweredOff
+                - poweredOn
+                type: string
+              uniqueID:
+                description: UniqueID describes a unique identifier that is provided
+                  by the underlying infrastructure provider, such as vSphere.
+                type: string
+              vmIp:
+                description: VmIp describes the Primary IP address assigned to the
+                  guest operating system, if known. Multiple IPs can be available
+                  for the VirtualMachine. Refer to networkInterfaces in the VirtualMachine
+                  status for additional IPs
+                type: string
+              volumes:
+                description: Volumes describes a list of current status information
+                  for each Volume that is desired to be attached to the VirtualMachine.
+                items:
+                  description: VirtualMachineVolumeStatus defines the observed state
+                    of a VirtualMachineVolume instance.
+                  properties:
+                    attached:
+                      description: Attached represents whether a volume has been successfully
+                        attached to the VirtualMachine or not.
+                      type: boolean
+                    diskUUID:
+                      description: DiskUuid represents the underlying virtual disk
+                        UUID and is present when attachment succeeds.
+                      type: string
+                    error:
+                      description: Error represents the last error seen when attaching
+                        or detaching a volume.  Error will be empty if attachment
+                        succeeds.
+                      type: string
+                    name:
+                      description: Name is the name of the volume in a VirtualMachine.
+                      type: string
+                  required:
+                  - attached
+                  - diskUUID
+                  - error
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -1,0 +1,187 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachineservices.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineService
+    listKind: VirtualMachineServiceList
+    plural: virtualmachineservices
+    shortNames:
+    - vmservice
+    singular: virtualmachineservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineService is the Schema for the virtualmachineservices
+          API. A VirtualMachineService represents the desired specification and the
+          observed status of a VirtualMachineService instance. A VirtualMachineService
+          represents a network service, provided by one or more VirtualMachines, that
+          is desired to be exposed to other workloads both internal and external to
+          the cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
+              Each VirtualMachineService exposes a set of TargetPorts on a set of
+              VirtualMachine instances as a network endpoint within or outside of
+              the Kubernetes cluster. The VirtualMachineService is loosely coupled
+              to the VirtualMachines that are backing it through the use of a Label
+              Selector. In Kubernetes, a Label Selector enables matching of a resource
+              using a set of key-value pairs, aka Labels. By using a Label Selector,
+              the VirtualMachineService can be generically defined to apply to any
+              VirtualMachine in the same namespace that has the appropriate set of
+              labels.
+            properties:
+              clusterIp:
+                description: 'clusterIP is the IP address of the service and is usually
+                  assigned randomly by the master. If an address is specified manually
+                  and is not in use by others, it will be allocated to the service;
+                  otherwise, creation of the service will fail. This field can not
+                  be changed through updates. Valid values are "None", empty string
+                  (""), or a valid IP address. "None" can be specified for headless
+                  services when proxying is not required. Only applies to types ClusterIP
+                  and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              externalName:
+                description: externalName is the external reference that kubedns or
+                  equivalent will return as a CNAME record for this service. No proxying
+                  will be involved. Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                  and requires Type to be ExternalName.
+                type: string
+              loadBalancerIP:
+                description: 'Only applies to VirtualMachineService Type: LoadBalancer
+                  LoadBalancer will get created with the IP specified in this field.
+                  This feature depends on whether the underlying load balancer provider
+                  supports specifying the loadBalancerIP when a load balancer is created.
+                  This field will be ignored if the provider does not support the
+                  feature.'
+                type: string
+              loadBalancerSourceRanges:
+                description: 'LoadBalancerSourceRanges is an array of IP addresses
+                  in the format of CIDRs, for example: 103.21.244.0/22 and 10.0.0.0/24.
+                  If specified and supported by the load balancer provider, this will
+                  restrict ingress traffic to the specified client IPs. This field
+                  will be ignored if the provider does not support the feature.'
+                items:
+                  type: string
+                type: array
+              ports:
+                description: Ports specifies a list of VirtualMachineServicePort to
+                  expose with this VirtualMachineService. Each of these ports will
+                  be an accessible network entry point to access this service by.
+                items:
+                  description: VirtualMachineServicePort describes the specification
+                    of a service port to be exposed by a VirtualMachineService. This
+                    VirtualMachineServicePort specification includes attributes that
+                    define the external and internal representation of the service
+                    port.
+                  properties:
+                    name:
+                      description: Name describes the name to be used to identify
+                        this VirtualMachineServicePort
+                      type: string
+                    port:
+                      description: Port describes the external port that will be exposed
+                        by the service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: Protocol describes the Layer 4 transport protocol
+                        for this port. Supports "TCP", "UDP", and "SCTP".
+                      type: string
+                    targetPort:
+                      description: TargetPort describes the internal port open on
+                        a VirtualMachine that should be mapped to the external Port.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  - targetPort
+                  type: object
+                type: array
+              selector:
+                additionalProperties:
+                  type: string
+                description: Selector specifies a map of key-value pairs, also known
+                  as a Label Selector, that is used to match this VirtualMachineService
+                  with the set of VirtualMachines that should back this VirtualMachineService.
+                type: object
+              type:
+                description: Type specifies a desired VirtualMachineServiceType for
+                  this VirtualMachineService. Supported types are ClusterIP, LoadBalancer,
+                  ExternalName.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: VirtualMachineServiceStatus defines the observed state of
+              VirtualMachineService
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load
+                  balancer, if one is present.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress addresses for
+                      the load balancer. Traffic intended for the service should be
+                      sent to any of these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point. IP or Hostname may both
+                        be set in this structure. It is up to the consumer to determine
+                        which field should be used when accessing this LoadBalancer.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load balancer ingress points
+                            that are specified by a DNS address.
+                          type: string
+                        ip:
+                          description: IP is set for load balancer ingress points
+                            that are specified by an IP address.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -1,0 +1,136 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachinesetresourcepolicies.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineSetResourcePolicy
+    listKind: VirtualMachineSetResourcePolicyList
+    plural: virtualmachinesetresourcepolicies
+    singular: virtualmachinesetresourcepolicy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSetResourcePolicySpec defines the desired state
+              of VirtualMachineSetResourcePolicy
+            properties:
+              clustermodules:
+                items:
+                  description: ClusterModuleSpec defines a grouping of VirtualMachines
+                    that are to be grouped together as a logical unit by the infrastructure
+                    provider.  Within vSphere, the ClusterModuleSpec maps directly
+                    to a vSphere ClusterModule.
+                  properties:
+                    groupname:
+                      description: GroupName describes the name of the ClusterModule
+                        Group.
+                      type: string
+                  required:
+                  - groupname
+                  type: object
+                type: array
+              folder:
+                description: Folder defines a Folder
+                properties:
+                  name:
+                    description: Name describes the name of the Folder
+                    type: string
+                type: object
+              resourcepool:
+                description: ResourcePoolSpec defines a Logical Grouping of workloads
+                  that share resource policies.
+                properties:
+                  limits:
+                    description: Limits describes the limit to resources available
+                      to the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  name:
+                    description: Name describes the name of the ResourcePool grouping.
+                    type: string
+                  reservations:
+                    description: Reservations describes the guaranteed resources reserved
+                      for the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+            type: object
+          status:
+            description: VirtualMachineSetResourcePolicyStatus defines the observed
+              state of VirtualMachineSetResourcePolicy
+            properties:
+              clustermodules:
+                items:
+                  properties:
+                    clusterMoID:
+                      type: string
+                    groupname:
+                      type: string
+                    moduleUUID:
+                      type: string
+                  required:
+                  - clusterMoID
+                  - groupname
+                  - moduleUUID
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
@@ -1,0 +1,77 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: webconsolerequests.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: WebConsoleRequest
+    listKind: WebConsoleRequestList
+    plural: webconsolerequests
+    singular: webconsolerequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WebConsoleRequest allows the creation of a one-time web console
+          ticket that can be used to interact with the VM.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WebConsoleRequestSpec describes the specification for used
+              to request a web console request.
+            properties:
+              publicKey:
+                description: PublicKey is used to encrypt the status.response. This
+                  is expected to be a RSA OAEP public key in X.509 PEM format.
+                type: string
+              virtualMachineName:
+                description: VirtualMachineName is the VM in the same namespace, for
+                  which the web console is requested.
+                type: string
+            required:
+            - publicKey
+            - virtualMachineName
+            type: object
+          status:
+            description: WebConsoleRequestStatus defines the observed state, which
+              includes the web console request itself.
+            properties:
+              expiryTime:
+                description: ExpiryTime is when the ticket referenced in Response
+                  will expire.
+                format: date-time
+                type: string
+              response:
+                description: Response will be the authenticated ticket corresponding
+                  to this web console request.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/kustomization.yaml
+++ b/config/deployments/integration-tests/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../supervisor
+- ./crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+- ./crds/vmoperator.vmware.com_contentsourcebindings.yaml
+- ./crds/vmoperator.vmware.com_contentsources.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineimages.yaml
+- ./crds/vmoperator.vmware.com_virtualmachines.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineservices.yaml
+- ./crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+- ./crds/vmoperator.vmware.com_webconsolerequests.yaml

--- a/config/rbac/aggregate_label_to_cluster_role_patch.yaml
+++ b/config/rbac/aggregate_label_to_cluster_role_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: true

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+patchesStrategicMerge:
+- aggregate_label_to_cluster_role_patch.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -350,6 +350,18 @@ rules:
   resources:
   - vspheremachinetemplates
   verbs:
+  - create
   - delete
   - get
   - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vmware.infrastructure.cluster.x-k8s.io
+  resources:
+  - vspheremachinetemplates/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/supervisor/kustomization.yaml
+++ b/config/supervisor/kustomization.yaml
@@ -7,6 +7,7 @@ namePrefix: capv-
 
 commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-vsphere"
+  cluster.x-k8s.io/v1beta1: v1beta1
 resources:
   - ../base
   - crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml

--- a/controllers/vmware/test/controllers_suite_test.go
+++ b/controllers/vmware/test/controllers_suite_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	goctx "context"
+	"encoding/json"
+	"os/exec"
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/controllers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	k8sClient     client.Client
+	testEnv       *envtest.Environment
+	ctx, cancel   = goctx.WithCancel(goctx.Background())
+	isLB          = false
+	clusterAPIDir = findModuleDir("sigs.k8s.io/cluster-api")
+)
+
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klogr.New())
+}
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"VMware Controllers Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+// TODO: can't call RunSpecs twice. Need to parameterize this externally and call the test suite twice
+//func TestAPIsLB(t *testing.T) {
+//	isLB = true
+//	RegisterFailHandler(Fail)
+//
+//	RunSpecsWithDefaultAndCustomReporters(t,
+//		"VMware Controller Suite with LB network provider",
+//		[]Reporter{printer.NewlineReporter{}})
+//}
+
+func getTestEnv() (*envtest.Environment, *rest.Config) {
+	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
+
+	// Get the root of the current file to use in CRD paths.
+	_, filename, _, _ := goruntime.Caller(0) //nolint
+	root := path.Join(path.Dir(filename), "..", "..", "..")
+
+	localTestEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join(root, "config", "supervisor", "crd"),
+			filepath.Join(root, "config", "deployments", "integration-tests", "crds"),
+			filepath.Join(clusterAPIDir, "config", "crd", "bases"),
+		},
+	}
+
+	localCfg, err := localTestEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(localCfg).ToNot(BeNil())
+	return localTestEnv, localCfg
+}
+
+func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
+	opts := manager.Options{
+		Options: ctrlmgr.Options{
+			Scheme: scheme.Scheme,
+			NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+				syncPeriod := 1 * time.Second
+				opts.Resync = &syncPeriod
+				return cache.New(config, opts)
+			},
+		},
+		KubeConfig:      cfg,
+		NetworkProvider: networkProvider,
+	}
+
+	opts.AddToManager = func(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+		if err := controllers.AddClusterControllerToManager(ctx, mgr, &vmwarev1.VSphereCluster{}); err != nil {
+			return err
+		}
+
+		if err := controllers.AddMachineControllerToManager(ctx, mgr, &vmwarev1.VSphereMachine{}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	mgr, err := manager.New(opts)
+	Expect(err).NotTo(HaveOccurred())
+	return mgr
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environments")
+	var cfg *rest.Config
+	testEnv, cfg = getTestEnv()
+	networkProvider := ""
+	if isLB {
+		networkProvider = manager.DummyLBNetworkProvider
+	}
+
+	By("setting up a new manager")
+	mgr := getManager(cfg, networkProvider)
+	k8sClient = mgr.GetClient()
+
+	By("starting the manager")
+	go func() {
+		Expect(mgr.Start(ctx)).ToNot(HaveOccurred())
+	}()
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environments")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func findModuleDir(module string) string {
+	cmd := exec.Command("go", "mod", "download", "-json", module)
+	out, err := cmd.Output()
+	if err != nil {
+		klog.Fatalf("Failed to run go mod to find module %q directory", module)
+	}
+	info := struct{ Dir string }{}
+	if err := json.Unmarshal(out, &info); err != nil {
+		klog.Fatalf("Failed to unmarshal output from go mod command: %v", err)
+	} else if info.Dir == "" {
+		klog.Fatalf("Failed to find go module %q directory, received %v", module, string(out))
+	}
+	return info.Dir
+}

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	namespace = "default"
+)
+
+// newInfraCluster returns an Infra cluster with the same name as the target
+// cluster
+func newInfraCluster(cluster *clusterv1.Cluster) client.Object {
+	//func newInfraCluster(cluster *clusterv1.Cluster) runtimeObject {
+	return &vmwarev1.VSphereCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// newAnonInfraCluster returns an Infra cluster with a generated name
+func newAnonInfraCluster() client.Object {
+	return &vmwarev1.VSphereCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    namespace,
+		},
+	}
+}
+
+// newInfraMachine creates an Infra machine with the same name as the target
+// machine
+func newInfraMachine(machine *clusterv1.Machine) client.Object {
+	return &vmwarev1.VSphereMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machine.Name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// newInfraMachine creates an Infra machine with a generated name
+func newAnonInfraMachine() client.Object {
+	return &vmwarev1.VSphereMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    namespace,
+		},
+	}
+}
+
+// Creates and deploys a Cluster and VSphereCluster in order. Function does not
+// block on VSphereCluster creation.
+func deployCluster() (client.ObjectKey, *clusterv1.Cluster, client.Object) {
+	// A finalizer is added to prevent it from being deleted until its
+	// dependents are removed.
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    namespace,
+			Finalizers:   []string{"test"},
+		},
+		Spec: clusterv1.ClusterSpec{},
+	}
+	Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+	clusterKey := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}
+	Eventually(func() error {
+		return k8sClient.Get(ctx, clusterKey, cluster)
+	}, time.Second*30).Should(Succeed())
+
+	By("Create the infrastructure cluster and wait for it to have a finalizer")
+	infraCluster := newInfraCluster(cluster)
+	infraCluster.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: cluster.APIVersion,
+			Kind:       cluster.Kind,
+			Name:       cluster.Name,
+			UID:        cluster.UID,
+		},
+	})
+	Expect(k8sClient.Create(ctx, infraCluster)).To(Succeed())
+
+	return clusterKey, cluster, infraCluster
+}
+
+// Creates and deploys a CAPI Machine. Function does not block on Machine
+// creation
+func deployCAPIMachine(cluster *clusterv1.Cluster) (client.ObjectKey, *clusterv1.Machine) {
+	// A finalizer is added to prevent it from being deleted until its
+	// dependents are removed.
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    namespace,
+			Finalizers:   []string{"test"},
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName:             cluster.Name,
+				clusterv1.MachineControlPlaneLabelName: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: cluster.APIVersion,
+					Kind:       cluster.Kind,
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+				},
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cluster.Name,
+		},
+	}
+	Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+	machineKey := client.ObjectKey{Namespace: machine.Namespace, Name: machine.Name}
+	return machineKey, machine
+}
+
+// Creates and deploys a VSphereMachine. Function does not block on Machine
+// creation
+func deployInfraMachine(machine *clusterv1.Machine, finalizers []string) (client.ObjectKey, client.Object) {
+	infraMachine := newInfraMachine(machine)
+	infraMachine.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: machine.APIVersion,
+			Kind:       machine.Kind,
+			Name:       machine.Name,
+			UID:        machine.UID,
+		},
+	})
+	infraMachine.SetFinalizers(finalizers)
+	Expect(k8sClient.Create(ctx, infraMachine)).To(Succeed())
+	infraMachineKey := client.ObjectKey{Namespace: infraMachine.GetNamespace(), Name: infraMachine.GetName()}
+	return infraMachineKey, infraMachine
+}
+
+// Updates the InfrastructureRef of a CAPI Cluster to a VSphereCluster. Function
+// does not block on update success
+func updateClusterInfraRef(cluster *clusterv1.Cluster, infraCluster client.Object) {
+	cluster.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: infraCluster.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:       infraCluster.GetObjectKind().GroupVersionKind().Kind,
+		Name:       infraCluster.GetName(),
+	}
+	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+}
+
+// Cache the type names of the infrastructure cluster and machine.
+var (
+	infraClusterTypeName = reflect.TypeOf(newAnonInfraCluster()).Elem().Name()
+	infraMachineTypeName = reflect.TypeOf(newAnonInfraCluster()).Elem().Name()
+)
+
+// The spec conformance tests assert that the infrastructure types
+// can be submitted to the API server without any errors.
+var _ = Describe("Spec conformance tests", func() {
+	var (
+		obj client.Object
+		key *client.ObjectKey
+	)
+
+	// assertObjEventuallyExists is used to assert that eventually obj can be
+	// retrieved from the API server.
+	assertObjEventuallyExists := func() {
+		EventuallyWithOffset(1, func() error {
+			return k8sClient.Get(ctx, *key, obj)
+		}, time.Second*30).Should(Succeed())
+	}
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+		key = &client.ObjectKey{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		}
+	})
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+	})
+	AfterEach(func() {
+		obj = nil
+		key = nil
+	})
+	Context(infraClusterTypeName, func() {
+		BeforeEach(func() {
+			obj = newAnonInfraCluster()
+		})
+		It("Will be created and wait on an OwnerRef", func() {
+			assertObjEventuallyExists()
+		})
+	})
+
+	Context(infraMachineTypeName, func() {
+		BeforeEach(func() {
+			obj = newAnonInfraMachine()
+		})
+		It("Will be created and wait on an OwnerRef", func() {
+			assertObjEventuallyExists()
+		})
+	})
+})
+
+// Verifies that the infrastructure types have finalizers set when an OwnerRef
+// is set that points to the corresponding CAPI resource.
+var _ = Describe("Reconciler tests", func() {
+	// assertEventuallyFinalizers is used to assert an object eventually has one
+	// or more finalizers.
+	assertEventuallyFinalizers := func(key client.ObjectKey, obj client.Object) {
+		EventuallyWithOffset(1, func() (int, error) {
+			if err := k8sClient.Get(ctx, key, obj); err != nil {
+				return 0, err
+			}
+			return len(obj.GetFinalizers()), nil
+		}, time.Second*30).Should(BeNumerically(">", 0))
+	}
+
+	assertEventuallyVMStatus := func(key client.ObjectKey, obj client.Object, expectedState vmwarev1.VirtualMachineState) {
+		EventuallyWithOffset(1, func() (vmwarev1.VirtualMachineState, error) {
+			if err := k8sClient.Get(ctx, key, obj); err != nil {
+				return "", err
+			}
+			vSphereMachine := obj.(*vmwarev1.VSphereMachine)
+			return vSphereMachine.Status.VMStatus, nil
+		}, time.Second*30).Should(Equal(expectedState))
+	}
+
+	assertEventuallyControlPlaneEndpoint := func(key client.ObjectKey, obj client.Object, expectedIP string) {
+		EventuallyWithOffset(1, func() (string, error) {
+			if err := k8sClient.Get(ctx, key, obj); err != nil {
+				return "", err
+			}
+			vsphereCluster := obj.(*vmwarev1.VSphereCluster)
+			return vsphereCluster.Spec.ControlPlaneEndpoint.Host, nil
+		}, time.Second*30).Should(Equal(expectedIP))
+	}
+
+	deleteAndWait := func(key client.ObjectKey, obj client.Object, removeFinalizers bool) {
+		// Delete the object.
+		Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+
+		// Issues updates until the patch to remove the finalizers is
+		// successful.
+		if removeFinalizers {
+			EventuallyWithOffset(1, func() error {
+				if err := k8sClient.Get(ctx, key, obj); err != nil {
+					return err
+				}
+				obj.SetFinalizers([]string{})
+				return k8sClient.Update(ctx, obj)
+			}, time.Second*30).Should(Succeed())
+		}
+
+		// Wait for the object to no longer be available.
+		EventuallyWithOffset(1, func() error {
+			return k8sClient.Get(ctx, key, obj)
+		}, time.Second*30).ShouldNot(Succeed())
+	}
+
+	Specify("Infrastructure resources should have finalizers after reconciliation", func() {
+		By("Create the CAPI Cluster and wait for it to exist")
+		clusterKey, cluster, infraCluster := deployCluster()
+
+		// Assert that eventually the infrastructure cluster will have a
+		// finalizer.
+		infraClusterKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
+		assertEventuallyFinalizers(infraClusterKey, infraCluster)
+
+		By("Update the CAPI Cluster's InfrastructureRef")
+		updateClusterInfraRef(cluster, infraCluster)
+
+		By("Expect a ResourcePolicy to exist")
+		rpKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
+		resourcePolicy := &vmoprv1.VirtualMachineSetResourcePolicy{}
+		Expect(k8sClient.Get(ctx, rpKey, resourcePolicy)).To(Succeed())
+		Expect(len(resourcePolicy.Spec.ClusterModules)).To(BeEquivalentTo(2))
+
+		By("Create the CAPI Machine and wait for it to exist")
+		machineKey, machine := deployCAPIMachine(cluster)
+		Eventually(func() error {
+			return k8sClient.Get(ctx, machineKey, machine)
+		}, time.Second*30).Should(Succeed())
+
+		By("Create the infrastructure machine and wait for it to have a finalizer")
+		infraMachineKey, infraMachine := deployInfraMachine(machine, nil)
+		assertEventuallyFinalizers(infraMachineKey, infraMachine)
+
+		// Delete the CAPI Cluster. To simulate the CAPI components we must:
+		//
+		// 1. Delete a resource.
+		// 2. Remove its finalizers (if its a CAPI object).
+		// 3. Update the resource.
+		// 4. Wait for the resource to be deleted.
+		By("Delete the infrastructure machine and wait for it to be removed")
+		deleteAndWait(infraMachineKey, infraMachine, false)
+
+		By("Delete the CAPI machine and wait for it to be removed")
+		deleteAndWait(machineKey, machine, true)
+
+		By("Delete the infrastructure cluster and wait for it to be removed")
+		deleteAndWait(infraClusterKey, infraCluster, false)
+
+		By("Delete the CAPI cluster and wait for it to be removed")
+		deleteAndWait(clusterKey, cluster, true)
+	})
+
+	Specify("VSphereClusters can be deleted without a corresponding Cluster", func() {
+		By("Creating an infrastructure cluster with no owner or cluster reference")
+		infraCluster := newAnonInfraCluster()
+		Expect(k8sClient.Create(ctx, infraCluster)).To(Succeed())
+		infraClusterKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
+
+		// We add the finalizer here to simulate an observed situation where
+		// there was no Cluster OwnerRef, but there _was_ a finalizer. This
+		// _shouldn't_ ever happen during normal operation, but it can happen
+		// if users muck with things.
+		infraCluster.SetFinalizers([]string{vmwarev1.ClusterFinalizer})
+		Expect(k8sClient.Update(ctx, infraCluster)).To(Succeed())
+		assertEventuallyFinalizers(infraClusterKey, infraCluster)
+
+		By("Deleting the infrastructure cluster and waiting for it to be removed")
+		deleteAndWait(infraClusterKey, infraCluster, false)
+	})
+
+	Specify("Create and Delete a VSphereMachine with a Machine but without a Cluster", func() {
+		By("Create the CAPI Machine and wait for it to exist")
+		// A finalizer is added to prevent it from being deleted until its
+		// dependents are removed.
+		machine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    namespace,
+				Finalizers:   []string{"test"},
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName: "crud",
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		machineKey := client.ObjectKey{Namespace: machine.Namespace, Name: machine.Name}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, machineKey, machine)
+		}, time.Second*30).Should(Succeed())
+
+		By("Create the infrastructure machine and set a finalizer")
+		infraMachineKey, infraMachine := deployInfraMachine(machine, []string{infrav1.MachineFinalizer})
+		Eventually(func() error {
+			return k8sClient.Get(ctx, infraMachineKey, infraMachine)
+		}, time.Second*30).Should(Succeed())
+
+		By("Delete the InfraMachine and wait for it to be removed")
+		deleteAndWait(infraMachineKey, infraMachine, false)
+	})
+
+	Specify("A VM gets properly reconciled for a Machine and reflects appropriate VM status", func() {
+		By("Create the CAPI Cluster and wait for it to exist")
+		_, cluster, infraCluster := deployCluster()
+		updateClusterInfraRef(cluster, infraCluster)
+		infraClusterKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, infraClusterKey, infraCluster)
+		}, time.Second*30).Should(Succeed())
+		updateClusterInfraRef(cluster, infraCluster)
+
+		By("Create the CAPI Machine and wait for it to exist")
+		machineKey, machine := deployCAPIMachine(cluster)
+		Eventually(func() error {
+			return k8sClient.Get(ctx, machineKey, machine)
+		}, time.Second*30).Should(Succeed())
+
+		By("Create the infrastructure machine and wait for it to exist")
+		infraMachineKey, infraMachine := deployInfraMachine(machine, nil)
+		Eventually(func() error {
+			return k8sClient.Get(ctx, infraMachineKey, infraMachine)
+		}, time.Second*30).Should(Succeed())
+
+		By("Add bootstrap data to the machine")
+		data := "test-bootstrap-data"
+		version := "test-version"
+		secretName := machine.GetName() + "-data"
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: machine.GetNamespace(),
+			},
+			Data: map[string][]byte{
+				"value": []byte(data),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		machine.Spec.Version = &version
+		machine.Spec.Bootstrap.DataSecretName = &secretName
+		Expect(k8sClient.Update(ctx, machine)).To(Succeed())
+
+		// At this point, the reconcile loop should create a VirtualMachine Note
+		// that the reconcile loop will continue to run while a VirtualMachine is
+		// going through its various stages of initialization due to vmoperator
+		// code returning reconcile errors
+
+		By("Expect the VSphereMachine to have its Status.VMStatus initialized to a new VM")
+		assertEventuallyVMStatus(infraMachineKey, infraMachine, vmwarev1.VirtualMachineStatePending)
+
+		By("Expect the VM to have been successfully created")
+		newVM := &vmoprv1.VirtualMachine{}
+		Expect(k8sClient.Get(ctx, machineKey, newVM)).Should(Succeed())
+
+		By("Modifying the VM to simulate it having been created")
+		// These two lines must be initialized as requirements of having valid Status
+		newVM.Status.Volumes = []vmoprv1.VirtualMachineVolumeStatus{}
+		newVM.Status.Phase = vmoprv1.Created
+		Expect(k8sClient.Status().Update(ctx, newVM)).Should(Succeed())
+
+		By("Expect the VSphereMachine VM status to reflect VM Created status")
+		assertEventuallyVMStatus(infraMachineKey, infraMachine, vmwarev1.VirtualMachineStateCreated)
+
+		By("Modifying the VM to simulate it having been powered on")
+		newVM.Status.PowerState = vmoprv1.VirtualMachinePoweredOn
+		Expect(k8sClient.Status().Update(ctx, newVM)).Should(Succeed())
+
+		By("Expect the VSphereMachine VM status to reflect VM PoweredOn status")
+		assertEventuallyVMStatus(infraMachineKey, infraMachine, vmwarev1.VirtualMachineStatePoweredOn)
+
+		By("Modifying the VM to simulate it having been successfully booted")
+		newVM.Status.VmIp = "1.2.3.4"
+		newVM.Status.BiosUUID = "test-bios-uuid"
+		Expect(k8sClient.Status().Update(ctx, newVM)).Should(Succeed())
+
+		By("Expect the VSphereMachine VM status to reflect VM Ready status")
+		assertEventuallyVMStatus(infraMachineKey, infraMachine, vmwarev1.VirtualMachineStateReady)
+
+		// In the case of a LoadBalanced endpoint, ControlPlaneEndpoint is a
+		// load-balancer Testing load-balanced endpoints is done in
+		// control_plane_endpoint_test.go
+		if !isLB {
+			By("Expect the Cluster to have the IP from the VM as an APIEndpoint")
+			assertEventuallyControlPlaneEndpoint(infraClusterKey, infraCluster, newVM.Status.VmIp)
+		}
+	})
+})

--- a/controllers/vmware/vspherecluster_reconciler_test.go
+++ b/controllers/vmware/vspherecluster_reconciler_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vmware
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
@@ -31,6 +33,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
+
+func TestVSphereClusterReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VSphereCluster reconciler test suite")
+}
 
 var _ = Describe("Cluster Controller Tests", func() {
 	const (

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -59,6 +59,8 @@ import (
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages;virtualmachineimages/status,verbs=get;list;watch;create;update;patch;delete

--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.19.2
+k8s_version=1.22.1
 goarch=amd64
 goos="unknown"
 

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 	flag.StringVar(
 		&managerOpts.NetworkProvider,
 		"network-provider",
-		manager.DummyNetworkProvider,
+		"",
 		"network provider to be used by Supervisor based clusters.")
 
 	flag.Parse()

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	NSXNetworkProvider   = "NSX"
-	VDSNetworkProvider   = "vsphere-network"
-	DummyNetworkProvider = "DummyNetworkProvider"
+	NSXNetworkProvider     = "NSX"
+	VDSNetworkProvider     = "vsphere-network"
+	DummyLBNetworkProvider = "DummyLBNetworkProvider"
 )
 
 // GetNetworkProvider will return a network provider instance based on the environment
@@ -39,11 +39,11 @@ func GetNetworkProvider(ctx *context.ControllerManagerContext) (services.Network
 	case VDSNetworkProvider:
 		ctx.Logger.Info("Pick NetOp (VDS) network provider")
 		return network.NetOpNetworkProvider(ctx.Client), nil
-	case DummyNetworkProvider:
+	case DummyLBNetworkProvider:
 		ctx.Logger.Info("Pick Dummy network provider")
-		return network.DummyNetworkProvider(), nil
-	default:
-		ctx.Logger.Info("NetworkProvider not set. Pick Dummy LB network provider")
 		return network.DummyLBNetworkProvider(), nil
+	default:
+		ctx.Logger.Info("NetworkProvider not set. Pick Dummy network provider")
+		return network.DummyNetworkProvider(), nil
 	}
 }

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	goctx "context"
+	"fmt"
 
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
@@ -177,4 +178,10 @@ func CreateMachineContext(clusterContext *vmware.ClusterContext, machine *cluste
 		VSphereCluster: clusterContext.VSphereCluster,
 		VSphereMachine: vsphereMachine,
 	}
+}
+
+// GetBootstrapConfigMapName returns the name of the bootstrap data ConfigMap
+// for a VM Operator VirtualMachine.
+func GetBootstrapConfigMapName(machineName string) string {
+	return fmt.Sprintf("%s-cloud-init", machineName)
 }

--- a/test/e2e/capv_quick_start_test.go
+++ b/test/e2e/capv_quick_start_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Cluster creation with vSphere validations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		var res []types.PbmServerObjectRef
 		if pbmClient != nil {
-			spName := getVariable(VsphereStoragePolicy)
+			spName := e2eConfig.GetVariable(VsphereStoragePolicy)
 			if spName == "" {
 				Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
 			}

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	goctx "context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+// Util functions to interact with the clusterctl e2e framework
+
+func LoadE2EConfig(configPath string) (*clusterctl.E2EConfig, error) {
+	config := clusterctl.LoadE2EConfig(goctx.TODO(), clusterctl.LoadE2EConfigInput{ConfigPath: configPath})
+	if config == nil {
+		return nil, fmt.Errorf("cannot load E2E config found at %s", configPath)
+	}
+	return config, nil
+}
+
+func CreateClusterctlLocalRepository(config *clusterctl.E2EConfig, repositoryFolder string, cniEnabled bool) (string, error) {
+	createRepositoryInput := clusterctl.CreateRepositoryInput{
+		E2EConfig:        config,
+		RepositoryFolder: repositoryFolder,
+	}
+	if cniEnabled {
+		// Ensuring a CNI file is defined in the config and register a FileTransformation to inject the referenced file as in place of the CNI_RESOURCES envSubst variable.
+		cniPath, ok := config.Variables[capi_e2e.CNIPath]
+		if !ok {
+			return "", fmt.Errorf("missing %s variable in the config", capi_e2e.CNIPath)
+		}
+
+		if _, err := os.Stat(cniPath); err != nil {
+			return "", fmt.Errorf("the %s variable should resolve to an existing file", capi_e2e.CNIPath)
+		}
+		createRepositoryInput.RegisterClusterResourceSetConfigMapTransformation(cniPath, capi_e2e.CNIResources)
+	}
+
+	clusterctlConfig := clusterctl.CreateRepository(goctx.TODO(), createRepositoryInput)
+	if _, err := os.Stat(clusterctlConfig); err != nil {
+		return "", fmt.Errorf("the clusterctl config file does not exists in the local repository %s", repositoryFolder)
+	}
+	return clusterctlConfig, nil
+}
+
+func SetupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme, useExistingCluster bool) (bootstrap.ClusterProvider, framework.ClusterProxy, error) {
+	var clusterProvider bootstrap.ClusterProvider
+	kubeconfigPath := ""
+	if !useExistingCluster {
+		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(goctx.TODO(), bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
+			Name:               config.ManagementClusterName,
+			RequiresDockerSock: config.HasDockerProvider(),
+			Images:             config.Images,
+		})
+		if clusterProvider == nil {
+			return nil, nil, errors.New("failed to create bootstrap cluster")
+		}
+
+		kubeconfigPath = clusterProvider.GetKubeconfigPath()
+		if _, err := os.Stat(kubeconfigPath); err != nil {
+			return nil, nil, errors.New("failed to get the kubeconfig file for the bootstrap cluster")
+		}
+	}
+
+	clusterProxy := framework.NewClusterProxy("bootstrap", kubeconfigPath, scheme)
+	if clusterProxy == nil {
+		return nil, nil, errors.New("failed to get a bootstrap cluster proxy")
+	}
+
+	return clusterProvider, clusterProxy, nil
+}
+
+func InitBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy, config *clusterctl.E2EConfig, clusterctlConfig, artifactFolder string) {
+	clusterctl.InitManagementClusterAndWatchControllerLogs(goctx.TODO(), clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+		ClusterProxy:            bootstrapClusterProxy,
+		ClusterctlConfigPath:    clusterctlConfig,
+		InfrastructureProviders: config.InfrastructureProviders(),
+		LogFolder:               filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+	}, config.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+}
+
+func TearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClusterProxy framework.ClusterProxy) {
+	if bootstrapClusterProxy != nil {
+		bootstrapClusterProxy.Dispose(goctx.TODO())
+	}
+	if bootstrapClusterProvider != nil {
+		bootstrapClusterProvider.Dispose(goctx.TODO())
+	}
+}

--- a/test/integration/cluster_lifecycle_test.go
+++ b/test/integration/cluster_lifecycle_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/utils/pointer"
+	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
+)
+
+// The purpose of this test is to start up a CAPI controller against a real API
+// server and run Cluster tests
+var _ = Describe("Cluster lifecycle tests", func() {
+
+	var (
+		mf            *Manifests
+		controlPlane  *ControlPlaneComponents
+		worker        *WorkerComponents
+		testNamespace string
+	)
+
+	JustBeforeEach(func() {
+		testNamespace = fmt.Sprintf("test-ns-%s", uuid.New())
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		createNonNamespacedResource(namespacesResource, ns)
+
+		By("Creating a dummy VM Image")
+		dummyVMImage := generateVirtualMachineImage()
+		createNonNamespacedResource(virtualmachineimageResource, dummyVMImage)
+
+		By("Generating manifests")
+		mf = generateManifests(testNamespace)
+
+		// Only the first control plane machine is used since any additional
+		// ones require an initialized control plane, something which is no
+		// longer possible to simulate in CAPI v1a2 without a working API
+		// endpoint.
+		// Expect(mf.ControlPlaneComponentsList).Should(HaveLen(1), "control plane must have exactly one machine")
+		controlPlane = mf.ControlPlaneComponentsList[0]
+		worker = mf.WorkerComponents
+	})
+
+	AfterEach(func() {
+		deleteResource(namespacesResource, testNamespace, "", nil)
+		mf = nil
+		controlPlane = nil
+		worker = nil
+	})
+
+	Context("Create a cluster", func() {
+		JustBeforeEach(func() {
+			// CREATE the CAPI Cluster and VSphereCluster resources.
+			createResource(clustersResource, mf.ClusterComponents.Cluster)
+			createResource(vsphereclustersResource, mf.ClusterComponents.VSphereCluster)
+
+			// ASSERT the CAPI Cluster and the VSphereCluster resources eventually exist
+			// and that the VSphereCluster has an OwnerRef that points to the CAPI
+			// Cluster.
+			cluster := assertEventuallyExists(clustersResource, mf.ClusterComponents.Cluster.Name, testNamespace, nil)
+			clusterOwnerRef := toOwnerRef(cluster)
+			clusterOwnerRef.Controller = pointer.BoolPtr(true)
+			clusterOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
+			assertEventuallyExists(vsphereclustersResource, mf.ClusterComponents.Cluster.Name, testNamespace, clusterOwnerRef)
+		})
+
+		JustAfterEach(func() {
+			// DELETE the CAPI Cluster.
+			deleteResource(clustersResource, mf.ClusterComponents.Cluster.Name, testNamespace, nil)
+
+			// ASSERT the CAPI Cluster and VSphereCluster are eventually deleted.
+			assertEventuallyDoesNotExist(vsphereclustersResource, mf.ClusterComponents.Cluster.Name, testNamespace)
+			assertEventuallyDoesNotExist(clustersResource, mf.ClusterComponents.Cluster.Name, testNamespace)
+		})
+
+		Context("with no machines", func() {
+			BeforeEach(func() {
+				testClusterName = "cc-testcluster1"
+			})
+			It("should delete successfully with default policy", func() {
+				// Handled by JustAfterEach
+			})
+		})
+
+		Context("with machines", func() {
+			JustBeforeEach(func() {
+				// CREATE the CAPI Machine, VSphereMachine, and KubeadmConfig resources for
+				// the control plane machine.
+				createResource(machinesResource, controlPlane.Machine)
+				createResource(vspheremachinesResource, controlPlane.VSphereMachine)
+				createResource(kubeadmconfigResources, controlPlane.KubeadmConfig)
+
+				// CREATE the CAPI MachineDeplopyment, VSphereMachineTemplate,
+				// and KubeadmConfigTemplate resources for the worker nodes.
+				createResource(machinedeploymentResource, worker.MachineDeployment)
+				createResource(vspheremachinetemplateResource, worker.VSphereMachineTemplate)
+				createResource(kubeadmconfigtemplateResource, worker.KubeadmConfigTemplate)
+
+				// ASSERT the CAPI Machine, VSphereMachine, KubeadmConfig, and VM
+				// Operator VirtualMachine, and bootstrap data ConfigMap
+				// resources for the control plane machine eventually exist, the
+				// VSphereMachine and KubeadmConfig resources have OwnerRefs that
+				// point to the CAPI Machine, and the ConfigMap resource has a
+				// controller OwnerRef that points to the VSphereMachine.
+				machine := assertEventuallyExists(machinesResource, controlPlane.Machine.Name, testNamespace, nil)
+				machineOwnerRef := toOwnerRef(machine)
+				machineOwnerRef.Controller = pointer.BoolPtr(true)
+				machineOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
+				assertEventuallyExists(kubeadmconfigResources, controlPlane.Machine.Name, testNamespace, machineOwnerRef)
+
+				vsphereMachine := assertEventuallyExists(vspheremachinesResource, controlPlane.Machine.Name, testNamespace, machineOwnerRef)
+				vsphereMachineOwnerRef := toControllerOwnerRef(vsphereMachine)
+
+				assertEventuallyExists(virtualmachinesResource, controlPlane.Machine.Name, testNamespace, nil)
+				assertEventuallyExists(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), testNamespace, vsphereMachineOwnerRef)
+
+				// TODO: gab-satchi these should also be looking for correct ownerReferences before proceeding to a delete in the AfterEach
+				assertEventuallyExists(machinedeploymentResource, worker.MachineDeployment.Name, testNamespace, nil)
+				assertEventuallyExists(vspheremachinetemplateResource, worker.VSphereMachineTemplate.Name, testNamespace, nil)
+				assertEventuallyExists(kubeadmconfigtemplateResource, worker.KubeadmConfigTemplate.Name, testNamespace, nil)
+			})
+			AfterEach(func() {
+				// ASSERT the CAPI Machine, VSphereMachine, KubeadmConfig, VM
+				// Operator VirtualMachine, and bootstrap data ConfigMap
+				// resources for the control plane machine are eventually
+				// deleted.
+				assertEventuallyDoesNotExist(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), testNamespace)
+				assertEventuallyDoesNotExist(virtualmachinesResource, controlPlane.Machine.Name, testNamespace)
+				assertEventuallyDoesNotExist(vspheremachinesResource, controlPlane.Machine.Name, testNamespace)
+				assertEventuallyDoesNotExist(kubeadmconfigResources, controlPlane.Machine.Name, testNamespace)
+				assertEventuallyDoesNotExist(machinesResource, controlPlane.Machine.Name, testNamespace)
+
+				// Assert that MachineDeployment and its descendents are eventually deleted
+				assertEventuallyDoesNotExist(machinedeploymentResource, worker.MachineDeployment.Name, testNamespace)
+				assertEventuallyDoesNotExist(vspheremachinetemplateResource, worker.VSphereMachineTemplate.Name, testNamespace)
+				assertEventuallyDoesNotExist(kubeadmconfigtemplateResource, worker.KubeadmConfigTemplate.Name, testNamespace)
+			})
+			Context("that are not explicitly deleted", func() {
+				BeforeEach(func() {
+					testClusterName = "cc-testcluster2"
+				})
+				It("should delete the cluster, deleting the machines via propagation with default policy", func() {
+					// Handled by JustBeforeEach and AfterEach
+				})
+				It("cluster should have a ControlPlaneEndpoint when a ControlPlane machine gets an IP", func() {
+					ipAddress := "127.0.0.1"
+					setIPAddressOnMachine(controlPlane.Machine.Name, testNamespace, ipAddress)
+					assertClusterEventuallyGetsControlPlaneEndpoint(testClusterName, testNamespace, ipAddress)
+				})
+			})
+			Context("that are explicitly deleted before the cluster", func() {
+				BeforeEach(func() {
+					testClusterName = "cc-testcluster3"
+				})
+				It("should delete both the machines and cluster successfully when Machine is deleted", func() {
+					// DELETE the CAPI Machine, VSphereMachine, and KubeadmConfig resources for
+					// the control plane machine.
+					// These are all deleted as a side effect of deleting the Machine due to ownerReferences
+					deleteResource(machinesResource, controlPlane.Machine.Name, testNamespace, nil)
+				})
+				It("should delete both the machines and cluster successfully when VSphereMachine is deleted", func() {
+					// DELETE the VSphereMachine resource for the control plane machine
+					// Expect the cluster and everything else to be cleaned up by JustAfterEach
+					deleteResource(vspheremachinesResource, controlPlane.Machine.Name, testNamespace, nil)
+				})
+			})
+		})
+	})
+})

--- a/test/integration/data/shared/metadata.yaml
+++ b/test/integration/data/shared/metadata.yaml
@@ -1,0 +1,20 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 0
+    contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1alpha4
+  - major: 0
+    minor: 3
+    contract: v1alpha3
+  - major: 0
+    minor: 2
+    contract: v1alpha2

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -1,0 +1,88 @@
+---
+# E2E test scenario using local dev images and manifests built from the source tree for following providers:
+# - cluster-api
+# - bootstrap kubeadm
+# - control-plane kubeadm
+# - vsphere
+
+# For creating local dev images built from the source tree;
+# - from the CAPI repository root, `make docker-build REGISTRY=gcr.io/k8s-staging-cluster-api` to build the cluster-api,
+#  bootstrap kubeadm, control-plane kubeadm provider images. This step can be skipped to use upstream images.
+# - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
+
+images:
+  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+    loadBehavior: mustLoad
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.0.1
+    loadBehavior: tryLoad
+  - name: quay.io/jetstack/cert-manager-webhook:v1.0.1
+    loadBehavior: tryLoad
+  - name: quay.io/jetstack/cert-manager-controller:v1.0.1
+    loadBehavior: tryLoad
+providers:
+  - name: cluster-api
+    type: CoreProvider
+    versions:
+      - name: v1.0.0
+        # Use manifest from source files
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+        type: "url"
+        contract: v1beta1
+        files:
+          - sourcePath: "./data/shared/metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+
+  - name: kubeadm
+    type: BootstrapProvider
+    versions:
+      - name: v1.0.0
+        # Use manifest from source files
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+        type: "url"
+        contract: "v1beta1"
+        files:
+          - sourcePath: "./data/shared/metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+
+  - name: kubeadm
+    type: ControlPlaneProvider
+    versions:
+      - name: v1.0.0
+        # Use manifest from source files
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+        type: "url"
+        files:
+          - sourcePath: "./data/shared/metadata.yaml"
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+
+  - name: vsphere
+    type: InfrastructureProvider
+    versions:
+      - name: v1.0.0
+        # Use manifest from source files
+        value: ../../../cluster-api-provider-vsphere/config/deployments/integration-tests
+        contract: v1beta1
+        files:
+          - sourcePath: "../../metadata.yaml"
+        replacements:
+          - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+variables:
+  VSPHERE_PASSWORD: "admin123"
+  VSPHERE_USERNAME: "admin123"
+intervals:
+  default/wait-controllers: ["5m", "10s"]

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,0 +1,812 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint
+package integration
+
+import (
+	goctx "context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	unstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	loglevel                           = "5"
+	waitTimeSecsForExists              = 60
+	dummyVirtualMachineImageName       = "dummy-image"
+	dummyDistributionVersion           = "dummy-distro.123"
+	dummyImageRepository               = "vmware"
+	dummyDnsVersion                    = "v1.3.1_vmware.1"
+	dummyEtcdVersion                   = "v3.3.10_vmware.1"
+	numControlPlaneMachines            = 1
+	controlPlaneMachineClassName       = "dummy-control-plane-class"
+	controlPlaneMachineStorageClass    = "dummy-control-plane-storage-class"
+	controlPlaneEndPoint               = "https://dummy-lb:6443"
+	numWorkerMachines                  = 1
+	VirtualMachineDistributionProperty = "vmware-system.guest.kubernetes.distribution.image.version"
+)
+
+var (
+	testClusterName        string
+	dummyKubernetesVersion = "1.15.0+vmware.1"
+	ctx                    goctx.Context
+	k8sClient              dynamic.Interface
+)
+
+var (
+	intervals = []interface{}{
+		time.Second * time.Duration(waitTimeSecsForExists),
+		time.Second * 1,
+	}
+
+	clustersResource = schema.GroupVersionResource{
+		Group:    clusterv1.GroupVersion.Group,
+		Version:  clusterv1.GroupVersion.Version,
+		Resource: "clusters",
+	}
+
+	vsphereclustersResource = schema.GroupVersionResource{
+		Group:    infrav1.GroupVersion.Group,
+		Version:  infrav1.GroupVersion.Version,
+		Resource: "vsphereclusters",
+	}
+
+	machinesResource = schema.GroupVersionResource{
+		Group:    clusterv1.GroupVersion.Group,
+		Version:  clusterv1.GroupVersion.Version,
+		Resource: "machines",
+	}
+
+	machinedeploymentResource = schema.GroupVersionResource{
+		Group:    clusterv1.GroupVersion.Group,
+		Version:  clusterv1.GroupVersion.Version,
+		Resource: "machinedeployments",
+	}
+
+	vspheremachinesResource = schema.GroupVersionResource{
+		Group:    infrav1.GroupVersion.Group,
+		Version:  infrav1.GroupVersion.Version,
+		Resource: "vspheremachines",
+	}
+
+	vspheremachinetemplateResource = schema.GroupVersionResource{
+		Group:    infrav1.GroupVersion.Group,
+		Version:  infrav1.GroupVersion.Version,
+		Resource: "vspheremachinetemplates",
+	}
+
+	kubeadmconfigResources = schema.GroupVersionResource{
+		Group:    bootstrapv1.GroupVersion.Group,
+		Version:  bootstrapv1.GroupVersion.Version,
+		Resource: "kubeadmconfigs",
+	}
+
+	kubeadmconfigtemplateResource = schema.GroupVersionResource{
+		Group:    bootstrapv1.GroupVersion.Group,
+		Version:  bootstrapv1.GroupVersion.Version,
+		Resource: "kubeadmconfigtemplates",
+	}
+
+	namespacesResource = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+
+	configmapsResource = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+
+	eventsResource = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "events",
+	}
+
+	virtualmachinesResource = schema.GroupVersionResource{
+		Group:    vmoprv1.SchemeGroupVersion.Group,
+		Version:  vmoprv1.SchemeGroupVersion.Version,
+		Resource: "virtualmachines",
+	}
+
+	virtualmachineimageResource = schema.GroupVersionResource{
+		Group:    vmoprv1.SchemeGroupVersion.Group,
+		Version:  vmoprv1.SchemeGroupVersion.Version,
+		Resource: "virtualmachineimages",
+	}
+)
+
+// Manifests contains the resources required to deploy a cluster with CAPV.
+type Manifests struct {
+	ClusterComponents *ClusterComponents
+
+	ControlPlaneComponentsList []*ControlPlaneComponents
+
+	WorkerComponents *WorkerComponents
+}
+
+type ClusterComponents struct {
+	Cluster        *clusterv1.Cluster
+	VSphereCluster *infrav1.VSphereCluster
+}
+
+// ControlPlaneComponents contains the resources required to create a control
+// plane machine.
+type ControlPlaneComponents struct {
+	Machine        *clusterv1.Machine
+	VSphereMachine *infrav1.VSphereMachine
+	KubeadmConfig  *bootstrapv1.KubeadmConfig
+}
+
+// WorkerComponents contains the resources required to create a
+// MachineDeployment.
+type WorkerComponents struct {
+	MachineDeployment      *clusterv1.MachineDeployment
+	VSphereMachineTemplate *infrav1.VSphereMachineTemplate
+	KubeadmConfigTemplate  *bootstrapv1.KubeadmConfigTemplate
+}
+
+func TestCAPV(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPV Supervisor integration tests")
+}
+
+// Test suite flags
+var (
+	// configPath is the path to the e2e config file.
+	configPath string
+
+	// useExistingCluster instructs the test to use the current cluster instead of creating a new one (default discovery rules apply).
+	useExistingCluster bool
+
+	// artifactFolder is the folder to store e2e test artifacts.
+	artifactFolder string
+
+	// skipCleanup prevents cleanup of test resources e.g. for debug purposes.
+	skipCleanup bool
+)
+
+// Test suite global vars
+var (
+	// e2eConfig to be used for this test, read from configPath.
+	e2eConfig *clusterctl.E2EConfig
+
+	// clusterctlConfigPath to be used for this test, created by generating a clusterctl local repository
+	// with the providers specified in the configPath.
+	clusterctlConfigPath string
+
+	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
+	bootstrapClusterProvider bootstrap.ClusterProvider
+
+	// bootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.
+	bootstrapClusterProxy framework.ClusterProxy
+)
+
+func init() {
+	flag.StringVar(&configPath, "config", "", "path to the config file")
+	flag.StringVar(&artifactFolder, "artifacts-folder", "", "folder where test artifacts should be stored")
+	flag.BoolVar(&skipCleanup, "skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
+	flag.BoolVar(&useExistingCluster, "use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	// Before all ParallelNodes.
+	flags := flag.NewFlagSet("flags", flag.PanicOnError)
+	klog.InitFlags(flags)
+	ctrl.SetLogger(klogr.New())
+	err := flags.Parse([]string{"-v", loglevel})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
+	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
+
+	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
+	scheme := initScheme()
+
+	Byf("Loading the e2e test configuration from %q", configPath)
+	e2eConfig, err = helpers.LoadE2EConfig(configPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	Byf("Creating a clusterctl local repository into %q", artifactFolder)
+	clusterctlConfigPath, err = helpers.CreateClusterctlLocalRepository(e2eConfig, filepath.Join(artifactFolder, "repository"), false)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Setting up the bootstrap cluster")
+	bootstrapClusterProvider, bootstrapClusterProxy, err = helpers.SetupBootstrapCluster(e2eConfig, scheme, useExistingCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Initializing the bootstrap cluster")
+	helpers.InitBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
+	ctx = goctx.Background()
+	return []byte(
+		strings.Join([]string{
+			artifactFolder,
+			configPath,
+			clusterctlConfigPath,
+			bootstrapClusterProxy.GetKubeconfigPath(),
+		}, ","),
+	)
+}, func(data []byte) {
+	// Before each ParallelNode.
+	parts := strings.Split(string(data), ",")
+	Expect(parts).To(HaveLen(4))
+
+	artifactFolder = parts[0]
+	configPath = parts[1]
+	clusterctlConfigPath = parts[2]
+	kubeconfigPath := parts[3]
+
+	var err error
+	e2eConfig, err = helpers.LoadE2EConfig(configPath)
+	Expect(err).NotTo(HaveOccurred())
+	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme())
+	config := bootstrapClusterProxy.GetRESTConfig()
+	k8sClient = dynamic.NewForConfigOrDie(config)
+})
+
+// Using a SynchronizedAfterSuite for controlling how to delete resources shared across ParallelNodes (~ginkgo threads).
+// The bootstrap cluster is shared across all the tests, so it should be deleted only after all ParallelNodes completes.
+// The local clusterctl repository is preserved like everything else created into the artifact folder.
+var _ = SynchronizedAfterSuite(func() {
+	// After each ParallelNode.
+}, func() {
+	// After all ParallelNodes.
+
+	By("Tearing down the management cluster")
+	if !skipCleanup {
+		helpers.TearDown(bootstrapClusterProvider, bootstrapClusterProxy)
+	}
+})
+
+func initScheme() *runtime.Scheme {
+	sc := runtime.NewScheme()
+	framework.TryAddDefaultSchemes(sc)
+	_ = infrav1.AddToScheme(sc)
+	return sc
+}
+
+type ImageVersion struct {
+	ImageRepository string `json:"imageRepository"`
+	Version         string `json:"version"`
+}
+
+type VirtualMachineDistributionSpec struct {
+	Version    string       `json:"version"`
+	Kubernetes ImageVersion `json:"kubernetes"`
+	Etcd       ImageVersion `json:"etcd"`
+	CoreDNS    ImageVersion `json:"coredns"`
+}
+
+func generateVirtualMachineImage() *vmoprv1.VirtualMachineImage {
+	annotations := map[string]string{}
+
+	spec := &VirtualMachineDistributionSpec{
+		Version: dummyDistributionVersion,
+		Kubernetes: ImageVersion{
+			ImageRepository: dummyImageRepository,
+			Version:         dummyKubernetesVersion,
+		},
+		Etcd: ImageVersion{
+			ImageRepository: dummyImageRepository,
+			Version:         dummyEtcdVersion,
+		},
+		CoreDNS: ImageVersion{
+			ImageRepository: dummyImageRepository,
+			Version:         dummyDnsVersion,
+		},
+	}
+
+	rawJSON, err := json.Marshal(spec)
+	Expect(err).NotTo(HaveOccurred())
+
+	annotations[VirtualMachineDistributionProperty] = string(rawJSON)
+
+	return &vmoprv1.VirtualMachineImage{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachineImage",
+			APIVersion: virtualmachineimageResource.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        dummyVirtualMachineImageName,
+			Annotations: annotations,
+		},
+	}
+}
+
+func generateManifests(testNamespace string) *Manifests {
+	By("Creating Cluster Components")
+	clusterComponents := createClusterComponents(testNamespace)
+
+	By("Creating ControlPlane Components List")
+	controlPlaneComponentsList := createControlPlaneComponentsList(testNamespace)
+
+	By("Creating Worker Components")
+	workerComponents := createWorkerComponents(testNamespace)
+
+	return &Manifests{
+		ClusterComponents: clusterComponents,
+
+		ControlPlaneComponentsList: controlPlaneComponentsList,
+
+		WorkerComponents: workerComponents,
+	}
+}
+
+func createClusterComponents(testNamespace string) *ClusterComponents {
+	By("Creating a VSphereCluster")
+	vsphereCluster := infrav1.VSphereCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       "VSphereCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testClusterName,
+			Namespace: testNamespace,
+		},
+	}
+
+	By("Creating a Cluster")
+	cluster := clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testClusterName,
+			Namespace: testNamespace,
+		},
+		Spec: clusterv1.ClusterSpec{
+			ClusterNetwork: &clusterv1.ClusterNetwork{
+				Services: &clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"100.64.0.0/13"},
+				},
+				Pods: &clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"100.96.0.0/11"},
+				},
+				ServiceDomain: "cluster.local",
+			},
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       "VSphereCluster",
+				Name:       vsphereCluster.Name,
+				Namespace:  vsphereCluster.Namespace,
+			},
+		},
+	}
+
+	return &ClusterComponents{
+		Cluster:        &cluster,
+		VSphereCluster: &vsphereCluster,
+	}
+}
+
+func createControlPlaneComponentsList(testNamespace string) []*ControlPlaneComponents {
+
+	cpMachineNameFmt := "%s-control-plane-%d"
+	var controlPlaneComponentsList []*ControlPlaneComponents
+
+	for i := 0; i < numControlPlaneMachines; i++ {
+		var controlPlaneComponents ControlPlaneComponents
+
+		By("Creating a VSphereMachine")
+		vsphereMachine := infrav1.VSphereMachine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       "VSphereMachine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf(cpMachineNameFmt, testClusterName, i),
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					clusterv1.MachineControlPlaneLabelName: "true",
+					clusterv1.ClusterLabelName:             testClusterName,
+				},
+			},
+			Spec: infrav1.VSphereMachineSpec{
+				ImageName:    dummyVirtualMachineImageName,
+				ClassName:    controlPlaneMachineClassName,
+				StorageClass: controlPlaneMachineStorageClass,
+			},
+		}
+		controlPlaneComponents.VSphereMachine = &vsphereMachine
+
+		By("Creating KubeadmConfigs")
+
+		kubeadmConfig := bootstrapv1.KubeadmConfig{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: bootstrapv1.GroupVersion.String(),
+				Kind:       "KubeadmConfig",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf(cpMachineNameFmt, testClusterName, i),
+				Namespace: testNamespace,
+			},
+			Spec: bootstrapv1.KubeadmConfigSpec{
+				ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+					ClusterName: testClusterName,
+				},
+				InitConfiguration: &bootstrapv1.InitConfiguration{},
+				JoinConfiguration: &bootstrapv1.JoinConfiguration{},
+			},
+		}
+		controlPlaneComponents.KubeadmConfig = &kubeadmConfig
+
+		By("Creating Machines")
+		machine := clusterv1.Machine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Machine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf(cpMachineNameFmt, testClusterName, i),
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					clusterv1.MachineControlPlaneLabelName: "true",
+					clusterv1.ClusterLabelName:             testClusterName,
+				},
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName: testClusterName,
+				Version:     &dummyKubernetesVersion,
+				Bootstrap: clusterv1.Bootstrap{
+					ConfigRef: &corev1.ObjectReference{
+						APIVersion: bootstrapv1.GroupVersion.String(),
+						Kind:       "KubeadmConfig",
+						Name:       kubeadmConfig.Name,
+						Namespace:  kubeadmConfig.Namespace,
+					},
+				},
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: infrav1.GroupVersion.String(),
+					Kind:       "VSphereMachine",
+					Name:       vsphereMachine.Name,
+					Namespace:  vsphereMachine.Namespace,
+				},
+			},
+		}
+
+		controlPlaneComponents.Machine = &machine
+
+		// Collect controlPlaneComponents
+		controlPlaneComponentsList = append(controlPlaneComponentsList, &controlPlaneComponents)
+	}
+
+	return controlPlaneComponentsList
+}
+
+func createWorkerComponents(testNamespace string) *WorkerComponents {
+	workerMachineDeploymentNameFmt := "%s-workers-0"
+
+	By("Creating VSphereMachineTemplates")
+	vsphereMachineTemplate := infrav1.VSphereMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       "VSphereMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(workerMachineDeploymentNameFmt, testClusterName),
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: testClusterName,
+			},
+		},
+	}
+
+	By("Creating a KubeadmConfigTemplate")
+	kubeadmConfigTemplate := bootstrapv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: bootstrapv1.GroupVersion.String(),
+			Kind:       "KubeadmConfigTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(workerMachineDeploymentNameFmt, testClusterName),
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: testClusterName,
+			},
+		},
+	}
+
+	By("Creating a MachineDeployment")
+	numWorker := int32(numWorkerMachines)
+	machineDeployment := clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(workerMachineDeploymentNameFmt, testClusterName),
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: testClusterName,
+			},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: testClusterName,
+			Replicas:    &numWorker,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					clusterv1.ClusterLabelName: testClusterName,
+				},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.ClusterLabelName: testClusterName,
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: testClusterName,
+					Version:     &dummyKubernetesVersion,
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: bootstrapv1.GroupVersion.String(),
+							Kind:       "KubeadmConfigTemplate",
+							Name:       kubeadmConfigTemplate.Name,
+							Namespace:  kubeadmConfigTemplate.Namespace,
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: infrav1.GroupVersion.String(),
+						Kind:       "VSphereMachineTemplate",
+						Name:       vsphereMachineTemplate.Name,
+						Namespace:  vsphereMachineTemplate.Namespace,
+					},
+				},
+			},
+		},
+	}
+
+	return &WorkerComponents{
+		MachineDeployment:      &machineDeployment,
+		VSphereMachineTemplate: &vsphereMachineTemplate,
+		KubeadmConfigTemplate:  &kubeadmConfigTemplate,
+	}
+}
+
+func createNonNamespacedResource(resource schema.GroupVersionResource, obj runtimeObjectWithName) {
+	input := toUnstructured(obj.GetName(), obj, false)
+	_, err := k8sClient.Resource(resource).Create(ctx, input, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred(), "Error creating %s %s", resource, obj.GetName())
+}
+
+func createResource(resource schema.GroupVersionResource, obj runtimeObjectWithName) {
+	input := toUnstructured(obj.GetName(), obj, false)
+	_, err := k8sClient.Resource(resource).Namespace(obj.GetNamespace()).Create(ctx, input, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Error creating %s %s/%s", resource, obj.GetNamespace(), obj.GetName())
+}
+
+func deleteResource(resource schema.GroupVersionResource, name, namespace string, propagationPolicy *metav1.DeletionPropagation) {
+	deleteOptions := metav1.DeleteOptions{PropagationPolicy: propagationPolicy}
+	err := k8sClient.Resource(resource).Namespace(namespace).Delete(ctx, name, deleteOptions)
+	Expect(err).NotTo(HaveOccurred(), "Error deleting %s %s", resource, name)
+}
+
+func deleteNonNamespacedResource(resource schema.GroupVersionResource, name string, propagationPolicy *metav1.DeletionPropagation) {
+	deleteOptions := metav1.DeleteOptions{PropagationPolicy: propagationPolicy}
+	err := k8sClient.Resource(resource).Delete(ctx, name, deleteOptions)
+	Expect(err).NotTo(HaveOccurred(), "Error deleting %s %s", resource, name)
+}
+
+func getResource(resource schema.GroupVersionResource, name, namespace string, obj runtime.Object) {
+	output, err := k8sClient.Resource(resource).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Error getting %s %s", resource, name)
+	toStructured(name, obj, output)
+}
+
+func updateResourceStatus(resource schema.GroupVersionResource, obj runtimeObjectWithName) {
+	input := toUnstructured(obj.GetName(), obj, true)
+	_, err := k8sClient.Resource(resource).Namespace(obj.GetNamespace()).UpdateStatus(ctx, input, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Error updating status of %s %s/%s", resource, obj.GetNamespace(), obj.GetName())
+}
+
+func assertEventuallyExists(resource schema.GroupVersionResource, name, ns string, ownerRef *metav1.OwnerReference) *unstructuredv1.Unstructured {
+	var obj *unstructuredv1.Unstructured
+	EventuallyWithOffset(1, func() (bool, error) {
+		output, err := k8sClient.Resource(resource).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if ownerRef != nil {
+			foundOwnerRef := false
+			for _, ref := range output.GetOwnerReferences() {
+				if ref.APIVersion != ownerRef.APIVersion {
+					continue
+				}
+				if ref.Kind != ownerRef.Kind {
+					continue
+				}
+				if ref.Name != ownerRef.Name {
+					continue
+				}
+				if ref.UID != ownerRef.UID {
+					continue
+				}
+				if ref.Controller != nil || ownerRef.Controller != nil {
+					if ref.Controller == nil && ownerRef.Controller != nil {
+						continue
+					} else if ref.Controller != nil && ownerRef.Controller == nil {
+						continue
+					} else if *ref.Controller != *ownerRef.Controller {
+						continue
+					}
+				}
+				if ref.BlockOwnerDeletion != nil || ownerRef.BlockOwnerDeletion != nil {
+					if ref.BlockOwnerDeletion == nil && ownerRef.BlockOwnerDeletion != nil {
+						continue
+					} else if ref.BlockOwnerDeletion != nil && ownerRef.BlockOwnerDeletion == nil {
+						continue
+					} else if *ref.BlockOwnerDeletion != *ownerRef.BlockOwnerDeletion {
+						continue
+					}
+				}
+				foundOwnerRef = true
+				break
+			}
+			if !foundOwnerRef {
+				return false, errors.Errorf(
+					"Unable to find expected OwnerRef %+v for %s %s/%s: %+v",
+					*ownerRef,
+					output.GroupVersionKind(),
+					output.GetNamespace(),
+					output.GetName(),
+					output.GetOwnerReferences())
+			}
+		}
+		obj = output
+		return true, nil
+	}, intervals...).Should(BeTrue(), "should exist %s %s", resource, name)
+	return obj
+}
+
+func assertEventuallyDoesNotExist(resource schema.GroupVersionResource, name, ns string) {
+	EventuallyWithOffset(1, func() (bool, error) {
+		_, err := k8sClient.Resource(resource).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}, intervals...).Should(BeTrue(), "should not exist %s %s", resource, name)
+}
+
+func assertVirtualMachineState(machine *clusterv1.Machine, vm *vmoprv1.VirtualMachine) {
+	Expect(vm.Name).Should(Equal(machine.Name))
+	Expect(vm.Namespace).Should(Equal(machine.Namespace))
+	Expect(vm.Spec.ImageName).ShouldNot(BeEmpty())
+	Expect(machine.Spec.Version).ShouldNot(BeNil(), "Error accessing nil Spec.Version for machine %s", machine.Name)
+	Expect(vm.Spec.VmMetadata).NotTo(BeNil())
+	// TODO: Aarti: not sure where to get this varaible from
+	//Expect(vm.Spec.VmMetadata.Transport).To(Equal(vmoprv1.VirtualMachineMetadataExtraConfigTransport))
+	Expect(vm.Spec.VmMetadata.ConfigMapName).ToNot(BeNil())
+}
+
+// assertClusterEventuallyGetsControlPlaneEndpoint ensures that the cluster
+// receives a control plane endpoint that matches the expected IP address
+func assertClusterEventuallyGetsControlPlaneEndpoint(clusterName, clusterNs string, ipAddress string) {
+	EventuallyWithOffset(1, func() bool {
+		vsphereCluster := &infrav1.VSphereCluster{}
+		getResource(vsphereclustersResource, clusterName, clusterNs, vsphereCluster)
+		// If the control plane endpoint is undefined, return false
+		if vsphereCluster.Spec.ControlPlaneEndpoint.IsZero() {
+			return false
+		}
+
+		return vsphereCluster.Spec.ControlPlaneEndpoint.Host == ipAddress
+	}, intervals...).Should(BeTrue(), "Expected ControlPlaneEndpoint was not set")
+}
+
+func toUnstructured(name string, obj runtime.Object, preserveStatus bool) *unstructuredv1.Unstructured {
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if !preserveStatus {
+		delete(data, "status")
+	}
+	Expect(err).NotTo(
+		HaveOccurred(),
+		"Error getting unstructured data for %s: %q",
+		obj.GetObjectKind().GroupVersionKind(), name)
+	return &unstructuredv1.Unstructured{Object: data}
+}
+
+func toStructured(name string, dst runtime.Object, src *unstructuredv1.Unstructured) {
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(src.UnstructuredContent(), dst)
+	Expect(err).NotTo(
+		HaveOccurred(),
+		"Error getting structured object for %s: %q",
+		src.GroupVersionKind(), name)
+}
+
+type canBeReferenced interface {
+	GetUID() types.UID
+	GetName() string
+	GroupVersionKind() schema.GroupVersionKind
+}
+
+type runtimeObjectWithName interface {
+	canBeReferenced
+	runtime.Object
+	GetNamespace() string
+}
+
+func toOwnerRef(obj canBeReferenced) *metav1.OwnerReference {
+	return &metav1.OwnerReference{
+		APIVersion: obj.GroupVersionKind().GroupVersion().String(),
+		Kind:       obj.GroupVersionKind().Kind,
+		Name:       obj.GetName(),
+		UID:        obj.GetUID(),
+	}
+}
+
+func toControllerOwnerRef(obj canBeReferenced) *metav1.OwnerReference {
+	ptrBool := true
+	return &metav1.OwnerReference{
+		APIVersion:         obj.GroupVersionKind().GroupVersion().String(),
+		Kind:               obj.GroupVersionKind().Kind,
+		Name:               obj.GetName(),
+		UID:                obj.GetUID(),
+		Controller:         &ptrBool,
+		BlockOwnerDeletion: &ptrBool,
+	}
+}
+
+func setIPAddressOnMachine(machineName, machineNs, ipAddress string) {
+	vsphereMachine := &infrav1.VSphereMachine{}
+	getResource(vspheremachinesResource, machineName, machineNs, vsphereMachine)
+	vsphereMachine.Status.IPAddr = ipAddress
+	updateResourceStatus(vspheremachinesResource, vsphereMachine)
+}
+
+func Byf(format string, a ...interface{}) {
+	By(fmt.Sprintf(format, a...))
+}

--- a/test/integration/sanity_test.go
+++ b/test/integration/sanity_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
+)
+
+// The purpose of this test is to start up a CAPI controller against a real API
+// server and run basic checks.
+var _ = Describe("Sanity tests", func() {
+
+	var (
+		mf            *Manifests
+		controlPlane  *ControlPlaneComponents
+		testNamespace string
+	)
+
+	JustBeforeEach(func() {
+		testNamespace = fmt.Sprintf("test-ns-%s", uuid.New())
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		createNonNamespacedResource(namespacesResource, ns)
+		By("Creating a dummy VM Image")
+		dummyVMImage := generateVirtualMachineImage()
+		createNonNamespacedResource(virtualmachineimageResource, dummyVMImage)
+
+		By("Generating manifests")
+		mf = generateManifests(testNamespace)
+
+		// Only the first control plane machine is used since any additional
+		// ones require an initialized control plane, something which is no
+		// longer possible to simulate in CAPI v1a2 without a working API
+		// endpoint.
+		Expect(mf.ControlPlaneComponentsList).Should(HaveLen(1), "control plane must have exactly one machine")
+		controlPlane = mf.ControlPlaneComponentsList[0]
+
+		// CREATE the CAPI Cluster and VSphereCluster resources.
+		createResource(clustersResource, mf.ClusterComponents.Cluster)
+		createResource(vsphereclustersResource, mf.ClusterComponents.VSphereCluster)
+
+		// ASSERT the CAPI Cluster and the VSphereCluster resources eventually exist
+		// and that the VSphereCluster has an OwnerRef that points to the CAPI Cluster.
+		cluster := assertEventuallyExists(clustersResource, mf.ClusterComponents.Cluster.Name, mf.ClusterComponents.Cluster.Namespace, nil)
+		clusterOwnerRef := toOwnerRef(cluster)
+		clusterOwnerRef.Controller = pointer.BoolPtr(true)
+		clusterOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
+		assertEventuallyExists(vsphereclustersResource, mf.ClusterComponents.Cluster.Name, mf.ClusterComponents.Cluster.Namespace, clusterOwnerRef)
+
+		// CREATE the CAPI Machine, VSphereMachine, and KubeadmConfig resources for
+		// the control plane machine.
+		createResource(machinesResource, controlPlane.Machine)
+		createResource(vspheremachinesResource, controlPlane.VSphereMachine)
+		createResource(kubeadmconfigResources, controlPlane.KubeadmConfig)
+
+		// ASSERT the CAPI Machine, VSphereMachine, and KubeadmConfig resources
+		// for the control plane machine eventually exist and that the
+		// VSphereMachine and KubeadmConfig resources have OwnerRefs that point to
+		// the CAPI Machine.
+		machine := assertEventuallyExists(machinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, nil)
+		machineOwnerRef := toOwnerRef(machine)
+		machineOwnerRef.Controller = pointer.BoolPtr(true)
+		machineOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
+		assertEventuallyExists(vspheremachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, machineOwnerRef)
+		assertEventuallyExists(kubeadmconfigResources, controlPlane.Machine.Name, controlPlane.Machine.Namespace, machineOwnerRef)
+	})
+
+	AfterEach(func() {
+		// DELETE the testNamespace
+		deleteNonNamespacedResource(namespacesResource, testNamespace, nil)
+		mf = nil
+		controlPlane = nil
+	})
+
+	JustAfterEach(func() {
+		// DELETE the CAPI Machine, VSphereMachine, and KubeadmConfig resources for
+		// the control plane machine.
+		deleteResource(machinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, nil)
+
+		// ASSERT the CAPI Machine, VSphereMachine, KubeadmConfig, VM
+		// Operator VirtualMachine, and bootstrap data ConfigMap
+		// resources for the control plane machine are eventually
+		// deleted.
+		assertEventuallyDoesNotExist(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), controlPlane.Machine.Namespace)
+		assertEventuallyDoesNotExist(virtualmachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
+		assertEventuallyDoesNotExist(vspheremachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
+		assertEventuallyDoesNotExist(kubeadmconfigResources, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
+		assertEventuallyDoesNotExist(machinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
+
+		// DELETE the CAPI Cluster.
+		deleteResource(clustersResource, mf.ClusterComponents.Cluster.Name, mf.ClusterComponents.Cluster.Namespace, nil)
+
+		// ASSERT the CAPI Cluster and VSphereCLuster are eventually deleted.
+		assertEventuallyDoesNotExist(vsphereclustersResource, mf.ClusterComponents.Cluster.Name, mf.ClusterComponents.Cluster.Namespace)
+		assertEventuallyDoesNotExist(clustersResource, mf.ClusterComponents.Cluster.Name, mf.ClusterComponents.Cluster.Namespace)
+	})
+
+	Context("Happy paths", func() {
+		BeforeEach(func() {
+			testClusterName = "sanity-testcluster"
+		})
+
+		It("Check Basic VirtualMachine creation", func() {
+			// GET the associated CAPI Machine.
+			machine := &clusterv1.Machine{}
+			getResource(machinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, machine)
+
+			// GET the associated VSphereMachine.
+			vsphereMachine := &infrav1.VSphereMachine{}
+			getResource(vspheremachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, vsphereMachine)
+
+			// ASSERT the VirtualMachine and bootstrap data ConfigMap resources
+			// eventually exist. Ensure ConfigMap has OwnerRef set to the VSphereMachine.
+			vmObj := assertEventuallyExists(virtualmachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, nil)
+			assertEventuallyExists(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), controlPlane.Machine.Namespace, toControllerOwnerRef(vsphereMachine))
+			vm := &vmoprv1.VirtualMachine{}
+			toStructured(controlPlane.Machine.Name, vm, vmObj)
+
+			// ASSERT the VirtualMachine resource has the expected state.
+			assertVirtualMachineState(machine, vm)
+		})
+	})
+})


### PR DESCRIPTION
Continuing the work done by @AartiJivrajani and @srm09, 

**What this PR does / why we need it**:
- Adds integration tests that utilize a kind cluster. Setup uses CAPI e2e framework
- Adds envtest based controller tests to exercise supervisor based functionality
- Adds required rbac changes so CAPI manager can manipulate the new `vmware.infrastructure.cluster.x-k8s.io.vspheremachinetemplates`
- Adds `cluster.x-k8s.io/aggregate-to-manager` label to ClusterRole so capi-manager can have the same privileges. CAPI automatically gets control over `infrastructure.cluster.x-k8s.io` but will miss the new `vmware.infrastructure.cluster.x-k8s.io` group
- Envtest based tests will be automatically part of `make test` target
- Will follow up a `test-infra` PR to add an integration-test job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```