### PR TITLE
Introduce override for kube-vip interface

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -115,6 +115,7 @@ VSPHERE_RESOURCE_POOL: "*/Resources"                          # The vSphere reso
 VSPHERE_FOLDER: "vm"                                          # The VM folder for your VMs. Set to "" to use the root vSphere folder
 VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.17.3"                  # The VM template to use for your management cluster.
 CONTROL_PLANE_ENDPOINT_IP: "192.168.9.230"                    # the IP that kube-vip is going to use as a control plane endpoint
+VIP_NETWORK_INTERFACE: "ens192"                               # The interface that kube-vip should apply the IP to. Omit to tell kube-vip to autodetect the interface.
 VSPHERE_TLS_THUMBPRINT: "..."                                 # sha1 thumbprint of the vcenter certificate: openssl x509 -sha1 -fingerprint -in ca.crt -noout
 EXP_CLUSTER_RESOURCE_SET: "true"                              # This enables the ClusterResourceSet feature that we are using to deploy CSI
 VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."              # The public ssh authorized key on all machines

--- a/packaging/flavorgen/flavors/env/envsubts_consts.go
+++ b/packaging/flavorgen/flavors/env/envsubts_consts.go
@@ -17,29 +17,31 @@ limitations under the License.
 package env
 
 const (
-	ClusterNameVar               = "${CLUSTER_NAME}"
-	ControlPlaneMachineCountVar  = "${CONTROL_PLANE_MACHINE_COUNT}"
-	DefaultCloudProviderImage    = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
-	DefaultClusterCIDR           = "192.168.0.0/16"
-	DefaultDiskGiB               = 25
-	DefaultMemoryMiB             = 8192
-	DefaultNumCPUs               = 2
-	KubernetesVersionVar         = "${KUBERNETES_VERSION}"
-	MachineDeploymentNameSuffix  = "-md-0"
-	NamespaceVar                 = "${NAMESPACE}"
-	VSphereDataCenterVar         = "${VSPHERE_DATACENTER}"
-	VSphereThumbprint            = "${VSPHERE_TLS_THUMBPRINT}"
-	VSphereDatastoreVar          = "${VSPHERE_DATASTORE}"
-	VSphereFolderVar             = "${VSPHERE_FOLDER}"
-	VSphereHaproxyTemplateVar    = "${VSPHERE_HAPROXY_TEMPLATE}"
-	VSphereNetworkVar            = "${VSPHERE_NETWORK}"
-	VSphereResourcePoolVar       = "${VSPHERE_RESOURCE_POOL}"
-	VSphereServerVar             = "${VSPHERE_SERVER}"
-	VSphereSSHAuthorizedKeysVar  = "${VSPHERE_SSH_AUTHORIZED_KEY}"
-	VSphereStoragePolicyVar      = "${VSPHERE_STORAGE_POLICY}"
-	VSphereTemplateVar           = "${VSPHERE_TEMPLATE}"
-	WorkerMachineCountVar        = "${WORKER_MACHINE_COUNT}"
-	ControlPlaneEndpointVar      = "${CONTROL_PLANE_ENDPOINT_IP}"
+	ClusterNameVar              = "${CLUSTER_NAME}"
+	ControlPlaneMachineCountVar = "${CONTROL_PLANE_MACHINE_COUNT}"
+	DefaultCloudProviderImage   = "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"
+	DefaultClusterCIDR          = "192.168.0.0/16"
+	DefaultDiskGiB              = 25
+	DefaultMemoryMiB            = 8192
+	DefaultNumCPUs              = 2
+	KubernetesVersionVar        = "${KUBERNETES_VERSION}"
+	MachineDeploymentNameSuffix = "-md-0"
+	NamespaceVar                = "${NAMESPACE}"
+	VSphereDataCenterVar        = "${VSPHERE_DATACENTER}"
+	VSphereThumbprint           = "${VSPHERE_TLS_THUMBPRINT}"
+	VSphereDatastoreVar         = "${VSPHERE_DATASTORE}"
+	VSphereFolderVar            = "${VSPHERE_FOLDER}"
+	VSphereHaproxyTemplateVar   = "${VSPHERE_HAPROXY_TEMPLATE}"
+	VSphereNetworkVar           = "${VSPHERE_NETWORK}"
+	VSphereResourcePoolVar      = "${VSPHERE_RESOURCE_POOL}"
+	VSphereServerVar            = "${VSPHERE_SERVER}"
+	VSphereSSHAuthorizedKeysVar = "${VSPHERE_SSH_AUTHORIZED_KEY}"
+	VSphereStoragePolicyVar     = "${VSPHERE_STORAGE_POLICY}"
+	VSphereTemplateVar          = "${VSPHERE_TEMPLATE}"
+	WorkerMachineCountVar       = "${WORKER_MACHINE_COUNT}"
+	ControlPlaneEndpointVar     = "${CONTROL_PLANE_ENDPOINT_IP}"
+	// Set the default to an empty string to let kube-vip autodetect the interface.
+	VipNetworkInterfaceVar       = "${VIP_NETWORK_INTERFACE=\"\"}"
 	VSphereUsername              = "${VSPHERE_USERNAME}"
 	VSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
 	ClusterResourceSetNameSuffix = "-crs-0"

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -265,9 +265,8 @@ func kubeVIPPod() string {
 						},
 						{
 							// Interface that the vip should bind to
-							// this is hardcoded since we use eth0 as a network interface for all of our machines in this template
 							Name:  "vip_interface",
-							Value: "eth0",
+							Value: env.VipNetworkInterfaceVar,
 						},
 						{
 							// VIP IP address


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Hardcoding `eth0` as the kube-vip interface breaks environments where interface names other than `eth0` are used.

kube-vip supports interface autodetection as of `v0.4.0`, which can be leveraged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1374 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't hardcode kube-vip interface
```