### PR TITLE
Use CloudInit bootstrap w VM Operator

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -277,7 +277,7 @@ func (v VmopMachineService) reconcileVMOperatorVM(ctx *vmware.SupervisorMachineC
 		vmOperatorVM.Spec.ResourcePolicyName = ctx.VSphereCluster.Status.ResourcePolicyName
 		vmOperatorVM.Spec.VmMetadata = &vmoprv1.VirtualMachineMetadata{
 			ConfigMapName: vmwareutil.GetBootstrapConfigMapName(ctx.VSphereMachine.Name),
-			Transport:     "ExtraConfig",
+			Transport:     "CloudInit",
 		}
 
 		// VMOperator supports readiness probe and will add/remove endpoints to a

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -727,8 +727,7 @@ func assertVirtualMachineState(machine *clusterv1.Machine, vm *vmoprv1.VirtualMa
 	Expect(vm.Spec.ImageName).ShouldNot(BeEmpty())
 	Expect(machine.Spec.Version).ShouldNot(BeNil(), "Error accessing nil Spec.Version for machine %s", machine.Name)
 	Expect(vm.Spec.VmMetadata).NotTo(BeNil())
-	// TODO: Aarti: not sure where to get this varaible from
-	//Expect(vm.Spec.VmMetadata.Transport).To(Equal(vmoprv1.VirtualMachineMetadataExtraConfigTransport))
+	Expect(vm.Spec.VmMetadata.Transport).To(Equal(vmoprv1.VirtualMachineMetadataCloudInitTransport))
 	Expect(vm.Spec.VmMetadata.ConfigMapName).ToNot(BeNil())
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates CAPV to use the VM Operator CloudInit bootstrap method instead of ExtraConfig. This change ensures there is no race between VM Tools and CloudInit since using ExtraConfig will cause Guest OS Customization
to configure the network, resulting in a reboot while CloudInit is running. Specifying CloudInit as the bootstrap provider ensures VM Operator uses CloudInit to bootstrap the network.

Please note this patch will only work in vSphere 7P05+.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NA

**Special notes for your reviewer**:
This is required for uTKG.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```