### PR TITLE
Removes usage of deprecated ObjecteMeta field

### DIFF
--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -214,8 +214,8 @@ func GetMachineMetadata(hostname string, vsphereVM infrav1.VSphereVM, networkSta
 	}); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"error getting cloud init metadata for vsphereVM %s/%s/%s",
-			vsphereVM.Namespace, vsphereVM.ClusterName, vsphereVM.Name)
+			"error getting cloud init metadata for vsphereVM %s/%s",
+			vsphereVM.Namespace, vsphereVM.Name)
 	}
 	return buf.Bytes(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch removes the reference to `ObjectMeta.ClusterName` field from the codebase.

**Which issue(s) this PR fixes**:
Fixes #1481

**Special notes for your reviewer**:
Removes the field being used in the error message, no behavioral change

**Release note**:
```release-note
Removes usage of deprecated ObjecteMeta field
```