### PR TITLE
Fix PVC OwnerRef bug for Supervisor

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -472,15 +472,15 @@ func addVolumes(ctx *vmware.SupervisorMachineContext, vm *vmoprv1.VirtualMachine
 
 		if _, err := ctrlutil.CreateOrPatch(ctx, ctx.Client, pvc, func() error {
 			if err := ctrlutil.SetOwnerReference(
-				ctx.VSphereCluster,
+				ctx.VSphereMachine,
 				pvc,
 				ctx.Scheme,
 			); err != nil {
 				return errors.Wrapf(
 					err,
 					"error setting %s/%s as owner of %s/%s",
-					ctx.VSphereCluster.Namespace,
-					ctx.VSphereCluster.Name,
+					ctx.VSphereMachine.Namespace,
+					ctx.VSphereMachine.Name,
 					pvc.Namespace,
 					pvc.Name,
 				)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The Supervisor integration broke with the CreateOrPatch PR when the PVC OwnerRefs were set to VSphereCluster and not the VSphereMachine.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
cc @sidharthsurana 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Fixes owner of PVCs attached to VsphereMachines to be the VsphereMachine and not the VsphereCluster
```