### PR TITLE
Update k8s version template for CI runs

### DIFF
--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -27,11 +27,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	v1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"
-
-	v1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
 func init() {

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -27,11 +27,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	v1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	apiv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	errors "sigs.k8s.io/cluster-api/errors"
-
-	v1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
 func init() {

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -113,10 +113,17 @@ func getTask(ctx *context.VMContext) *mo.Task {
 	return &obj
 }
 
+// reconcileInFlightTask determines if a task associated to the VSphereVM object
+// is in flight or not.
 func reconcileInFlightTask(ctx *context.VMContext) (bool, error) {
 	// Check to see if there is an in-flight task.
 	task := getTask(ctx)
+	return checkAndRetryTask(ctx, task)
+}
 
+// checkAndRetryTask verifies whether the task exists and if the
+// task should be reconciled which is determined by the task state retryAfter value set.
+func checkAndRetryTask(ctx *context.VMContext, task *mo.Task) (bool, error) {
 	// If no task was found then make sure to clear the VSphereVM
 	// resource's Status.TaskRef field.
 	if task == nil {
@@ -354,7 +361,7 @@ func waitForMacAddresses(ctx *virtualMachineContext) error {
 
 // getMacAddresses gets the MAC addresses for all network devices.
 // This happens separately from waitForMacAddresses to ensure returned order of
-// devices matches the spec and not order in which the propery changes were
+// devices matches the spec and not order in which the property changes were
 // noticed.
 func getMacAddresses(ctx *virtualMachineContext) ([]string, map[string]int, map[int]string, error) {
 	var (
@@ -383,7 +390,7 @@ func getMacAddresses(ctx *virtualMachineContext) ([]string, map[string]int, map[
 // IP address to have an IP address. This is any network device that specifies a
 // network name and DHCP for v4 or v6 or one or more static IP addresses.
 // The gocyclo detector is disabled for this function as it is difficult to
-// rewrite muchs simpler due to the maps used to track state and the lambdas
+// rewrite much simpler due to the maps used to track state and the lambdas
 // that use the maps.
 // nolint:gocyclo,gocognit
 func waitForIPAddresses(
@@ -436,7 +443,7 @@ func waitForIPAddresses(
 				// Get the network device spec that corresponds to the MAC.
 				deviceSpec := ctx.VSphereVM.Spec.Network.Devices[deviceSpecIndex]
 
-				// Look at each IP and determine whether or not a reconcile has
+				// Look at each IP and determine whether a reconcile has
 				// been triggered for the IP.
 				for _, discoveredIPInfo := range nic.IpConfig.IpAddress {
 					discoveredIP := discoveredIPInfo.IpAddress
@@ -558,7 +565,7 @@ func waitForIPAddresses(
 
 	// The wait function will not return true until all the VM's
 	// network devices have IP assignments that match the requested
-	// network devie specs. However, every time a new IP is discovered,
+	// network device specs. However, every time a new IP is discovered,
 	// a reconcile request will be triggered for the VSphereVM.
 	go func() {
 		if err := property.Wait(

--- a/pkg/services/govmomi/util_test.go
+++ b/pkg/services/govmomi/util_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+)
+
+func Test_ShouldRetryTask(t *testing.T) {
+	t.Run("when no task is present", func(t *testing.T) {
+		g := NewWithT(t)
+		vmCtx := &context.VMContext{
+			VSphereVM: &infrav1.VSphereVM{Status: infrav1.VSphereVMStatus{TaskRef: ""}},
+		}
+
+		reconciled, err := checkAndRetryTask(vmCtx, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(reconciled).To(BeFalse())
+		g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
+	})
+
+	t.Run("when failed task was previously checked & RetryAfter time has not yet passed", func(t *testing.T) {
+		g := NewWithT(t)
+		vmCtx := &context.VMContext{
+			VSphereVM: &infrav1.VSphereVM{Status: infrav1.VSphereVMStatus{
+				TaskRef:    "task-123",
+				RetryAfter: metav1.Time{Time: time.Now().Add(1 * time.Minute)},
+			}},
+		}
+
+		// passing nil task since the task will not be reconciled
+		reconciled, err := checkAndRetryTask(vmCtx, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(reconciled).To(BeFalse())
+		g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
+	})
+
+	t.Run("when failed task was previously checked & RetryAfter time has passed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		vmCtx := &context.VMContext{
+			Logger: logr.Discard(),
+			VSphereVM: &infrav1.VSphereVM{Status: infrav1.VSphereVMStatus{
+				TaskRef:    "task-123",
+				RetryAfter: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			}},
+		}
+
+		t.Run("for non error states", func(t *testing.T) {
+			tests := []struct {
+				task       mo.Task
+				isRefEmpty bool
+			}{
+				{baseTask(types.TaskInfoStateQueued, ""), false},
+				{baseTask(types.TaskInfoStateRunning, ""), false},
+				{baseTask(types.TaskInfoStateSuccess, ""), true},
+			}
+			for _, tt := range tests {
+				t.Run(fmt.Sprintf("state: %s", tt.task.Info.State), func(t *testing.T) {
+					g = NewWithT(t)
+					reconciled, err := checkAndRetryTask(vmCtx, &tt.task)
+					g.Expect(err).NotTo(HaveOccurred())
+					if tt.isRefEmpty {
+						g.Expect(reconciled).To(BeFalse())
+						g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
+					} else {
+						g.Expect(reconciled).To(BeTrue())
+						g.Expect(vmCtx.VSphereVM.Status.TaskRef).NotTo(BeEmpty())
+					}
+				})
+			}
+		})
+
+		t.Run("for task in error state", func(t *testing.T) {
+			task := baseTask(types.TaskInfoStateError, "task is stuck")
+
+			reconciled, err := checkAndRetryTask(vmCtx, &task)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(reconciled).To(BeTrue())
+			g.Expect(conditions.IsFalse(vmCtx.VSphereVM, infrav1.VMProvisionedCondition))
+			g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
+			g.Expect(vmCtx.VSphereVM.Status.RetryAfter.IsZero()).To(BeTrue())
+		})
+	})
+
+	t.Run("when failed task was previously not checked", func(t *testing.T) {
+		g := NewWithT(t)
+		vmCtx := &context.VMContext{
+			Logger: logr.Discard(),
+			VSphereVM: &infrav1.VSphereVM{Status: infrav1.VSphereVMStatus{
+				// RetryAfter is not set since this is the first reconcile
+				TaskRef: "task-123",
+			}},
+		}
+		task := baseTask(types.TaskInfoStateError, "task is stuck")
+
+		reconciled, err := checkAndRetryTask(vmCtx, &task)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(reconciled).To(BeTrue())
+		g.Expect(conditions.IsFalse(vmCtx.VSphereVM, infrav1.VMProvisionedCondition))
+		g.Expect(vmCtx.VSphereVM.Status.RetryAfter.Unix()).To(BeNumerically("<=", metav1.Now().Add(1*time.Minute).Unix()))
+	})
+}
+
+func baseTask(state types.TaskInfoState, errorDescription string) mo.Task {
+	t := mo.Task{
+		ExtensibleManagedObject: mo.ExtensibleManagedObject{
+			Self: types.ManagedObjectReference{
+				Value: "-for-logger",
+			},
+		},
+	}
+	if state != "" {
+		t.Info = types.TaskInfo{
+			State: state,
+		}
+	}
+	if errorDescription != "" {
+		t.Info.Description = &types.LocalizableMessage{
+			Message: errorDescription,
+		}
+	}
+	return t
+}

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -8,19 +8,19 @@
 # For creating local images, run ./hack/e2e.sh
 
 images:
-  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller :v1.1.0
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
-  - name: quay.io/jetstack/cert-manager-cainjector:v0.16.1
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.5.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v0.16.1
+  - name: quay.io/jetstack/cert-manager-webhook:v1.5.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v0.16.1
+  - name: quay.io/jetstack/cert-manager-controller:v1.5.3
     loadBehavior: tryLoad
 
 providers:
@@ -46,9 +46,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/core-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/metadata.yaml"
@@ -77,9 +77,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/bootstrap-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/metadata.yaml"
@@ -108,9 +108,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/metadata.yaml"
@@ -121,15 +121,15 @@ providers:
   - name: vsphere
     type: InfrastructureProvider
     versions:
-      - name: v0.7.10
-        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.7.10/infrastructure-components.yaml
+      - name: v0.7.12
+        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.7.12/infrastructure-components.yaml
         type: "url"
         contract: v1alpha3
         files:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml"
           - sourcePath: "../../../metadata.yaml"
-      - name: v0.8.1
-        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.8.1/infrastructure-components.yaml
+      - name: v0.8.2
+        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.8.2/infrastructure-components.yaml
         type: "url"
         contract: v1alpha4
         files:
@@ -152,7 +152,7 @@ providers:
           - sourcePath: "../../../metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.19.1"
+  KUBERNETES_VERSION: "v1.20.1"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   CONTROL_PLANE_MACHINE_COUNT: 1
@@ -165,10 +165,10 @@ variables:
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.19.1"
+  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.20.1"
   INIT_WITH_BINARY_V1ALPHA3: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}"
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_KUBERNETES_VERSION: "v1.19.1"
+  INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
 

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -11,19 +11,19 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v1.0.0
+  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller :v1.1.0
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
-  - name: quay.io/jetstack/cert-manager-cainjector:v1.0.1
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.5.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v1.0.1
+  - name: quay.io/jetstack/cert-manager-webhook:v1.5.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v1.0.1
+  - name: quay.io/jetstack/cert-manager-controller:v1.5.3
     loadBehavior: tryLoad
 
 providers:
@@ -49,9 +49,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -81,9 +81,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -113,9 +113,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.0.0
+      - name: v1.1.0
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/metadata.yaml"
@@ -126,18 +126,18 @@ providers:
   - name: vsphere
     type: InfrastructureProvider
     versions:
-      - name: v0.7.10
-        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.7.10/infrastructure-components.yaml
+      - name: v0.7.12
+        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.7.12/infrastructure-components.yaml
         type: url
         contract: v1alpha3
         files:
           # TODO: v1a3 cluster-template includes WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml"
           - sourcePath: "../../../metadata.yaml"
-      - name: v0.8.1
+      - name: v0.8.2
         type: url
         contract: v1alpha4
-        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.8.1/infrastructure-components.yaml
+        value: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.8.2/infrastructure-components.yaml
         files:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml"
           - sourcePath: "../../../metadata.yaml"
@@ -158,7 +158,7 @@ providers:
           - sourcePath: "../../../metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.19.1"
+  KUBERNETES_VERSION: "v1.20.1"
   CNI: "./data/cni/calico/calico.yaml"
   #CNI: "./data/cni/kindnet/kindnet.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -173,10 +173,10 @@ variables:
   VSPHERE_FOLDER: "FolderName"
   VSPHERE_NETWORK: "network-1"
   VSPHERE_RESOURCE_POOL: "ResourcePool"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.18.2"
+  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.20.1"
   INIT_WITH_BINARY_V1ALPHA3: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}"
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_KUBERNETES_VERSION: "v1.19.1"
+  INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
   # WORKLOAD_CONTROL_PLANE_ENDPOINT_IP:
   # Also following variables are required but it is recommended to use env variables to avoid disclosure of sensitive data
   # VSPHERE_SSH_AUTHORIZED_KEY:

--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
     minor: 0
     contract: v1beta1
   - major: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the clusterctl upgrade tests which test API conversions between `v1alpha3 -> v1beta1` and `v1alpha4 -> v1beta1` types.
As part of the tests, a bug was identified which caused the workload clusters upgraded from alpha to beta version to not get deleted since patching of the VSphereVM objects was failing due to zero value for `.status.RetryAfter` being set to `null` which was not a valid string. The issue was due to a bug in the K8s 1.19 release line which was fixed in the 1.20 release line onwards.

This patch updates the template to point to a v1.20.1 k8s version template

```release-note
NONE
```