### PR TITLE
Backport deletion logic for VSphereDeploymentZone

### DIFF
--- a/api/v1alpha3/vspheredeploymentzone_conversion.go
+++ b/api/v1alpha3/vspheredeploymentzone_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereDeploymentZone to the Hub version (v1alpha4).
+func (src *VSphereDeploymentZone) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1.VSphereDeploymentZone)
+	return Convert_v1alpha3_VSphereDeploymentZone_To_v1alpha4_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1alpha4) to this VSphereDeploymentZone.
+func (dst *VSphereDeploymentZone) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1.VSphereDeploymentZone)
+	return Convert_v1alpha4_VSphereDeploymentZone_To_v1alpha3_VSphereDeploymentZone(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereDeploymentZoneList to the Hub version (v1alpha4).
+func (src *VSphereDeploymentZoneList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1.VSphereDeploymentZoneList)
+	return Convert_v1alpha3_VSphereDeploymentZoneList_To_v1alpha4_VSphereDeploymentZoneList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereDeploymentZoneList to the Hub version (v1alpha4).
+func (dst *VSphereDeploymentZoneList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1.VSphereDeploymentZoneList)
+	return Convert_v1alpha4_VSphereDeploymentZoneList_To_v1alpha3_VSphereDeploymentZoneList(src, dst, nil)
+}

--- a/api/v1alpha3/vspherefailuredomain_conversion.go
+++ b/api/v1alpha3/vspherefailuredomain_conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this VSphereFailureDomain to the Hub version (v1alpha4).
+func (src *VSphereFailureDomain) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1.VSphereFailureDomain)
+	return Convert_v1alpha3_VSphereFailureDomain_To_v1alpha4_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1alpha4) to this VSphereFailureDomain.
+func (dst *VSphereFailureDomain) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1.VSphereFailureDomain)
+	return Convert_v1alpha4_VSphereFailureDomain_To_v1alpha3_VSphereFailureDomain(src, dst, nil)
+}
+
+// ConvertTo converts this VSphereFailureDomainList to the Hub version (v1alpha4).
+func (src *VSphereFailureDomainList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*infrav1.VSphereFailureDomainList)
+	return Convert_v1alpha3_VSphereFailureDomainList_To_v1alpha4_VSphereFailureDomainList(src, dst, nil)
+}
+
+// ConvertFrom converts this VSphereFailureDomainList to the Hub version (v1alpha4).
+func (dst *VSphereFailureDomainList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*infrav1.VSphereFailureDomainList)
+	return Convert_v1alpha4_VSphereFailureDomainList_To_v1alpha3_VSphereFailureDomainList(src, dst, nil)
+}

--- a/api/v1alpha4/vspheredeploymentzone_conversion.go
+++ b/api/v1alpha4/vspheredeploymentzone_conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+// Hub marks VSphereDeploymentZone as a conversion hub.
+func (*VSphereDeploymentZone) Hub() {}
+
+// Hub marks VSphereDeploymentZoneList as a conversion hub.
+func (*VSphereDeploymentZoneList) Hub() {}

--- a/api/v1alpha4/vspheredeploymentzone_types.go
+++ b/api/v1alpha4/vspheredeploymentzone_types.go
@@ -21,6 +21,13 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
+const (
+	// DeploymentZoneFinalizer allows ReconcileVSphereDeploymentZone to
+	// check for dependents associated with VSphereDeploymentZone
+	// before removing it from the API Server.
+	DeploymentZoneFinalizer = "vspheredeploymentzone.infrastructure.cluster.x-k8s.io"
+)
+
 // VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
 type VSphereDeploymentZoneSpec struct {
 

--- a/api/v1alpha4/vspherefailuredomain_conversion.go
+++ b/api/v1alpha4/vspherefailuredomain_conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+// Hub marks VSphereFailureDomain as a conversion hub.
+func (*VSphereFailureDomain) Hub() {}
+
+// Hub marks VSphereFailureDomainList as a conversion hub.
+func (*VSphereFailureDomainList) Hub() {}

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -80,6 +80,9 @@ func setup() {
 	if err := AddVsphereClusterIdentityControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
+	if err := AddVSphereDeploymentZoneControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
+	}
 
 	go func() {
 		fmt.Println("Starting the manager")

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -24,14 +24,18 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheredeploymentzones,verbs=get;list;watch;create;update;patch;delete
@@ -147,6 +152,9 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx goctx.Context, request re
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileNormal(ctx *context.VSphereDeploymentZoneContext) (reconcile.Result, error) {
+
+	ctrlutil.AddFinalizer(ctx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
+
 	authSession, err := r.getVCenterSession(ctx)
 	if err != nil {
 		ctx.Logger.V(4).Error(err, "unable to create session")
@@ -170,6 +178,24 @@ func (r vsphereDeploymentZoneReconciler) reconcileNormal(ctx *context.VSphereDep
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile failure domain")
 	}
 	conditions.MarkTrue(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+
+	// Ensure the VSphereDeploymentZone is marked as an owner of the VSphereFailureDomain.
+	if !clusterutilv1.HasOwnerRef(ctx.VSphereFailureDomain.GetOwnerReferences(), metav1.OwnerReference{
+		APIVersion: infrav1.GroupVersion.String(),
+		Kind:       "VSphereDeploymentZone",
+		Name:       ctx.VSphereDeploymentZone.Name,
+	}) {
+		if err := updateOwnerReferences(ctx, ctx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
+			return append(ctx.VSphereFailureDomain.OwnerReferences, metav1.OwnerReference{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       ctx.VSphereDeploymentZone.Kind,
+				Name:       ctx.VSphereDeploymentZone.Name,
+				UID:        ctx.VSphereDeploymentZone.UID,
+			})
+		}); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 
 	ctx.VSphereDeploymentZone.Status.Ready = pointer.Bool(true)
 	return reconcile.Result{}, nil
@@ -233,7 +259,63 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx *context.VSphereD
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx *context.VSphereDeploymentZoneContext) (reconcile.Result, error) {
+	r.Logger.Info("Deleting VSphereDeploymentZone")
+
+	machines := &clusterv1.MachineList{}
+	if err := r.Client.List(ctx, machines); err != nil {
+		r.Logger.Error(err, "unable to list machines")
+		return reconcile.Result{}, errors.Wrapf(err, "unable to list machines")
+	}
+
+	machinesUsingDeploymentZone := collections.FromMachineList(machines).Filter(collections.ActiveMachines, func(machine *clusterv1.Machine) bool {
+		return *machine.Spec.FailureDomain == ctx.VSphereDeploymentZone.Name
+	})
+	if len(machinesUsingDeploymentZone) > 0 {
+		machineNamesStr := util.MachinesAsString(machinesUsingDeploymentZone.SortedByCreationTimestamp())
+		err := errors.Errorf("%s is currently in use by machines: %s", ctx.VSphereDeploymentZone.Name, machineNamesStr)
+		r.Logger.Error(err, "Error deleting VSphereDeploymentZone", "name", ctx.VSphereDeploymentZone.Name)
+		return reconcile.Result{}, err
+	}
+
+	if err := updateOwnerReferences(ctx, ctx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
+		return clusterutilv1.RemoveOwnerRef(ctx.VSphereFailureDomain.OwnerReferences, metav1.OwnerReference{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       ctx.VSphereDeploymentZone.Kind,
+			Name:       ctx.VSphereDeploymentZone.Name,
+		})
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(ctx.VSphereFailureDomain.OwnerReferences) == 0 {
+		ctx.Logger.Info("deleting vsphereFailureDomain", "name", ctx.VSphereFailureDomain.Name)
+		if err := r.Client.Delete(ctx, ctx.VSphereFailureDomain); err != nil && !apierrors.IsNotFound(err) {
+			ctx.Logger.Error(err, "failed to delete related %s %s", ctx.VSphereFailureDomain.GroupVersionKind(), ctx.VSphereFailureDomain.Name)
+		}
+	}
+
+	ctrlutil.RemoveFinalizer(ctx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
+
 	return reconcile.Result{}, nil
+}
+
+// updateOwnerReferences uses the ownerRef function to calculate the owner references
+// to be set on the object and patches the object.
+func updateOwnerReferences(ctx goctx.Context, obj client.Object, client client.Client, ownerRefFunc func() []metav1.OwnerReference) error {
+	patchHelper, err := patch.NewHelper(obj, client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to init patch helper for %s %s",
+			obj.GetObjectKind(),
+			obj.GetName())
+	}
+
+	obj.SetOwnerReferences(ownerRefFunc())
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return errors.Wrapf(err, "failed to patch object %s %s",
+			obj.GetObjectKind(),
+			obj.GetName())
+	}
+	return nil
 }
 
 func (r vsphereDeploymentZoneReconciler) failureDomainsToDeploymentZones(a client.Object) []reconcile.Request {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -477,44 +477,41 @@ func (r machineReconciler) reconcileNormalPre7(ctx *context.MachineContext, vsph
 // generateOverrideFunc returns a function which can override the values in the VSphereVM Spec
 // with the values from the FailureDomain (if any) set on the owner CAPI machine.
 func (r machineReconciler) generateOverrideFunc(ctx *context.MachineContext) (func(vm *infrav1.VSphereVM), bool) {
-	var overrideWithFailureDomainFunc func(vm *infrav1.VSphereVM)
-	if failureDomainName := ctx.Machine.Spec.FailureDomain; failureDomainName != nil {
-		var vsphereDeploymentZoneList infrav1.VSphereDeploymentZoneList
-		if err := r.Client.List(ctx, &vsphereDeploymentZoneList); err != nil {
-			r.Logger.Error(err, "unable to fetch list of deployment zones")
-			return overrideWithFailureDomainFunc, false
-		}
+	failureDomainName := ctx.Machine.Spec.FailureDomain
+	if failureDomainName == nil {
+		return nil, false
+	}
 
-		var vsphereFailureDomain infrav1.VSphereFailureDomain
-		if err := r.Client.Get(ctx, client.ObjectKey{Name: *failureDomainName}, &vsphereFailureDomain); err != nil {
-			r.Logger.Error(err, "unable to fetch failure domain", "name", *failureDomainName)
-			return overrideWithFailureDomainFunc, false
-		}
+	// Use the failureDomain name to fetch the vSphereDeploymentZone object
+	var vsphereDeploymentZone infrav1.VSphereDeploymentZone
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: *failureDomainName}, &vsphereDeploymentZone); err != nil {
+		r.Logger.Error(err, "unable to fetch vsphere deployment zone", "name", *failureDomainName)
+		return nil, false
+	}
 
-		for index := range vsphereDeploymentZoneList.Items {
-			zone := vsphereDeploymentZoneList.Items[index]
-			if zone.Spec.FailureDomain == *failureDomainName {
-				overrideWithFailureDomainFunc = func(vm *infrav1.VSphereVM) {
-					vm.Spec.Server = zone.Spec.Server
-					vm.Spec.Datacenter = vsphereFailureDomain.Spec.Topology.Datacenter
-					if zone.Spec.PlacementConstraint.Folder != "" {
-						vm.Spec.Folder = zone.Spec.PlacementConstraint.Folder
-					}
-					if zone.Spec.PlacementConstraint.ResourcePool != "" {
-						vm.Spec.ResourcePool = zone.Spec.PlacementConstraint.ResourcePool
-					}
-					if vsphereFailureDomain.Spec.Topology.Datastore != "" {
-						vm.Spec.Datastore = vsphereFailureDomain.Spec.Topology.Datastore
-					}
-					if len(vsphereFailureDomain.Spec.Topology.Networks) > 0 {
-						vm.Spec.Network.Devices = overrideNetworkDeviceSpecs(vm.Spec.Network.Devices, vsphereFailureDomain.Spec.Topology.Networks)
-					}
-				}
-				return overrideWithFailureDomainFunc, true
-			}
+	var vsphereFailureDomain infrav1.VSphereFailureDomain
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: vsphereDeploymentZone.Spec.FailureDomain}, &vsphereFailureDomain); err != nil {
+		r.Logger.Error(err, "unable to fetch failure domain", "name", vsphereDeploymentZone.Spec.FailureDomain)
+		return nil, false
+	}
+
+	overrideWithFailureDomainFunc := func(vm *infrav1.VSphereVM) {
+		vm.Spec.Server = vsphereDeploymentZone.Spec.Server
+		vm.Spec.Datacenter = vsphereFailureDomain.Spec.Topology.Datacenter
+		if vsphereDeploymentZone.Spec.PlacementConstraint.Folder != "" {
+			vm.Spec.Folder = vsphereDeploymentZone.Spec.PlacementConstraint.Folder
+		}
+		if vsphereDeploymentZone.Spec.PlacementConstraint.ResourcePool != "" {
+			vm.Spec.ResourcePool = vsphereDeploymentZone.Spec.PlacementConstraint.ResourcePool
+		}
+		if vsphereFailureDomain.Spec.Topology.Datastore != "" {
+			vm.Spec.Datastore = vsphereFailureDomain.Spec.Topology.Datastore
+		}
+		if len(vsphereFailureDomain.Spec.Topology.Networks) > 0 {
+			vm.Spec.Network.Devices = overrideNetworkDeviceSpecs(vm.Spec.Network.Devices, vsphereFailureDomain.Spec.Topology.Networks)
 		}
 	}
-	return overrideWithFailureDomainFunc, false
+	return overrideWithFailureDomainFunc, true
 }
 
 // overrideNetworkDeviceSpecs updates the network devices with the network definitions from the PlacementConstraint.

--- a/controllers/vspheremachine_controller_unit_test.go
+++ b/controllers/vspheremachine_controller_unit_test.go
@@ -78,7 +78,7 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 
 	Context("When Failure Domain is present", func() {
 		BeforeEach(func() {
-			machineCtx.Machine.Spec.FailureDomain = pointer.String("fd-one")
+			machineCtx.Machine.Spec.FailureDomain = pointer.String("zone-one")
 		})
 
 		It("generates an override function", func() {
@@ -100,6 +100,19 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 			Expect(vm.Spec.Datastore).To(Equal("ds-one"))
 			Expect(vm.Spec.ResourcePool).To(Equal("rp-one"))
 			Expect(vm.Spec.Datacenter).To(Equal("dc-one"))
+		})
+
+		Context("for non-existent failure domain value", func() {
+			BeforeEach(func() {
+				machineCtx.Machine.Spec.FailureDomain = pointer.String("non-existent-zone")
+			})
+
+			It("fails to generate an override function", func() {
+				r := machineReconciler{controllerCtx}
+				overrideFunc, ok := r.generateOverrideFunc(machineCtx)
+				Expect(ok).To(BeFalse())
+				Expect(overrideFunc).To(BeNil())
+			})
 		})
 
 		Context("with network specified in the topology", func() {

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -158,7 +158,11 @@ func (r vmReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Res
 	if !clusterutilv1.HasOwner(vsphereVM.OwnerReferences, infrav1.GroupVersion.String(), []string{"HAProxyLoadBalancer"}) {
 		// Fetch the owner VSphereMachine.
 		vsphereMachine, err := util.GetOwnerVSphereMachine(r, r.Client, vsphereVM.ObjectMeta)
-		if err != nil {
+		// vsphereMachine can be nil in cases where custom mover other than clusterctl
+		// moves the resources without ownerreferences set
+		// in that case nil vsphereMachine can cause panic and CrashLoopBackOff the pod
+		// preventing vspheremachine_controller from setting the ownerref
+		if err != nil || vsphereMachine == nil {
 			r.Logger.Info("Owner VSphereMachine not found, won't reconcile", "key", req.NamespacedName)
 			return reconcile.Result{}, nil
 		}

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -174,9 +174,14 @@ func (r vmReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Res
 		}
 
 		if failureDomain := machine.Spec.FailureDomain; failureDomain != nil {
+			vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{}
+			if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereDeploymentZone); err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere deployment zone %s", *failureDomain)
+			}
+
 			vsphereFailureDomain = &infrav1.VSphereFailureDomain{}
-			if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereFailureDomain); err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", *failureDomain)
+			if err := r.Client.Get(r, apitypes.NamespacedName{Name: vsphereDeploymentZone.Spec.FailureDomain}, vsphereFailureDomain); err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", vsphereDeploymentZone.Spec.FailureDomain)
 			}
 		}
 	}

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"regexp"
 	"text/template"
@@ -269,4 +270,26 @@ func ConvertUUIDToProviderID(uuid string) string {
 		return ""
 	}
 	return ProviderIDPrefix + uuid
+}
+
+// MachinesAsString constructs a string (with correct punctuations) to be
+// used in logging and error messages.
+func MachinesAsString(machines []*clusterv1.Machine) string {
+	var message string
+	count := 1
+	for _, m := range machines {
+		if count == 1 {
+			message = fmt.Sprintf("%s/%s", m.Namespace, m.Name)
+		} else {
+			var format string
+			if count > 1 && count != len(machines) {
+				format = "%s, %s/%s"
+			} else if count == len(machines) {
+				format = "%s and %s/%s"
+			}
+			message = fmt.Sprintf(format, message, m.Namespace, m.Name)
+		}
+		count++
+	}
+	return message
 }

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
@@ -750,6 +751,41 @@ func TestConvertUUIDtoProviderID(t *testing.T) {
 			actualProviderID := util.ConvertUUIDToProviderID(tc.uuid)
 			g.Expect(actualProviderID).To(gomega.Equal(tc.expectedProviderID))
 		})
+	}
+}
+
+func Test_MachinesAsString(t *testing.T) {
+	tests := []struct {
+		machines     []*clusterv1.Machine
+		errorMessage string
+	}{
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+			},
+			errorMessage: "m1-ns/m1",
+		},
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+			},
+			errorMessage: "m1-ns/m1 and m2-ns/m2",
+		},
+		{
+			machines: []*clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m3", Namespace: "m3-ns"}},
+			},
+			errorMessage: "m1-ns/m1, m2-ns/m2 and m3-ns/m3",
+		},
+	}
+
+	for _, tt := range tests {
+		g := gomega.NewWithT(t)
+		msg := util.MachinesAsString(tt.machines)
+		g.Expect(msg).To(gomega.Equal(tt.errorMessage))
 	}
 }
 

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -173,6 +173,13 @@ func NewTestEnvironment() *TestEnvironment {
 			return err
 		}
 
+		if err := (&infrav1.VSphereFailureDomain{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+		if err := (&infrav1.VSphereFailureDomainList{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch includes the following changes:
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.

It is a back port of #1316 with changes to API versions for VSphereDeploymentZone conversions

**Which issue(s) this PR fixes**:
Fixes #1359 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.
```