### PR TITLE
🌱 Uses cluster name for resource policy creation

### DIFF
--- a/pkg/services/vmoperator/resource_policy.go
+++ b/pkg/services/vmoperator/resource_policy.go
@@ -52,8 +52,8 @@ func (s RPService) ReconcileResourcePolicy(ctx *vmware.ClusterContext) (string, 
 func (s RPService) newVirtualMachineSetResourcePolicy(ctx *vmware.ClusterContext) *vmoprv1.VirtualMachineSetResourcePolicy {
 	return &vmoprv1.VirtualMachineSetResourcePolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ctx.VSphereCluster.Namespace,
-			Name:      ctx.VSphereCluster.Name,
+			Namespace: ctx.Cluster.Namespace,
+			Name:      ctx.Cluster.Name,
 		},
 	}
 }
@@ -61,8 +61,8 @@ func (s RPService) newVirtualMachineSetResourcePolicy(ctx *vmware.ClusterContext
 func (s RPService) getVirtualMachineSetResourcePolicy(ctx *vmware.ClusterContext) (*vmoprv1.VirtualMachineSetResourcePolicy, error) {
 	vmResourcePolicy := &vmoprv1.VirtualMachineSetResourcePolicy{}
 	vmResourcePolicyName := client.ObjectKey{
-		Namespace: ctx.VSphereCluster.Namespace,
-		Name:      ctx.VSphereCluster.Name,
+		Namespace: ctx.Cluster.Namespace,
+		Name:      ctx.Cluster.Name,
 	}
 	err := ctx.Client.Get(ctx, vmResourcePolicyName, vmResourcePolicy)
 	return vmResourcePolicy, err
@@ -74,10 +74,10 @@ func (s RPService) createVirtualMachineSetResourcePolicy(ctx *vmware.ClusterCont
 	_, err := ctrlutil.CreateOrUpdate(ctx, ctx.Client, vmResourcePolicy, func() error {
 		vmResourcePolicy.Spec = vmoprv1.VirtualMachineSetResourcePolicySpec{
 			ResourcePool: vmoprv1.ResourcePoolSpec{
-				Name: ctx.VSphereCluster.Name,
+				Name: ctx.Cluster.Name,
 			},
 			Folder: vmoprv1.FolderSpec{
-				Name: ctx.VSphereCluster.Name,
+				Name: ctx.Cluster.Name,
 			},
 			ClusterModules: []vmoprv1.ClusterModuleSpec{
 				{

--- a/pkg/services/vmoperator/resource_policy_test.go
+++ b/pkg/services/vmoperator/resource_policy_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmoperator
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	capi_util "sigs.k8s.io/cluster-api/util"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
+)
+
+func TestRPService(t *testing.T) {
+	clusterName := "test-cluster"
+	vsphereClusterName := fmt.Sprintf("%s-%s", clusterName, capi_util.RandomString((6)))
+	cluster := util.CreateCluster(clusterName)
+	vsphereCluster := util.CreateVSphereCluster(vsphereClusterName)
+	ctx := util.CreateClusterContext(cluster, vsphereCluster)
+
+	rpService := RPService{}
+
+	t.Run("Creates Resource Policy using the cluster name", func(t *testing.T) {
+		g := NewWithT(t)
+		name, err := rpService.ReconcileResourcePolicy(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(name).To(Equal(clusterName))
+
+		resourcePolicy, err := rpService.getVirtualMachineSetResourcePolicy(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resourcePolicy.Spec.ResourcePool.Name).To(Equal(clusterName))
+		g.Expect(resourcePolicy.Spec.Folder.Name).To(Equal(clusterName))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the resource policy creation logic to use the name of the Cluster object, instead of the `VSphereCluster` object which is not deterministic in case of topology controller. Hence, using the Cluster object name makes it deterministic for the purpose of UX.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Uses cluster name for resource policy creation
```