### PR TITLE
Fix vm-operator dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,15 +8,14 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-version v1.3.0
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff
-	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211118193625-3a50e2e58c47
-	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211118193625-3a50e2e58c47
+	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f
+	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f
 	github.com/vmware/govmomi v0.27.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
@@ -26,7 +25,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
-	k8s.io/cluster-bootstrap v0.22.2 // indirect
+	k8s.io/cluster-bootstrap v0.22.2
 	k8s.io/component-base v0.22.2
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -855,10 +855,10 @@ github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707 h1:2
 github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707/go.mod h1:pDB0pUiFYufuP3lUkQX9fZ67PYnKvqBpDcJN3mSrw5U=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff h1:ThuEcNdWY5aXymrx0iOYhkIDwAQhZnOwXyEQ776lepI=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
-github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211118193625-3a50e2e58c47 h1:TNuLY6iE8yaVoL150eOw1alga1fJrHkaJBh3qr0ShEA=
-github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211118193625-3a50e2e58c47/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
-github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211118193625-3a50e2e58c47 h1:zJAQmYtZSwCt7nS9qBsT91NTuE3ZN2WW438t5JQJcnI=
-github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211118193625-3a50e2e58c47/go.mod h1:dfYrWS8DMRN+XZfhu8M4LVHmeGvYB29Ipd7j4uIq+mU=
+github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f h1:RUuS5lh25citvQoXmDSfxJ1BB72LXOjD5cXvJETJ7Cc=
+github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
+github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f h1:wwYUf16/g8bLywQMQJB5VHbDtuf6aOFH24Ar2/yA7+I=
+github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f/go.mod h1:dfYrWS8DMRN+XZfhu8M4LVHmeGvYB29Ipd7j4uIq+mU=
 github.com/vmware/govmomi v0.27.1 h1:Rf3o1btFrkJa9be5KtgJ4CyOO8mbFnBxmNtAVHNyFes=
 github.com/vmware/govmomi v0.27.1/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=


### PR DESCRIPTION
**What this PR does / why we need it**:
Revision `v0.0.0-20211118193625-3a50e2e58c47` of `github.com/vmware-tanzu/vm-operator` no longer exists. Update to latest master since there isn't a recent tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1342 

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```