### PR TITLE
🐛 Automated cherry pick of #1465: Fixes clusterctl metadata for v1.1.x release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,3 +24,6 @@ releaseSeries:
   - major: 1
     minor: 0
     contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1


### PR DESCRIPTION
Cherry pick of #1465 on release-1.1.

#1465: Add missing 1.1 releaseseries data to metadata.yaml.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```