### PR TITLE
fix virtualnetwork name in configureVirtualMachine

### DIFF
--- a/pkg/services/network/network.go
+++ b/pkg/services/network/network.go
@@ -318,7 +318,7 @@ func (np *nsxtNetworkProvider) GetVMServiceAnnotations(ctx *vmware.ClusterContex
 
 // ConfigureVirtualMachine configures a VirtualMachine object based on the networking configuration.
 func (np *nsxtNetworkProvider) ConfigureVirtualMachine(ctx *vmware.ClusterContext, vm *vmopv1.VirtualMachine) error {
-	nsxtClusterNetworkName := GetNSXTVirtualNetworkName(ctx.Cluster.Name)
+	nsxtClusterNetworkName := GetNSXTVirtualNetworkName(ctx.VSphereCluster.Name)
 	for _, vnif := range vm.Spec.NetworkInterfaces {
 		if vnif.NetworkType == NSXTTypeNetwork && vnif.NetworkName == nsxtClusterNetworkName {
 			// expected network interface is already found

--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -179,6 +179,7 @@ var _ = Describe("Network provider", func() {
 			})
 			AfterEach(func() {
 				Expect(err).To(BeNil())
+				Expect(vm.Spec.NetworkInterfaces[0].NetworkName).To(Equal(GetNSXTVirtualNetworkName(vSphereCluster.Name)))
 				Expect(vm.Spec.NetworkInterfaces[0].NetworkType).To(Equal("nsx-t"))
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: The virtualnetwork name is derived from vspherecluster name. While configuring VirtualMachine's virtualnetwork, the virtualnetwork name is derived from cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```