### PR TITLE
🌱 Adds write permission for PR Verify workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
+<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
+<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
+Here are some other tips for you:
 1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
 2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -2,16 +2,15 @@ name: Verify PR
 
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  checks: write # Allow access to checks to write check runs.
 
 jobs:
   verify:
     runs-on: ubuntu-latest
-    name: Check PR contents
+    name: Verify PR contents
     steps:
       - name: Verifier action
         id: verifier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,9 @@ Kubernetes projects require that you sign a Contributor License Agreement (CLA) 
 1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
 1. Fork the desired repo, develop and test your code changes.
 1. Submit a pull request.
+    * All code PR must be labeled with one of
+        * ⚠️ (:warning:, major or breaking changes)
+        * ✨ (:sparkles:, feature additions)
+        * 🐛 (:bug:, patch and bugfixes)
+        * 📖 (:book:, documentation or proposals)
+        * 🌱 (:seedling:, minor or other)


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the permissions for the PR Verify workflow. It also updates the pull request template to include the instructions to add an icon to the PR title.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes  _the failing the PR Verify workflow_

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```