### PR TITLE
🌱 Updates CAPV manager cluster role

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -21,6 +21,7 @@ patchesStrategicMerge:
   - manager_credentials_patch.yaml
   - manager_webhook_patch.yaml
   - webhookcainjection_patch.yaml
+  - manager_role_aggregation_patch.yaml
     # Protect the /metrics endpoint by putting it behind auth.
     # Only one of manager_auth_proxy_patch.yaml and
     # manager_prometheus_metrics_patch.yaml should be enabled.

--- a/config/base/manager_role_aggregation_patch.yaml
+++ b/config/base/manager_role_aggregation_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    capv.infrastucture.cluster.x-k8s.io/aggregate-to-manager: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-manager-role

--- a/config/rbac/aggregate_kcp_label_to_clusterrole_patch.yaml
+++ b/config/rbac/aggregate_kcp_label_to_clusterrole_patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: manager-role
-  labels:
-    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"

--- a/config/rbac/aggregate_labels.yaml
+++ b/config/rbac/aggregate_labels.yaml
@@ -3,4 +3,5 @@ kind: ClusterRole
 metadata:
   name: manager-role
   labels:
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
     cluster.x-k8s.io/aggregate-to-manager: "true"

--- a/config/rbac/aggregate_role.yaml
+++ b/config/rbac/aggregate_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregated-manager-role
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        capv.infrastucture.cluster.x-k8s.io/aggregate-to-manager: "true"
+rules: []

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- aggregate_role.yaml
 patchesStrategicMerge:
-- aggregate_label_to_cluster_role_patch.yaml
-- aggregate_kcp_label_to_clusterrole_patch.yaml
+- aggregate_labels.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -99,15 +99,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - bootstrap.cluster.x-k8s.io
-  resources:
-  - kubeadmconfigtemplates
-  verbs:
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters
@@ -394,6 +385,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - vmware.infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclustertemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - vmware.infrastructure.cluster.x-k8s.io
   resources:

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -55,16 +55,13 @@ type ClusterReconciler struct {
 
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclustertemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmware.com,resources=virtualnetworks;virtualnetworks/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies;virtualmachinesetresourcepolicies/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices;virtualmachineservices/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=netoperator.vmware.com,resources=networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;create;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims/status,verbs=get;update;patch
-
-// TODO: Remove once we have a version of CAPI with https://github.com/kubernetes-sigs/cluster-api/issues/1775 fixed
-// +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates,verbs=get;list;delete
-// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,verbs=get;list;delete;watch
 
 func (r ClusterReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := r.Logger.WithName(req.Namespace).WithName(req.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds an aggregration rule for the CAPV manager role which can be used to add permissions to the CAPV manager ClusterRole on the fly. External clients such as addons providers for CPI/CSI can use this label to add permissions to the manager dynamically, thereby reducing the need to  hardcode these permissions in CAPV.
It also cleans up the patch files to add the CAPI and KCP aggregation labels to the CAPV manager role.

**Which issue(s) this PR fixes**:
Fixes #1526 
Fixes #1523 

**Special notes for the reviewer**:
The aggregation rule will help the clients creating ProviderServiceAccount objects to add the permissions specified in the `spec.Rules` field to the CAPV manager ClusterRole. Without these permissions, the CAPV manager fails to create the role and role binding during the reconciliation of the `ProviderServiceAccount` object.

**Release note**:
```release-note
Adds aggregation rule to the CAPV manager ClusterRole
```