### PR TITLE
Update mdlint to v0.31.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ lint-go-full: lint-go ## Run slower linters to detect possible issues
 
 .PHONY: lint-markdown
 lint-markdown: ## Lint the project's markdown
-	docker run --rm -v "$$(pwd)":/build$(DOCKER_VOL_OPTS) gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 -- /md/lint -i vendor -i contrib/haproxy/openapi .
+	docker run --rm -v "$$(pwd)":/build$(DOCKER_VOL_OPTS) gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.31.1 -- /md/lint -i vendor -i contrib/haproxy/openapi .
 
 .PHONY: lint-shell
 lint-shell: ## Lint the project's shell scripts

--- a/hack/tools/mdlint/Dockerfile
+++ b/hack/tools/mdlint/Dockerfile
@@ -16,7 +16,7 @@
 ##                             INSTALL MDLINT                                 ##
 ################################################################################
 FROM node:12.6.0-slim as build
-ARG MDLINT_CLI_VERSION=0.23.2
+ARG MDLINT_CLI_VERSION=0.31.1
 ENV MDLINT_CLI_VERSION=${MDLINT_CLI_VERSION}
 RUN npm install -g --prefix=/md markdownlint-cli@${MDLINT_CLI_VERSION} && \
     ln -s /md/lib/node_modules/markdownlint-cli/markdownlint.js /md/lint

--- a/hack/tools/mdlint/Makefile
+++ b/hack/tools/mdlint/Makefile
@@ -14,7 +14,7 @@
 
 all: build
 
-MDLINT_CLI_VERSION ?= 0.23.2
+MDLINT_CLI_VERSION ?= 0.31.1
 IMAGE_NAME ?= gcr.io/cluster-api-provider-vsphere/extra/mdlint
 IMAGE_TAG ?= $(IMAGE_NAME):$(MDLINT_CLI_VERSION)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The v0.31.1 release of markdownlint was created in Feb 2022. This
updates our mdlint container to use this latest version.

**Special notes for your reviewer**:

Testing locally by creating image with:

```
cd hack/tools/mdlint
make
docker images # Just to check
cd ../../..
make lint-markdown
```