### PR TITLE
🌱 Exposes a new reason for VMProvisionedCondition

### DIFF
--- a/apis/v1beta1/condition_consts.go
+++ b/apis/v1beta1/condition_consts.go
@@ -61,6 +61,12 @@ const (
 	// a static IP address.
 	WaitingForStaticIPAllocationReason = "WaitingForStaticIPAllocation"
 
+	// WaitingForIPAllocationReason (Severity=Info) documents a VSphereVM waiting for the allocation of
+	// an IP address.
+	// This is used when the dhcp4 or dhcp6 for a VSphereVM is set and the VSphereVM is waiting for the
+	// relevant IP address  to show up on the VM.
+	WaitingForIPAllocationReason = "WaitingForIPAllocation"
+
 	// CloningReason documents (Severity=Info) a VSphereMachine/VSphereVM currently executing the clone operation.
 	CloningReason = "Cloning"
 

--- a/pkg/context/fake/fake_vm_context.go
+++ b/pkg/context/fake/fake_vm_context.go
@@ -18,7 +18,6 @@ package fake
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
@@ -54,7 +53,7 @@ func newVSphereVM() infrav1.VSphereVM {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: Namespace,
 			Name:      VSphereVMName,
-			UID:       types.UID(VSphereVMUUID),
+			UID:       VSphereVMUUID,
 		},
 		Spec: infrav1.VSphereVMSpec{
 			VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{

--- a/pkg/services/fake/vmservice.go
+++ b/pkg/services/fake/vmservice.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+)
+
+type vmService struct {
+	fakeMachine infrav1.VirtualMachine
+	err         error
+}
+
+func NewVMServiceWithVM(fakeMachine infrav1.VirtualMachine) services.VirtualMachineService {
+	return vmService{
+		fakeMachine: fakeMachine,
+	}
+}
+
+func (v vmService) ReconcileVM(_ *context.VMContext) (infrav1.VirtualMachine, error) {
+	return v.fakeMachine, v.err
+}
+
+func (v vmService) DestroyVM(ctx *context.VMContext) (infrav1.VirtualMachine, error) {
+	return v.fakeMachine, v.err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new reason on the VSphereVM object's condition to convey that the Machine is waiting on the IP address. This is set if the VSphereVM has no IP addresses reported in its state.

**Which issue(s) this PR fixes**:
Fixes #1490

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Exposes reason to convey VSphereVM waiting for IP address
```