### PR TITLE
Add tests for `pkg/services/govmomi/service.go`

### DIFF
--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package govmomi_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+)
+
+// @todo.
+func TestReconcileVM(t *testing.T) {
+	g := NewWithT(t)
+
+	sim, err := helpers.VCSimBuilder().Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Cleanup(func() {
+		sim.Destroy()
+	})
+
+	vms := govmomi.VMService{}
+
+	// @todo: refactor subtests to desc-fn-expect []struct
+
+	// Case 1: error if vm is "in flight", it must return an error --
+	// ? how do we configure a preflight task on the fake context?
+	t.Run("when vm context has an inflight task", func(t *testing.T) {
+		g := NewWithT(t)
+		vmCtx, err := getFakeContext(sim)
+		g.Expect(err).ToNot(HaveOccurred())
+		vmCtx.VSphereVM.Status = infrav1.VSphereVMStatus{
+			TaskRef:    "some-inflight-task",
+			RetryAfter: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+		}
+
+		// ? how to mock this task on the VM?
+		// task := getFakeTask(types.TaskInfoStateRunning, "")
+
+		vm, err := vms.ReconcileVM(vmCtx)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(vm).To(Equal(infrav1.VirtualMachine{
+			Name:  vmCtx.VSphereVM.Name,
+			State: infrav1.VirtualMachineStatePending,
+		}))
+	})
+
+	// Case 2: Returns error on failure to find VM by BiosUUID (pass an invalid UUID?)
+	t.Run("when vm reference is set but it cannot be found", func(t *testing.T) {
+
+	})
+
+	// Case 3: Bootstraps new VM when the VM doesn't exist already
+	t.Run("when vm does not exist already", func(t *testing.T) {
+
+	})
+
+	// ...
+}
+
+// @todo.
+func TestDestroyVM(t *testing.T) {
+
+}
+
+func getFakeContext(sim *helpers.Simulator) (*context.VMContext, error) {
+	ctx := fake.NewVMContext(fake.NewControllerContext(fake.NewControllerManagerContext()))
+	ctx.VSphereVM.Spec.Server = sim.ServerURL().Host
+
+	authSession, err := session.GetOrCreate(
+		ctx,
+		session.NewParams().
+			WithServer(ctx.VSphereVM.Spec.Server).
+			WithUserInfo(sim.Username(), sim.Password()).
+			WithDatacenter("*"))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Session = authSession
+
+	return ctx, nil
+}
+
+// nolint:deadcode,unused
+// @todo: remove nolint decl.
+func getFakeTask(state types.TaskInfoState, errorDescription string) mo.Task {
+	t := mo.Task{
+		ExtensibleManagedObject: mo.ExtensibleManagedObject{
+			Self: types.ManagedObjectReference{
+				Value: "-for-logger",
+			},
+		},
+	}
+	if state != "" {
+		t.Info = types.TaskInfo{
+			State: state,
+		}
+	}
+	if errorDescription != "" {
+		t.Info.Description = &types.LocalizableMessage{
+			Message: errorDescription,
+		}
+	}
+	return t
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds tests for exported functions in `pkg/services/govmomi/service.go`. These functions include:
- [ ] ReconcileVM()
	This function reconciles a vm reference to make sure it is in a consistent and desired state by:
	- Creating the VM if it doesn't exist.
	- Updating the VM with bootstrap init data (cloud and user).
	- Powering on the VM.
	- Returning a VirtualMachine struct with updated real-time state of the machine.

	To test this function, it is necessary to mock the various states a target VM can be in, passing in contexts with invalid
	VM UUIDs, contexts with non-existent VMs and then asserting for desired behaviors like non-reconcillation of VMs with
	inflight tasks, errors on invalid VM refs, creation of new VMs with contexts lacking a VM, etc. I'm yet to document all the
	scenarios but would appreciate any insights here.

- [ ] DestroyVM()
	This function is used to destroy the VM referenced by the context. DestroyVM() seems to share some reconcilation logic with ReconcileVM() which might be an opportunity for refactoring. The behaviors to test for include ensuring VMs with inflight tasks are not destroyed, errors are *not* returned when invalid references are passed (the VMs are assumed to be destroyed), and that on passing valid refs the underlying VM is destroyed if its powered on and if not, a task to destroy the VM is queued in the context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1479

**Special notes for your reviewer**: None yet.

Signed-off-by: ditsuke <ditsuke@protonmail.com>
