### PR TITLE
🐛  Adds default resource pool logic for cluster module creation

### DIFF
--- a/pkg/clustermodule/error.go
+++ b/pkg/clustermodule/error.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustermodule
+
+import (
+	"fmt"
+	"strings"
+)
+
+const errString = "not a compute cluster"
+
+// IncompatibleOwnerError represents the error condition wherein the resource pool in use
+// during cluster module creation is not owned by compute cluster resource but owned by
+// a standalone host.
+type IncompatibleOwnerError struct {
+	resource string
+}
+
+func (e IncompatibleOwnerError) Error() string {
+	return fmt.Sprintf("%s %s", e.resource, errString)
+}
+
+// NewIncompatibleOwnerError creates an instance of the IncompatibleOwnerError struct.
+// This is introduced for testing purposes only.
+func NewIncompatibleOwnerError(name string) IncompatibleOwnerError {
+	return IncompatibleOwnerError{resource: name}
+}
+
+func IsIncompatibleOwnerError(err error) bool {
+	return strings.HasSuffix(err.Error(), errString)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds the logic to fall back to the default resource pool, if no resource pool is specified, during cluster module creation. It also checks whether the resource pool is owned by a compute cluster or a standalone host. In case of the owner being a standalone host, a warning is introduced on the VSphereCluster object and the cluster creation proceeds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1640

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds default resource pool logic for cluster module creation
```