### PR TITLE
Start the Keep Alive handler for VSphere client used in e2e tests

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -187,6 +187,7 @@ intervals:
   default/wait-worker-nodes: ["10m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
-  default/wait-machine-remediation: ["5m", "10s"]
+  default/wait-machine-remediation: ["15m", "10s"]
+  mhc-remediation/mhc-remediation: ["30m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]
   node-drain/wait-machine-deleted: ["2m", "10s"]

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -160,6 +160,7 @@ var _ = SynchronizedAfterSuite(func() {
 }, func() {
 	// After all ParallelNodes.
 
+	By("Cleaning up the vSphere session", terminateVSphereSession)
 	By("Tearing down the management cluster")
 	if !skipCleanup {
 		helpers.TearDown(bootstrapClusterProvider, bootstrapClusterProxy)


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of the e2e test runs on testgrid keep failing due to failures in the test listed in `storage_policy_test.go` file. The reason for the failure is that the govmomi Client object we use to assert some conditions times out due to inactivity. As part of an earlier PR, a `Keep-Alive` handler was added to the client which did not seem to solve the issue. The reason was that the groutine for the handler needs an explicit call to `client.Login()` method to get activated. 

This patch slightly modifies the creation of the govmomi Client object and adds an explicit call to login after adding the keep alive handler and also logs out the session once the test is finished.

**Which issue(s) this PR fixes**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```