### PR TITLE
🌱 Removes failure domain condition from Cluster

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -356,6 +356,9 @@ func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext)
 		} else {
 			conditions.MarkTrue(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
 		}
+	} else {
+		// Remove the condition if failure domains do not exist
+		conditions.Delete(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
 	}
 	return true, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the logic to remove the FailureDomainsAvailable condition from the `VSphereCluster` object if the failure domain CRs are deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1542 

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Removes failure domain available condition from Cluster
```