### PR TITLE
🌱 Moves vcsim builder code to remove cyclic dependency

### DIFF
--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 const (
@@ -716,11 +717,11 @@ func deploymentZone(server, fdName string, cp, ready *bool) *infrav1.VSphereDepl
 	}
 }
 
-func startVcenter() *helpers.Simulator {
+func startVcenter() *vcsim.Simulator {
 	model := simulator.VPX()
 	model.Pool = 1
 
-	simr, err := helpers.VCSimBuilder().WithModel(model).Build()
+	simr, err := vcsim.NewBuilder().WithModel(model).Build()
 	if err != nil {
 		panic(fmt.Sprintf("unable to create simulator %s", err))
 	}

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 //nolint:paralleltest
@@ -44,7 +44,7 @@ func ForComputeClusterZone(t *testing.T) {
 	model := simulator.VPX()
 	model.Cluster = 2
 
-	simr, err := helpers.VCSimBuilder().
+	simr, err := vcsim.NewBuilder().
 		WithModel(model).
 		WithOperations("tags.category.create k8s-region",
 			"tags.create -c k8s-region k8s-region-west",
@@ -126,7 +126,7 @@ func ForHostGroupZone(t *testing.T) {
 	model := simulator.VPX()
 	model.Cluster = 2
 
-	simr, err := helpers.VCSimBuilder().
+	simr, err := vcsim.NewBuilder().
 		WithModel(model).
 		WithOperations("tags.category.create k8s-region",
 			"tags.create -c k8s-region k8s-region-west",
@@ -203,7 +203,7 @@ func ForHostGroupZone(t *testing.T) {
 }
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *testing.T) {
-	simr, err := helpers.VCSimBuilder().
+	simr, err := vcsim.NewBuilder().
 		WithOperations("cluster.group.create -cluster DC0_C0 -name group-one -host DC0_C0_H0 DC0_C0_H1",
 			"cluster.group.create -cluster DC0_C0 -name group-two -host DC0_C0_H2").
 		Build()

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -37,12 +37,12 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 	var (
-		simr *helpers.Simulator
+		simr *vcsim.Simulator
 		ctx  goctx.Context
 
 		failureDomainKey, deploymentZoneKey client.ObjectKey
@@ -56,7 +56,7 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 		model.Pool = 1
 
 		var err error
-		simr, err = helpers.VCSimBuilder().
+		simr, err = vcsim.NewBuilder().
 			WithModel(model).
 			WithOperations().
 			Build()
@@ -314,7 +314,7 @@ func TestVSphereDeploymentZone_Reconcile(t *testing.T) {
 	model := simulator.VPX()
 	model.Pool = 1
 
-	simr, err := helpers.VCSimBuilder().
+	simr, err := vcsim.NewBuilder().
 		WithModel(model).
 		WithOperations().
 		Build()
@@ -540,7 +540,7 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 			model.Cluster = 2
 			model.Pool = 2
 
-			simr, err := helpers.VCSimBuilder().
+			simr, err := vcsim.NewBuilder().
 				WithModel(model).
 				Build()
 			if err != nil {

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
@@ -44,7 +44,7 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 	model := simulator.VPX()
 	model.Host = 0
 
-	simr, err := helpers.VCSimBuilder().WithModel(model).Build()
+	simr, err := vcsim.NewBuilder().WithModel(model).Build()
 	if err != nil {
 		t.Fatalf("unable to create simulator: %s", err)
 	}
@@ -209,7 +209,7 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 	model := simulator.VPX()
 	model.Host = 0
 
-	simr, err := helpers.VCSimBuilder().WithModel(model).Build()
+	simr, err := vcsim.NewBuilder().WithModel(model).Build()
 	if err != nil {
 		t.Fatalf("unable to create simulator: %s", err)
 	}

--- a/pkg/services/govmomi/cluster/rule_test.go
+++ b/pkg/services/govmomi/cluster/rule_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func TestVerifyAffinityRule(t *testing.T) {
 	g := NewWithT(t)
-	sim, err := helpers.VCSimBuilder().
+	sim, err := vcsim.NewBuilder().
 		WithOperations("cluster.group.create -cluster DC0_C0 -name blah-vm-group -vm",
 			"cluster.group.create -cluster DC0_C0 -name blah-host-group -host DC0_C0_H0 DC0_C0_H1",
 			"cluster.rule.create -name blah-rule -enable -mandatory -vm-host -vm-group blah-vm-group -host-affine-group blah-host-group").

--- a/pkg/services/govmomi/cluster/service_test.go
+++ b/pkg/services/govmomi/cluster/service_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func TestListHostsFromGroup(t *testing.T) {
 	g := NewWithT(t)
-	sim, err := helpers.VCSimBuilder().
+	sim, err := vcsim.NewBuilder().
 		WithOperations("cluster.group.create -cluster DC0_C0 -name test_grp_1 -host DC0_C0_H0 DC0_C0_H1",
 			"cluster.group.create -cluster DC0_C0 -name test_grp_2 -host DC0_C0_H1").
 		Build()

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func Test_VMGroup(t *testing.T) {
 	g := NewWithT(t)
-	sim, err := helpers.VCSimBuilder().
+	sim, err := vcsim.NewBuilder().
 		WithOperations("cluster.group.create -cluster DC0_C0 -name blah-vm-group -vm DC0_C0_RP0_VM0 DC0_C0_RP0_VM1").
 		Build()
 	g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -25,7 +25,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 //nolint:forcetypeassert
@@ -33,7 +33,7 @@ func TestCreate(t *testing.T) {
 	model := simulator.VPX()
 	model.Host = 0 // ClusterHost only
 
-	simr, err := helpers.VCSimBuilder().WithModel(model).Build()
+	simr, err := vcsim.NewBuilder().WithModel(model).Build()
 	if err != nil {
 		t.Fatalf("unable to create simulator: %s", err)
 	}

--- a/pkg/services/govmomi/find/object_test.go
+++ b/pkg/services/govmomi/find/object_test.go
@@ -31,7 +31,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/find"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 const TestHostGroup = "host-group-alpha"
@@ -112,12 +112,12 @@ func TestObjectFunc(t *testing.T) {
 
 // setupSimulatorAndSession sets up a VC Simulator and a session.Session that connects to it.
 // The function also returns a resourceCount instance as a convenient reference of resource counts to test against.
-func setupSimulatorAndSession(model *simulator.Model) (*helpers.Simulator, *session.Session, resourceCount, error) {
+func setupSimulatorAndSession(model *simulator.Model) (*vcsim.Simulator, *session.Session, resourceCount, error) {
 	setupCommands := []string{
 		fmt.Sprintf("cluster.group.create -name %s -cluster DC0_C0 -host DC0_C0_H0 DC0_C0_H1", TestHostGroup),
 	}
 
-	sim, err := helpers.VCSimBuilder().WithOperations(setupCommands...).WithModel(model).Build()
+	sim, err := vcsim.NewBuilder().WithOperations(setupCommands...).WithModel(model).Build()
 	if err != nil {
 		return sim, nil, resourceCount{}, err
 	}
@@ -153,7 +153,7 @@ func setupSimulatorAndSession(model *simulator.Model) (*helpers.Simulator, *sess
 }
 
 // countResources counts resources relevant to testing find.ObjectFunc into a resourceCount struct.
-func countResources(sim *helpers.Simulator, session *session.Session) (resources resourceCount, err error) {
+func countResources(sim *vcsim.Simulator, session *session.Session) (resources resourceCount, err error) {
 	defaultDc, err := session.Finder.DefaultDatacenter(context.Background())
 	if err != nil {
 		return resources, err

--- a/pkg/services/govmomi/metadata/metadata_suite_test.go
+++ b/pkg/services/govmomi/metadata/metadata_suite_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func TestMetadata(t *testing.T) {
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	sim *helpers.Simulator
+	sim *vcsim.Simulator
 	ctx *context.VMContext
 
 	existingCategoryID string
@@ -135,7 +135,7 @@ var _ = Describe("Metadata_CreateTag", func() {
 })
 
 func configureSimulatorAndContext() (err error) {
-	sim, err = helpers.VCSimBuilder().Build()
+	sim, err = vcsim.NewBuilder().Build()
 	if err != nil {
 		return
 	}

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -53,6 +53,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
 
 func init() {
@@ -61,7 +62,7 @@ func init() {
 
 	// use klog as the internal logger for this envtest environment.
 	log.SetLogger(logger)
-	// additionally force all of the controllers to use the Ginkgo logger.
+	// Additionally, force all the controllers to use the Ginkgo logger.
 	ctrl.SetLogger(logger)
 	// add logger for ginkgo
 	klog.SetOutput(ginkgo.GinkgoWriter)
@@ -109,7 +110,7 @@ type (
 		manager.Manager
 		client.Client
 		Config    *rest.Config
-		Simulator *Simulator
+		Simulator *vcsim.Simulator
 
 		cancel goctx.CancelFunc
 	}
@@ -127,7 +128,7 @@ func NewTestEnvironment() *TestEnvironment {
 
 	model := simulator.VPX()
 	model.Pool = 1
-	simr, err := VCSimBuilder().
+	simr, err := vcsim.NewBuilder().
 		WithModel(model).
 		Build()
 	if err != nil {

--- a/test/helpers/vcsim/builder.go
+++ b/test/helpers/vcsim/builder.go
@@ -14,43 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package helpers
+package vcsim
 
 import (
 	"crypto/tls"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/onsi/gomega/gbytes"
 	"github.com/vmware/govmomi/simulator"
-
-	// run init func to register the tagging API endpoints.
-	_ "github.com/vmware/govmomi/vapi/simulator"
 )
-
-type Simulator struct {
-	model  *simulator.Model
-	server *simulator.Server
-}
-
-func (s Simulator) Destroy() {
-	s.server.Close()
-	s.model.Remove()
-}
-
-func (s Simulator) ServerURL() *url.URL {
-	return s.server.URL
-}
 
 type Builder struct {
 	model      *simulator.Model
 	operations []string
 }
 
-func VCSimBuilder() *Builder {
+func NewBuilder() *Builder {
 	return &Builder{model: simulator.VPX()}
 }
 
@@ -108,21 +90,4 @@ func govcCommand(govcURL, commandStr string, buffers ...*gbytes.Buffer) *exec.Cm
 		cmd.Stderr = buffers[1]
 	}
 	return cmd
-}
-
-func (s Simulator) Run(commandStr string, buffers ...*gbytes.Buffer) error {
-	pwd, _ := s.server.URL.User.Password()
-	govcURL := fmt.Sprintf("https://%s:%s@%s", s.server.URL.User.Username(), pwd, s.server.URL.Host)
-
-	cmd := govcCommand(govcURL, commandStr, buffers...)
-	return cmd.Run()
-}
-
-func (s Simulator) Username() string {
-	return s.server.URL.User.Username()
-}
-
-func (s Simulator) Password() string {
-	pwd, _ := s.server.URL.User.Password()
-	return pwd
 }

--- a/test/helpers/vcsim/simulator.go
+++ b/test/helpers/vcsim/simulator.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcsim
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/vmware/govmomi/simulator"
+
+	// run init func to register the tagging API endpoints.
+	_ "github.com/vmware/govmomi/vapi/simulator"
+)
+
+type Simulator struct {
+	model  *simulator.Model
+	server *simulator.Server
+}
+
+func (s Simulator) Destroy() {
+	s.server.Close()
+	s.model.Remove()
+}
+
+func (s Simulator) ServerURL() *url.URL {
+	return s.server.URL
+}
+
+func (s Simulator) Run(commandStr string, buffers ...*gbytes.Buffer) error {
+	pwd, _ := s.server.URL.User.Password()
+	govcURL := fmt.Sprintf("https://%s:%s@%s", s.server.URL.User.Username(), pwd, s.server.URL.Host)
+
+	cmd := govcCommand(govcURL, commandStr, buffers...)
+	return cmd.Run()
+}
+
+func (s Simulator) Username() string {
+	return s.server.URL.User.Username()
+}
+
+func (s Simulator) Password() string {
+	pwd, _ := s.server.URL.User.Password()
+	return pwd
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch moves the vcsim builder to a different package under `test/helpers` directory to remove cyclic dependency/

**Which issue(s) this PR fixes**:
Fixes the issue raised in the [PR comment](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1336#issuecomment-1121405785)

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```