### PR TITLE
🌱 make clusterclass test non `PR-Blocking`

### DIFF
--- a/test/e2e/capv_clusterclass_quickstart_test.go
+++ b/test/e2e/capv_clusterclass_quickstart_test.go
@@ -22,7 +22,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("ClusterClass Creation using Cluster API quick-start test [PR-Blocking]", func() {
+var _ = Describe("ClusterClass Creation using Cluster API quick-start test", func() {
 	Byf("Creating single-node control plane with one worker node")
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
As part of the ClusterClass flavorgen PR, I made the tests `PR-Blocking` in order to get immediate feedback from the prow jobs. But we don't need these tests to be PR-Blocking. This PR takes care of that. 
