### PR TITLE
🌱 Adds release 1.2.0 to metadata file

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,3 +27,6 @@ releaseSeries:
   - major: 1
     minor: 1
     contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds entry for release v1.2.0 to metadata file

**Release note**:
```release-note
NONE
```