### PR TITLE
chore: Add apidiff target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ GOVC := $(TOOLS_BIN_DIR)/govc
 KIND := $(TOOLS_BIN_DIR)/kind
 KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/conversion-verifier)
-TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER)
+GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
+TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF)
 ARTIFACTS_PATH := $(ROOT_DIR)/_artifacts
 
 # Set --output-base for conversion-gen if we are not within GOPATH
@@ -226,6 +227,12 @@ lint-shell: ## Lint the project's shell scripts
 .PHONY: fix
 fix: GOLANGCI_LINT_FLAGS = --fast=false --fix
 fix: lint-go ## Tries to fix errors reported by lint-go-full target
+
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+
+.PHONY: apidiff
+apidiff: $(GO_APIDIFF) ## Run the apidiff tool
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
 ## --------------------------------------
 ## Generate

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -43,6 +43,7 @@ KIND := $(BIN_DIR)/kind
 GOVC := $(BIN_DIR)/govc
 GINKGO := $(BIN_DIR)/ginkgo
 CONVERSION_VERIFIER := $(BIN_DIR)/conversion-verifier
+APIDIFF := $(BIN_DIR)/go-apidiff
 
 ## --------------------------------------
 ## Help
@@ -86,6 +87,10 @@ $(KUSTOMIZE): go.mod
 conversion-verifier: $(CONVERSION_VERIFIER) $(SRCS) ## fetch CAPI's conversion verifier
 $(CONVERSION_VERIFIER): go.mod
 	go build -tags=tools -o $@ sigs.k8s.io/cluster-api/hack/tools/conversion-verifier
+
+go-apidiff: $(APIDIFF) $(SRCS) ## Build go-apidiff
+$(APIDIFF): go.mod
+	go build -tags=tools -o $@ github.com/joelanford/go-apidiff
 
 ## --------------------------------------
 ## Generate

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/golangci/golangci-lint v1.44.0
+	github.com/joelanford/go-apidiff v0.1.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/vmware/govmomi v0.23.1
 	k8s.io/code-generator v0.22.2

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,6 @@
+//go:build tools
+// +build tools
+
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -14,14 +17,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:build tools
-// +build tools
-
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/joelanford/go-apidiff"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "github.com/vmware/govmomi"
 	_ "github.com/vmware/govmomi/govc/flags"


### PR DESCRIPTION
**What this PR does / why we need it**:
We were lacking a target to generate apidiffs in our Makefile. Upstream, CAPI already had such a target referenced in the parent issue. This target will make it c convenient to check for and keep track of our public API changes.

**Special notes for your reviewer**:
`apidiff` might report `git tree is dirty` in Windows environments. I've reproduced this on CAPI, and its likely either an issue with my environment or an upstream issue in [joelanford/go-apidiff](https://github.com/joelanford/go-apidiff). I've verified that this PR works in clean UNIX environments and will investigate the issue independent of this PR.

**Which issue(s) this PR fixes**
Fixes #1445
