### PR TITLE
Add USE_EXISTING_CLUSTER variable for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ VMOP_CRD_ROOT ?= $(MANIFEST_ROOT)/deployments/integration-tests/crds
 WEBHOOK_ROOT ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 SKIP_RESOURCE_CLEANUP ?= false
+USE_EXISTING_CLUSTER ?= false
 RELEASE_DIR := out
 BUILD_DIR := .build
 OVERRIDES_DIR := $(HOME)/.cluster-api/overrides/infrastructure-vsphere/$(VERSION)
@@ -164,7 +165,8 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	time $(GINKGO) -v -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) ./test/e2e -- \
 		--e2e.config="$(E2E_CONF_FILE)" \
 		--e2e.artifacts-folder="$(ARTIFACTS_PATH)" \
-		--e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP)
+		--e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
+		--e2e.use-existing-cluster="$(USE_EXISTING_CLUSTER)"
 
 .PHONY: test-cover
 test-cover: ## Run tests with code coverage and code generate  reports

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -40,6 +40,7 @@ The first step to running the e2e tests is setting up the required environment v
 
 | Flag                       | Description                                                           |Default Value
 `SKIP_RESOURCE_CLEANUP`      | This flags skips cleanup of the resources created during the tests as well as the kind/bootstrap cluster        | `false`
+`USE_EXISTING_CLUSTER`       | This flag enables the usage of an existing K8S cluster as the management cluster to run tests against.          | `false`
 
 ### Running the e2e tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**

Adds `USE_EXISTING_CLUSTER` as an environment variable to the Makefile. This variable is passed to the e2e test command where it enables using an existing cluster instead of creating a new one.:

**Which issue(s) this PR fixes**:
Fixes #1439.

**Special notes for your reviewer**:
`nil`
