### PR TITLE
Reuse CAPI bootstrap secret with Supervisor

### DIFF
--- a/pkg/services/vmoperator/constants.go
+++ b/pkg/services/vmoperator/constants.go
@@ -19,14 +19,6 @@ package vmoperator
 const (
 	kubeTopologyZoneLabelKey = "topology.kubernetes.io/zone"
 
-	metadataFormat = `
-instance-id: "{{ .Hostname }}"
-local-hostname: "{{ .Hostname }}"
-{{ if .ControlPlaneEndpoint }}
-controlPlaneEndpoint: "{{ .ControlPlaneEndpoint }}"
-{{ end }}
-`
-
 	ControlPlaneVMClusterModuleGroupName = "control-plane-group"
 	ClusterModuleNameAnnotationKey       = "vsphere-cluster-module-group"
 	ProviderTagsAnnotationKey            = "vsphere-tag"

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -17,12 +17,9 @@ limitations under the License.
 package vmoperator
 
 import (
-	"bytes"
 	goctx "context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"text/template"
 
 	"github.com/pkg/errors"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
@@ -32,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -170,16 +166,6 @@ func (v *VmopMachineService) ReconcileNormal(c context.MachineContext) (bool, er
 		return false, err
 	}
 
-	// Define the bootstrap data ConfigMap resource to reconcile.
-	bootstrapDataConfigMap := v.newBootstrapDataConfigMap(ctx)
-
-	// Reconcile the bootstrap data ConfigMap.
-	if err := v.reconcileBootstrapDataConfigMap(ctx, bootstrapDataConfigMap); err != nil {
-		conditions.MarkFalse(ctx.VSphereMachine, infrav1.VMProvisionedCondition, vmwarev1.VMCreationFailedReason, clusterv1.ConditionSeverityWarning,
-			fmt.Sprintf("failed to create or update bootstrap configmap: %v", err))
-		return false, err
-	}
-
 	// Update the VM's state to Pending
 	ctx.VSphereMachine.Status.VMStatus = vmwarev1.VirtualMachineStatePending
 
@@ -266,6 +252,11 @@ func (v VmopMachineService) reconcileVMOperatorVM(ctx *vmware.SupervisorMachineC
 			ctx.Machine.Name)
 	}
 
+	var dataSecretName string
+	if dsn := ctx.Machine.Spec.Bootstrap.DataSecretName; dsn != nil {
+		dataSecretName = *dsn
+	}
+
 	_, err := ctrlutil.CreateOrPatch(ctx, ctx.Client, vmOperatorVM, func() error {
 		// Define a new VM Operator virtual machine.
 		// NOTE: Set field-by-field in order to preserve changes made directly
@@ -276,8 +267,8 @@ func (v VmopMachineService) reconcileVMOperatorVM(ctx *vmware.SupervisorMachineC
 		vmOperatorVM.Spec.PowerState = vmoprv1.VirtualMachinePoweredOn
 		vmOperatorVM.Spec.ResourcePolicyName = ctx.VSphereCluster.Status.ResourcePolicyName
 		vmOperatorVM.Spec.VmMetadata = &vmoprv1.VirtualMachineMetadata{
-			ConfigMapName: vmwareutil.GetBootstrapConfigMapName(ctx.VSphereMachine.Name),
-			Transport:     "CloudInit",
+			SecretName: dataSecretName,
+			Transport:  vmoprv1.VirtualMachineMetadataCloudInitTransport,
 		}
 
 		// VMOperator supports readiness probe and will add/remove endpoints to a
@@ -333,76 +324,6 @@ func (v VmopMachineService) reconcileVMOperatorVM(ctx *vmware.SupervisorMachineC
 		return nil
 	})
 	return err
-}
-
-func (v VmopMachineService) newBootstrapDataConfigMap(ctx *vmware.SupervisorMachineContext) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ctx.VSphereMachine.Namespace,
-			Name:      vmwareutil.GetBootstrapConfigMapName(ctx.VSphereMachine.Name),
-		},
-	}
-}
-
-func (v VmopMachineService) reconcileBootstrapDataConfigMap(ctx *vmware.SupervisorMachineContext, configMap *corev1.ConfigMap) error {
-	bootstrapData, err := vmwareutil.GetBootstrapData(ctx, ctx.Client, ctx.Machine)
-	if err != nil {
-		return err
-	}
-
-	_, err = ctrlutil.CreateOrPatch(ctx, ctx.Client, configMap, func() error {
-		// Make sure the VSphereMachine owns the bootstrap data ConfigMap.
-		if err := ctrlutil.SetControllerReference(ctx.VSphereMachine, configMap, ctx.Scheme); err != nil {
-			return errors.Wrapf(err, "failed to mark %s %s/%s as owner of %s %s/%s",
-				ctx.VSphereMachine.GroupVersionKind(),
-				ctx.VSphereMachine.Namespace,
-				ctx.VSphereMachine.Name,
-				configMap.GroupVersionKind(),
-				configMap.Namespace,
-				configMap.Name)
-		}
-
-		metadata, err := v.getGuestInfoMetadata(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get guest info metadata for machine %s", ctx.Machine.Name)
-		}
-
-		// The CAPI contract states that the string assigned to the field
-		// Machine.Spec.Bootstrap.Data will be base64 encoded.
-		configMap.Data = map[string]string{
-			"guestinfo.userdata":          bootstrapData,
-			"guestinfo.userdata.encoding": "base64",
-			"guestinfo.metadata":          metadata,
-			"guestinfo.metadata.encoding": "base64",
-		}
-		return nil
-	})
-	return err
-}
-
-func (v VmopMachineService) getGuestInfoMetadata(ctx *vmware.SupervisorMachineContext) (string, error) {
-	tpl := template.Must(template.New("t").Parse(metadataFormat))
-
-	// We can configure this for control plane machines - only the init node will
-	// likely leverage it for controlPlaneEndpoint
-	controlPlaneEndpoint := ""
-	if util.IsControlPlaneMachine(ctx.Machine) && !ctx.Cluster.Spec.ControlPlaneEndpoint.IsZero() {
-		apiEndpoint := ctx.Cluster.Spec.ControlPlaneEndpoint
-		controlPlaneEndpoint = fmt.Sprintf("%s:%d", apiEndpoint.Host, apiEndpoint.Port)
-	}
-
-	buf := &bytes.Buffer{}
-	if err := tpl.Execute(buf, struct {
-		Hostname             string
-		ControlPlaneEndpoint string
-	}{
-		Hostname:             ctx.Machine.Name,
-		ControlPlaneEndpoint: controlPlaneEndpoint,
-	}); err != nil {
-		return "", err
-	}
-
-	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
 func (v *VmopMachineService) reconcileNetwork(ctx *vmware.SupervisorMachineContext, vm *vmoprv1.VirtualMachine) bool {

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	goctx "context"
-	"fmt"
 
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
@@ -176,10 +175,4 @@ func CreateMachineContext(clusterContext *vmware.ClusterContext, machine *cluste
 		VSphereCluster: clusterContext.VSphereCluster,
 		VSphereMachine: vsphereMachine,
 	}
-}
-
-// GetBootstrapConfigMapName returns the name of the bootstrap data ConfigMap
-// for a VM Operator VirtualMachine.
-func GetBootstrapConfigMapName(machineName string) string {
-	return fmt.Sprintf("%s-cloud-init", machineName)
 }

--- a/pkg/util/vmware/util.go
+++ b/pkg/util/vmware/util.go
@@ -17,54 +17,13 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
-	"encoding/base64"
 	"fmt"
 
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetMachineDeploymentName returns the MachineDeployment name for a Cluster.
 // This is also the name used by VSphereMachineTemplate and KubeadmConfigTemplate.
 func GetMachineDeploymentNameForCluster(cluster *clusterv1.Cluster) string {
 	return fmt.Sprintf("%s-workers-0", cluster.Name)
-}
-
-// GetBootstrapConfigMapName returns the name of the bootstrap data ConfigMap
-// for a VM Operator VirtualMachine.
-func GetBootstrapConfigMapName(machineName string) string {
-	return fmt.Sprintf("%s-cloud-init", machineName)
-}
-
-func GetBootstrapData(ctx context.Context, c client.Client, machine *clusterv1.Machine) (string, error) {
-	value, err := GetRawBootstrapData(ctx, c, machine)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(value), nil
-}
-
-// GetRawBootstrapData returns the bootstrap data from the secret in the
-// Machine's bootstrap.dataSecretName.
-func GetRawBootstrapData(ctx context.Context, c client.Client, machine *clusterv1.Machine) ([]byte, error) {
-	if machine.Spec.Bootstrap.DataSecretName == nil {
-		return nil, errors.New("error retrieving bootstrap data: linked Machine's bootstrap.dataSecretName is nil")
-	}
-
-	secret := &corev1.Secret{}
-	key := apitypes.NamespacedName{Namespace: machine.GetNamespace(), Name: *machine.Spec.Bootstrap.DataSecretName}
-	if err := c.Get(ctx, key, secret); err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve bootstrap data secret for Machine %s/%s", machine.GetNamespace(), machine.GetName())
-	}
-
-	value, ok := secret.Data["value"]
-	if !ok {
-		return nil, errors.New("error retrieving bootstrap data: secret value key is missing")
-	}
-
-	return value, nil
 }

--- a/test/integration/cluster_lifecycle_test.go
+++ b/test/integration/cluster_lifecycle_test.go
@@ -24,8 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 // The purpose of this test is to start up a CAPI controller against a real API
@@ -130,11 +128,7 @@ var _ = Describe("Cluster lifecycle tests", func() {
 				machineOwnerRef.BlockOwnerDeletion = pointer.BoolPtr(true)
 				assertEventuallyExists(kubeadmconfigResources, controlPlane.Machine.Name, testNamespace, machineOwnerRef)
 
-				vsphereMachine := assertEventuallyExists(vspheremachinesResource, controlPlane.Machine.Name, testNamespace, machineOwnerRef)
-				vsphereMachineOwnerRef := toControllerOwnerRef(vsphereMachine)
-
 				assertEventuallyExists(virtualmachinesResource, controlPlane.Machine.Name, testNamespace, nil)
-				assertEventuallyExists(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), testNamespace, vsphereMachineOwnerRef)
 
 				// TODO: gab-satchi these should also be looking for correct ownerReferences before proceeding to a delete in the AfterEach
 				assertEventuallyExists(machinedeploymentResource, worker.MachineDeployment.Name, testNamespace, nil)
@@ -146,7 +140,6 @@ var _ = Describe("Cluster lifecycle tests", func() {
 				// Operator VirtualMachine, and bootstrap data ConfigMap
 				// resources for the control plane machine are eventually
 				// deleted.
-				assertEventuallyDoesNotExist(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), testNamespace)
 				assertEventuallyDoesNotExist(virtualmachinesResource, controlPlane.Machine.Name, testNamespace)
 				assertEventuallyDoesNotExist(vspheremachinesResource, controlPlane.Machine.Name, testNamespace)
 				assertEventuallyDoesNotExist(kubeadmconfigResources, controlPlane.Machine.Name, testNamespace)

--- a/test/integration/sanity_test.go
+++ b/test/integration/sanity_test.go
@@ -29,7 +29,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 // The purpose of this test is to start up a CAPI controller against a real API
@@ -109,7 +108,6 @@ var _ = Describe("Sanity tests", func() {
 		// Operator VirtualMachine, and bootstrap data ConfigMap
 		// resources for the control plane machine are eventually
 		// deleted.
-		assertEventuallyDoesNotExist(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), controlPlane.Machine.Namespace)
 		assertEventuallyDoesNotExist(virtualmachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
 		assertEventuallyDoesNotExist(vspheremachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
 		assertEventuallyDoesNotExist(kubeadmconfigResources, controlPlane.Machine.Name, controlPlane.Machine.Namespace)
@@ -140,7 +138,6 @@ var _ = Describe("Sanity tests", func() {
 			// ASSERT the VirtualMachine and bootstrap data ConfigMap resources
 			// eventually exist. Ensure ConfigMap has OwnerRef set to the VSphereMachine.
 			vmObj := assertEventuallyExists(virtualmachinesResource, controlPlane.Machine.Name, controlPlane.Machine.Namespace, nil)
-			assertEventuallyExists(configmapsResource, infrautilv1.GetBootstrapConfigMapName(controlPlane.Machine.Name), controlPlane.Machine.Namespace, toControllerOwnerRef(vsphereMachine))
 			vm := &vmoprv1.VirtualMachine{}
 			toStructured(controlPlane.Machine.Name, vm, vmObj)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This patch removes the logic for creating a new ConfigMap resource for Supervisor VMs. Instead CAPV simply points the Supervisor resources to the existing CAPI bootstrap secrets.

Previously Supervisor integration required setting the ControlPlaneEndpoint value in Cloud-Init metadata.
However, this was recognized as vestigial as the KubeadmBootstrap controller automatically grabs the
ControlPlaneEndpoint from the Cluster.Spec.ControlPlaneEndpoint field if the value is not explicitly specified.

For more information please see the following links:

1. The CAPV Cluster reconciler does not proceed until there is a control plane endpoint https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/cc735927f7c7671dc8f30bc796474fa62555a127/controllers/vmware/vspherecluster_reconciler.go#L184-L188
1. The CAPV Cluster reconciler sets `Cluster.Spec.ControlPlaneEndpoint` to the value of the load balancer https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/cc735927f7c7671dc8f30bc796474fa62555a127/controllers/vmware/vspherecluster_reconciler.go#L254-L255
1. The CAPV Cluster reconciler only marks the Cluster as "ready" when there is a valid control plane endpoint https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/cc735927f7c7671dc8f30bc796474fa62555a127/controllers/vmware/vspherecluster_reconciler.go#L190
1. The CAPI Core KubeadmBootstrap reconciler [does not proceed](https://github.com/kubernetes-sigs/cluster-api/blob/bc177c6906e8b7063520777c2d608b7297fd86b9/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go#L234-L238) unless the Cluster is marked as "ready"
1. The CAPI Core KubeadmBootstrap reconciler [uses the value](https://github.com/kubernetes-sigs/cluster-api/blob/ffee0a45cf823965d6e6d578d93eb3b6730ec734/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go#L925-L931) of `Cluster.Spec.ControlPlaneEndpoint` if one is not provided explicitly
1. The CAPV Machine reconciler does not proceed until the bootstrap data is ready https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/cc735927f7c7671dc8f30bc796474fa62555a127/controllers/vspheremachine_controller.go#L292-L302


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NA

**Special notes for your reviewer**:

Please note that I raised the failing `go-apidiff` test with @srm09 in internal Slack:

> **@akutz**
> I have no idea what make o-apidiff is or why it's causing a PR precheck to fail...
>
> **@srm09**
> `apidiff` just uses the same mechanism CAPI uses to figure out if any public facing method signatures get changed or removed. For the sake of consistency, this was done across all providers.
>
> It is not a required check, so the PR should be ready to be merged even w/o it passing

Therefore it seems like we are okay moving ahead with this PR with that test failing. If anyone has any concerns, please let me know. Thanks!

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* Supervisor integration no longer requires duplicating the bootstrap Secret resource as a plain-text ConfigMap resource.
```