### PR TITLE
Adds a provision to skip E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,12 @@ test-integration: $(GINKGO) $(KUSTOMIZE) $(KIND)
 	time $(GINKGO) -v ./test/integration -- --config="$(INTEGRATION_CONF_FILE)" --artifacts-folder="$(ARTIFACTS_PATH)"
 
 GINKGO_FOCUS ?=
+GINKGO_SKIP ?=
+
+# to set multiple ginkgo skip flags, if any
+ifneq ($(strip $(GINKGO_SKIP)),)
+_SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),-skip="$(arg)")
+endif
 
 .PHONY: e2e
 e2e: e2e-image e2e-templates
@@ -145,17 +151,8 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-	time $(GINKGO) -v -skip="ClusterAPI Upgrade Tests" ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(ARTIFACTS_PATH)"
+	time $(GINKGO) -v  -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(ARTIFACTS_PATH)"
 
-.PHONY: e2e-upgrade
-e2e-upgrade: e2e-image e2e-templates
-e2e-upgrade: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run only upgrade e2e tests
-	@echo PATH="$(PATH)"
-	@echo
-	@echo Contents of $(TOOLS_BIN_DIR):
-	@ls $(TOOLS_BIN_DIR)
-	@echo
-	time $(GINKGO) -v -focus="ClusterAPI Upgrade Tests" ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)"
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -102,9 +102,5 @@ E2E_IMAGE_SHA=$(docker inspect --format='{{index .Id}}' gcr.io/k8s-staging-clust
 export E2E_IMAGE_SHA
 gsutil cp "$ARTIFACTS"/tempContainers/image.tar gs://capv-ci/"$E2E_IMAGE_SHA"
 
-# Run e2e-upgrade tests
-# TODO: move e2e-upgrade into its own prow job
-make e2e-upgrade
-
 # Run e2e tests
 make e2e

--- a/test/e2e/capi_upgrade_test.go
+++ b/test/e2e/capi_upgrade_test.go
@@ -23,7 +23,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = PContext("ClusterAPI Upgrade Tests", func() {
+var _ = PContext("ClusterAPI Upgrade Tests [clusterctl-Upgrade]", func() {
 	Describe("Upgrading cluster from v1alpha3 to v1beta1 using clusterctl", func() {
 		capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
 			return capi_e2e.ClusterctlUpgradeSpecInput{


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the `GINKGO_SKIP` args to add `-skip` flag (to the `ginkgo run` command) for each space separated arguments passed to the variable. This alongwith GINKGO_FOCUS var enables us to run/skip specific e2e tests
This has been borrowed from the CAPI E2E test setup which eliminates the
need to create multiple sh files to run specific tests.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
Once the PR is merged, the follow up task would be to create test-infra jobs to run `conformance` and `clusterctl-upgrade` tests in their own jobs.

**Release note**:
```release-note
NONE
```

**Example**
To skip say the PR Blocking test (the PR Blocking tests should have the label [PR-Blocking] in its `Describe` directive), we can use:
```bash
# This will skip all tests with [PR-Blocking] when running all the tests
GINKGO_SKIP="\[PR-Blocking\]" go test ./...
```