### PR TITLE
Add legacy `capw` labels to VirtualMachine for backward compatibility

### DIFF
--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -41,6 +41,14 @@ const (
 	nodeSelectorKey    = "capv.vmware.com/cluster.role"
 	roleNode           = "node"
 	roleControlPlane   = "controlplane"
+
+	// TODO(lubronzhan): Deprecated, will be removed in a future release.
+	// https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1483
+	// legacyClusterSelectorKey and legacyNodeSelectorKey are added for backward compatibility.
+	// These will be removed in the future release.
+	// Please refer to the issue above for deprecation process.
+	legacyClusterSelectorKey = "capw.vmware.com/cluster.name"
+	legacyNodeSelectorKey    = "capw.vmware.com/cluster.role"
 )
 
 // CPService represents the ability to reconcile a ControlPlaneEndpoint.
@@ -104,14 +112,18 @@ func controlPlaneVMServiceName(ctx *vmware.ClusterContext) string {
 
 // ClusterRoleVMLabels returns labels applied to a VirtualMachine in the cluster. The Control Plane
 // VM Service uses these labels to select VMs, as does the Cloud Provider.
+// Add the legacyNodeSelectorKey and legacyClusterSelectorKey to machines as well.
 func clusterRoleVMLabels(ctx *vmware.ClusterContext, controlPlane bool) map[string]string {
 	result := map[string]string{
-		clusterSelectorKey: ctx.Cluster.Name,
+		clusterSelectorKey:       ctx.Cluster.Name,
+		legacyClusterSelectorKey: ctx.Cluster.Name,
 	}
 	if controlPlane {
 		result[nodeSelectorKey] = roleControlPlane
+		result[legacyNodeSelectorKey] = roleControlPlane
 	} else {
 		result[nodeSelectorKey] = roleNode
+		result[legacyNodeSelectorKey] = roleControlPlane
 	}
 	return result
 }

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -168,6 +168,12 @@ var _ = Describe("VirtualMachine tests", func() {
 				Expect(vmopVM.Spec.PowerState).To(Equal(vmoprv1.VirtualMachinePoweredOn))
 				Expect(vmopVM.ObjectMeta.Annotations[ClusterModuleNameAnnotationKey]).To(Equal(ControlPlaneVMClusterModuleGroupName))
 				Expect(vmopVM.ObjectMeta.Annotations[ProviderTagsAnnotationKey]).To(Equal(ControlPlaneVMVMAntiAffinityTagValue))
+
+				Expect(vmopVM.Labels[clusterSelectorKey]).To(Equal(clusterName))
+				Expect(vmopVM.Labels[nodeSelectorKey]).To(Equal(roleControlPlane))
+				// for backward compatibility, will be removed in the future
+				Expect(vmopVM.Labels[legacyClusterSelectorKey]).To(Equal(clusterName))
+				Expect(vmopVM.Labels[legacyNodeSelectorKey]).To(Equal(roleControlPlane))
 			}
 
 			for _, expectedCondition := range expectedConditions {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
There are old version of cluster created by CAPW that depends on `capw` labels on `VirtualMachine` for some functionality. For example CloudProviderVsphere depends on this https://github.com/kubernetes/cloud-provider-vsphere/issues/608

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1483

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

The deprecation process hasn't been decided yet. Once it's decided, will update in the original issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add legacy `capw` label to `VirtualMachine` object
```