### PR TITLE
Update OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,6 @@ approvers:
 reviewers:
   - cluster-api-vsphere-maintainers
   - cluster-api-vsphere-reviewers
+
+emeritus_approvers:
+  - gab-satchi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,7 +14,6 @@ aliases:
     - vincepri
   cluster-api-vsphere-maintainers:
     - frapposelli
-    - gab-satchi
     - randomvariable
     - srm09
     - yastij


### PR DESCRIPTION
- remove gab-satchi from cluster-api-vsphere-maintainers
- add gab-satchi to emeritus-approvers

I'm stepping away from CAPV, so moving myself to emeritus. 