### PR TITLE
Backport deletion logic for VSphereDeploymentZone

### DIFF
--- a/api/v1alpha3/vspheredeploymentzone_types.go
+++ b/api/v1alpha3/vspheredeploymentzone_types.go
@@ -21,6 +21,13 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
+const (
+	// DeploymentZoneFinalizer allows ReconcileVSphereDeploymentZone to
+	// check for dependents associated with VSphereDeploymentZone
+	// before removing it from the API Server.
+	DeploymentZoneFinalizer = "vspheredeploymentzone.infrastructure.cluster.x-k8s.io"
+)
+
 // VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
 type VSphereDeploymentZoneSpec struct {
 

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -83,6 +83,9 @@ func setup() {
 	if err := AddVsphereClusterIdentityControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
+	if err := AddVSphereDeploymentZoneControllerToManager(testEnv.GetContext(), testEnv.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
+	}
 
 	go func() {
 		fmt.Println("Starting the manager")

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -17,13 +17,20 @@ limitations under the License.
 package controllers
 
 import (
+	goctx "context"
 	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/vmware/govmomi/simulator"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
@@ -31,47 +38,67 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
 )
 
-func Success(t *testing.T) {
-	g := NewWithT(t)
+var _ = Describe("VSphereDeploymentZoneReconciler", func() {
+	var (
+		simr *helpers.Simulator
+		ctx  goctx.Context
 
-	model := simulator.VPX()
-	model.Pool = 1
+		vsphereDeploymentZone *infrav1.VSphereDeploymentZone
+		vsphereFailureDomain  *infrav1.VSphereFailureDomain
+	)
 
-	simr, err := helpers.VCSimBuilder().
-		WithModel(model).
-		WithOperations("tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
+	BeforeEach(func() {
+		model := simulator.VPX()
+		model.Pool = 1
+
+		var err error
+		simr, err = helpers.VCSimBuilder().
+			WithModel(model).
+			WithOperations().
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		operations := []string{
+			"tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
 			"tags.category.create -t Datacenter,ClusterComputeResource k8s-zone",
 			"tags.create -c k8s-region k8s-region-west",
 			"tags.create -c k8s-zone k8s-zone-west-1",
 			"tags.attach -c k8s-region k8s-region-west /DC0",
-			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0").
-		Build()
-	if err != nil {
-		t.Fatalf("unable to create simulator %s", err)
-	}
-	defer simr.Destroy()
+			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0",
+		}
+		for _, op := range operations {
+			Expect(simr.Run(op, gbytes.NewBuffer(), gbytes.NewBuffer())).To(Succeed())
+		}
 
-	mgmtContext := fake.NewControllerManagerContext()
-	mgmtContext.Username = simr.ServerURL().User.Username()
-	pass, _ := simr.ServerURL().User.Password()
-	mgmtContext.Password = pass
+		ctx = goctx.Background()
+	})
 
-	controllerCtx := fake.NewControllerContext(mgmtContext)
+	AfterEach(func() {
+		Expect(testEnv.Cleanup(ctx, vsphereDeploymentZone, vsphereFailureDomain)).To(Succeed())
+	})
 
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
-		ControllerContext: controllerCtx,
-		VSphereDeploymentZone: &infrav1.VSphereDeploymentZone{Spec: infrav1.VSphereDeploymentZoneSpec{
-			Server:        simr.ServerURL().Host,
-			FailureDomain: "blah",
-			ControlPlane:  pointer.BoolPtr(true),
-			PlacementConstraint: infrav1.PlacementConstraint{
-				ResourcePool: "DC0_C0_RP1",
-				Folder:       "/",
-			},
-		}},
-		VSphereFailureDomain: &infrav1.VSphereFailureDomain{
+	It("should create a deployment zone & failure domain", func() {
+		dzName := "blah"
+		fdName := "blah-fd"
+
+		vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "blah",
+				Name: dzName,
+			},
+			Spec: infrav1.VSphereDeploymentZoneSpec{
+				Server:        simr.ServerURL().Host,
+				FailureDomain: fdName,
+				ControlPlane:  pointer.BoolPtr(true),
+				PlacementConstraint: infrav1.PlacementConstraint{
+					ResourcePool: "DC0_C0_RP1",
+					Folder:       "/",
+				},
+			}}
+		Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
+
+		vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fdName,
 			},
 			Spec: infrav1.VSphereFailureDomainSpec{
 				Region: infrav1.FailureDomain{
@@ -93,91 +120,158 @@ func Success(t *testing.T) {
 					Networks:       []string{"VM Network"},
 				},
 			},
-		},
-		Logger: logr.DiscardLogger{},
-	}
+		}
+		Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
 
-	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-	_, err = reconciler.reconcileNormal(deploymentZoneCtx)
-	g.Expect(err).NotTo(HaveOccurred())
-}
+		Eventually(func() bool {
+			if err := testEnv.Get(ctx, client.ObjectKey{Name: dzName}, vsphereDeploymentZone); err != nil {
+				return false
+			}
+			return len(vsphereDeploymentZone.Finalizers) > 0
+		}, timeout).Should(BeTrue())
 
-func FailResourcePoolNotOwnedComputeCluster(t *testing.T) {
-	g := NewWithT(t)
+		Eventually(func() bool {
+			if err := testEnv.Get(ctx, client.ObjectKey{Name: dzName}, vsphereDeploymentZone); err != nil {
+				return false
+			}
+			return conditions.IsTrue(vsphereDeploymentZone, infrav1.VCenterAvailableCondition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+		}, timeout).Should(BeTrue())
 
-	model := simulator.VPX()
-	model.Cluster = 2
-	model.Pool = 2
+		By("sets the owner ref on the vsphereFailureDomain object")
+		Expect(testEnv.Get(ctx, client.ObjectKey{Name: fdName}, vsphereFailureDomain)).To(Succeed())
+		ownerRefs := vsphereFailureDomain.GetOwnerReferences()
+		Expect(ownerRefs).To(HaveLen(1))
+		Expect(ownerRefs[0].Name).To(Equal(dzName))
+		Expect(ownerRefs[0].Kind).To(Equal("VSphereDeploymentZone"))
+	})
 
-	simr, err := helpers.VCSimBuilder().
-		WithModel(model).
-		WithOperations("tags.category.create -t Datacenter,ClusterComputeResource k8s-region",
-			"tags.category.create -t Datacenter,ClusterComputeResource k8s-zone",
-			"tags.create -c k8s-region k8s-region-west",
-			"tags.create -c k8s-zone k8s-zone-west-1",
-			"tags.attach -c k8s-region k8s-region-west /DC0",
-			"tags.attach -c k8s-zone k8s-zone-west-1 /DC0/host/DC0_C0").
-		Build()
-	if err != nil {
-		t.Fatalf("unable to create simulator %s", err)
-	}
-	defer simr.Destroy()
-
-	mgmtContext := fake.NewControllerManagerContext()
-	mgmtContext.Username = simr.ServerURL().User.Username()
-	pass, _ := simr.ServerURL().User.Password()
-	mgmtContext.Password = pass
-
-	controllerCtx := fake.NewControllerContext(mgmtContext)
-
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
-		ControllerContext: controllerCtx,
-		VSphereDeploymentZone: &infrav1.VSphereDeploymentZone{Spec: infrav1.VSphereDeploymentZoneSpec{
-			Server:        simr.ServerURL().Host,
-			FailureDomain: "blah",
-			ControlPlane:  pointer.BoolPtr(true),
-			PlacementConstraint: infrav1.PlacementConstraint{
-				ResourcePool: "DC0_C1_RP1",
-				Folder:       "/",
-			},
-		}},
-		VSphereFailureDomain: &infrav1.VSphereFailureDomain{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "blah",
-			},
-			Spec: infrav1.VSphereFailureDomainSpec{
-				Region: infrav1.FailureDomain{
-					Name:          "k8s-region-west",
-					Type:          infrav1.DatacenterFailureDomain,
-					TagCategory:   "k8s-region",
-					AutoConfigure: pointer.BoolPtr(false),
+	Context("With incorrect details: when resource pool is not owned by compute cluster", func() {
+		It("should fail creation of deployment zone", func() {
+			vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-two",
 				},
-				Zone: infrav1.FailureDomain{
-					Name:          "k8s-zone-west-1",
-					Type:          infrav1.ComputeClusterFailureDomain,
-					TagCategory:   "k8s-zone",
-					AutoConfigure: pointer.BoolPtr(false),
-				},
-				Topology: infrav1.Topology{
-					Datacenter:     "DC0",
-					ComputeCluster: pointer.StringPtr("DC0_C0"),
-					Datastore:      "LocalDS_0",
-					Networks:       []string{"VM Network"},
-				},
-			},
-		},
-		Logger: logr.DiscardLogger{},
-	}
+				Spec: infrav1.VSphereDeploymentZoneSpec{
+					Server:        simr.ServerURL().Host,
+					FailureDomain: "blah-fd-two",
+					ControlPlane:  pointer.BoolPtr(true),
+					PlacementConstraint: infrav1.PlacementConstraint{
+						ResourcePool: "DC0_C1_RP1",
+						Folder:       "/",
+					},
+				}}
+			Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
 
-	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-	_, err = reconciler.reconcileNormal(deploymentZoneCtx)
-	g.Expect(err).To(HaveOccurred())
-}
+			vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereFailureDomain",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-fd-two",
+				},
+				Spec: infrav1.VSphereFailureDomainSpec{
+					Region: infrav1.FailureDomain{
+						Name:          "k8s-region-west",
+						Type:          infrav1.DatacenterFailureDomain,
+						TagCategory:   "k8s-region",
+						AutoConfigure: pointer.BoolPtr(false),
+					},
+					Zone: infrav1.FailureDomain{
+						Name:          "k8s-zone-west-1",
+						Type:          infrav1.ComputeClusterFailureDomain,
+						TagCategory:   "k8s-zone",
+						AutoConfigure: pointer.BoolPtr(false),
+					},
+					Topology: infrav1.Topology{
+						Datacenter:     "DC0",
+						ComputeCluster: pointer.StringPtr("DC0_C0"),
+						Datastore:      "LocalDS_0",
+						Networks:       []string{"VM Network"},
+					},
+				},
+			}
+			Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
 
-func TestVsphereDeploymentZoneReconciler(t *testing.T) {
-	t.Run("VSphereDeploymentZone reconciliation is successful", Success)
-	t.Run("VSphereDeploymentZone reconciliation fails when resource pool is not owned by compute cluster", FailResourcePoolNotOwnedComputeCluster)
-}
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, client.ObjectKey{Name: "blah-two"}, vsphereDeploymentZone); err != nil {
+					return false
+				}
+				return conditions.IsFalse(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition)
+			}, timeout).Should(BeTrue())
+		})
+	})
+
+	Context("Delete VSphereDeploymentZone", func() {
+		It("should delete the associated failure domain", func() {
+			fdName := "blah-fd-three"
+
+			vsphereDeploymentZone = &infrav1.VSphereDeploymentZone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah-three",
+				},
+				Spec: infrav1.VSphereDeploymentZoneSpec{
+					Server:        simr.ServerURL().Host,
+					FailureDomain: fdName,
+					ControlPlane:  pointer.BoolPtr(true),
+					PlacementConstraint: infrav1.PlacementConstraint{
+						ResourcePool: "DC0_C0_RP1",
+						Folder:       "/",
+					},
+				}}
+			Expect(testEnv.Create(ctx, vsphereDeploymentZone)).To(Succeed())
+
+			vsphereFailureDomain = &infrav1.VSphereFailureDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fdName,
+				},
+				Spec: infrav1.VSphereFailureDomainSpec{
+					Region: infrav1.FailureDomain{
+						Name:          "k8s-region-west",
+						Type:          infrav1.DatacenterFailureDomain,
+						TagCategory:   "k8s-region",
+						AutoConfigure: pointer.BoolPtr(false),
+					},
+					Zone: infrav1.FailureDomain{
+						Name:          "k8s-zone-west-1",
+						Type:          infrav1.ComputeClusterFailureDomain,
+						TagCategory:   "k8s-zone",
+						AutoConfigure: pointer.BoolPtr(false),
+					},
+					Topology: infrav1.Topology{
+						Datacenter:     "DC0",
+						ComputeCluster: pointer.StringPtr("DC0_C0"),
+						Datastore:      "LocalDS_0",
+						Networks:       []string{"VM Network"},
+					},
+				},
+			}
+			Expect(testEnv.Create(ctx, vsphereFailureDomain)).To(Succeed())
+
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, client.ObjectKey{Name: "blah-three"}, vsphereDeploymentZone); err != nil {
+					return false
+				}
+				readyPtr := false
+				if vsphereDeploymentZone.Status.Ready != nil {
+					readyPtr = *vsphereDeploymentZone.Status.Ready
+				}
+				return readyPtr && conditions.IsTrue(vsphereDeploymentZone, clusterv1.ReadyCondition)
+			}, timeout).Should(BeTrue())
+
+			By("deleting the vsphere deployment zone")
+			Expect(testEnv.Delete(ctx, vsphereFailureDomain)).To(Succeed())
+
+			Eventually(func() bool {
+				fd := &infrav1.VSphereFailureDomain{}
+				err := testEnv.Get(ctx, client.ObjectKey{Name: fdName}, fd)
+				return apierrors.IsNotFound(err)
+			}, timeout).Should(BeTrue())
+		})
+	})
+})
 
 func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T) {
 	tests := []struct {

--- a/controllers/vspheremachine_controller_unit_test.go
+++ b/controllers/vspheremachine_controller_unit_test.go
@@ -78,7 +78,7 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 
 	Context("When Failure Domain is present", func() {
 		BeforeEach(func() {
-			machineCtx.Machine.Spec.FailureDomain = pointer.StringPtr("fd-one")
+			machineCtx.Machine.Spec.FailureDomain = pointer.StringPtr("zone-one")
 		})
 
 		It("generates an override function", func() {
@@ -100,6 +100,19 @@ var _ = Describe("MachineReconciler_GenerateOverrideFunc", func() {
 			Expect(vm.Spec.Datastore).To(Equal("ds-one"))
 			Expect(vm.Spec.ResourcePool).To(Equal("rp-one"))
 			Expect(vm.Spec.Datacenter).To(Equal("dc-one"))
+		})
+
+		Context("for non-existent failure domain value", func() {
+			BeforeEach(func() {
+				machineCtx.Machine.Spec.FailureDomain = pointer.StringPtr("non-existent-zone")
+			})
+
+			It("fails to generate an override function", func() {
+				r := machineReconciler{controllerCtx}
+				overrideFunc, ok := r.generateOverrideFunc(machineCtx)
+				Expect(ok).To(BeFalse())
+				Expect(overrideFunc).To(BeNil())
+			})
 		})
 
 		Context("with network specified in the topology", func() {

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -175,9 +175,14 @@ func (r vmReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) 
 		}
 
 		if failureDomain := machine.Spec.FailureDomain; failureDomain != nil {
+			vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{}
+			if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereDeploymentZone); err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere deployment zone %s", *failureDomain)
+			}
+
 			vsphereFailureDomain = &infrav1.VSphereFailureDomain{}
-			if err := r.Client.Get(r, apitypes.NamespacedName{Name: *failureDomain}, vsphereFailureDomain); err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", *failureDomain)
+			if err := r.Client.Get(r, apitypes.NamespacedName{Name: vsphereDeploymentZone.Spec.FailureDomain}, vsphereFailureDomain); err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to find vsphere failure domain %s", vsphereDeploymentZone.Spec.FailureDomain)
 			}
 		}
 	}

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"regexp"
 	"text/template"
@@ -269,4 +270,26 @@ func ConvertUUIDToProviderID(uuid string) string {
 		return ""
 	}
 	return ProviderIDPrefix + uuid
+}
+
+// MachinesAsString constructs a string (with correct punctuations) to be
+// used in logging and error messages.
+func MachinesAsString(machines []clusterv1.Machine) string {
+	var message string
+	count := 1
+	for _, m := range machines {
+		if count == 1 {
+			message = fmt.Sprintf("%s/%s", m.Namespace, m.Name)
+		} else {
+			var format string
+			if count > 1 && count != len(machines) {
+				format = "%s, %s/%s"
+			} else if count == len(machines) {
+				format = "%s and %s/%s"
+			}
+			message = fmt.Sprintf(format, message, m.Namespace, m.Name)
+		}
+		count++
+	}
+	return message
 }

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
@@ -750,6 +751,41 @@ func TestConvertUUIDtoProviderID(t *testing.T) {
 			actualProviderID := util.ConvertUUIDToProviderID(tc.uuid)
 			g.Expect(actualProviderID).To(gomega.Equal(tc.expectedProviderID))
 		})
+	}
+}
+
+func Test_MachinesAsString(t *testing.T) {
+	tests := []struct {
+		machines     []clusterv1.Machine
+		errorMessage string
+	}{
+		{
+			machines: []clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+			},
+			errorMessage: "m1-ns/m1",
+		},
+		{
+			machines: []clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+			},
+			errorMessage: "m1-ns/m1 and m2-ns/m2",
+		},
+		{
+			machines: []clusterv1.Machine{
+				{ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "m1-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m2", Namespace: "m2-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m3", Namespace: "m3-ns"}},
+			},
+			errorMessage: "m1-ns/m1, m2-ns/m2 and m3-ns/m3",
+		},
+	}
+
+	for _, tt := range tests {
+		g := gomega.NewWithT(t)
+		msg := util.MachinesAsString(tt.machines)
+		g.Expect(msg).To(gomega.Equal(tt.errorMessage))
 	}
 }
 

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -177,6 +177,13 @@ func NewTestEnvironment() *TestEnvironment {
 			return err
 		}
 
+		if err := (&infrav1.VSphereFailureDomain{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+		if err := (&infrav1.VSphereFailureDomainList{}).SetupWebhookWithManager(mgr); err != nil {
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch includes the following changes:
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.

It is a back port of #1316 with changes to API versions for VSphereDeploymentZone conversions

**Which issue(s) this PR fixes**:
Fixes #1359 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Updates the key to be set for failure domain lookup to be the name of the VSphereDeploymentZone
- Adds conversion functions for VSphereDeploymentZone & VSphereFailureDomain types
- Implements deletion logic for VSphereDeploymentZone CRs.
```