### PR TITLE
Align CAPV Makefile targets with CAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,24 @@ verify-boilerplate: ## Verifies all sources have appropriate boilerplate
 verify-crds: ## Verifies the committed CRDs are up-to-date
 	./hack/verify-crds.sh
 
+.PHONY: verify-gen
+verify-gen: generate  ## Verfiy go generated files are up to date
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi
+
+.PHONY: verify-modules
+verify-modules: modules  ## Verify go modules are up to date
+	@if !(git diff --quiet HEAD -- go.sum go.mod $(TOOLS_DIR)/go.mod $(TOOLS_DIR)/go.sum); then \
+		git diff; \
+		echo "go module files are out of date"; exit 1; \
+	fi
+	@if (find . -name 'go.mod' | xargs -n1 grep -q -i 'k8s.io/client-go.*+incompatible'); then \
+		find . -name "go.mod" -exec grep -i 'k8s.io/client-go.*+incompatible' {} \; -print; \
+		echo "go module contains an incompatible client-go version"; exit 1; \
+	fi
+
 ## --------------------------------------
 ## Check
 ## --------------------------------------

--- a/apis/v1alpha3/conversion.go
+++ b/apis/v1alpha3/conversion.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apis/v1alpha4/conversion.go
+++ b/apis/v1alpha4/conversion.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,6 +1,3 @@
-//go:build tools
-// +build tools
-
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -16,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+//go:build tools
+// +build tools
 
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package services
 
 import (


### PR DESCRIPTION
- `verify-boilerplate`: updated the Copyright section in the required files
- `verify-gen`: added this target to verify go generated files are up to date
- `verify-modules`: added this target to verify go modules are up to date

Fixes #1388 