### PR TITLE
Cherry pick #1370 to release 0.8

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -94,7 +94,7 @@ variables:
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 1
   IP_FAMILY: "IPv4"
-  VSPHERE_TLS_THUMBPRINT: "4F:AF:22:BD:C8:B2:AC:DE:0A:04:71:02:D1:62:05:50:2B:A2:54:E9"
+  VSPHERE_TLS_THUMBPRINT: "9E:7F:01:3B:13:CF:B2:93:16:2C:31:6A:03:6A:D1:5D:C7:79:D8:DE"
   VSPHERE_DATACENTER:  "SDDC-Datacenter"
   VSPHERE_FOLDER: "clusterapi"
   VSPHERE_RESOURCE_POOL: "clusterapi"
@@ -102,6 +102,7 @@ variables:
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"
   VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.19.1"
+  VSPHERE_INSECURE_CSI: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -113,6 +113,8 @@ variables:
   # VSPHERE_USERNAME:
   # Dedicated IP to be used by kube-vip
   # CONTROL_PLANE_ENDPOINT_IP:
+  # Sets the insecure-flag for vsphere-csi-controller config
+  VSPHERE_INSECURE_CSI: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-csi-insecure.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-csi-insecure.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-vsphere-config
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: csi-vsphere-config
+      namespace: kube-system
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        insecure-flag = "${VSPHERE_INSECURE_CSI}"
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/test/e2e/data/infrastructure-vsphere/kustomization/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 patchesStrategicMerge:
   - cluster-resource-set-label.yaml
   - cluster-network-CIDR.yaml
+  - cluster-resource-set-csi-insecure.yaml


### PR DESCRIPTION
Signed-off-by: Sagar Muchhal <muchhals@vmware.com>
(cherry picked from commit 9280be79bcbf440edf56f11c71515b0be8cf5a9e)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cherry picking [this](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/commit/9280be79bcbf440edf56f11c71515b0be8cf5a9e) commit to release-0.8


```release-note
NONE
```