### PR TITLE
Adds conditional ginkgo foucs to e2e job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 
 .PHONY: e2e-upgrade
 e2e-upgrade: e2e-image e2e-templates
-e2e-upgrade: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
+e2e-upgrade: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run only upgrade e2e tests
 	@echo PATH="$(PATH)"
 	@echo
 	@echo Contents of $(TOOLS_BIN_DIR):

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ test-integration: e2e-image
 test-integration: $(GINKGO) $(KUSTOMIZE) $(KIND)
 	time $(GINKGO) -v ./test/integration -- --config="$(INTEGRATION_CONF_FILE)" --artifacts-folder="$(ARTIFACTS_PATH)"
 
+GINKGO_FOCUS ?=
+
 .PHONY: e2e
 e2e: e2e-image e2e-templates
 e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
@@ -143,7 +145,6 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-
 	time $(GINKGO) -v -skip="ClusterAPI Upgrade Tests" ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(ARTIFACTS_PATH)"
 
 .PHONY: e2e-upgrade
@@ -154,7 +155,6 @@ e2e-upgrade: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-
 	time $(GINKGO) -v -focus="ClusterAPI Upgrade Tests" ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)"
 ## --------------------------------------
 ## Binaries

--- a/test/e2e/capv_quick_start_test.go
+++ b/test/e2e/capv_quick_start_test.go
@@ -18,26 +18,13 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/pbm"
-	"github.com/vmware/govmomi/pbm/types"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
-var _ = Describe("Cluster Creation using Cluster API quick-start test", func() {
+var _ = Describe("Cluster Creation using Cluster API quick-start test [PR-Blocking]", func() {
+
 	Byf("Creating single-node control plane with one worker node")
 	capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
@@ -49,101 +36,3 @@ var _ = Describe("Cluster Creation using Cluster API quick-start test", func() {
 		}
 	})
 })
-
-var _ = Describe("Cluster creation with vSphere validations", func() {
-	var namespace *corev1.Namespace
-
-	BeforeEach(func() {
-		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-		namespace = setupSpecNamespace("capv-e2e")
-	})
-
-	AfterEach(func() {
-		cleanupSpecNamespace(namespace)
-	})
-
-	It("should create a cluster with storage policy", func() {
-		clusterName := fmt.Sprintf("cluster-%s", util.RandomString(6))
-		Expect(namespace).NotTo(BeNil())
-
-		By("creating a workload cluster")
-		configCluster := defaultConfigCluster(clusterName, namespace.Name)
-
-		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-			ClusterProxy:                 bootstrapClusterProxy,
-			ConfigCluster:                configCluster,
-			WaitForClusterIntervals:      e2eConfig.GetIntervals("", "wait-cluster"),
-			WaitForControlPlaneIntervals: e2eConfig.GetIntervals("", "wait-control-plane"),
-			WaitForMachineDeployments:    e2eConfig.GetIntervals("", "wait-worker-nodes"),
-		}, &clusterctl.ApplyClusterTemplateAndWaitResult{})
-
-		pbmClient, err := pbm.NewClient(ctx, vsphereClient.Client)
-		Expect(err).NotTo(HaveOccurred())
-		var res []types.PbmServerObjectRef
-		if pbmClient != nil {
-			spName := e2eConfig.GetVariable(VsphereStoragePolicy)
-			if spName == "" {
-				Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
-			}
-
-			spID, err := pbmClient.ProfileIDByName(ctx, spName)
-			Expect(err).NotTo(HaveOccurred())
-
-			res, err = pbmClient.QueryAssociatedEntity(ctx, types.PbmProfileId{UniqueId: spID}, "virtualMachine")
-			Expect(err).NotTo(HaveOccurred())
-		}
-		Expect(len(res)).To(BeNumerically(">", 0))
-
-		vms := getVSphereVMsForCluster(clusterName, namespace.Name)
-		Expect(len(vms.Items)).To(BeNumerically(">", 0))
-
-		datacenter, err := vsphereFinder.DatacenterOrDefault(ctx, vsphereDatacenter)
-		Expect(err).ShouldNot(HaveOccurred())
-		By("verifying storage policy is used by VMs")
-		for _, vm := range vms.Items {
-			si := object.NewSearchIndex(vsphereClient.Client)
-			ref, err := si.FindByUuid(ctx, datacenter, vm.Spec.BiosUUID, true, pointer.BoolPtr(false))
-			Expect(err).NotTo(HaveOccurred())
-			found := false
-
-			for _, o := range res {
-				if ref.Reference().Value == o.Key {
-					found = true
-					break
-				}
-			}
-
-			Expect(found).To(BeTrue(), "failed to find vm in list of vms using storage policy")
-		}
-	})
-})
-
-func defaultConfigCluster(clusterName, namespace string) clusterctl.ConfigClusterInput {
-	return clusterctl.ConfigClusterInput{
-		LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
-		ClusterctlConfigPath:     clusterctlConfigPath,
-		KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
-		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-		Flavor:                   clusterctl.DefaultFlavor,
-		Namespace:                namespace,
-		ClusterName:              clusterName,
-		KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
-		ControlPlaneMachineCount: pointer.Int64Ptr(1),
-		WorkerMachineCount:       pointer.Int64Ptr(0),
-	}
-}
-
-func getVSphereVMsForCluster(clustername, namespace string) *infrav1.VSphereVMList {
-	var vms infrav1.VSphereVMList
-	err := bootstrapClusterProxy.GetClient().List(
-		ctx,
-		&vms,
-		client.InNamespace(namespace),
-		client.MatchingLabels{
-			clusterv1.ClusterLabelName: clustername,
-		},
-	)
-	Expect(err).NotTo(HaveOccurred())
-
-	return &vms
-}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -188,6 +188,15 @@ func setupSpecNamespace(specName string) *corev1.Namespace {
 }
 
 func cleanupSpecNamespace(namespace *corev1.Namespace) {
+	Byf("Dumping all the Cluster API resources in the %q namespace", namespace.Name)
+
+	// Dump all Cluster API related resources to artifacts before deleting them.
+	framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+		Lister:    bootstrapClusterProxy.GetClient(),
+		Namespace: namespace.Name,
+		LogPath:   filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName(), "resources"),
+	})
+
 	Byf("cleaning up namespace: %s", namespace.Name)
 	cancelWatches := namespaces[namespace]
 

--- a/test/e2e/storage_policy_test.go
+++ b/test/e2e/storage_policy_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
+	"github.com/vmware/govmomi/pbm/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	v1beta12 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+)
+
+var _ = Describe("Cluster creation with storage policy", func() {
+	var namespace *v1.Namespace
+
+	BeforeEach(func() {
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace = setupSpecNamespace("capv-e2e")
+	})
+
+	AfterEach(func() {
+		cleanupSpecNamespace(namespace)
+	})
+
+	It("should create a cluster successfully", func() {
+		clusterName := fmt.Sprintf("cluster-%s", util.RandomString(6))
+		Expect(namespace).NotTo(BeNil())
+
+		By("creating a workload cluster")
+		configCluster := defaultConfigCluster(clusterName, namespace.Name, 1, 0)
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy:                 bootstrapClusterProxy,
+			ConfigCluster:                configCluster,
+			WaitForClusterIntervals:      e2eConfig.GetIntervals("", "wait-cluster"),
+			WaitForControlPlaneIntervals: e2eConfig.GetIntervals("", "wait-control-plane"),
+			WaitForMachineDeployments:    e2eConfig.GetIntervals("", "wait-worker-nodes"),
+		}, &clusterctl.ApplyClusterTemplateAndWaitResult{})
+
+		pbmClient, err := pbm.NewClient(ctx, vsphereClient.Client)
+		Expect(err).NotTo(HaveOccurred())
+		var res []types.PbmServerObjectRef
+		if pbmClient != nil {
+			spName := e2eConfig.GetVariable(VsphereStoragePolicy)
+			if spName == "" {
+				Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
+			}
+
+			spID, err := pbmClient.ProfileIDByName(ctx, spName)
+			Expect(err).NotTo(HaveOccurred())
+
+			res, err = pbmClient.QueryAssociatedEntity(ctx, types.PbmProfileId{UniqueId: spID}, "virtualMachine")
+			Expect(err).NotTo(HaveOccurred())
+		}
+		Expect(len(res)).To(BeNumerically(">", 0))
+
+		vms := getVSphereVMsForCluster(clusterName, namespace.Name)
+		Expect(len(vms.Items)).To(BeNumerically(">", 0))
+
+		datacenter, err := vsphereFinder.DatacenterOrDefault(ctx, vsphereDatacenter)
+		Expect(err).ShouldNot(HaveOccurred())
+		By("verifying storage policy is used by VMs")
+		for _, vm := range vms.Items {
+			si := object.NewSearchIndex(vsphereClient.Client)
+			ref, err := si.FindByUuid(ctx, datacenter, vm.Spec.BiosUUID, true, pointer.BoolPtr(false))
+			Expect(err).NotTo(HaveOccurred())
+			found := false
+
+			for _, o := range res {
+				if ref.Reference().Value == o.Key {
+					found = true
+					break
+				}
+			}
+
+			Expect(found).To(BeTrue(), "failed to find vm in list of vms using storage policy")
+		}
+	})
+})
+
+func defaultConfigCluster(clusterName, namespace string, controlPlaneNodeCount, workerNodeCount int64) clusterctl.ConfigClusterInput {
+	return clusterctl.ConfigClusterInput{
+		LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+		ClusterctlConfigPath:     clusterctlConfigPath,
+		KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+		Flavor:                   clusterctl.DefaultFlavor,
+		Namespace:                namespace,
+		ClusterName:              clusterName,
+		KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: pointer.Int64Ptr(controlPlaneNodeCount),
+		WorkerMachineCount:       pointer.Int64Ptr(workerNodeCount),
+	}
+}
+
+func getVSphereVMsForCluster(clusterName, namespace string) *v1beta1.VSphereVMList {
+	var vms v1beta1.VSphereVMList
+	err := bootstrapClusterProxy.GetClient().List(
+		ctx,
+		&vms,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			v1beta12.ClusterLabelName: clusterName,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &vms
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding Ginkgo focus variable to facilitate running different sets of E2E tests in CAPV prow jobs

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:
This does not change the default behavior of any tests, this will be used later in the prow jobs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```