### PR TITLE
Fixes CAPI CRD path lookup for envtests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f
 	github.com/vmware/govmomi v0.27.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/mod v0.4.2
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -999,6 +999,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"regexp"
 	goruntime "runtime"
-	"strings"
 
 	"github.com/onsi/ginkgo"
 	"github.com/vmware/govmomi/simulator"
@@ -248,20 +247,14 @@ func (t *TestEnvironment) CreateKubeconfigSecret(ctx goctx.Context, cluster *clu
 }
 
 func getFilePathToCAPICRDs(root string) string {
-	modBits, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	mod, err := NewMod(filepath.Join(root, "go.mod"))
 	if err != nil {
 		return ""
 	}
 
-	var clusterAPIVersion string
-	for _, line := range strings.Split(string(modBits), "\n") {
-		matches := clusterAPIVersionRegex.FindStringSubmatch(line)
-		if len(matches) == 3 {
-			clusterAPIVersion = matches[2]
-		}
-	}
-
-	if clusterAPIVersion == "" {
+	packageName := "sigs.k8s.io/cluster-api"
+	clusterAPIVersion, err := mod.FindDependencyVersion(packageName)
+	if err != nil {
 		return ""
 	}
 

--- a/test/helpers/mod.go
+++ b/test/helpers/mod.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
+)
+
+type Mod struct {
+	path    string
+	content []byte
+}
+
+func NewMod(path string) (Mod, error) {
+	var mod Mod
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return mod, err
+	}
+	return Mod{
+		path:    path,
+		content: content,
+	}, nil
+}
+
+func (m Mod) FindDependencyVersion(dependency string) (string, error) {
+	f, err := modfile.Parse(m.path, m.content, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var version string
+	for _, entry := range f.Require {
+		if entry.Mod.Path == dependency {
+			version = entry.Mod.Version
+			break
+		}
+	}
+	if version == "" {
+		return version, errors.Errorf("could not find required package: %s", dependency)
+	}
+
+	for _, entry := range f.Replace {
+		if entry.New.Path == dependency && entry.New.Version != "" {
+			version = entry.New.Version
+		}
+	}
+	return version, nil
+}

--- a/test/helpers/mod_test.go
+++ b/test/helpers/mod_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMod_FindDependencyVersion(t *testing.T) {
+	goModData := `module sigs.k8s.io/dummy-project
+
+go 1.17
+
+require (
+    github.com/foo/bar v1.0.0
+	github.com/foo/baz v0.9.1
+)
+
+replace (
+	github.com/foo/bar v1.0.0 => github.com/foo/bar v1.0.1 
+)
+`
+	tempPath, err := createTempGoMod(goModData)
+	if err != nil {
+		t.Fatal("failed to create test file")
+	}
+	defer os.RemoveAll(tempPath)
+
+	m, err := NewMod(tempPath)
+	if err != nil {
+		t.Fatalf("failed to init %s", err)
+	}
+
+	t.Run("find version for existing package with replace", func(t *testing.T) {
+		name := "github.com/foo/bar"
+		ver, err := m.FindDependencyVersion(name)
+		if err != nil {
+			t.Fatalf("failed to find version for package %s", name)
+		}
+		if ver != "v1.0.1" {
+			t.Fatalf("incorrect version %s", ver)
+		}
+	})
+
+	t.Run("find version for non-existing package", func(t *testing.T) {
+		name := "sigs.k8s.io/no-such-project"
+		ver, err := m.FindDependencyVersion(name)
+		if err == nil || ver != "" {
+			t.Fatalf("found not existent package %s", name)
+		}
+	})
+
+	t.Run("find version for existing package without replace", func(t *testing.T) {
+		name := "github.com/foo/baz"
+		ver, err := m.FindDependencyVersion(name)
+		if err != nil {
+			t.Fatalf("failed to find version for package %s", name)
+		}
+		if ver != "v0.9.1" {
+			t.Fatalf("incorrect version %s", ver)
+		}
+	})
+}
+
+func createTempGoMod(data string) (string, error) {
+	dir, err := os.MkdirTemp("", "parse-mod-")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(dir, "test.mod")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := f.WriteString(data); err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	return f.Name(), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of getting the CRDs from the `require` section of `go.mod`, this takes into  account the highest version in the `go.mod` file.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```