### PR TITLE
Re-enable cluster upgrade e2e tests

### DIFF
--- a/test/e2e/capi_upgrade_test.go
+++ b/test/e2e/capi_upgrade_test.go
@@ -23,7 +23,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = PContext("ClusterAPI Upgrade Tests [clusterctl-Upgrade]", func() {
+var _ = Context("ClusterAPI Upgrade Tests [clusterctl-Upgrade]", func() {
 	Describe("Upgrading cluster from v1alpha3 to v1beta1 using clusterctl", func() {
 		capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
 			return capi_e2e.ClusterctlUpgradeSpecInput{


### PR DESCRIPTION
Re-enabling the cluster upgrade tests that had been disabled earlier

fixes #1369 