### PR TITLE
Add replace directive for `cluster-api` in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 
 go 1.17
 
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.3
+
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `replace` directive for `sigs.k8s.io/cluster-api`, which is required because of our dependence on the `cluster-api/test` package which uses a relative import for `cluster-api`. Reference: https://github.com/vmware-tanzu/tanzu-framework/issues/1590.

Currently, running `go mod tidy` / `make modules` or `go get -d ./...` returns (tested on go `1.16.0` and `1.17.0`):
```
go: sigs.k8s.io/cluster-api/test@v1.1.3 requires
        sigs.k8s.io/cluster-api@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
make: *** [Makefile:236: modules] Error 1
```

With this patch applied, we should no longer expect this outcome.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1509