### PR TITLE
✨ Adds golang linter GH action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,22 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          version: v1.44.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds golang linter Github Action 

**Which issue(s) this PR fixes**
n/a

**Special notes for your reviewer**:
This will make upgrading golang versions easier since currently we have to make a separate PR to `test-infra` repo to update the golang version used in the base images.

**Release note**:
```release-note
NONE
```