### PR TITLE
🌱 add aggregate cluster-role label to the KCP manager role

### DIFF
--- a/config/rbac/aggregate_kcp_label_to_clusterrole_patch.yaml
+++ b/config/rbac/aggregate_kcp_label_to_clusterrole_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - leader_election_role_binding.yaml
 patchesStrategicMerge:
 - aggregate_label_to_cluster_role_patch.yaml
+- aggregate_kcp_label_to_clusterrole_patch.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds the `kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"` label to the ClusterRole. This is to ensure that the KCP is allowed to create `vsphereMachineTemplates` and `vsphereMachines`.

**Which issue(s) this PR fixes**:
Fixes #1345

cc: @weikaipan 
```release-note
NONE
```