### PR TITLE
Allow secrets to be owned by external tools

### DIFF
--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -61,6 +61,14 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "secret-",
 					Namespace:    "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "bitnami.com/v1alpha1",
+							Kind:       "SealedSecret",
+							Name:       "some-name",
+							UID:        "some-uid",
+						},
+					},
 				},
 				Data: map[string][]byte{
 					identity.UsernameKey: []byte(vcURL.User.Username()),
@@ -177,8 +185,8 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 					Namespace:    "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: "api-version",
-							Kind:       "cluster",
+							APIVersion: infrav1.GroupVersion.String(),
+							Kind:       "VSphereClusterIdentity",
 							Name:       "another-cluster",
 							UID:        "some-uid",
 						},

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,6 +128,20 @@ func IsSecretIdentity(cluster *infrav1.VSphereCluster) bool {
 	}
 
 	return cluster.Spec.IdentityRef.Kind == infrav1.SecretKind
+}
+
+func IsOwnedByIdentityOrCluster(ownerReferences []metav1.OwnerReference) bool {
+	if len(ownerReferences) > 0 {
+		for _, ownerReference := range ownerReferences {
+			if !strings.Contains(ownerReference.APIVersion, infrav1.GroupName+"/") {
+				continue
+			}
+			if ownerReference.Kind == "VSphereCluster" || ownerReference.Kind == "VSphereClusterIdentity" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func getData(secret *apiv1.Secret, key string) string {

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package identity
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -267,4 +269,160 @@ func createIdentity(secretName string) *infrav1.VSphereClusterIdentity {
 	identity.Status.Ready = true
 	Expect(k8sclient.Status().Update(ctx, identity)).To(Succeed())
 	return identity
+}
+
+func TestIsOwnedByIdentityOrCluster(t *testing.T) {
+	type args struct {
+		ownerReferences []metav1.OwnerReference
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "No Owners",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{},
+			},
+			want: false,
+		},
+		{
+			name: "Owned by external entity",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "api",
+						Kind:       "bla",
+						Name:       "test",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Owned by external different entity",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "api2",
+						Kind:       "bla2",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Owned by VSphereCluster/v1beta1",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "VSphereCluster",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by VSphereClusterIdentity/v1beta1",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "VSphereClusterIdentity",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by VSphereCluster/v1alpha4",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+						Kind:       "VSphereCluster",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by VSphereClusterIdentity/v1alpha4",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+						Kind:       "VSphereClusterIdentity",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by VSphereCluster/v1alpha3",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "VSphereCluster",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by VSphereClusterIdentity/v1alpha3",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "VSphereClusterIdentity",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by vmware.infrastructure.cluster.x-k8s.io/VSphereCluster",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "VSphereCluster",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Owned by vmware.infrastructure.cluster.x-k8s.io/VSphereClusterIdentity",
+			args: args{
+				ownerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "VSphereClusterIdentity",
+						Name:       "tes2t",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOwnedByIdentityOrCluster(tt.args.ownerReferences); got != tt.want {
+				t.Errorf("IsOwnedByIdentityOrCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This change allows that secrets can be owned by external tools such as sealed secret.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1431 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow secrets to be owned by external tools
```