### PR TITLE
Bump kube-vip to v0.4.1

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -252,7 +252,7 @@ func kubeVIPPod() string {
 			Containers: []corev1.Container{
 				{
 					Name:            "kube-vip",
-					Image:           "ghcr.io/kube-vip/kube-vip:v0.4.0",
+					Image:           "ghcr.io/kube-vip/kube-vip:v0.4.1",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args: []string{
 						"manager",
@@ -309,7 +309,6 @@ func kubeVIPPod() string {
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{
 								"NET_ADMIN",
-								"SYS_TIME",
 								"NET_RAW",
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps kube-vip to `v0.4.1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update kube-vip to v0.4.1
```