### PR TITLE
🌱 Adds CM environment variables to CAPV manifest

### DIFF
--- a/config/supervisor/add-configmap-env-vars.yaml
+++ b/config/supervisor/add-configmap-env-vars.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+          - name: SERVICE_ACCOUNTS_CM_NAMESPACE
+            value: ${SERVICE_ACCOUNTS_CM_NAMESPACE}
+          - name: SERVICE_ACCOUNTS_CM_NAME
+            value: ${SERVICE_ACCOUNTS_CM_NAME}

--- a/config/supervisor/kustomization.yaml
+++ b/config/supervisor/kustomization.yaml
@@ -15,3 +15,6 @@ resources:
   - crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
   - crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
   - crd/vmware.infrastructure.cluster.x-k8s.io_providerserviceaccounts.yaml
+
+patchesStrategicMerge:
+  - add-configmap-env-vars.yaml

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -85,5 +85,7 @@ providers:
 variables:
   VSPHERE_PASSWORD: "admin123"
   VSPHERE_USERNAME: "admin123"
+  SERVICE_ACCOUNTS_CM_NAMESPACE: "foo-system"
+  SERVICE_ACCOUNTS_CM_NAME: "foo"
 intervals:
   default/wait-controllers: ["5m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds the required environment variables to the `capv-controller-manager` Deployment used by the ProviderServiceAccount reconciliation loop to lookup the name and namespace of the Configmap to add the ServiceAccount info to.

**Which issue(s) this PR fixes**:
Fixes #1533 

**Special notes for your reviewer**:
This PR makes changes to the deployment manifest that gets generated for the supervisor types.

**Release note**:
```release-note
Adds CM environment variables to CAPV deployment for Supervisor types
```