### PR TITLE
Fix Go lint errors for Go 1.18

### DIFF
--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -17,8 +17,8 @@ limitations under the License.
 package record
 
 import (
-	"strings"
-
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -53,22 +53,22 @@ type recorder struct {
 
 // Event constructs an event from the given information and puts it in the queue for sending.
 func (r recorder) Event(object runtime.Object, reason, message string) {
-	r.EventRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+	r.EventRecorder.Event(object, corev1.EventTypeNormal, title(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func (r recorder) Eventf(object runtime.Object, reason, message string, args ...interface{}) {
-	r.EventRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+	r.EventRecorder.Eventf(object, corev1.EventTypeNormal, title(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
 func (r recorder) Warn(object runtime.Object, reason, message string) {
-	r.EventRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+	r.EventRecorder.Event(object, corev1.EventTypeWarning, title(reason), message)
 }
 
 // Warnf is just like Event, but with Sprintf for the message field.
 func (r recorder) Warnf(object runtime.Object, reason, message string, args ...interface{}) {
-	r.EventRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+	r.EventRecorder.Eventf(object, corev1.EventTypeWarning, title(reason), message, args...)
 }
 
 // EmitEvent records a Success or Failure depending on whether or not an error occurred.
@@ -80,4 +80,8 @@ func (r recorder) EmitEvent(object runtime.Object, opName string, err error, ign
 	} else {
 		r.Warn(object, opName+"Failure", err.Error())
 	}
+}
+
+func title(s string) string {
+	return cases.Title(language.English, cases.NoLower).String(s)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: This PR fixes some linter issues for Go 1.18, similar to https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1184.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**: None

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```