### PR TITLE
🐛 Automated cherry pick of #1675: Adds label validation & sanitization logic

### DIFF
--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// SanitizeHostInfoLabel ensures that the ESXi host information passed as a parameter confirms to
+// the label value constraints documented at
+// https://k8s.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+//
+// The expected inputs for the object are IP addresses or FQDNs of the ESXi hosts.
+func SanitizeHostInfoLabel(info string) string {
+	updatedInfo := stripZoneInfo(info)
+	ip := net.ParseIP(updatedInfo)
+	if ip != nil {
+		if ipv4 := ip.To4(); ipv4 == nil {
+			// In case of an IPv6 address, replace `:` with the acceptable `-` character.
+			// The size for the string would never exceed 52 (8 * 4 (address) + 7 (dashes) + 13 (suffix) = 52) characters.
+			return fmt.Sprintf("%s.ipv6-literal", strings.ReplaceAll(updatedInfo, ":", "-"))
+		}
+		return updatedInfo
+	}
+	return truncateLabelLength(info)
+}
+
+// stripZoneInfo removes the zone info from an IPv6 address.
+// This might not be exactly relevant since zone is used for link-local addresses and
+// would not be meaningful outside the host.
+// TODO (srm09): consider removing it in the future.
+func stripZoneInfo(info string) string {
+	idx := strings.LastIndex(info, "%")
+	if idx == -1 {
+		return info
+	}
+	return info[:idx]
+}
+
+func truncateLabelLength(inputURL string) string {
+	if len(inputURL) <= validation.LabelValueMaxLength {
+		return inputURL
+	}
+
+	for {
+		pos := strings.LastIndex(inputURL, ".")
+		if pos == -1 {
+			return inputURL[:validation.LabelValueMaxLength]
+		}
+		inputURL = inputURL[0:pos]
+		if len(inputURL) <= validation.LabelValueMaxLength {
+			break
+		}
+	}
+	return inputURL
+}

--- a/pkg/util/label_test.go
+++ b/pkg/util/label_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestSanitizeHostInfoLabel(t *testing.T) {
+	t.Run("for IP addresses", testIPAddressLogic)
+	t.Run("for DNS entries", testDNSLogic)
+}
+
+func testIPAddressLogic(t *testing.T) {
+	tests := []struct {
+		name, input, expected string
+	}{
+		{
+			name:     "for valid IPv4 address",
+			input:    "1.2.3.4",
+			expected: "1.2.3.4",
+		},
+		{
+			name:     "for valid IPv6 address",
+			input:    "2620:124:6020:c003:0:69ff:fe59:80ac",
+			expected: "2620-124-6020-c003-0-69ff-fe59-80ac.ipv6-literal",
+		},
+		{
+			name:     "for a shorthand valid IPv6 address",
+			input:    "2620::c003:0:69ff:fe59:80ac",
+			expected: "2620--c003-0-69ff-fe59-80ac.ipv6-literal",
+		},
+		{
+			name:     "for a valid IPv6 address with zone index",
+			input:    "2620:124:6020:c003:0:69ff:fe59:80ac%3",
+			expected: "2620-124-6020-c003-0-69ff-fe59-80ac.ipv6-literal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			g.Expect(SanitizeHostInfoLabel(tt.input)).To(gomega.Equal(tt.expected))
+		})
+	}
+}
+
+func testDNSLogic(t *testing.T) {
+	tests := []struct {
+		name, input, expected string
+	}{
+		{
+			name:     "for DNS entry with less than 63 characters",
+			input:    "foo-1.bar.com",
+			expected: "foo-1.bar.com",
+		},
+		{
+			name:     "for DNS entry with 63 characters",
+			input:    "esx13-r09.p01.1d91f0ee4f14b7e83bd42.australiaeast.avs.belch.com",
+			expected: "esx13-r09.p01.1d91f0ee4f14b7e83bd42.australiaeast.avs.belch.com",
+		},
+		{
+			name:     "for DNS entry with > 63 characters",
+			input:    "esx13-r09.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch.com",
+			expected: "esx13-r09.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch",
+		},
+		{
+			name:     "for DNS entry with > 63 characters with multiple segments dropped",
+			input:    "esx13-r09.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch.com.us",
+			expected: "esx13-r09.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch",
+		},
+		{
+			name:     "for DNS entry with > 63 characters with length = 63 after truncation",
+			input:    "esx13-r09.p01.1d91f0ee4f14b7e83bd420az.australiaeast.avs.belch.us",
+			expected: "esx13-r09.p01.1d91f0ee4f14b7e83bd420az.australiaeast.avs.belch",
+		},
+		{
+			name:     "for DNS entry with > 63 characters with first segment > 63 characters",
+			input:    "esx-zcvU3CecjX8Tr5qXQgztj9ZKCp369p3hLFdzAu8VwEyWGq4hzkLTNZq089TI.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch.com",
+			expected: "esx-zcvU3CecjX8Tr5qXQgztj9ZKCp369p3hLFdzAu8VwEyWGq4hzkLTNZq089T",
+		},
+		{
+			name:     "for DNS entry with > 63 characters with first segment = 63 characters",
+			input:    "esx-zcvU3CecjX8Tr5qXQgztj9ZKCp369p3hLFdzAu8VwEyWGq4hzkLTNZq089T.p01.1d91f0ee4f14b7e83bd420.australiaeast.avs.belch.com",
+			expected: "esx-zcvU3CecjX8Tr5qXQgztj9ZKCp369p3hLFdzAu8VwEyWGq4hzkLTNZq089T",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			g.Expect(SanitizeHostInfoLabel(tt.input)).To(gomega.Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #1675 on release-1.3.

#1675: Adds label validation & sanitization logic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```