### PR TITLE
✨ Adds logic to label nodes with special prefixes

### DIFF
--- a/apis/v1alpha3/conversion_test.go
+++ b/apis/v1alpha3/conversion_test.go
@@ -113,12 +113,12 @@ func CustomObjectMetaFuzzer(in *clusterv1.ObjectMeta, c fuzz.Continue) {
 
 func CustomNewFieldFuzzFunc(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
-		CustomNewFieldFuzzer,
+		CustomSpecNewFieldFuzzer,
 		CustomStatusNewFieldFuzzer,
 	}
 }
 
-func CustomNewFieldFuzzer(in *nextver.VirtualMachineCloneSpec, c fuzz.Continue) {
+func CustomSpecNewFieldFuzzer(in *nextver.VirtualMachineCloneSpec, c fuzz.Continue) {
 	c.FuzzNoCustom(in)
 
 	in.PciDevices = nil
@@ -129,5 +129,6 @@ func CustomNewFieldFuzzer(in *nextver.VirtualMachineCloneSpec, c fuzz.Continue) 
 func CustomStatusNewFieldFuzzer(in *nextver.VSphereVMStatus, c fuzz.Continue) {
 	c.FuzzNoCustom(in)
 
+	in.Host = ""
 	in.ModuleUUID = nil
 }

--- a/apis/v1alpha3/vspherevm_conversion.go
+++ b/apis/v1alpha3/vspherevm_conversion.go
@@ -38,6 +38,7 @@ func (src *VSphereVM) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	dst.Spec.TagIDs = restored.Spec.TagIDs
 	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
+	dst.Status.Host = restored.Status.Host
 
 	return nil
 }

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1579,6 +1579,7 @@ func Convert_v1alpha3_VSphereVMStatus_To_v1beta1_VSphereVMStatus(in *VSphereVMSt
 }
 
 func autoConvert_v1beta1_VSphereVMStatus_To_v1alpha3_VSphereVMStatus(in *v1beta1.VSphereVMStatus, out *VSphereVMStatus, s conversion.Scope) error {
+	// WARNING: in.Host requires manual conversion: does not exist in peer-type
 	out.Ready = in.Ready
 	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
 	out.CloneMode = CloneMode(in.CloneMode)

--- a/apis/v1alpha4/vspherevm_conversion.go
+++ b/apis/v1alpha4/vspherevm_conversion.go
@@ -38,6 +38,7 @@ func (src *VSphereVM) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	dst.Spec.TagIDs = restored.Spec.TagIDs
 	dst.Spec.AdditionalDisksGiB = restored.Spec.AdditionalDisksGiB
+	dst.Status.Host = restored.Status.Host
 
 	return nil
 }

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1737,6 +1737,7 @@ func Convert_v1alpha4_VSphereVMStatus_To_v1beta1_VSphereVMStatus(in *VSphereVMSt
 }
 
 func autoConvert_v1beta1_VSphereVMStatus_To_v1alpha4_VSphereVMStatus(in *v1beta1.VSphereVMStatus, out *VSphereVMStatus, s conversion.Scope) error {
+	// WARNING: in.Host requires manual conversion: does not exist in peer-type
 	out.Ready = in.Ready
 	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
 	out.CloneMode = CloneMode(in.CloneMode)

--- a/apis/v1beta1/vspherevm_types.go
+++ b/apis/v1beta1/vspherevm_types.go
@@ -51,6 +51,11 @@ type VSphereVMSpec struct {
 
 // VSphereVMStatus defines the observed state of VSphereVM
 type VSphereVMStatus struct {
+	// Host describes the hostname or IP address of the infrastructure host
+	// that the VSphereVM is residing on.
+	// +optional
+	Host string `json:"host,omitempty"`
+
 	// Ready is true when the provider resource is ready.
 	// This field is required at runtime for other controllers that read
 	// this CRD as unstructured data.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1235,6 +1235,10 @@ spec:
                   of vspherevms can be added as events to the vspherevm object and/or
                   logged in the controller's output."
                 type: string
+              host:
+                description: Host describes the hostname or IP address of the infrastructure
+                  host that the VSphereVM is residing on.
+                type: string
               moduleUUID:
                 description: ModuleUUID is the unique identifier for the vCenter cluster
                   module construct which is used to configure anti-affinity. Objects

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
         - --leader-elect
         - --logtostderr
         - --v=4
-        - "--feature-gates=NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false}"
+        - "--feature-gates=NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false},NodeLabeling=${EXP_NODE_LABELING:=false}"
         image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -128,6 +128,14 @@ rules:
   - cluster.x-k8s.io
   resources:
   - machines
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines/status
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -110,6 +110,15 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - clusters
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machinedeployments
   verbs:
   - get
@@ -165,6 +174,9 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	goctx "context"
+	"fmt"
+	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
+)
+
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;clusters,verbs=get;watch;list
+
+const (
+	nodeLabelControllerNameShort = "node-label-controller"
+)
+
+// AddNodeLabelControllerToManager adds the VM controller to the provided manager.
+func AddNodeLabelControllerToManager(ctx *context.ControllerManagerContext, mgr manager.Manager) error {
+	var (
+		controllerNameLong = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, nodeLabelControllerNameShort)
+	)
+
+	controllerContext := &context.ControllerContext{
+		ControllerManagerContext: ctx,
+		Name:                     nodeLabelControllerNameShort,
+		Recorder:                 record.New(mgr.GetEventRecorderFor(controllerNameLong)),
+		Logger:                   ctx.Logger.WithName(nodeLabelControllerNameShort),
+	}
+	r := nodeLabelReconciler{
+		ControllerContext:  controllerContext,
+		remoteClientGetter: remote.NewClusterClient,
+	}
+	if _, err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Machine{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		WithEventFilter(predicates.ResourceNotPaused(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+				return false
+			},
+		}).
+		Build(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+type nodeLabelReconciler struct {
+	*context.ControllerContext
+
+	remoteClientGetter remote.ClusterClientGetter
+}
+
+type nodeContext struct {
+	Cluster *clusterv1.Cluster
+	Machine *clusterv1.Machine
+}
+
+func (r nodeLabelReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	logger := r.Logger.WithName(req.Namespace).WithName(req.Name)
+
+	machine := &clusterv1.Machine{}
+	key := client.ObjectKey{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}
+	if err := r.Client.Get(ctx, key, machine); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Machine not found, won't reconcile", "machine", key)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, machine.ObjectMeta)
+	if err == nil {
+		if annotations.IsPaused(cluster, machine) {
+			logger.V(4).Info("Machine linked to a cluster that is paused")
+			return reconcile.Result{}, nil
+		}
+	}
+
+	if !machine.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	nodeCtx := &nodeContext{
+		Cluster: cluster,
+		Machine: machine,
+	}
+	return r.reconcileNormal(nodeCtx)
+}
+
+func (r nodeLabelReconciler) reconcileNormal(ctx *nodeContext) (reconcile.Result, error) {
+	logger := r.Logger.WithName(ctx.Machine.Namespace).WithName(ctx.Machine.Name)
+	logger = logger.WithValues("cluster", ctx.Cluster.Name, "machine", ctx.Machine.Name)
+
+	// Check the current labels on the machine
+	labels := ctx.Machine.GetLabels()
+	nodePrefixLabels := map[string]string{}
+	for key, value := range labels {
+		if strings.HasPrefix(key, constants.NodeLabelPrefix) {
+			nodePrefixLabels[key] = value
+		}
+	}
+
+	if len(nodePrefixLabels) == 0 {
+		return reconcile.Result{}, nil
+	}
+
+	clusterClient, err := r.remoteClientGetter(r, nodeLabelControllerNameShort, r.Client, client.ObjectKeyFromObject(ctx.Cluster))
+	if err != nil {
+		logger.Info("The control plane is not ready yet", "err", err)
+		return reconcile.Result{RequeueAfter: clusterNotReadyRequeueTime}, nil
+	}
+
+	node := &apiv1.Node{}
+	if err := clusterClient.Get(r, client.ObjectKey{Name: ctx.Machine.GetName()}, node); err != nil {
+		logger.Error(err, "unable to get node object", "node", ctx.Machine.GetName())
+		return reconcile.Result{}, err
+	}
+
+	patchHelper, err := patch.NewHelper(node, clusterClient)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	nodeLabels := node.GetLabels()
+	for k, v := range nodePrefixLabels {
+		nodeLabels[k] = v
+	}
+	node.Labels = nodeLabels
+	if err := patchHelper.Patch(r, node); err != nil {
+		logger.Error(err, "unable to patch node object", "node", node.Name)
+		return reconcile.Result{}, err
+	}
+
+	logger.V(4).Info("Marked node with prefixed labels", "node", node.Name, "number-of-labels", len(nodePrefixLabels))
+	return reconcile.Result{}, nil
+}

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -30,8 +30,17 @@ const (
 
 	// NodeAntiAffinity is a feature gate for the NodeAntiAffinity functionality.
 	//
-	// alpha: v1.5
+	// alpha: v1.4
 	NodeAntiAffinity featuregate.Feature = "NodeAntiAffinity"
+
+	// NodeLabeling is a feature gate for the functionality to propagate Machine labels
+	// with the prefix to the Node objects.
+	// This is a stop-gap measure which will be removed when we have this functionality
+	// present in CAPI.
+	// See https://github.com/kubernetes-sigs/cluster-api/pull/6255
+	//
+	// alpha: v1.4
+	NodeLabeling featuregate.Feature = "NodeLabeling"
 )
 
 func init() {
@@ -43,4 +52,5 @@ func init() {
 var defaultCAPVFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
 	NodeAntiAffinity: {Default: false, PreRelease: featuregate.Alpha},
+	NodeLabeling:     {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/main.go
+++ b/main.go
@@ -301,6 +301,9 @@ func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Man
 	if err := controllers.AddVSphereDeploymentZoneControllerToManager(ctx, mgr); err != nil {
 		return err
 	}
+	if err := controllers.AddNodeLabelControllerToManager(ctx, mgr); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -301,8 +301,11 @@ func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Man
 	if err := controllers.AddVSphereDeploymentZoneControllerToManager(ctx, mgr); err != nil {
 		return err
 	}
-	if err := controllers.AddNodeLabelControllerToManager(ctx, mgr); err != nil {
-		return err
+
+	if feature.Gates.Enabled(feature.NodeLabeling) {
+		if err := controllers.AddNodeLabelControllerToManager(ctx, mgr); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,4 +56,8 @@ const (
 
 	// KeepaliveDuration unit minutes.
 	DefaultKeepAliveDuration = time.Minute * 5
+
+	NodeLabelPrefix = "node.cluster.x-k8s.io"
+
+	ESXiHostInfoLabel = NodeLabelPrefix + "/esxi-host"
 )

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -145,6 +145,10 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 		return vm, err
 	}
 
+	if err := vms.reconcileHostInfo(vmCtx); err != nil {
+		return vm, err
+	}
+
 	if err := vms.reconcileTags(vmCtx); err != nil {
 		conditions.MarkFalse(ctx.VSphereVM, infrav1.VMProvisionedCondition, infrav1.TagsAttachmentFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return vm, err
@@ -449,6 +453,19 @@ func (vms *VMService) getMetadata(ctx *virtualMachineContext) (string, error) {
 	}
 
 	return string(metadataBuf), nil
+}
+
+func (vms *VMService) reconcileHostInfo(ctx *virtualMachineContext) error {
+	host, err := ctx.Obj.HostSystem(ctx)
+	if err != nil {
+		return err
+	}
+	name, err := host.ObjectName(ctx)
+	if err != nil {
+		return err
+	}
+	ctx.VSphereVM.Status.Host = name
+	return nil
 }
 
 func (vms *VMService) setMetadata(ctx *virtualMachineContext, metadata []byte) (string, error) {

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -35,6 +35,7 @@ type VSphereMachineService interface {
 	ReconcileDelete(ctx context.MachineContext) error
 	SyncFailureReason(ctx context.MachineContext) (bool, error)
 	ReconcileNormal(ctx context.MachineContext) (bool, error)
+	GetHostInfo(ctx context.MachineContext) (string, error)
 }
 
 // VirtualMachineService is a service for creating/updating/deleting virtual

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -229,6 +229,23 @@ func (v *VmopMachineService) ReconcileNormal(c context.MachineContext) (bool, er
 	return false, nil
 }
 
+func (v VmopMachineService) GetHostInfo(c context.MachineContext) (string, error) {
+	ctx, ok := c.(*vmware.SupervisorMachineContext)
+	if !ok {
+		return "", errors.New("received unexpected SupervisorMachineContext type")
+	}
+
+	vmOperatorVM := &vmoprv1.VirtualMachine{}
+	if err := ctx.Client.Get(ctx, client.ObjectKey{
+		Name:      ctx.Machine.Name,
+		Namespace: ctx.Machine.Namespace,
+	}, vmOperatorVM); err != nil {
+		return "", err
+	}
+
+	return vmOperatorVM.Status.Host, nil
+}
+
 func (v VmopMachineService) newVMOperatorVM(ctx *vmware.SupervisorMachineContext) *vmoprv1.VirtualMachine {
 	return &vmoprv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -147,6 +147,7 @@ variables:
   VENDOR_ID: 4318
   # CAPV feature flags
   EXP_NODE_ANTI_AFFINITY: "true"
+  EXP_NODE_LABELING: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -163,6 +163,7 @@ variables:
   VENDOR_ID: 4318
   # CAPV feature flags
   EXP_NODE_ANTI_AFFINITY: "true"
+  EXP_NODE_LABELING: "true"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/node_labeling_test.go
+++ b/test/e2e/node_labeling_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
+)
+
+type NodeLabelingSpecInput struct {
+	InfraClients
+	Global    GlobalInput
+	Namespace *corev1.Namespace
+}
+
+var _ = Describe("Label nodes with ESXi host info", func() {
+	var (
+		namespace *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace = setupSpecNamespace("node-labeling-e2e")
+	})
+
+	AfterEach(func() {
+		cleanupSpecNamespace(namespace)
+	})
+
+	It("creates a workload cluster whose nodes have the ESXi host info", func() {
+		VerifyNodeLabeling(ctx, NodeLabelingSpecInput{
+			Namespace: namespace,
+			InfraClients: InfraClients{
+				Client:     vsphereClient,
+				RestClient: restClient,
+				Finder:     vsphereFinder,
+			},
+			Global: GlobalInput{
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				E2EConfig:             e2eConfig,
+				ArtifactFolder:        artifactFolder,
+			},
+		})
+	})
+})
+
+func VerifyNodeLabeling(ctx context.Context, input NodeLabelingSpecInput) {
+	var (
+		specName         = "node-labeling"
+		namespace        = input.Namespace
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	)
+
+	clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+	By("creating a workload cluster")
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, 1, 1, input.Global)
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 input.Global.BootstrapClusterProxy,
+		ConfigCluster:                configCluster,
+		WaitForClusterIntervals:      input.Global.E2EConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: input.Global.E2EConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+	workloadProxy := input.Global.BootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)
+
+	Byf("fetching the nodes of the workload cluster %s", clusterName)
+	nodes := corev1.NodeList{}
+	Expect(workloadProxy.GetClient().List(ctx, &nodes)).To(Succeed())
+	nodeMap := map[string]*corev1.Node{}
+	for _, node := range nodes.Items {
+		nodeMap[node.Name] = node.DeepCopy()
+	}
+
+	Byf("fetching the VSphereVM objects for the workload cluster %s", clusterName)
+	vms := getVSphereVMsForCluster(clusterName, namespace.Name)
+	Expect(vms.Items).To(HaveLen(len(nodeMap)))
+
+	By("verifying the ESXi host info label on the nodes")
+	for _, vm := range vms.Items {
+		// since the name of the VSphereVM is the name of the K8s node.
+		Expect(nodeMap).To(HaveKey(vm.Name))
+		labels := nodeMap[vm.Name].GetLabels()
+		Expect(labels).To(HaveKey(constants.ESXiHostInfoLabel))
+		Expect(labels).To(HaveKeyWithValue(constants.ESXiHostInfoLabel, vm.Status.Host))
+	}
+
+	By("verifying the ESXi host information from the virtual machines")
+	for _, vm := range vms.Items {
+		vmObj, err := input.Finder.VirtualMachine(ctx, vm.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		host, err := vmObj.HostSystem(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		name, err := host.ObjectName(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(name).To(Equal(vm.Status.Host))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds the following:
- Exposing ESXi host information onto the VSphereVM object
- Exposing ESXi host information as a label onto the Machine object `node.cluster.x-k8s.io/esxi-host: <host-address>`
- Copying the labels prefixed with `node.cluster.x-k8s.io` from the Machine to the Node objects (this will eventually be deprecated in favor of CAPI v1.3.0 release)

This functionality is exposed under a feature flag which is turned off by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1633

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Adds logic to label nodes with special prefixes
```