### PR TITLE
Automated cherry pick of #1272: handle nil vsphere machine for vsphere vm

### DIFF
--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -158,7 +158,11 @@ func (r vmReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Res
 	if !clusterutilv1.HasOwner(vsphereVM.OwnerReferences, infrav1.GroupVersion.String(), []string{"HAProxyLoadBalancer"}) {
 		// Fetch the owner VSphereMachine.
 		vsphereMachine, err := util.GetOwnerVSphereMachine(r, r.Client, vsphereVM.ObjectMeta)
-		if err != nil {
+		// vsphereMachine can be nil in cases where custom mover other than clusterctl
+		// moves the resources without ownerreferences set
+		// in that case nil vsphereMachine can cause panic and CrashLoopBackOff the pod
+		// preventing vspheremachine_controller from setting the ownerref
+		if err != nil || vsphereMachine == nil {
 			r.Logger.Info("Owner VSphereMachine not found, won't reconcile", "key", req.NamespacedName)
 			return reconcile.Result{}, nil
 		}


### PR DESCRIPTION
Cherry pick of #1272 on release-0.8.

#1272: handle nil vsphere machine for vsphere vm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```