### PR TITLE
🐛 Backport secret deletion fix to v1.0.0 from PR #1486

### DIFF
--- a/controllers/vspherecluster_controller_test.go
+++ b/controllers/vspherecluster_controller_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/simulator"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -234,6 +233,118 @@ var _ = Describe("ClusterReconciler", func() {
 					Severity: clusterv1.ConditionSeverityError,
 					Reason:   infrav1.VCenterUnreachableReason,
 				}))
+			}, timeout).Should(BeTrue())
+		})
+	})
+
+	Context("Reconcile delete", func() {
+		var (
+			ctx             context.Context
+			secret          *corev1.Secret
+			capiCluster     *clusterv1.Cluster
+			instance        *infrav1.VSphereCluster
+			legacyFinalizer = "identity/infrastructure.cluster.x-k8s.io"
+			key             client.ObjectKey
+		)
+		It("should remove legacy finalizer if present during the cluster deletion", func() {
+			ctx = context.Background()
+			capiCluster = &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test1-",
+					Namespace:    "default",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						APIVersion: infrav1.GroupVersion.String(),
+						Kind:       "VsphereCluster",
+						Name:       "vsphere-test1",
+					},
+				},
+			}
+			defer func() {
+				Expect(testEnv.Cleanup(ctx, capiCluster)).To(Succeed())
+			}()
+
+			// Create the CAPI cluster (owner) object
+			Expect(testEnv.Create(ctx, capiCluster)).To(Succeed())
+
+			fakeVCenter := startVcenter()
+			vcURL := fakeVCenter.ServerURL()
+			defer fakeVCenter.Destroy()
+			// Create the secret containing the credentials
+			password, _ := vcURL.User.Password()
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "secret-",
+					Namespace:    "default",
+					Finalizers:   []string{legacyFinalizer},
+				},
+				Data: map[string][]byte{
+					identity.UsernameKey: []byte(vcURL.User.Username()),
+					identity.PasswordKey: []byte(password),
+				},
+			}
+			Expect(testEnv.Create(ctx, secret)).To(Succeed())
+			Eventually(func() error {
+				secretKey := client.ObjectKey{Namespace: secret.Namespace, Name: secret.Name}
+				return testEnv.Get(ctx, secretKey, secret)
+			}).Should(BeNil())
+
+			// Create the VSphereCluster object
+			instance = &infrav1.VSphereCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vsphere-test1",
+					Namespace: "default",
+				},
+				Spec: infrav1.VSphereClusterSpec{
+					IdentityRef: &infrav1.VSphereIdentityReference{
+						Kind: infrav1.SecretKind,
+						Name: secret.Name,
+					},
+					Server: fmt.Sprintf("%s://%s", vcURL.Scheme, vcURL.Host),
+				},
+			}
+			Expect(testEnv.Create(ctx, instance)).To(Succeed())
+
+			// Make sure the VSphereCluster exists.
+			key = client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}
+			Eventually(func() error {
+				return testEnv.Get(ctx, key, instance)
+			}, timeout).Should(BeNil())
+
+			By("setting the OwnerRef on the VSphereCluster")
+			Eventually(func() bool {
+				ph, err := patch.NewHelper(instance, testEnv)
+				Expect(err).ShouldNot(HaveOccurred())
+				instance.OwnerReferences = append(instance.OwnerReferences, metav1.OwnerReference{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String(), Name: capiCluster.Name, UID: "blah"})
+				Expect(ph.Patch(ctx, instance, patch.WithStatusObservedGeneration{})).ShouldNot(HaveOccurred())
+				return true
+			}, timeout).Should(BeTrue())
+
+			By("setting the VSphereCluster's VCenterAvailableCondition to true")
+			Eventually(func() bool {
+				if err := testEnv.Get(ctx, key, instance); err != nil {
+					return false
+				}
+				return conditions.IsTrue(instance, infrav1.VCenterAvailableCondition)
+			}, timeout).Should(BeTrue())
+
+			By("deleting the vspherecluster which has the secret with legacy finalizer")
+			Eventually(func() error {
+				return testEnv.Delete(ctx, instance)
+			}, timeout).Should(BeNil())
+			// confirm that the VSphereCluster is deleted
+			Eventually(func() bool {
+				err := testEnv.Get(ctx, key, instance)
+				return apierrors.IsNotFound(err)
+			}, timeout).Should(BeTrue())
+
+			By("checking that the secret is deleted")
+			secretKey := client.ObjectKey{Namespace: secret.Namespace, Name: secret.Name}
+			Eventually(func() bool {
+				err := testEnv.Get(ctx, secretKey, secret)
+				return apierrors.IsNotFound(err)
 			}, timeout).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR backports the secret deletion fix from `v1.1.0`. More more details, please refer to [this](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1486) PR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```