### PR TITLE
Quote PATH variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ test-integration: $(GINKGO) $(KUSTOMIZE) $(KIND)
 .PHONY: e2e
 e2e: e2e-image e2e-templates
 e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
-	@echo PATH=$(PATH)
+	@echo PATH="$(PATH)"
 	@echo
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
@@ -149,7 +149,7 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 .PHONY: e2e-upgrade
 e2e-upgrade: e2e-image e2e-templates
 e2e-upgrade: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
-	@echo PATH=$(PATH)
+	@echo PATH="$(PATH)"
 	@echo
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)


### PR DESCRIPTION
**What this PR does / why we need it**:

The `PATH` assignment is currently breaking on WSL when `$(PATH)` contains parentheses, e.g. when the variable contains a substring such as the following: `/mnt/c/Program Files (x86)/`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```