### PR TITLE
Automated cherry pick of #1653: Creates token secret for service account

### DIFF
--- a/controllers/serviceaccount_controller_suite_test.go
+++ b/controllers/serviceaccount_controller_suite_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	goctx "context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -35,13 +36,10 @@ import (
 )
 
 const (
-	testProviderSvcAccountName = "test-pvcsi"
-
-	testTargetNS             = "test-pvcsi-system"
-	testTargetSecret         = "test-pvcsi-secret" // nolint:gosec
-	testSvcAccountSecretName = testProviderSvcAccountName + "-token-abcdef"
-	testSystemSvcAcctNs      = "test-system-svc-acct-namespace"
-	testSystemSvcAcctCM      = "test-system-svc-acct-cm"
+	testTargetNS        = "test-pvcsi-system"
+	testTargetSecret    = "test-pvcsi-secret" //nolint:gosec
+	testSystemSvcAcctNs = "test-system-svc-acct-namespace"
+	testSystemSvcAcctCM = "test-system-svc-acct-cm"
 
 	testSecretToken = "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklp" // nolint:gosec
 )
@@ -94,15 +92,14 @@ func assertNoEntities(ctx goctx.Context, ctrlClient client.Client, namespace str
 func assertServiceAccountAndUpdateSecret(ctx goctx.Context, ctrlClient client.Client, namespace, name string) {
 	svcAccount := &corev1.ServiceAccount{}
 	assertEventuallyExistsInNamespace(ctx, ctrlClient, namespace, name, svcAccount)
-	// Update the service account with a prototype secret
-	secret := getTestSvcAccountSecret(namespace, testSvcAccountSecretName)
-	Expect(ctrlClient.Create(ctx, secret)).To(Succeed())
-	svcAccount.Secrets = []corev1.ObjectReference{
-		{
-			Name: testSvcAccountSecretName,
-		},
+	secret := &corev1.Secret{}
+	assertEventuallyExistsInNamespace(ctx, ctrlClient, namespace, fmt.Sprintf("%s-secret", name), secret)
+
+	// Update the data on the secret
+	secret.Data = map[string][]byte{
+		"token": []byte(testSecretToken),
 	}
-	Expect(ctrlClient.Update(ctx, svcAccount)).To(Succeed())
+	Expect(ctrlClient.Update(ctx, secret)).To(Succeed())
 }
 
 func assertTargetSecret(ctx goctx.Context, guestClient client.Client, namespace, name string) { // nolint
@@ -159,9 +156,8 @@ func assertRoleBinding(_ *helpers.UnitTestContextForController, ctrlClient clien
 	}))
 }
 
-// nolint
-func assertProviderServiceAccountsCondition(vCluster *vmwarev1.VSphereCluster, status corev1.ConditionStatus,
-	message string, reason string, severity clusterv1.ConditionSeverity) {
+// assertProviderServiceAccountsCondition asserts the condition on the ProviderServiceAccount CR.
+func assertProviderServiceAccountsCondition(vCluster *vmwarev1.VSphereCluster, status corev1.ConditionStatus, message string, reason string, severity clusterv1.ConditionSeverity) { //nolint
 	c := conditions.Get(vCluster, vmwarev1.ProviderServiceAccountsReadyCondition)
 	Expect(c).NotTo(BeNil())
 	Expect(c.Status).To(Equal(status))
@@ -242,18 +238,6 @@ func getSystemServiceAccountsConfigMap(namespace, name string) *corev1.ConfigMap
 		Data: map[string]string{
 			"system-account-1": "true",
 			"system-account-2": "true",
-		},
-	}
-}
-
-func getTestSvcAccountSecret(namespace, name string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			"token": []byte(testSecretToken),
 		},
 	}
 }

--- a/controllers/serviceaccount_controller_unit_test.go
+++ b/controllers/serviceaccount_controller_unit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -78,6 +79,16 @@ func unitTestsReconcileNormal() {
 				getSystemServiceAccountsConfigMap(testSystemSvcAcctNs, testSystemSvcAcctCM),
 				getTestProviderServiceAccount(namespace, vsphereCluster, false),
 			}
+		})
+		It("should create a service account and a secret", func() {
+			_, err := reconciler.ReconcileNormal(ctx.GuestClusterContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			svcAccount := &corev1.ServiceAccount{}
+			assertEventuallyExistsInNamespace(ctx, ctx.Client, namespace, vsphereCluster.GetName(), svcAccount)
+
+			secret := &corev1.Secret{}
+			assertEventuallyExistsInNamespace(ctx, ctx.Client, namespace, fmt.Sprintf("%s-secret", vsphereCluster.GetName()), secret)
 		})
 		Context("When serviceaccount secret is created", func() {
 			It("Should reconcile", func() {


### PR DESCRIPTION
Cherry pick of #1653 on release-1.3.

#1653: Creates token secret for service account

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```