### PR TITLE
Fixes panic while deployment zone deletion

### DIFF
--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -267,7 +267,10 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx *context.VSphereDep
 	}
 
 	machinesUsingDeploymentZone := collections.FromMachineList(machines).Filter(collections.ActiveMachines, func(machine *clusterv1.Machine) bool {
-		return *machine.Spec.FailureDomain == ctx.VSphereDeploymentZone.Name
+		if machine.Spec.FailureDomain != nil {
+			return *machine.Spec.FailureDomain == ctx.VSphereDeploymentZone.Name
+		}
+		return false
 	})
 	if len(machinesUsingDeploymentZone) > 0 {
 		machineNamesStr := util.MachinesAsString(machinesUsingDeploymentZone.SortedByCreationTimestamp())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a panic while deleting the deployment zone when machines are using it.

**Which issue(s) this PR fixes**:
Fixes #1424 

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Fixes panic while deployment zone deletion
```