### PR TITLE
🌱 Clean up stale nodes left behind on a workload cluster

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -154,9 +154,6 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 				ctx.Logger.Error(err, "Failed to delete for VSphereMachine", "namespace", vsphereMachine.Namespace, "name", vsphereMachine.Name)
 				deletionErrors = append(deletionErrors, err)
 			}
-
-			// Attempt to delete the node corresponding to the vsphereMachine
-			r.deleteNode(ctx, vsphereMachine.Name)
 		}
 	}
 	if len(deletionErrors) > 0 {
@@ -203,18 +200,6 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 	ctrlutil.RemoveFinalizer(ctx.VSphereCluster, infrav1.ClusterFinalizer)
 
 	return reconcile.Result{}, nil
-}
-
-func (r clusterReconciler) deleteNode(ctx *context.ClusterContext, name string) {
-	node := &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-	// Attempt to delete the corresponding node, silently fail on error
-	if err := r.Client.Delete(ctx, node); err != nil {
-		r.Logger.V(4).Info("Unable to delete node ", "node", name)
-	}
 }
 
 func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconcile.Result, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Reaped nodes by MHC show up in the output of `kubectl get nodes` 

The name of the k8s node is same to the name of the owning CAPI Machine. We implemented a workaround that post the deletion of the VSphereMachine, we get the workload cluster k8s client and attempt to delete the node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1519 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```