### PR TITLE
Adds E2E tests from the CAPI e2e suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/e2e/data/infrastructure-vsphere/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml
+test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml
 _artifacts/
 
 # env vars file used in getting-started.md and manifests generation

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 test/e2e/data/infrastructure-vsphere/kustomization/base/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml
+test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml
+test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml
 _artifacts/
 
 # env vars file used in getting-started.md and manifests generation

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ e2e-templates: ## Generate e2e cluster templates
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/base > $(E2E_TEMPLATE_DIR)/cluster-template.yaml
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/remote-management > $(E2E_TEMPLATE_DIR)/cluster-template-remote-management.yaml
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/conformance > $(E2E_TEMPLATE_DIR)/cluster-template-conformance.yaml
+	# Since CAPI uses different flavor names for KCP and MD remediation using MHC
+	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/kcp > $(E2E_TEMPLATE_DIR)/cluster-template-kcp-remediation.yaml
+	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/md > $(E2E_TEMPLATE_DIR)/cluster-template-md-remediation.yaml
+
 
 .PHONY: test-integration
 test-integration: e2e-image

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ e2e-templates: ## Generate e2e cluster templates
 	# Since CAPI uses different flavor names for KCP and MD remediation using MHC
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/kcp > $(E2E_TEMPLATE_DIR)/cluster-template-kcp-remediation.yaml
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/md > $(E2E_TEMPLATE_DIR)/cluster-template-md-remediation.yaml
+	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/node-drain > $(E2E_TEMPLATE_DIR)/cluster-template-node-drain.yaml
 
 
 .PHONY: test-integration

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -151,6 +151,7 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -173,6 +174,7 @@ variables:
   INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
+  NODE_DRAIN_TIMEOUT: "60s"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]
@@ -182,3 +184,5 @@ intervals:
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
   default/wait-machine-remediation: ["5m", "10s"]
+  node-drain/wait-deployment-available: ["3m", "10s"]
+  node-drain/wait-machine-deleted: ["2m", "10s"]

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -149,6 +149,8 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-conformance.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -179,3 +181,4 @@ intervals:
   default/wait-worker-nodes: ["10m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-machine-remediation: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -155,6 +155,8 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-conformance.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -195,3 +197,4 @@ intervals:
   default/wait-worker-nodes: ["20m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-machine-remediation: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -157,6 +157,7 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -189,6 +190,7 @@ variables:
   # Sets the insecure-flag for vsphere-csi-controller config
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance-fast.yaml"
+  NODE_DRAIN_TIMEOUT: "60s"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]
@@ -198,3 +200,5 @@ intervals:
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
   default/wait-machine-remediation: ["5m", "10s"]
+  node-drain/wait-deployment-available: [ "3m", "10s" ]
+  node-drain/wait-machine-deleted: [ "2m", "10s" ]

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - mhc.yaml
+patchesStrategicMerge:
+  - vcpu.yaml

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/mhc.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/mhc.yaml
@@ -1,0 +1,18 @@
+---
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label cluster.x-k8s.io/control-plane=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-kcp"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/vcpu.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/kcp/vcpu.yaml
@@ -1,0 +1,13 @@
+# VSphereMachineTemplate object with the number of CPUs raised to 4
+# for the purposes of mitigating the CPU spikes caused by scaling up
+# the control plane (during upgrades and for HA control planes)
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      numCPUs: 4

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - mhc.yaml
+patchesStrategicMerge:
+  - mhc-label.yaml

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/mhc-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/mhc-label.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: '${CLUSTER_NAME}-md-0'
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    metadata:
+      labels:
+        "e2e.remediation.label": ""

--- a/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/mhc.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/mhc-remediation/md/mhc.yaml
@@ -1,0 +1,17 @@
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label e2e.remediation.label=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-md"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      e2e.remediation.label: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/kcp-drain.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/kcp-drain.yaml
@@ -1,0 +1,10 @@
+# KubeadmControlPlane referenced by the Cluster object with
+# - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  machineTemplate:
+    nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT}

--- a/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patchesStrategicMerge:
+  - kcp-drain.yaml
+  - md-drain.yaml
+  - vcpu.yaml

--- a/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/md-drain.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/md-drain.yaml
@@ -1,0 +1,9 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      nodeDrainTimeout: "${NODE_DRAIN_TIMEOUT}"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/vcpu.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/node-drain/vcpu.yaml
@@ -1,0 +1,13 @@
+# VSphereMachineTemplate object with the number of CPUs raised to 4
+# for the purposes of mitigating the CPU spikes caused by scaling up
+# the control plane (during upgrades and for HA control planes)
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      numCPUs: 4

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("When testing MachineDeployment scale out/in", func() {
+	capi_e2e.MachineDeploymentScaleSpec(ctx, func() capi_e2e.MachineDeploymentScaleSpecInput {
+		return capi_e2e.MachineDeploymentScaleSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})

--- a/test/e2e/mhc_remediation_test.go
+++ b/test/e2e/mhc_remediation_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("When testing unhealthy machines remediation", func() {
+	capi_e2e.MachineRemediationSpec(ctx, func() capi_e2e.MachineRemediationSpecInput {
+		return capi_e2e.MachineRemediationSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})

--- a/test/e2e/node_drain_timeout_test.go
+++ b/test/e2e/node_drain_timeout_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("When testing node drain timeout", func() {
+	capi_e2e.NodeDrainTimeoutSpec(ctx, func() capi_e2e.NodeDrainTimeoutSpecInput {
+		return capi_e2e.NodeDrainTimeoutSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds the following E2E tests:
- Machine Deployment Scale in/out tests ([CAPI ref](https://github.com/kubernetes-sigs/cluster-api/blob/dd3c2515c3edab63ab08b506c612932ecf3b08f8/test/e2e/mhc_remediations_test.go#L26))
- MHC Remediation tests ([CAPI ref](https://github.com/kubernetes-sigs/cluster-api/blob/dd3c2515c3edab63ab08b506c612932ecf3b08f8/test/e2e/md_scale_test.go#L26))
   - For Control plane nodes
   - For Worker nodes
- Node drain timeout tests ([CAPI ref](https://github.com/kubernetes-sigs/cluster-api/blob/dd3c2515c3edab63ab08b506c612932ecf3b08f8/test/e2e/node_drain_timeout_test.go#L26))
   - For Control plane nodes
   - For Worker nodes 

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
These tests will be run as part of the prow job which runs every 12 hours. [This prow job](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-vsphere#periodic-e2e-main) would be running these tests.

**Release note**:
```release-note
NONE
```

/area testing