### PR TITLE
✨ Add ClusterClass quick start test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml
 test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml
+test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml
 _artifacts/
 
 # env vars file used in getting-started.md and manifests generation

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ e2e-templates: ## Generate e2e cluster templates
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/kcp > $(E2E_TEMPLATE_DIR)/cluster-template-kcp-remediation.yaml
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/mhc-remediation/md > $(E2E_TEMPLATE_DIR)/cluster-template-md-remediation.yaml
 	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/node-drain > $(E2E_TEMPLATE_DIR)/cluster-template-node-drain.yaml
-
+	"$(KUSTOMIZE)" build $(E2E_TEMPLATE_DIR)/kustomization/topology > $(E2E_TEMPLATE_DIR)/cluster-template-topology.yaml
 
 .PHONY: test-integration
 test-integration: e2e-image

--- a/test/e2e/capv_clusterclass_quickstart_test.go
+++ b/test/e2e/capv_clusterclass_quickstart_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	"k8s.io/utils/pointer"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("ClusterClass Creation using Cluster API quick-start test", func() {
+	Byf("Creating single-node control plane with one worker node")
+	capi_e2e.QuickStartSpec(context.TODO(), func() capi_e2e.QuickStartSpecInput {
+		return capi_e2e.QuickStartSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                pointer.String("topology"),
+		}
+	})
+})

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -152,6 +152,8 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -175,6 +177,7 @@ variables:
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
+  CLUSTER_TOPOLOGY: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -158,6 +158,8 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml"
           - sourcePath: "../../../metadata.yaml"
 
 variables:
@@ -191,6 +193,7 @@ variables:
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance-fast.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
+  CLUSTER_TOPOLOGY: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml
@@ -1,0 +1,268 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterTemplate
+metadata:
+  name: quick-start-infra-cluster
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: 'quick-start'
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: quick-start-template
+        namespace: '${NAMESPACE}'
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: quick-start-kcp
+      namespace: '${NAMESPACE}'
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereClusterTemplate
+      name: quick-start-infra-cluster
+      namespace: '${NAMESPACE}'
+  patches:
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/users
+              valueFrom:
+                template: |
+                  - name: capv
+                    sshAuthorizedKeys:
+                    - '{{ .sshKey }}'
+                    sudo: ALL=(ALL) NOPASSWD:ALL
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/users
+              valueFrom:
+                template: |
+                  - name: capv
+                    sshAuthorizedKeys:
+                    - '{{ .sshKey }}'
+                    sudo: ALL=(ALL) NOPASSWD:ALL
+          selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+      enabledIf: '{{ if .sshKey }}true{{end}}'
+      name: enableSSHIntoNodes
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/controlPlaneEndpoint
+              valueFrom:
+                template: |
+                  host: {{ .controlPlaneIpAddr }}
+                  port: 6443
+            - op: add
+              path: /spec/template/spec/identityRef
+              valueFrom:
+                template: |
+                  kind: Secret
+                  name: {{ .credsSecretName }}
+            - op: add
+              path: /spec/template/spec/server
+              valueFrom:
+                variable: infraServer.url
+            - op: add
+              path: /spec/template/spec/thumbprint
+              valueFrom:
+                variable: infraServer.thumbprint
+          selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+      name: infraClusterSubstitutions
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/files/0/content
+              valueFrom:
+                variable: kubeVipPodManifest
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+      name: kubeVipEnabled
+  variables:
+    - name: sshKey
+      required: false
+      schema:
+        openAPIV3Schema:
+          description: Public key to SSH onto the cluster nodes.
+          type: string
+    - name: infraServer
+      required: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            thumbprint:
+              type: string
+            url:
+              type: string
+          type: object
+    - name: controlPlaneIpAddr
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: Floating VIP for the control plane.
+          type: string
+    - name: credsSecretName
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: Secret containing the credentials for the infra cluster.
+          type: string
+    - name: kubeVipPodManifest
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: kube-vip manifest for the control plane.
+          type: string
+  workers:
+    machineDeployments:
+      - class: default-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: quick-start-worker-template
+              namespace: '${NAMESPACE}'
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: VSphereMachineTemplate
+              name: quick-start-worker-template
+              namespace: '${NAMESPACE}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: quick-start-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
+      diskGiB: 25
+      folder: '${VSPHERE_FOLDER}'
+      memoryMiB: 8192
+      network:
+        devices:
+          - dhcp4: true
+            networkName: '${VSPHERE_NETWORK}'
+      numCPUs: 2
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
+      storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
+      template: '${VSPHERE_TEMPLATE}'
+      thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: quick-start-worker-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: '${VSPHERE_DATACENTER}'
+      datastore: '${VSPHERE_DATASTORE}'
+      diskGiB: 25
+      folder: '${VSPHERE_FOLDER}'
+      memoryMiB: 8192
+      network:
+        devices:
+          - dhcp4: true
+            networkName: '${VSPHERE_NETWORK}'
+      numCPUs: 2
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
+      server: '${VSPHERE_SERVER}'
+      storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
+      template: '${VSPHERE_TEMPLATE}'
+      thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: quick-start-kcp
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              cloud-provider: external
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        files:
+          - owner: root:root
+            path: /etc/kubernetes/manifests/kube-vip.yaml
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data.hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data.hostname }}'
+        preKubeadmCommands:
+          - hostname "{{ ds.meta_data.hostname }}"
+          - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+          - echo "127.0.0.1   localhost" >>/etc/hosts
+          - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+          - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+        useExperimentalRetryJoin: true
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: quick-start-worker-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+        - hostname "{{ ds.meta_data.hostname }}"
+        - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+        - echo "127.0.0.1   localhost" >>/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+        - echo "{{ ds.meta_data.hostname }}" >/etc/hostname

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-network-CIDR.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-network-CIDR.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.30.0/24

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set-csi-insecure.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set-csi-insecure.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-vsphere-config
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: csi-vsphere-config
+      namespace: kube-system
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        insecure-flag = "${VSPHERE_INSECURE_CSI}"
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-resource-set.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-template-topology-base.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-template-topology-base.yaml
@@ -1,0 +1,810 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  topology:
+    class: 'quick-start'
+    controlPlane:
+      replicas: 1
+    variables:
+      - name: sshKey
+        value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
+      - name: infraServer
+        value:
+          thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+          url: '${VSPHERE_SERVER}'
+      - name: kubeVipPodManifest
+        value: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            creationTimestamp: null
+            name: kube-vip
+            namespace: kube-system
+          spec:
+            containers:
+            - args:
+              - manager
+              env:
+              - name: cp_enable
+                value: "true"
+              - name: vip_interface
+                value: ${VIP_NETWORK_INTERFACE=""}
+              - name: address
+                value: ${CONTROL_PLANE_ENDPOINT_IP}
+              - name: port
+                value: "6443"
+              - name: vip_arp
+                value: "true"
+              - name: vip_leaderelection
+                value: "true"
+              - name: vip_leaseduration
+                value: "15"
+              - name: vip_renewdeadline
+                value: "10"
+              - name: vip_retryperiod
+                value: "2"
+              image: ghcr.io/kube-vip/kube-vip:v0.4.1
+              imagePullPolicy: IfNotPresent
+              name: kube-vip
+              resources: {}
+              securityContext:
+                capabilities:
+                  add:
+                  - NET_ADMIN
+                  - NET_RAW
+              volumeMounts:
+              - mountPath: /etc/kubernetes/admin.conf
+                name: kubeconfig
+            hostAliases:
+            - hostnames:
+              - kubernetes
+              ip: 127.0.0.1
+            hostNetwork: true
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/admin.conf
+                type: FileOrCreate
+              name: kubeconfig
+          status: {}
+      - name: controlPlaneIpAddr
+        value: ${CONTROL_PLANE_ENDPOINT_IP}
+      - name: credsSecretName
+        value: '${CLUSTER_NAME}'
+    version: '${KUBERNETES_VERSION}'
+    workers:
+      machineDeployments:
+        - class: default-worker
+          metadata: {}
+          name: md-0
+          replicas: 3
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+stringData:
+  password: ${VSPHERE_PASSWORD}
+  username: ${VSPHERE_USERNAME}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: '${NAMESPACE}'
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  resources:
+    - kind: Secret
+      name: vsphere-csi-controller
+    - kind: ConfigMap
+      name: vsphere-csi-controller-role
+    - kind: ConfigMap
+      name: vsphere-csi-controller-binding
+    - kind: Secret
+      name: csi-vsphere-config
+    - kind: ConfigMap
+      name: csi.vsphere.vmware.com
+    - kind: ConfigMap
+      name: vsphere-csi-node
+    - kind: ConfigMap
+      name: vsphere-csi-controller
+    - kind: Secret
+      name: cloud-controller-manager
+    - kind: Secret
+      name: cloud-provider-vsphere-credentials
+    - kind: ConfigMap
+      name: cpi-manifests
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-csi-controller
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-controller
+      namespace: kube-system
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-controller-role
+    rules:
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - csidrivers
+      verbs:
+      - create
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - pods
+      - secrets
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+      - patch
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - storageclasses
+      - csinodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshots
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents
+      verbs:
+      - get
+      - list
+kind: ConfigMap
+metadata:
+  name: vsphere-csi-controller-role
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+data:
+  data: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-controller-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-controller-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-controller
+      namespace: kube-system
+kind: ConfigMap
+metadata:
+  name: vsphere-csi-controller-binding
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-vsphere-config
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: csi-vsphere-config
+      namespace: kube-system
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |
+    apiVersion: storage.k8s.io/v1
+    kind: CSIDriver
+    metadata:
+      name: csi.vsphere.vmware.com
+    spec:
+      attachRequired: true
+kind: ConfigMap
+metadata:
+  name: csi.vsphere.vmware.com
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+data:
+  data: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node
+            role: vsphere-csi
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+            image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /bin/sh
+                  - -c
+                  - rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock
+            name: node-driver-registrar
+            resources: {}
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: INFO
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 3
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+              privileged: true
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+              name: pods-mount-dir
+            - mountPath: /dev
+              name: device-dir
+          - args:
+            - --csi-address=/csi/csi.sock
+            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            name: liveness-probe
+            resources: {}
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          dnsPolicy: Default
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - name: vsphere-config-volume
+            secret:
+              secretName: csi-vsphere-config
+          - hostPath:
+              path: /var/lib/kubelet/plugins_registry
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: /var/lib/kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: /dev
+            name: device-dir
+      updateStrategy:
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: vsphere-csi-node
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+data:
+  data: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vsphere-csi-controller
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vsphere-csi-controller
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-controller
+            role: vsphere-csi
+        spec:
+          containers:
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: quay.io/k8scsi/csi-attacher:v3.0.0
+            name: csi-attacher
+            resources: {}
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: INFO
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 3
+            name: vsphere-csi-controller
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+          - args:
+            - --csi-address=$(ADDRESS)
+            env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            name: liveness-probe
+            resources: {}
+            volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+          - args:
+            - --leader-election
+            env:
+            - name: X_CSI_FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0
+            name: vsphere-syncer
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --default-fstype=ext4
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: quay.io/k8scsi/csi-provisioner:v2.0.0
+            name: csi-provisioner
+            resources: {}
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          dnsPolicy: Default
+          serviceAccountName: vsphere-csi-controller
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          volumes:
+          - name: vsphere-config-volume
+            secret:
+              secretName: csi-vsphere-config
+          - emptyDir: {}
+            name: socket-dir
+kind: ConfigMap
+metadata:
+  name: vsphere-csi-controller
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-controller-manager
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-vsphere-credentials
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloud-provider-vsphere-credentials
+      namespace: kube-system
+    stringData:
+      ${VSPHERE_SERVER}.password: ${VSPHERE_PASSWORD}
+      ${VSPHERE_SERVER}.username: ${VSPHERE_USERNAME}
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-controller-manager
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    data:
+      vsphere.conf: |
+        global:
+          secretName: cloud-provider-vsphere-credentials
+          secretNamespace: kube-system
+          thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+        vcenter:
+          ${VSPHERE_SERVER}:
+            datacenters:
+            - '${VSPHERE_DATACENTER}'
+            secretName: cloud-provider-vsphere-credentials
+            secretNamespace: kube-system
+            server: '${VSPHERE_SERVER}'
+            thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+    kind: ConfigMap
+    metadata:
+      name: vsphere-cloud-config
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: servicecatalog.k8s.io:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        component: cloud-controller-manager
+      name: cloud-controller-manager
+      namespace: kube-system
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: 43001
+      selector:
+        component: cloud-controller-manager
+      type: NodePort
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+      name: vsphere-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: vsphere-cloud-controller-manager
+      template:
+        metadata:
+          labels:
+            k8s-app: vsphere-cloud-controller-manager
+        spec:
+          containers:
+          - args:
+            - --v=2
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/vsphere.conf
+            image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.18.1
+            name: vsphere-cloud-controller-manager
+            resources:
+              requests:
+                cpu: 200m
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          hostNetwork: true
+          serviceAccountName: cloud-controller-manager
+          tolerations:
+          - effect: NoSchedule
+            key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node.kubernetes.io/not-ready
+          volumes:
+          - configMap:
+              name: vsphere-cloud-config
+            name: vsphere-config-volume
+      updateStrategy:
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: cpi-manifests
+  namespace: '${NAMESPACE}'

--- a/test/e2e/data/infrastructure-vsphere/kustomization/topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/topology/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-resource-set.yaml
+  - cluster-template-topology-base.yaml
+patchesStrategicMerge:
+  - cluster-resource-set-label.yaml
+  - cluster-network-CIDR.yaml
+  - cluster-resource-set-csi-insecure.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds the ClusterClass quick start tests to the e2e test suite of CAPV. This PR assumes that the ClusterClass and cluster topology templates are already generated.

**Which issue(s) this PR fixes**:
Fixes #1448 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```