### PR TITLE
🐛 Fixes logic to fetch credentials of remote cluster

### DIFF
--- a/controllers/svcdiscovery_controller_intg_test.go
+++ b/controllers/svcdiscovery_controller_intg_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -33,12 +31,10 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		initObjects []client.Object
 	)
 	BeforeEach(func() {
-		serviceDiscoveryTestSuite.SetIntegrationTestClient(testEnv.Manager.GetClient())
-		intCtx = serviceDiscoveryTestSuite.NewIntegrationTestContextWithClusters(goctx.Background(), testEnv.Manager.GetClient(), true)
+		intCtx = serviceDiscoveryTestSuite.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 	})
 	AfterEach(func() {
 		intCtx.AfterEach()
-		intCtx = nil
 	})
 
 	Context("When VIP is available", func() {

--- a/controllers/svcdiscovery_controller_unit_test.go
+++ b/controllers/svcdiscovery_controller_unit_test.go
@@ -22,21 +22,26 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1b1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/builder"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 )
 
 var _ = Describe("ServiceDiscoveryReconciler ReconcileNormal", serviceDiscoveryUnitTestsReconcileNormal)
 
 func serviceDiscoveryUnitTestsReconcileNormal() {
 	var (
-		ctx         *builder.UnitTestContextForController
-		initObjects []client.Object
+		ctx            *builder.UnitTestContextForController
+		vsphereCluster vmwarev1b1.VSphereCluster
+		initObjects    []client.Object
 	)
+	namespace := capiutil.RandomString(6)
 	JustBeforeEach(func() {
-		ctx = serviceDiscoveryTestSuite.NewUnitTestContextForController(initObjects...)
+		vsphereCluster = fake.NewVSphereCluster(namespace)
+		ctx = serviceDiscoveryTestSuite.NewUnitTestContextForController(namespace, &vsphereCluster, initObjects...)
 	})
 	JustAfterEach(func() {
 		ctx = nil

--- a/pkg/builder/flags.go
+++ b/pkg/builder/flags.go
@@ -32,10 +32,6 @@ type TestFlags struct {
 	// flag.
 	// Defaults to false.
 	IntegrationTestsEnabled bool
-
-	// unitTestsEnabled is set to true with the -enable-unit-tests flag.
-	// Defaults to true.
-	UnitTestsEnabled bool
 }
 
 var flags TestFlags
@@ -60,7 +56,6 @@ func init() {
 		i++
 	}
 	cmdLine.BoolVar(&flags.IntegrationTestsEnabled, "enable-integration-tests", false, "Enables integration tests")
-	cmdLine.BoolVar(&flags.UnitTestsEnabled, "enable-unit-tests", true, "Enables unit tests")
 	_ = cmdLine.Parse(args)
 
 	// We still need to add the flags to the default flagset, because otherwise

--- a/pkg/builder/unit_test_context.go
+++ b/pkg/builder/unit_test_context.go
@@ -39,20 +39,20 @@ type UnitTestContextForController struct {
 
 	VirtualMachineImage *vmoprv1.VirtualMachineImage
 
-	// reconciler is the builder.Reconciler being unit tested.
+	// Reconciler is the builder.Reconciler being unit tested.
 	Reconciler Reconciler
 }
 
 // NewUnitTestContextForController returns a new UnitTestContextForController
 // with an optional prototype cluster for unit testing controllers that do not
 // invoke the VSphereCluster spec controller.
-func NewUnitTestContextForController(newReconcilerFn NewReconcilerFunc, vSphereCluster *vmwarev1.VSphereCluster,
+func NewUnitTestContextForController(newReconcilerFn NewReconcilerFunc, namespace string, vSphereCluster *vmwarev1.VSphereCluster,
 	prototypeCluster bool, initObjects, gcInitObjects []client.Object) *UnitTestContextForController {
 	reconciler := newReconcilerFn()
 	ctx := &UnitTestContextForController{
 		GuestClusterContext: fake.NewGuestClusterContext(fake.NewVmwareClusterContext(
 			fake.NewControllerContext(
-				fake.NewControllerManagerContext(initObjects...)), vSphereCluster), prototypeCluster, gcInitObjects...),
+				fake.NewControllerManagerContext(initObjects...)), namespace, vSphereCluster), prototypeCluster, gcInitObjects...),
 		Reconciler: reconciler,
 	}
 	ctx.Key = client.ObjectKey{Namespace: ctx.VSphereCluster.Namespace, Name: ctx.VSphereCluster.Name}

--- a/pkg/context/fake/fake_util.go
+++ b/pkg/context/fake/fake_util.go
@@ -23,10 +23,10 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 )
 
-func NewVSphereCluster() vmwarev1.VSphereCluster {
+func NewVSphereCluster(namespace string) vmwarev1.VSphereCluster {
 	return vmwarev1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: Namespace,
+			Namespace: namespace,
 			Name:      VSphereClusterName,
 			UID:       VSphereClusterUUID,
 		},

--- a/pkg/context/fake/fake_vmware_cluster_context.go
+++ b/pkg/context/fake/fake_vmware_cluster_context.go
@@ -24,11 +24,11 @@ import (
 
 // NewVmwareClusterContext returns a fake ClusterContext for unit testing
 // reconcilers with a fake client.
-func NewVmwareClusterContext(ctx *context.ControllerContext, vsphereCluster *infrav1.VSphereCluster) *vmware.ClusterContext {
+func NewVmwareClusterContext(ctx *context.ControllerContext, namespace string, vsphereCluster *infrav1.VSphereCluster) *vmware.ClusterContext {
 	// Create the cluster resources.
 	cluster := newClusterV1()
 	if vsphereCluster == nil {
-		v := NewVSphereCluster()
+		v := NewVSphereCluster(namespace)
 		vsphereCluster = &v
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update the logic to get remote cluster config using the name of the CAPI cluster. This was working previously since there was an assumption that the name of the `Cluster` and `VSphereCluster` object is the same which has changed with the advent of `ClusterClass`.
- Updates the provider service account and service discovery controllers to work with different names of cluster and infra cluster objects.

**Which issue(s) this PR fixes** :
Fixes #1514 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes logic to fetch credentials of remote cluster
```