### PR TITLE
Move the `keep-alive` functionality out of the feature flag (+ deprecate the flag)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,6 @@ spec:
         - --enable-leader-election
         - --logtostderr
         - --v=4
-        - --enable-keep-alive
         image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -294,7 +294,6 @@ func (r clusterReconciler) reconcileVCenterConnectivity(ctx *context.ClusterCont
 		WithServer(ctx.VSphereCluster.Spec.Server).
 		WithThumbprint(ctx.VSphereCluster.Spec.Thumbprint).
 		WithFeatures(session.Feature{
-			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -226,7 +226,6 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx *context.VSphereD
 		WithDatacenter(ctx.VSphereFailureDomain.Spec.Topology.Datacenter).
 		WithUserInfo(r.ControllerContext.Username, r.ControllerContext.Password).
 		WithFeatures(session.Feature{
-			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -382,7 +382,6 @@ func (r *vmReconciler) retrieveVcenterSession(ctx goctx.Context, vsphereVM *infr
 		WithUserInfo(r.ControllerContext.Username, r.ControllerContext.Password).
 		WithThumbprint(vsphereVM.Spec.Thumbprint).
 		WithFeatures(session.Feature{
-			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, vsphereVM.ObjectMeta)

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 		&managerOpts.EnableKeepAlive,
 		"enable-keep-alive",
 		defaultEnableKeepAlive,
-		"feature to enable keep alive handler in vsphere sessions")
+		"DEPRECATED: feature to enable keep alive handler in vsphere sessions. This functionality is enabled by default now")
 
 	flag.DurationVar(
 		&managerOpts.KeepAliveDuration,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We now use the `keep-alive` functionality by default, eliminating the need for it to be an opt-in flag. Thus this PR:
- [x] Deprecates the `--enable-keep-alive` command line flag.
- [x] Decouples the `keep-alive` functionality from the feature flag and removes the flag from the session-management feature config.
- [x] Updates controller-manager deployment manifests to reflect the flag's removal.


**Which issue(s) this PR fixes**
Fixes #1520

