### PR TITLE
Add notifier for CAPV credentials file

### DIFF
--- a/controllers/vmware/test/controllers_suite_test.go
+++ b/controllers/vmware/test/controllers_suite_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	goctx "context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -102,6 +104,16 @@ func getTestEnv() (*envtest.Environment, *rest.Config) {
 }
 
 func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
+	contentFmt := `username: '%s'
+	password: '%s'
+	`
+	tmpFile, err := os.CreateTemp("", "creds")
+	Expect(err).NotTo(HaveOccurred())
+
+	content := fmt.Sprintf(contentFmt, cfg.Username, cfg.Password)
+	_, err = tmpFile.Write([]byte(content))
+	Expect(err).NotTo(HaveOccurred())
+
 	opts := manager.Options{
 		Options: ctrlmgr.Options{
 			Scheme: scheme.Scheme,
@@ -113,6 +125,7 @@ func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
 		},
 		KubeConfig:      cfg,
 		NetworkProvider: networkProvider,
+		CredentialsFile: tmpFile.Name(),
 	}
 
 	opts.AddToManager = func(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.43.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1413,6 +1413,7 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"time"
 
+	"gopkg.in/fsnotify.v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
@@ -211,6 +212,16 @@ func main() {
 		setupLog.Error(err, "problem running controller manager")
 		os.Exit(1)
 	}
+
+	// initialize notifier for capv-manager-bootstrap-credentials
+	watch, err := manager.InitializeWatch(mgr.GetContext(), &managerOpts)
+	if err != nil {
+		setupLog.Error(err, "failed to initialize watch on CAPV credentials file")
+		os.Exit(1)
+	}
+	defer func(watch *fsnotify.Watcher) {
+		_ = watch.Close()
+	}(watch)
 }
 
 func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"gopkg.in/fsnotify.v1"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+)
+
+const (
+	username        = "abcd"
+	updatedUsername = "efgh"
+	password        = "pass"
+	updatedPassword = "ssap"
+)
+
+func TestManager_FileWatch(t *testing.T) {
+	g := NewWithT(t)
+	contentFmt := `---
+username: '%s'
+password: '%s'
+`
+	t.Run("update username & password for CAPV credentials", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "creds")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		managerOptsTest := &Options{
+			// needs an object ref to be present
+			CredentialsFile: tmpFile.Name(),
+			Username:        username,
+			Password:        password,
+		}
+
+		watch, err := InitializeWatch(fake.NewControllerManagerContext(), managerOptsTest)
+		// Match initial credentials
+		g.Expect(err).To(BeNil())
+		g.Expect(managerOptsTest.Username).To(Equal(username))
+		g.Expect(managerOptsTest.Password).To(Equal(password))
+
+		// Update the file and wait for watch to detect the change
+		content := fmt.Sprintf(contentFmt, updatedUsername, updatedPassword)
+		_, err = tmpFile.Write([]byte(content))
+		g.Expect(err).To(BeNil())
+
+		g.Eventually(func() bool {
+			return managerOptsTest.Username == updatedUsername && managerOptsTest.Password == updatedPassword
+		}, 10*time.Second).Should(BeTrue())
+
+		defer func(watch *fsnotify.Watcher) {
+			_ = watch.Close()
+		}(watch)
+	})
+
+	t.Run("send an error on watch error channel", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "creds")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		managerOptsTest := &Options{
+			// needs an object ref to be present
+			CredentialsFile: tmpFile.Name(),
+			Username:        username,
+			Password:        password,
+		}
+		watch, err := InitializeWatch(fake.NewControllerManagerContext(), managerOptsTest)
+		// Match initial credentials
+		g.Expect(err).To(BeNil())
+		g.Expect(managerOptsTest.Username).To(Equal(username))
+		g.Expect(managerOptsTest.Password).To(Equal(password))
+
+		t.Log("sending an error on the channel")
+		watch.Errors <- errors.Errorf("force failure")
+
+		// Update the file and wait for watch to detect the change
+		content := fmt.Sprintf(contentFmt, updatedUsername, updatedPassword)
+		if _, err := tmpFile.Write([]byte(content)); err != nil {
+			fmt.Printf("failed to update credentials in the file err:%s", err.Error())
+		}
+
+		g.Eventually(func() bool {
+			return managerOptsTest.Username == updatedUsername && managerOptsTest.Password == updatedPassword
+		}, 10*time.Second).Should(BeTrue())
+
+		defer func(watch *fsnotify.Watcher) {
+			_ = watch.Close()
+		}(watch)
+	})
+
+	t.Run("force fail the watch", func(t *testing.T) {
+		_, err := os.CreateTemp("", "creds")
+		if err != nil {
+			t.Fatal(err)
+		}
+		managerOptsTest := &Options{
+			// needs an object ref to be present
+			CredentialsFile: "fail",
+			Username:        username,
+			Password:        password,
+		}
+		_, err = InitializeWatch(fake.NewControllerManagerContext(), managerOptsTest)
+		// Match initial credentials
+		g.Expect(err).NotTo(BeNil())
+	})
+}

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -107,9 +107,7 @@ func (o *Options) defaults() {
 	}
 
 	if o.Username == "" || o.Password == "" {
-		credentials := o.getCredentials()
-		o.Username = credentials["username"]
-		o.Password = credentials["password"]
+		o.readAndSetCredentials()
 	}
 
 	if ns, ok := os.LookupEnv("POD_NAMESPACE"); ok {
@@ -137,4 +135,10 @@ func (o *Options) getCredentials() map[string]string {
 	}
 
 	return credentials
+}
+
+func (o *Options) readAndSetCredentials() {
+	credentials := o.getCredentials()
+	o.Username = credentials["username"]
+	o.Password = credentials["password"]
 }


### PR DESCRIPTION
Add filesystem watch on the file storing credentials for
capv-manager-bootstrap-credentials

Unit tests added

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: This PR adds a filesystem Watch for the CAPV bootstrap credentials that updates the file under /etc/capv/credentials.yaml. If there's any update the manager is updated accordingly through the Watch events notifier. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1275 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```