### PR TITLE
Updates CI config for E2E tests

### DIFF
--- a/test/e2e/capi_upgrade_test.go
+++ b/test/e2e/capi_upgrade_test.go
@@ -23,7 +23,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Context("ClusterAPI Upgrade Tests [clusterctl-Upgrade]", func() {
+var _ = PContext("ClusterAPI Upgrade Tests [clusterctl-Upgrade]", func() {
 	Describe("Upgrading cluster from v1alpha4 to v1beta1 using clusterctl", func() {
 		capi_e2e.ClusterctlUpgradeSpec(context.TODO(), func() capi_e2e.ClusterctlUpgradeSpecInput {
 			return capi_e2e.ClusterctlUpgradeSpecInput{

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -158,23 +158,21 @@ providers:
           - sourcePath: "../../../metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.20.1"
+  KUBERNETES_VERSION: "v1.23.5"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 1
   IP_FAMILY: "IPv4"
   CLUSTER_CLASS_NAME: "quick-start"
-  VSPHERE_TLS_THUMBPRINT: "9E:7F:01:3B:13:CF:B2:93:16:2C:31:6A:03:6A:D1:5D:C7:79:D8:DE"
+  VSPHERE_TLS_THUMBPRINT: "AA:70:F9:CF:5A:5F:CF:6C:81:15:E0:A1:88:B9:E9:2B:DC:19:0E:D0"
   VSPHERE_DATACENTER:  "SDDC-Datacenter"
   VSPHERE_FOLDER: "clusterapi"
   VSPHERE_RESOURCE_POOL: "clusterapi"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.20.1"
-  INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.23.5"
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -164,7 +164,7 @@ providers:
           - sourcePath: "../../../metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.20.1"
+  KUBERNETES_VERSION: "v1.23.5"
   CNI: "./data/cni/calico/calico.yaml"
   #CNI: "./data/cni/kindnet/kindnet.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
@@ -180,10 +180,7 @@ variables:
   VSPHERE_FOLDER: "FolderName"
   VSPHERE_NETWORK: "network-1"
   VSPHERE_RESOURCE_POOL: "ResourcePool"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.20.1"
-  INIT_WITH_BINARY_V1ALPHA3: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.23.5"
   # WORKLOAD_CONTROL_PLANE_ENDPOINT_IP:
   # Also following variables are required but it is recommended to use env variables to avoid disclosure of sensitive data
   # VSPHERE_SSH_AUTHORIZED_KEY:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update the k8s version used by the templates v1.23.5
- Update the thumbprint of the vCenter
- Marks the upgrade test as pending since v1alpha4 and v1alpha3 API versions are EOL now.
 
**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```