### PR TITLE
Fix clusterctl subcommand typo in getting_started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,6 +12,7 @@ depth, check out the the [Cluster API book][cluster-api-book].
   - [Configuring and installing Cluster API Provider vSphere in a management cluster](#configuring-and-installing-cluster-api-provider-vsphere-in-a-management-cluster)
   - [Creating a vSphere-based workload cluster](#creating-a-vsphere-based-workload-cluster)
   - [Accessing the workload cluster](#accessing-the-workload-cluster)
+  - [Custom cluster templates](#custom-cluster-templates)
 
 ## Install Requirements
 
@@ -132,7 +133,7 @@ VSPHERE_HAPROXY_TEMPLATE: "capv-haproxy-v0.6.4"               # The VM template 
 
 **NOTE**: Technically, SSH keys and vSphere folders are optional, but optional template variables are not currently
 supported by clusterctl. If you need to not set the vSphere folder or SSH keys, then remove the appropriate fields after
-running `clusterctl config`.
+running `clusterctl generate`.
 
 the `CONTROL_PLANE_ENDPOINT_IP` is an IP that must be an IP on the same subnet as the control plane machines, it should be also an IP that is not part of your DHCP range
 
@@ -153,7 +154,7 @@ clusterctl init --infrastructure vsphere
 The following command
 
 ```shell
-$ clusterctl config cluster vsphere-quickstart \
+$ clusterctl generate cluster vsphere-quickstart \
     --infrastructure vsphere \
     --kubernetes-version v1.17.3 \
     --control-plane-machine-count 1 \
@@ -198,12 +199,12 @@ vsphere-quickstart-9qtfd                                      Ready      master 
 
 ```
 
-## custom cluster templates
+## Custom cluster templates
 
 the provided cluster templates are quickstarts. If you need anything specific that requires a more complex setup, we recommand to use custom templates:
 
 ```shell
-$ clusterctl config custom-cluster vsphere-quickstart \
+$ clusterctl generate custom-cluster vsphere-quickstart \
     --infrastructure vsphere \
     --kubernetes-version v1.17.3 \
     --control-plane-machine-count 1 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

`clusterctl config`  command was deprecated, it should be adjusted to `clusterctl generate`

https://github.com/kubernetes-sigs/cluster-api/pull/4778


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```