### PR TITLE
build: Support arm64 images

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ export DEV_TAG ?= dev
 The following make targets build and push a test image to your repository:
 
 ``` shell
-make docker-build docker-push
+make docker-push
 ```
 
 ### Generating clusterctl overrides

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -135,7 +135,7 @@ providers:
         files:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml"
           - sourcePath: "../../../metadata.yaml"
-      - name: v1.1.1
+      - name: v1.2.0
         # Use manifest from source files
         value: ../../../../cluster-api-provider-vsphere/config/default
         contract: v1beta1

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -71,7 +71,7 @@ providers:
   - name: vsphere
     type: InfrastructureProvider
     versions:
-      - name: v1.1.1
+      - name: v1.2.0
         # Use manifest from source files
         value: ../../../cluster-api-provider-vsphere/config/deployments/integration-tests
         contract: v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR uses buildx to create multi-platform images, both for amd64
and arm64. This enables creating bootstrap clusters on Macs with M1
chips, which require pulling arm64 based images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support running CAPV controller manager on arm64
```