### PR TITLE
OS field and Windows VM name shrink

### DIFF
--- a/apis/v1alpha3/conversion_test.go
+++ b/apis/v1alpha3/conversion_test.go
@@ -100,4 +100,5 @@ func CustomNewFieldFuzzer(in *nextver.VirtualMachineCloneSpec, c fuzz.Continue) 
 
 	in.PciDevices = nil
 	in.AdditionalDisksGiB = nil
+	in.OS = ""
 }

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1680,5 +1680,6 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha3_VirtualMachineClone
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	// WARNING: in.PciDevices requires manual conversion: does not exist in peer-type
+	// WARNING: in.OS requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1798,5 +1798,6 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha4_VirtualMachineClone
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	// WARNING: in.PciDevices requires manual conversion: does not exist in peer-type
+	// WARNING: in.OS requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -52,6 +52,17 @@ const (
 	LinkedClone CloneMode = "linkedClone"
 )
 
+// OS is the type of Operating System the virtual machine uses.
+type OS string
+
+const (
+	// Linux indicates the VM uses a Linux Operating System.
+	Linux OS = "Linux"
+
+	// Windows indicates the VM uses Windows Server 2019 as the OS.
+	Windows OS = "Windows"
+)
+
 // VirtualMachineCloneSpec is information used to clone a virtual machine.
 type VirtualMachineCloneSpec struct {
 	// Template is the name or inventory path of the template used to clone
@@ -154,6 +165,11 @@ type VirtualMachineCloneSpec struct {
 	// PciDevices is the list of pci devices used by the virtual machine.
 	// +optional
 	PciDevices []PCIDeviceSpec `json:"pciDevices,omitempty"`
+
+	// OS is the Operating System of the virtual machine
+	// Defaults to Linux
+	// +optional
+	OS OS `json:"os,omitempty"`
 }
 
 // VSphereMachineTemplateResource describes the data needed to create a VSphereMachine from a template

--- a/apis/v1beta1/vspherevm_webhook_test.go
+++ b/apis/v1beta1/vspherevm_webhook_test.go
@@ -21,14 +21,40 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var biosUUID = "vsphere://42305f0b-dad7-1d3d-5727-0eafffffbbbfc"
+const (
+	biosUUID      = "vsphere://42305f0b-dad7-1d3d-5727-0eafffffbbbfc"
+	windowsVMName = "cluster-md-containerd-b7fccbf59-2qj6q"
+	linuxVMName   = "linux-control-plane-qkkbv"
+)
+
+//nolint
+func TestVSphereVM_Default(t *testing.T) {
+	g := NewWithT(t)
+
+	WindowsVM := createVSphereVM(windowsVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows)
+	LinuxVM := createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux)
+	NoOSVM := createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, "")
+
+	WindowsVM.Default()
+	LinuxVM.Default()
+	NoOSVM.Default()
+
+	g.Expect(LinuxVM.Spec.OS).To(Equal(Linux))
+	g.Expect(WindowsVM.Spec.OS).To(Equal(Windows))
+	g.Expect(NoOSVM.Spec.OS).To(Equal(Linux))
+
+	// WindowsVM gets name updated to be 15 characters. Linux remains unchanged
+	g.Expect(WindowsVM.Name).To(Equal("cluster-m-2qj6q"))
+	g.Expect(LinuxVM.Name).To(Equal("linux-control-plane-qkkbv"))
+}
 
 //nolint
 func TestVSphereVM_ValidateCreate(t *testing.T) {
-
 	g := NewWithT(t)
+
 	tests := []struct {
 		name      string
 		vSphereVM *VSphereVM
@@ -36,17 +62,27 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 	}{
 		{
 			name:      "preferredAPIServerCIDR set on creation ",
-			vSphereVM: createVSphereVM("foo.com", "", "192.168.0.1/32", []string{}, nil),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "192.168.0.1/32", []string{}, nil, Linux),
 			wantErr:   true,
 		},
 		{
 			name:      "IPs are not in CIDR format",
-			vSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3"}, nil),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3"}, nil, Linux),
 			wantErr:   true,
 		},
 		{
 			name:      "successful VSphereVM creation",
-			vSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
+			wantErr:   false,
+		},
+		{
+			name:      "name too long for Windows VM",
+			vSphereVM: createVSphereVM(windowsVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows),
+			wantErr:   true,
+		},
+		{
+			name:      "name too long for Linux VM",
+			vSphereVM: createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
 			wantErr:   false,
 		},
 	}
@@ -64,7 +100,6 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 
 //nolint
 func TestVSphereVM_ValidateUpdate(t *testing.T) {
-
 	g := NewWithT(t)
 
 	tests := []struct {
@@ -75,26 +110,26 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:         "ProviderID can be updated",
-			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}, nil),
-			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32"}, nil),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32"}, nil, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating ips can be done",
-			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}, nil),
-			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating bootstrapRef can be done",
-			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}, nil),
-			vSphereVM:    createVSphereVM("foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, &corev1.ObjectReference{}),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, &corev1.ObjectReference{}, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating server cannot be done",
-			oldVSphereVM: createVSphereVM("foo.com", "", "", []string{"192.168.0.1/32"}, nil),
-			vSphereVM:    createVSphereVM("bar.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "bar.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
 			wantErr:      true,
 		},
 	}
@@ -110,8 +145,11 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createVSphereVM(server string, biosUUID string, preferredAPIServerCIDR string, ips []string, bootstrapRef *corev1.ObjectReference) *VSphereVM {
+func createVSphereVM(name, server, biosUUID, preferredAPIServerCIDR string, ips []string, bootstrapRef *corev1.ObjectReference, os OS) *VSphereVM {
 	VSphereVM := &VSphereVM{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
 		Spec: VSphereVMSpec{
 			BiosUUID:     biosUUID,
 			BootstrapRef: bootstrapRef,
@@ -123,6 +161,10 @@ func createVSphereVM(server string, biosUUID string, preferredAPIServerCIDR stri
 				},
 			},
 		},
+	}
+
+	if os != "" {
+		VSphereVM.Spec.OS = os
 	}
 	for _, ip := range ips {
 		VSphereVM.Spec.Network.Devices = append(VSphereVM.Spec.Network.Devices, NetworkDeviceSpec{

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1032,6 +1032,10 @@ spec:
                   value in the template from which the virtual machine is cloned.
                 format: int32
                 type: integer
+              os:
+                description: OS is the Operating System of the virtual machine Defaults
+                  to Linux
+                type: string
               pciDevices:
                 description: PciDevices is the list of pci devices used by the virtual
                   machine.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -931,6 +931,10 @@ spec:
                           virtual machine is cloned.
                         format: int32
                         type: integer
+                      os:
+                        description: OS is the Operating System of the virtual machine
+                          Defaults to Linux
+                        type: string
                       pciDevices:
                         description: PciDevices is the list of pci devices used by
                           the virtual machine.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1088,6 +1088,10 @@ spec:
                   value in the template from which the virtual machine is cloned.
                 format: int32
                 type: integer
+              os:
+                description: OS is the Operating System of the virtual machine Defaults
+                  to Linux
+                type: string
               pciDevices:
                 description: PciDevices is the list of pci devices used by the virtual
                   machine.

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -69,6 +69,27 @@ webhooks:
     resources:
     - vspheremachines
   sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-vspherevm
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.vspherevm.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspherevms
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -228,6 +228,7 @@ func defaultVirtualMachineCloneSpec() infrav1.VirtualMachineCloneSpec {
 		Datastore:         env.VSphereDatastoreVar,
 		StoragePolicyName: env.VSphereStoragePolicyVar,
 		Folder:            env.VSphereFolderVar,
+		OS:                infrav1.Linux,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Windows VM name greater than 15 characters can cause issues when multiple machines join a domain and end up with the same NetBIOS name due the OS shrink of the name and same cluster prefix.

This PR adds a new field to identify the machine OS and mutate the VM name via Mutation Webhook when the OS=Windows. The same approach is being used on CAPZ.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1292

**Special notes for your reviewer**:
This is a reopen of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1052

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding OS field on VirtualMachineCloneSpec and renaming of Windows VMs when the length is greater than 15 characters.
```