### PR TITLE
⚠️ Automated cherry pick of #1648: Introduces new flag for setting min TLS version

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	managerOpts     manager.Options
 	syncPeriod      time.Duration
 	profilerAddress string
+	tlsMinVersion   string
 
 	defaultProfilerAddr      = os.Getenv("PROFILER_ADDR")
 	defaultSyncPeriod        = manager.DefaultSyncPeriod
@@ -143,6 +144,12 @@ func InitFlags(fs *pflag.FlagSet) {
 		"",
 		"network provider to be used by Supervisor based clusters.",
 	)
+	flag.StringVar(
+		&tlsMinVersion,
+		"tls-min-version",
+		"",
+		"minimum TLS version in use by the webhook server. Possible values are  \"\", \"1.0\", \"1.1\", \"1.2\" and \"1.3\".",
+	)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -226,6 +233,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = tlsMinVersion
 	setupChecks(mgr)
 
 	sigHandler := ctrlsig.SetupSignalHandler()

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ var (
 	defaultWebhookPort       = manager.DefaultWebhookServiceContainerPort
 	defaultEnableKeepAlive   = constants.DefaultEnableKeepAlive
 	defaultKeepAliveDuration = constants.DefaultKeepAliveDuration
+	defaultTLSMinVersion     = "1.2"
 )
 
 // InitFlags initializes the flags.
@@ -147,7 +148,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	flag.StringVar(
 		&tlsMinVersion,
 		"tls-min-version",
-		"",
+		defaultTLSMinVersion,
 		"minimum TLS version in use by the webhook server. Possible values are  \"\", \"1.0\", \"1.1\", \"1.2\" and \"1.3\".",
 	)
 


### PR DESCRIPTION
Cherry pick of #1648 on release-1.4.

#1648: Introduces new flag for setting min TLS version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```