### PR TITLE
Add tests for the `services/govmomi/extra` package

### DIFF
--- a/pkg/services/govmomi/extra/extra_suite_test.go
+++ b/pkg/services/govmomi/extra/extra_suite_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extra
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestExtra(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extra Suite")
+}
+
+type ConfigInitFn func(*Config, string) error
+
+var _ = Describe("Config_SetCustomVMXKeys", func() {
+	Context("we try to set custom keys in the config", func() {
+		config := getMockConfig()
+		customConfigKeys := map[string]string{
+			"customKey1": "customVal1",
+			"customKey2": "customKey2",
+		}
+
+		var configKeys []interface{}
+		for k, v := range customConfigKeys {
+			configKeys = append(configKeys, &types.OptionValue{
+				Key:   k,
+				Value: v,
+			})
+		}
+
+		It("adds the keys to the config", func() {
+			err := config.SetCustomVMXKeys(customConfigKeys)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*config).To(ConsistOf(configKeys...))
+		})
+	})
+})
+
+var _ = Describe("Config_SetCloudInitUserData", func() {
+	ConfigInitFnTester(
+		func(config *Config, s string) error {
+			return config.SetCloudInitUserData([]byte(s))
+		},
+		"SetCloudInitUserData",
+		"guestinfo.userdata",
+		"guestinfo.userdata.encoding",
+	)
+})
+
+var _ = Describe("Config_SetCloudInitMetadata", func() {
+	ConfigInitFnTester(func(config *Config, s string) error {
+		return config.SetCloudInitMetadata([]byte(s))
+	},
+		"SetCloudInitMetadata",
+		"guestinfo.metadata",
+		"guestinfo.metadata.encoding",
+	)
+})
+
+func getMockConfig() *Config {
+	return new(Config)
+}
+
+func base64Encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+// ConfigInitFnTester is a common testing method for config.SetCloudInitUserData and config.SetCloudInitMetadata.
+func ConfigInitFnTester(method ConfigInitFn, methodName string, dataKey string, encodingKey string) {
+	const sampleData = "some sample data, "
+	var expectedData = base64Encode(sampleData)
+
+	Context(fmt.Sprintf("we call %q with some non-encoded sample data", methodName), func() {
+		config := getMockConfig()
+		err := method(config, sampleData)
+
+		It("must set 2 keys in the config", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(*config)).To(Equal(2))
+		})
+
+		It(fmt.Sprintf("must set data as a base64 encoded string with the key %q", dataKey), func() {
+			Expect(*config).To(ContainElement(&types.OptionValue{
+				Key:   dataKey,
+				Value: expectedData,
+			}))
+		})
+
+		It("must set a key to indicate base64 encoding of the data", func() {
+			Expect(*config).To(ContainElement(&types.OptionValue{
+				Key:   encodingKey,
+				Value: "base64",
+			}))
+		})
+	})
+
+	Context(fmt.Sprintf("We call %q with some pre-encoded data (single pass)", methodName), func() {
+		config := getMockConfig()
+		preEncodedData := base64Encode(sampleData)
+		err := method(config, preEncodedData)
+
+		It("does not encode the data further on storing", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*config).To(ContainElement(&types.OptionValue{
+				Key:   dataKey,
+				Value: preEncodedData,
+			}))
+		})
+	})
+
+	Context(fmt.Sprintf("We call %q with some pre-encoded data (multiple passes)", methodName), func() {
+		config := getMockConfig()
+		const passCount = 5
+		multiPassEncodedData := sampleData
+		for i := 0; i < passCount; i++ {
+			multiPassEncodedData = base64Encode(multiPassEncodedData)
+		}
+
+		err := method(config, multiPassEncodedData)
+
+		It("saves data with a single pass of encoding", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*config).To(ContainElement(&types.OptionValue{
+				Key:   dataKey,
+				Value: expectedData,
+			}))
+		})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**
This PR adds test cases for the public methods under the services/govmomi/extra package. These methods are used to
set cloud init data (used on VM startup) and to set other configuration keys. The new tests cover:
- [x] `config.SetCustomVMXKeys()`
	Passed a string => string map, this method should append all these key, value pairs to the config as `types.OptionValue` structs.
- [x] `config.SetCloudInitUserData()`, `config.SetCloudInitMetadata()`
	Passed byte arrays, these methods are expected to:
	- Store the data in a `guestinfo.userdata`/`guestinfo.metadata` key with a single pass of base64 encoding.
	- Add a key to indicate the encoding format.
	- Ensure the data passed is encoded with exactly a single pass of base64, which includes checking for existing
	  base64 encoding and undoing them before encoding again with 1x base64.

**Which issue(s) this PR fixes**
Fixes #1471

Signed-off by: ditsuke <ditsuke@protonmail.com>
