### PR TITLE
🌱 Bump kube-vip to v0.4.2

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -339,7 +339,7 @@ func kubeVIPPodSpec() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:            "kube-vip",
-					Image:           "ghcr.io/kube-vip/kube-vip:v0.4.1",
+					Image:           "ghcr.io/kube-vip/kube-vip:v0.4.2",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args: []string{
 						"manager",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the `kube-vip` version to `v0.4.2`. More details about this version [here](https://github.com/kube-vip/kube-vip/releases/tag/v0.4.2)

**Which issue(s) this PR fixes**:
Fixes #1528 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump kube-vip to v0.4.2
```