### PR TITLE
⚠️ Align flag names with upstream Kubernetes & CAPI components

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
+        - --leader-elect
         - --logtostderr
         - --v=4
         image: gcr.io/cluster-api-provider-vsphere/release/manager:latest

--- a/main.go
+++ b/main.go
@@ -71,12 +71,12 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	flag.StringVar(
 		&managerOpts.MetricsBindAddress,
-		"metrics-addr",
+		"metrics-bind-addr",
 		"localhost:8080",
 		"The address the metric endpoint binds to.")
 	flag.BoolVar(
 		&managerOpts.LeaderElection,
-		"enable-leader-election",
+		"leader-elect",
 		true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the names of the flags to align with the k8s components
Below are the flags that have been altered:
```
--metrics-addr ==> --metrics-bind-addr
--enable-leader-election ==> --leader-elect
```

**Which issue(s) this PR fixes**:
Fixes #1438 

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Align flag names with upstream Kubernetes & CAPI components
```