### PR TITLE
Switch to CreateOrPatch; ignore manager binary at root of project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Do not commit the manager binary at the project's root.
+/manager
+
 # Do not commit any JSON keys at the project's root.
 /gcs*.json
 

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -283,7 +283,7 @@ func (r ServiceAccountReconciler) ensureRole(ctx *vmwarecontext.ClusterContext, 
 	}
 	logger := ctx.Logger.WithValues("providerserviceaccount", pSvcAccount.Name, "role", role.Name)
 	logger.V(4).Info("Creating or updating role")
-	_, err := controllerutil.CreateOrUpdate(ctx, ctx.Client, &role, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, &role, func() error {
 		if err := controllerutil.SetControllerReference(&pSvcAccount, &role, ctx.Scheme); err != nil {
 			return err
 		}
@@ -304,7 +304,7 @@ func (r ServiceAccountReconciler) ensureRoleBinding(ctx *vmwarecontext.ClusterCo
 	}
 	logger := ctx.Logger.WithValues("providerserviceaccount", pSvcAccount.Name, "rolebinding", roleBinding.Name)
 	logger.V(4).Info("Creating or updating rolebinding")
-	_, err := controllerutil.CreateOrUpdate(ctx, ctx.Client, &roleBinding, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, ctx.Client, &roleBinding, func() error {
 		if err := controllerutil.SetControllerReference(&pSvcAccount, &roleBinding, ctx.Scheme); err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func (r ServiceAccountReconciler) syncServiceAccountSecret(ctx *vmwarecontext.Gu
 		},
 	}
 	logger.V(4).Info("Creating or updating secret in cluster", "namespace", targetSecret.Namespace, "name", targetSecret.Name)
-	_, err = controllerutil.CreateOrUpdate(ctx, ctx.GuestClient, targetSecret, func() error {
+	_, err = controllerutil.CreateOrPatch(ctx, ctx.GuestClient, targetSecret, func() error {
 		targetSecret.Data = sourceSecret.Data
 		return nil
 	})
@@ -409,7 +409,7 @@ func (r ServiceAccountReconciler) deleteServiceAccountConfigMap(ctx *vmwareconte
 		return nil
 	}
 	logger.Info("Deleting config map entry for provider service account")
-	_, err = controllerutil.CreateOrUpdate(ctx, ctx.Client, configMapBuffer, func() error {
+	_, err = controllerutil.CreateOrPatch(ctx, ctx.Client, configMapBuffer, func() error {
 		configMapBuffer.Data = configMap.Data
 		delete(configMapBuffer.Data, svcAccountName)
 		return nil
@@ -430,7 +430,7 @@ func (r ServiceAccountReconciler) ensureServiceAccountConfigMap(ctx *vmwareconte
 		return nil
 	}
 	logger.Info("Updating config map for provider service account")
-	_, err = controllerutil.CreateOrUpdate(ctx, ctx.Client, configMapBuffer, func() error {
+	_, err = controllerutil.CreateOrPatch(ctx, ctx.Client, configMapBuffer, func() error {
 		configMapBuffer.Data = configMap.Data
 		configMapBuffer.Data[svcAccountName] = "true"
 		return nil

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -266,7 +266,7 @@ func (v VmopMachineService) reconcileVMOperatorVM(ctx *vmware.SupervisorMachineC
 			ctx.Machine.Name)
 	}
 
-	_, err := ctrlutil.CreateOrUpdate(ctx, ctx.Client, vmOperatorVM, func() error {
+	_, err := ctrlutil.CreateOrPatch(ctx, ctx.Client, vmOperatorVM, func() error {
 		// Define a new VM Operator virtual machine.
 		// NOTE: Set field-by-field in order to preserve changes made directly
 		//  to the VirtualMachine spec by other sources (e.g. the cloud provider)
@@ -350,7 +350,7 @@ func (v VmopMachineService) reconcileBootstrapDataConfigMap(ctx *vmware.Supervis
 		return err
 	}
 
-	_, err = ctrlutil.CreateOrUpdate(ctx, ctx.Client, configMap, func() error {
+	_, err = ctrlutil.CreateOrPatch(ctx, ctx.Client, configMap, func() error {
 		// Make sure the VSphereMachine owns the bootstrap data ConfigMap.
 		if err := ctrlutil.SetControllerReference(ctx.VSphereMachine, configMap, ctx.Scheme); err != nil {
 			return errors.Wrapf(err, "failed to mark %s %s/%s as owner of %s %s/%s",
@@ -549,11 +549,28 @@ func addVolumes(ctx *vmware.SupervisorMachineContext, vm *vmoprv1.VirtualMachine
 			}
 		}
 
-		_, err := ctrlutil.CreateOrUpdate(ctx, ctx.Client, pvc, func() error {
-			return ctrlutil.SetOwnerReference(ctx.VSphereMachine, pvc, ctx.Scheme)
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to create volume %s/%s", ctx.VSphereMachine.Namespace, pvc.Name)
+		if _, err := ctrlutil.CreateOrPatch(ctx, ctx.Client, pvc, func() error {
+			if err := ctrlutil.SetOwnerReference(
+				ctx.VSphereCluster,
+				pvc,
+				ctx.Scheme,
+			); err != nil {
+				return errors.Wrapf(
+					err,
+					"error setting %s/%s as owner of %s/%s",
+					ctx.VSphereCluster.Namespace,
+					ctx.VSphereCluster.Name,
+					pvc.Namespace,
+					pvc.Name,
+				)
+			}
+			return nil
+		}); err != nil {
+			return errors.Wrapf(
+				err,
+				"failed to create volume %s/%s",
+				pvc.Namespace,
+				pvc.Name)
 		}
 
 		addVolume(vm, pvc.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch updates instances of CreateOrUpdate to CreateOrPatch in order to avoid being destructive during mutation of existing resources. This patch also updates a few instances of the `MutateFn` to ensure labels/annotations/ownerrefs are updated instead of replaced when appropriate.

This patch also updates the project's `.gitignore` file to ignore the manager binary that gets created at the root of the project if `go build` is used to build the manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Switch to controllerutil.CreateOrPatch for more surgical updates
* Ignore the manager binary when it is built at the root of the project with "go build"
```