### PR TITLE
🌱 Add script to run go-apidiff in a CI context

### DIFF
--- a/hack/ci-apidiff.sh
+++ b/hack/ci-apidiff.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+cd "${REPO_ROOT}"
+
+echo "*** Running go-apidiff ***"
+APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a script that runs our new `apidiff` make target. We'll need this
script to run apidiff as a prowjob.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1445

**Special notes for your reviewer**:
#1525 added the make target. I'm opening a PR in `kubernetes/test-infra` to add apidiff as one of our optional PR jobs.
