### PR TITLE
chore: Fix reference link in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # If you update this file, please follow
-# https://suva.sh/posts/well-documented-makefiles
+# https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
 # Ensure Make is run with bash shell as some syntax below is bash-specific
 SHELL := /usr/bin/env bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Our makefile links to a blog on writing well-documented makefiles. This blog was moved to a new location recently, breaking our reference.
