### PR TITLE
🐛 Fixes role name for worker nodes

### DIFF
--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -123,7 +123,7 @@ func clusterRoleVMLabels(ctx *vmware.ClusterContext, controlPlane bool) map[stri
 		result[legacyNodeSelectorKey] = roleControlPlane
 	} else {
 		result[nodeSelectorKey] = roleNode
-		result[legacyNodeSelectorKey] = roleControlPlane
+		result[legacyNodeSelectorKey] = roleNode
 	}
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the correct role name to the legacy label `capw.vmware.com`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1559

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Fixes role name for worker nodes
```