### PR TITLE
✨ Creates an explicit token secret for service account

### DIFF
--- a/controllers/serviceaccount_controller_unit_test.go
+++ b/controllers/serviceaccount_controller_unit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -78,6 +79,16 @@ func unitTestsReconcileNormal() {
 				getSystemServiceAccountsConfigMap(testSystemSvcAcctNs, testSystemSvcAcctCM),
 				getTestProviderServiceAccount(namespace, vsphereCluster, false),
 			}
+		})
+		It("should create a service account and a secret", func() {
+			_, err := reconciler.ReconcileNormal(ctx.GuestClusterContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			svcAccount := &corev1.ServiceAccount{}
+			assertEventuallyExistsInNamespace(ctx, ctx.Client, namespace, vsphereCluster.GetName(), svcAccount)
+
+			secret := &corev1.Secret{}
+			assertEventuallyExistsInNamespace(ctx, ctx.Client, namespace, fmt.Sprintf("%s-secret", vsphereCluster.GetName()), secret)
 		})
 		Context("When serviceaccount secret is created", func() {
 			It("Should reconcile", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch changes the default behavior of waiting for the generation of a default secret for the service account and propagate that over to the guest cluster.
Instead, alongwith the service account a secret of type "kubernetes.io/service-account-token" is created to host the token for the service account. The controller waits for the realization of this secret and then propagates this data over to the guest cluster.

This is required since 1.24 disables the auto generation of a default token secret for every service account created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1651 

**Release note**:
```release-note
Creates an explicit token secret for service account
```