### PR TITLE
Automated cherry pick of #1622: Fixes panic when creating VSphereVM

### DIFF
--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -121,8 +121,8 @@ func (v *VimMachineService) ReconcileNormal(c context.MachineContext) (bool, err
 	}
 
 	vm, err := v.createOrPatchVSPhereVM(ctx, vsphereVM)
-
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err != nil {
+		ctx.Logger.Error(err, "error creating or patching VM", "vsphereVM", vsphereVM)
 		return false, err
 	}
 


### PR DESCRIPTION
Cherry pick of #1622 on release-1.3.

#1622: Fixes panic when creating VSphereVM

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```