### PR TITLE
🐛 Fixes panic when reconciling VSphereMachine objects

### DIFF
--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -121,8 +121,8 @@ func (v *VimMachineService) ReconcileNormal(c context.MachineContext) (bool, err
 	}
 
 	vm, err := v.createOrPatchVSPhereVM(ctx, vsphereVM)
-
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err != nil {
+		ctx.Logger.Error(err, "error creating or patching VM", "vsphereVM", vsphereVM)
 		return false, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a panic that was caused because of a race condition between the VSphere machine controller creating the VM which was causing another reconcile event being requeued for the same object. The other reconcile event was sometimes failing to find the created VSphereVM from the earlier request and trying to create the same object and failing with an already exists error.
Now, the VSphereMachine controller omits the create events for the VSphereVM objects since the controller is the author of those objects and should not be notified for the same event.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1372

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Fixes panic when reconciling VSphereMachine objects
```