### PR TITLE
Changes for private vCenter URL in CI

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -157,7 +157,7 @@ variables:
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 1
   IP_FAMILY: "IPv4"
-  VSPHERE_TLS_THUMBPRINT: "4F:AF:22:BD:C8:B2:AC:DE:0A:04:71:02:D1:62:05:50:2B:A2:54:E9"
+  VSPHERE_TLS_THUMBPRINT: "9E:7F:01:3B:13:CF:B2:93:16:2C:31:6A:03:6A:D1:5D:C7:79:D8:DE"
   VSPHERE_DATACENTER:  "SDDC-Datacenter"
   VSPHERE_FOLDER: "clusterapi"
   VSPHERE_RESOURCE_POOL: "clusterapi"
@@ -168,6 +168,7 @@ variables:
   INIT_WITH_BINARY_V1ALPHA3: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}"
   INIT_WITH_KUBERNETES_VERSION: "v1.19.1"
+  VSPHERE_INSECURE_CSI: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -183,6 +183,8 @@ variables:
   # VSPHERE_USERNAME:
   # Dedicated IP to be used by kube-vip
   # CONTROL_PLANE_ENDPOINT_IP:
+  # Sets the insecure-flag for vsphere-csi-controller config
+  VSPHERE_INSECURE_CSI: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere/kustomization/base/cluster-resource-set-csi-insecure.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/base/cluster-resource-set-csi-insecure.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-vsphere-config
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: csi-vsphere-config
+      namespace: kube-system
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        insecure-flag = "${VSPHERE_INSECURE_CSI}"
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/test/e2e/data/infrastructure-vsphere/kustomization/base/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 patchesStrategicMerge:
   - cluster-resource-set-label.yaml
   - cluster-network-CIDR.yaml
+  - cluster-resource-set-csi-insecure.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
CI fixes for private vCenter URL, supersedes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1346

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```