### PR TITLE
Add tests for the `services/govomi/metadata` package

### DIFF
--- a/pkg/services/govmomi/metadata/metadata_suite_test.go
+++ b/pkg/services/govmomi/metadata/metadata_suite_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"bufio"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pkg/errors"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+)
+
+func TestMetadata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metadata Suite")
+}
+
+const (
+	existingCategory             = "existingCategory"
+	existingCategoryAssocType    = infrav1.DatacenterFailureDomain
+	existingCategoryNewAssocType = infrav1.HostGroupFailureDomain
+	existingTag                  = "existingTag"
+)
+
+var (
+	sim *helpers.Simulator
+	ctx *context.VMContext
+
+	existingCategoryID string
+)
+
+var _ = BeforeSuite(func() {
+	Expect(configureSimulatorAndContext()).To(Succeed())
+	Expect(createTagsAndCategories()).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	sim.Destroy()
+})
+
+var _ = Describe("Metadata_CreateCategory", func() {
+	const (
+		testCategory          = "testCategory"
+		testCategoryAssocType = infrav1.HostGroupFailureDomain
+	)
+
+	Context("we attempt to create a new category", func() {
+		It("creates a matching category in the context's TagManager", func() {
+			catID, err := CreateCategory(ctx, testCategory, testCategoryAssocType)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(catID).NotTo(BeEmpty())
+
+			cat, err := ctx.GetSession().TagManager.GetCategory(ctx, catID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cat.Name).To(Equal(testCategory))
+			Expect(cat.AssociableTypes).To(ConsistOf(categoryAssociableTypes()[testCategoryAssocType]))
+		})
+	})
+
+	Context("we attempt to update an existing category", func() {
+		It("updates the matching category in the context's TagManager", func() {
+			if existingCategoryID == "" {
+				Fail("category required to run this test has not been setup in the VCSim!")
+			}
+
+			catID, err := CreateCategory(ctx, existingCategory, existingCategoryNewAssocType)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(catID).To(Equal(existingCategoryID))
+
+			cat, err := ctx.GetSession().TagManager.GetCategory(ctx, catID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cat.Name).To(Equal(existingCategory))
+			Expect(cat.AssociableTypes).To(ConsistOf(
+				categoryAssociableTypes()[existingCategoryAssocType],
+				categoryAssociableTypes()[existingCategoryNewAssocType],
+			))
+		})
+	})
+})
+
+var _ = Describe("Metadata_CreateTag", func() {
+	const (
+		testTag        = "testTag"
+		mockCategoryID = "mockCategory"
+	)
+
+	BeforeEach(func() {
+		if existingCategoryID == "" {
+			Fail("category and tags required to run this test have not been setup in the VCSim!")
+		}
+	})
+
+	Context("we attempt to create a new tag", func() {
+		It("creates a tag in the context's TagManager", func() {
+			Expect(CreateTag(ctx, testTag, existingCategoryID)).To(Succeed())
+
+			tag, err := ctx.GetSession().TagManager.GetTag(ctx, testTag)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tag.CategoryID).To(Equal(existingCategoryID))
+		})
+	})
+
+	Context("we attempt to create a tag which already exists but for a different category ID", func() {
+		It("does not return an error and does not modify the existing tag", func() {
+			Expect(CreateTag(ctx, existingTag, mockCategoryID)).To(Succeed())
+
+			tag, err := ctx.GetSession().TagManager.GetTag(ctx, existingTag)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tag.CategoryID).To(Equal(existingCategoryID), "the tag's category ID must not change")
+		})
+	})
+})
+
+func configureSimulatorAndContext() (err error) {
+	sim, err = helpers.VCSimBuilder().Build()
+	if err != nil {
+		return
+	}
+
+	ctx = fake.NewVMContext(fake.NewControllerContext(fake.NewControllerManagerContext()))
+	ctx.VSphereVM.Spec.Server = sim.ServerURL().Host
+
+	authSession, err := session.GetOrCreate(
+		ctx.Context,
+		session.NewParams().
+			WithServer(ctx.VSphereVM.Spec.Server).
+			WithUserInfo(sim.Username(), sim.Password()).
+			WithDatacenter("*"))
+
+	ctx.Session = authSession
+
+	return
+}
+
+// createTagsAndCategories creates tag(s) and category(s) required to run the tests on the VCSim.
+func createTagsAndCategories() (err error) {
+	stdout := gbytes.NewBuffer()
+	scanner := bufio.NewScanner(stdout)
+
+	// create a category to support tests for both CreateCategory() and CreateTag()
+	err = sim.Run(fmt.Sprintf("tags.category.create -t %s %s",
+		categoryAssociableTypes()[existingCategoryAssocType],
+		existingCategory),
+		stdout,
+	)
+	if err != nil {
+		return
+	}
+
+	if scanned := scanner.Scan(); !scanned {
+		err = errors.New("failed to retrieve category ID from govc stdout buffer")
+		return
+	}
+
+	existingCategoryID = scanner.Text()
+
+	// create a tag to support tests for CreateTag()
+	err = sim.Run(fmt.Sprintf("tags.create -c %s %s", existingCategory, existingTag))
+	return
+}
+
+// categoryAssociableTypes() maps failure domain types to resource type strings
+// We use this function instead of getCategoryAssociableTypes() to avoid a hard dependency on a package private function.
+func categoryAssociableTypes() map[infrav1.FailureDomainType]string {
+	return map[infrav1.FailureDomainType]string{
+		infrav1.DatacenterFailureDomain:     "Datacenter",
+		infrav1.ComputeClusterFailureDomain: "ClusterComputeResource",
+		infrav1.HostGroupFailureDomain:      "HostSystem",
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**
Adds test cases for public methods from the metadata package. The metadata package's exposed methods are used in creating tags and tag categories for `VSphereFailureDomain` objects.
- [x] metadata.CreateCategory()
	Passed a valid metadata context, a category name and associable resource type the method should:
	- If a category with the same name doesn't already exist -- create a new category with a matching name and and associable resource type. The method should also return a valid non-empty category ID which can be used to reference the ID through the context's tag manager. 
	- If a category with the same name exists -- update the category by merging in any new associable resource type. The category ID returned must be the same as the existing category's ID.
- [x] metadata.CreateTag()
	Passed a valid metadata context, tag name and category ID this method should:
	- If a tag with the same name doesn't already exist -- create a new tag matching the name and category ID passed.
	- If a tag with the same name exists -- not do anything. The existing tag must not be mutated in any way.

**Which issue(s) this PR fixes**:
Fixes #1472

Signed-off-by: ditsuke <ditsuke@protonmail.com>