### PR TITLE
Fix flake in unit tests for the `services/govmomi` package

### DIFF
--- a/pkg/services/govmomi/create.go
+++ b/pkg/services/govmomi/create.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/vcenter"
 )
 
+// createVM creates a new VM with the data in the VMContext passed. This method does not wait
+// for the new VM to be created.
 func createVM(ctx *context.VMContext, bootstrapData []byte) error {
 	if ctx.Session.IsVC() {
 		return vcenter.Clone(ctx, bootstrapData)

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
@@ -53,7 +54,11 @@ func TestCreate(t *testing.T) {
 	}
 	vmContext.Session = authSession
 
-	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	vmRef := simulator.Map.Any("VirtualMachine")
+	vm, ok := vmRef.(*simulator.VirtualMachine)
+	if !ok {
+		t.Fatal("failed to get reference to an existing VM on the vcsim instance")
+	}
 	vmContext.VSphereVM.Spec.Template = vm.Name
 
 	disk := object.VirtualDeviceList(vm.Config.Hardware.Device).SelectByType((*types.VirtualDisk)(nil))[0].(*types.VirtualDisk)
@@ -61,6 +66,20 @@ func TestCreate(t *testing.T) {
 
 	if err := createVM(vmContext, []byte("")); err != nil {
 		t.Fatal(err)
+	}
+
+	taskRef := types.ManagedObjectReference{
+		Type:  morefTypeTask,
+		Value: vmContext.VSphereVM.Status.TaskRef,
+	}
+	vimClient, err := vim25.NewClient(vmContext, vmContext.Session.RoundTripper)
+	if err != nil {
+		t.Fatal("could not make vim25 client.")
+	}
+	task := object.NewTask(vimClient, taskRef)
+	err = task.Wait(vmContext)
+	if err != nil {
+		t.Fatal("error waiting for task:", err)
 	}
 
 	if model.Machine+1 != model.Count().Machine {

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -39,7 +39,9 @@ const (
 	linkCloneDiskMoveType = types.VirtualMachineRelocateDiskMoveOptionsCreateNewChildDiskBacking
 )
 
-// Clone kicks off a clone operation on vCenter to create a new virtual machine.
+// Clone kicks off a clone operation on vCenter to create a new virtual machine. This function does not wait for
+// the virtual machine to be created on the vCenter, which can be resolved by waiting on the task reference stored
+// in VMContext.VSphereVM.Status.TaskRef.
 // nolint:gocognit,gocyclo
 func Clone(ctx *context.VMContext, bootstrapData []byte) error {
 	ctx = &context.VMContext{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a flake in unit tests for `pkg/services/govmomi` that has been affecting a lot of our PRs in recent months.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1391

**Special notes for your reviewer**:
I imagine there's likely a more concise way of waiting on the VM's creation. Please drop a hint and I'll be happy to work on it.