### PR TITLE
Automated cherry pick of #1644: Allow mutation of OS field and only when it's empty

### DIFF
--- a/apis/v1beta1/vspherevm_webhook.go
+++ b/apis/v1beta1/vspherevm_webhook.go
@@ -106,6 +106,12 @@ func (r *VSphereVM) ValidateUpdate(old runtime.Object) error {
 	delete(oldVSphereVMNetwork, "devices")
 	delete(newVSphereVMNetwork, "devices")
 
+	// allow changes to os only if the old spec has empty OS field
+	if _, ok := oldVSphereVMSpec["os"]; !ok {
+		delete(oldVSphereVMSpec, "os")
+		delete(newVSphereVMSpec, "os")
+	}
+
 	if !reflect.DeepEqual(oldVSphereVMSpec, newVSphereVMSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
 	}

--- a/apis/v1beta1/vspherevm_webhook_test.go
+++ b/apis/v1beta1/vspherevm_webhook_test.go
@@ -132,6 +132,18 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 			vSphereVM:    createVSphereVM("vsphere-vm-1", "bar.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
 			wantErr:      true,
 		},
+		{
+			name:         "updating OS can be done only when empty",
+			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, ""),
+			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			wantErr:      false,
+		},
+		{
+			name:         "updating OS cannot be done when alreadySet",
+			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Windows),
+			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			wantErr:      true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #1644 on release-1.4.

#1644: Allow mutation of OS field and only when it's empty

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.