### PR TITLE
📖 Adds info to update metadata.yaml during release generation

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,8 +5,12 @@
 1. Login using `gcloud auth login`. You should see
    `cluster-api-provider-vsphere` in your list of available projects.
 2. Make sure your repo is clean by git's standards
-3. If this is a new minor release, create a new release branch and push
-   to github, otherwise switch to it, for example `release-0.7`
+3. If this is a new minor release,
+   1. Verify that the `metadata.yaml` file has an entry binding the CAPI contract
+      to this new release version.
+      If this is not yet done, create a new commit to add this entry.
+   2. Create a new release branch and push
+      to github, otherwise switch to it, for example `release-0.7`
 4. Create an env var VERSION=v0.x.x Ensure the version is prefixed with a v
 5. Tag the repository and push the tag `git tag -m $VERSION $VERSION`
    * If you have a GPG key for use with git use `git tag -s -m $VERSION $VERSION`


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the release doc to include the step to verify the presence of an entry in the `metadata.yaml` file when releasing a new minor version.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1464

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```