### PR TITLE
Only set PVC zone annotation when zonal storage classes are required

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -457,7 +457,13 @@ func addVolumes(ctx *vmware.SupervisorMachineContext, vm *vmoprv1.VirtualMachine
 			},
 		}
 
-		if zone := ctx.VSphereMachine.Spec.FailureDomain; zone != nil {
+		// The CSI zone annotation must be set when using a zonal storage class,
+		// which is required when the cluster has multiple (3) zones.
+		// Single zone clusters (legacy/default) do not support zonal storage and must not
+		// have the zone annotation set.
+		zonal := len(ctx.VSphereCluster.Status.FailureDomains) > 1
+
+		if zone := ctx.VSphereMachine.Spec.FailureDomain; zonal && zone != nil {
 			topology := []map[string]string{
 				{kubeTopologyZoneLabelKey: *zone},
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

The CSI zone annotation must be set when using a zonal storage class,
which is required when the cluster has multiple (3) zones.
Single zone clusters (legacy/default) do not support zonal storage and must not
have the zone annotation set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Follow up to #1573
