### PR TITLE
✨Set minimum TLS version for webhook server

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	managerOpts     manager.Options
 	syncPeriod      time.Duration
 	profilerAddress string
+	tlsMinVersion   string
 
 	defaultProfilerAddr      = os.Getenv("PROFILER_ADDR")
 	defaultSyncPeriod        = manager.DefaultSyncPeriod
@@ -143,6 +144,12 @@ func InitFlags(fs *pflag.FlagSet) {
 		"",
 		"network provider to be used by Supervisor based clusters.",
 	)
+	flag.StringVar(
+		&tlsMinVersion,
+		"tls-min-version",
+		"",
+		"minimum TLS version in use by the webhook server. Possible values are  \"\", \"1.0\", \"1.1\", \"1.2\" and \"1.3\".",
+	)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -226,6 +233,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = tlsMinVersion
 	setupChecks(mgr)
 
 	sigHandler := ctrlsig.SetupSignalHandler()

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ var (
 	defaultWebhookPort       = manager.DefaultWebhookServiceContainerPort
 	defaultEnableKeepAlive   = constants.DefaultEnableKeepAlive
 	defaultKeepAliveDuration = constants.DefaultKeepAliveDuration
+	defaultTLSMinVersion     = "1.2"
 )
 
 // InitFlags initializes the flags.
@@ -147,7 +148,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	flag.StringVar(
 		&tlsMinVersion,
 		"tls-min-version",
-		"",
+		defaultTLSMinVersion,
 		"minimum TLS version in use by the webhook server. Possible values are  \"\", \"1.0\", \"1.1\", \"1.2\" and \"1.3\".",
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new flag to set the TLS version to the webhook server.

**Which issue(s) this PR fixes**:
Fixes #1639

**Special notes for your reviewer**:
Added defaulting to TLS 1.2 as a separate commit to facilitate backport

**Release note**:
```release-note
Flag to configure the min TLS version of the webhook server
```