### PR TITLE
Removes a separate IP claim for upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-	time $(GINKGO) -v  -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(ARTIFACTS_PATH)"
+	time $(GINKGO) -v -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) ./test/e2e -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(ARTIFACTS_PATH)"
 
 .PHONY: test-cover
 test-cover: ## Run tests with code coverage and code generate  reports

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -83,14 +83,6 @@ CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get ipaddresses "
 export CONTROL_PLANE_ENDPOINT_IP
 echo "Acquired Control Plane IP: $CONTROL_PLANE_ENDPOINT_IP"
 
-# Retrieve an IP to be used for the workload cluster in v1a3/v1a4 -> v1b1 upgrade tests
-WORKLOAD_IPCLAIM_NAME="workload-ip-claim-$(openssl rand -hex 20)"
-sed "s/IPCLAIM_NAME/${WORKLOAD_IPCLAIM_NAME}/" "${REPO_ROOT}/hack/ipclaim-template.yaml" | kubectl --kubeconfig=${KUBECONFIG} create -f -
-WORKLOAD_IPADDRESS_NAME=$(kubectl --kubeconfig=${KUBECONFIG} get ipclaim "${WORKLOAD_IPCLAIM_NAME}" -o=jsonpath='{@.status.address.name}')
-WORKLOAD_CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get ipaddresses "${WORKLOAD_IPADDRESS_NAME}" -o=jsonpath='{@.spec.address}')
-export WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
-echo "Acquired Workload Cluster Control Plane IP: $WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"
-
 # save the docker image locally
 make e2e-image
 mkdir -p "$ARTIFACTS"/tempContainers

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
@@ -47,7 +47,7 @@ spec:
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
   controlPlaneEndpoint:
-    host: ${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443
   identityRef:
     kind: Secret
@@ -119,7 +119,7 @@ spec:
                 - name: vip_interface
                   value: eth0
                 - name: address
-                  value: ${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}
+                  value: ${CONTROL_PLANE_ENDPOINT_IP}
                 - name: port
                   value: "6443"
                 - name: vip_arp

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: '${NAMESPACE}'
 spec:
   controlPlaneEndpoint:
-    host: ${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443
   identityRef:
     kind: Secret
@@ -95,7 +95,7 @@ spec:
                 - name: vip_interface
                   value: eth0
                 - name: address
-                  value: ${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}
+                  value: ${CONTROL_PLANE_ENDPOINT_IP}
                 - name: port
                   value: "6443"
                 - name: vip_arp


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the prow jobs now run the clusterctl upgrade tests as a separate job, we do not need two separate IP claims. 
Plus the IP claim freeing up logic does not get run if the job abruptly gets killed off, which leads two orphaned IP claims which can never be reused unless explicitly cleaned up.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
Fix for smoother CI operations

**Release note**:
```release-note
NONE
```