### PR TITLE
🐛 Fixes nil reference for logger

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -181,7 +181,7 @@ func (r machineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctr
 		return reconcile.Result{}, err
 	}
 	if machine == nil {
-		r.Logger.V(2).Info("waiting on Machine controller to set OwnerRef on infra machine")
+		logger.V(2).Info("waiting on Machine controller to set OwnerRef on infra machine")
 		return reconcile.Result{}, nil
 	}
 
@@ -200,7 +200,7 @@ func (r machineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctr
 		ControllerContext: r.ControllerContext,
 		Cluster:           cluster,
 		Machine:           machine,
-		Logger:            r.Logger.WithName(req.Namespace).WithName(req.Name),
+		Logger:            logger,
 		PatchHelper:       patchHelper,
 	})
 	// always patch the VSphereMachine object
@@ -231,9 +231,9 @@ func (r machineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctr
 	}
 
 	// Fetch the VSphereCluster and update the machine context
-	machineContext, err = r.VMService.FetchVSphereCluster(r.Client, cluster, r.ControllerContext, machineContext)
+	machineContext, err = r.VMService.FetchVSphereCluster(r.Client, cluster, machineContext)
 	if err != nil {
-		r.Logger.Info("unable to retrieve VSphereCluster", "error", err)
+		logger.Info("unable to retrieve VSphereCluster", "error", err)
 		return reconcile.Result{}, nil
 	}
 
@@ -355,7 +355,7 @@ func (r *machineReconciler) setVMModifiers(c context.MachineContext) error {
 		// No need to check the type. We know this will be a VirtualMachine
 		vm, _ := obj.(*vmoprv1.VirtualMachine)
 		ctx.Logger.V(3).Info("Applying network config to VM", "vm-name", vm.Name)
-		err := r.networkProvider.ConfigureVirtualMachine(ctx.ClusterContext, vm)
+		err := r.networkProvider.ConfigureVirtualMachine(ctx.GetClusterContext(), vm)
 		if err != nil {
 			return nil, errors.Errorf("failed to configure machine network: %+v", err)
 		}

--- a/pkg/context/vmware/machine_context.go
+++ b/pkg/context/vmware/machine_context.go
@@ -33,7 +33,6 @@ type VMModifier func(runtime.Object) (runtime.Object, error)
 // SupervisorMachineContext is a Go context used with a VSphereMachine.
 type SupervisorMachineContext struct {
 	*context.BaseMachineContext
-	ClusterContext *ClusterContext
 	VSphereCluster *vmwarev1.VSphereCluster
 	VSphereMachine *vmwarev1.VSphereMachine
 	VMModifiers    []VMModifier
@@ -55,6 +54,15 @@ func (c *SupervisorMachineContext) GetVSphereMachine() context.VSphereMachine {
 
 func (c *SupervisorMachineContext) GetObjectMeta() v1.ObjectMeta {
 	return c.VSphereMachine.ObjectMeta
+}
+
+func (c *SupervisorMachineContext) GetClusterContext() *ClusterContext {
+	return &ClusterContext{
+		ControllerContext: c.ControllerContext,
+		Cluster:           c.Cluster,
+		VSphereCluster:    c.VSphereCluster,
+		Logger:            c.GetLogger(),
+	}
 }
 
 func (c *SupervisorMachineContext) SetBaseMachineContext(base *context.BaseMachineContext) {

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -31,7 +31,7 @@ import (
 // VSphereMachineService is used for vsphere VM lifecycle and syncing with VSphereMachine types.
 type VSphereMachineService interface {
 	FetchVSphereMachine(client client.Client, name types.NamespacedName) (context.MachineContext, error)
-	FetchVSphereCluster(client client.Client, cluster *clusterv1.Cluster, controllerContext *context.ControllerContext, machineContext context.MachineContext) (context.MachineContext, error)
+	FetchVSphereCluster(client client.Client, cluster *clusterv1.Cluster, machineContext context.MachineContext) (context.MachineContext, error)
 	ReconcileDelete(ctx context.MachineContext) error
 	SyncFailureReason(ctx context.MachineContext) (bool, error)
 	ReconcileNormal(ctx context.MachineContext) (bool, error)

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -49,7 +49,7 @@ func (v *VimMachineService) FetchVSphereMachine(c client.Client, name types.Name
 	return &context.VIMMachineContext{VSphereMachine: vsphereMachine}, err
 }
 
-func (v *VimMachineService) FetchVSphereCluster(c client.Client, cluster *clusterv1.Cluster, controllerContext *context.ControllerContext, machineContext context.MachineContext) (context.MachineContext, error) {
+func (v *VimMachineService) FetchVSphereCluster(c client.Client, cluster *clusterv1.Cluster, machineContext context.MachineContext) (context.MachineContext, error) {
 	ctx, ok := machineContext.(*context.VIMMachineContext)
 	if !ok {
 		return nil, errors.New("received unexpected VIMMachineContext type")

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -173,7 +173,6 @@ func CreateMachineContext(clusterContext *vmware.ClusterContext, machine *cluste
 			Machine: machine,
 			Cluster: clusterContext.Cluster,
 		},
-		ClusterContext: clusterContext,
 		VSphereCluster: clusterContext.VSphereCluster,
 		VSphereMachine: vsphereMachine,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the nil reference for logger in the network provider which was causing the controllers to panic.

**Which issue(s) this PR fixes**:
Fixes #1543 

**Special notes for your reviewer**:
Instead of creating the `ClusterContext` while fetching the object, this patch creates a `ClusterContext` which gets returned when the `GetClusterContext()` method gets called.

**Release note**:
```release-note
Fixes nil reference for logger in network provider
```