### PR TITLE
🌱 Adds keep alive support for the session tag manager client

### DIFF
--- a/controllers/session_test.go
+++ b/controllers/session_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/vmware/govmomi/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+	"k8s.io/klog/v2/klogr"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+)
+
+func TestGetSession(t *testing.T) {
+	g := NewWithT(t)
+	log := klogr.New()
+	ctrllog.SetLogger(log)
+
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password()).WithDatacenter("*")
+
+	// Get first session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	assertSessionCountEqualTo(g, simr, 1)
+
+	// Get session key
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	firstSession := sessionInfo.Key
+
+	// remove session expect no session
+	g.Expect(s.TagManager.Logout(context.Background())).To(Succeed())
+	g.Expect(simr.Run(fmt.Sprintf("session.rm %s", firstSession))).To(Succeed())
+	assertSessionCountEqualTo(g, simr, 0)
+
+	// request sesion again should be a new and different session
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+
+	// Get session info, session key should be different from
+	// last session
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(firstSession))
+	assertSessionCountEqualTo(g, simr, 1)
+}
+
+func sessionCount(stdout io.Reader) (int, error) {
+	buf := make([]byte, 1024)
+	count := 0
+	lineSep := []byte(v1beta1.GroupVersion.String())
+
+	for {
+		c, err := stdout.Read(buf)
+		count += bytes.Count(buf[:c], lineSep)
+
+		switch {
+		case err == io.EOF:
+			return count, nil
+
+		case err != nil:
+			return count, err
+		}
+	}
+}
+
+func assertSessionCountEqualTo(g *WithT, simr *helpers.Simulator, count int) {
+	g.Eventually(func() bool {
+		stdout := gbytes.NewBuffer()
+		g.Expect(simr.Run("session.ls", stdout)).To(Succeed())
+		sessions, err := sessionCount(stdout)
+		g.Expect(err).ToNot(HaveOccurred())
+		return sessions == count
+	}, timeout).Should(BeTrue())
+}
+
+func TestGetSessionWithKeepAlive(t *testing.T) {
+	g := NewWithT(t)
+	log := klogr.New()
+	ctrllog.SetLogger(log)
+
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithDatacenter("*")
+
+	// Get first Session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	assertSessionCountEqualTo(g, simr, 1)
+
+	// Get session key
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	firstSession := sessionInfo.Key
+
+	// Get the session again
+	// as keep alive is enabled and session is
+	// not expired we must get the same cached session
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	g.Expect(sessionInfo.Key).To(BeEquivalentTo(firstSession))
+	assertSessionCountEqualTo(g, simr, 1)
+
+	// Try to remove vim session
+	g.Expect(s.Logout(context.Background())).To(Succeed())
+
+	// after logging out old session must be deleted and
+	// we must get a new different session
+	// total session count must remain 1
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(firstSession))
+	assertSessionCountEqualTo(g, simr, 1)
+}
+
+func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
+	g := NewWithT(t)
+	log := klogr.New()
+	ctrllog.SetLogger(log)
+
+	simulator.SessionIdleTimeout = 200 * time.Millisecond
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithFeatures(session.Feature{KeepAliveDuration: 400 * time.Millisecond}).WithDatacenter("*")
+
+	// Get first session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	assertSessionCountEqualTo(g, simr, 1)
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	sessionKey := sessionInfo.Key
+	assertSessionCountEqualTo(g, simr, 1)
+
+	// wait enough time so the session is expired
+	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
+	assertSessionCountEqualTo(g, simr, 0)
+
+	// Get session again
+	// as session is deleted we must get new session
+	// old session is expected to be cleaned up so count == 1
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	assertSessionCountEqualTo(g, simr, 1)
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(sessionKey))
+	sessionKey = sessionInfo.Key
+	assertSessionCountEqualTo(g, simr, 1)
+
+	// wait enough time so the session is expired
+	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
+	assertSessionCountEqualTo(g, simr, 0)
+
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(s).ToNot(BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sessionInfo).ToNot(BeNil())
+	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(sessionKey))
+	assertSessionCountEqualTo(g, simr, 1)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
@@ -38,9 +39,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
-var sessionCache = map[string]Session{}
-
-var sessionMU sync.Mutex
+// global Session map against sessionKeys
+// in map[sessionKey]Session.
+var sessionCache sync.Map
 
 // Session is a vSphere session with a configured Finder.
 type Session struct {
@@ -101,17 +102,29 @@ func (p *Params) WithFeatures(feature Feature) *Params {
 // already exist.
 func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("session")
-	sessionMU.Lock()
-	defer sessionMU.Unlock()
 
 	sessionKey := params.server + params.userinfo.Username() + params.datacenter
-	if cachedSession, ok := sessionCache[sessionKey]; ok {
-		// Since keepalive is always enabled, we return a cached session when available.
-		// To make sure that the cached session is still active, we depend on the roundtripper -- which, as configured
-		// in newClient(), removes the session from the cache if it dies.
-		return &cachedSession, nil
+	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+		s := cachedSession.(*Session)
+		logger = logger.WithValues("server", params.server, "datacenter", params.datacenter)
+
+		vimSessionActive, err := s.SessionManager.SessionIsActive(ctx)
+		if err != nil {
+			logger.Error(err, "unable to check if vim session is active")
+		}
+
+		tagManagerSession, err := s.TagManager.Session(ctx)
+		if err != nil {
+			logger.Error(err, "unable to check if rest session is active")
+		}
+
+		if vimSessionActive && tagManagerSession != nil {
+			logger.V(2).Info("found active cached vSphere client session")
+			return s, nil
+		}
 	}
 
+	clearCache(logger, sessionKey)
 	soapURL, err := soap.ParseURL(params.server)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing vSphere URL %q", params.server)
@@ -132,7 +145,7 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	// Assign the finder to the session.
 	session.Finder = find.NewFinder(session.Client.Client, false)
 	// Assign tag manager to the session.
-	manager, err := newManager(ctx, client.Client, soapURL.User)
+	manager, err := newManager(ctx, logger, sessionKey, client.Client, soapURL.User, params.feature)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create tags manager")
 	}
@@ -148,7 +161,7 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 		session.Finder.SetDatacenter(dc)
 	}
 	// Cache the session.
-	sessionCache[sessionKey] = session
+	sessionCache.Store(sessionKey, &session)
 
 	logger.V(2).Info("cached vSphere client session", "server", params.server, "datacenter", params.datacenter)
 
@@ -173,12 +186,16 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 	}
 
 	vimClient.RoundTripper = session.KeepAliveHandler(vimClient.RoundTripper, feature.KeepAliveDuration, func(tripper soap.RoundTripper) error {
-		// GetCurrentTime is used to keep the session alive. If it fails then we clear the cache
-		// and expect the client to be recreated in the next GetOrCreate() call.
+		// we tried implementing
+		// c.Login here but the client once logged out
+		// keeps errong in invalid username or password
+		// we tried with cached username and password in session still the error persisted
+		// hence we just clear the cache and expect the client to
+		// be recreated in next GetOrCreate call
 		_, err := methods.GetCurrentTime(ctx, tripper)
 		if err != nil {
 			logger.Error(err, "failed to keep alive govmomi client")
-			clearCache(sessionKey)
+			clearCache(logger, sessionKey)
 		}
 		return err
 	})
@@ -190,15 +207,54 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 	return c, nil
 }
 
-func clearCache(sessionKey string) {
-	sessionMU.Lock()
-	defer sessionMU.Unlock()
-	delete(sessionCache, sessionKey)
+func clearCache(logger logr.Logger, sessionKey string) {
+	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+		s := cachedSession.(*Session)
+
+		// check for the presence of tagmanager session
+		// since calling Logout on an expired session blocks
+		session, err := s.TagManager.Session(context.Background())
+		if err != nil {
+			logger.Error(err, "unable to get tag manager session")
+		}
+		if session != nil {
+			logger.V(6).Info("found active tag manager session, logging out")
+			err := s.TagManager.Logout(context.Background())
+			if err != nil {
+				logger.Error(err, "unable to logout tag manager session")
+			}
+		}
+
+		vimSessionActive, err := s.SessionManager.SessionIsActive(context.Background())
+		if err != nil {
+			logger.Error(err, "unable to get vim client session")
+		} else if vimSessionActive {
+			logger.V(6).Info("found active vim session, logging out")
+			err := s.SessionManager.Logout(context.Background())
+			if err != nil {
+				logger.Error(err, "unable to logout vim session")
+			}
+		}
+	}
+	sessionCache.Delete(sessionKey)
 }
 
 // newManager creates a Manager that encompasses the REST Client for the VSphere tagging API.
-func newManager(ctx context.Context, client *vim25.Client, user *url.Userinfo) (*tags.Manager, error) {
+func newManager(ctx context.Context, logger logr.Logger, sessionKey string, client *vim25.Client, user *url.Userinfo, feature Feature) (*tags.Manager, error) {
 	rc := rest.NewClient(client)
+	rc.Transport = keepalive.NewHandlerREST(rc, feature.KeepAliveDuration, func() error {
+		s, err := rc.Session(ctx)
+		if err != nil {
+			return err
+		}
+		if s != nil {
+			return nil
+		}
+
+		logger.V(6).Info("rest client session expired, clearing cache")
+		clearCache(logger, sessionKey)
+		return errors.New("rest client session expired")
+	})
 	if err := rc.Login(ctx, user); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
feature enablekeepalive

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
currently session.Tagmanger is initialized separately from vim.Client and there is not keep-alive added to it.
this PR adds keep-alive support to session.Tagmanager rest.Client 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1362 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```