### PR TITLE
🌱 Removes storage policy usage from all e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,14 +13,7 @@
 /examples/provider-components/provider-components*.yaml
 test/e2e/data/infrastructure-vsphere/kustomization/base/cluster-template.yaml
 test/e2e/data/infrastructure-vsphere/kustomization/topology/cluster-template-topology.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-conformance.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-pci.yaml
-test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml
+test/e2e/data/infrastructure-vsphere/cluster-template*.yaml
 test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml
 _artifacts/
 

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ e2e-templates: ## Generate e2e cluster templates
 	$(MAKE) release-manifests
 	cp $(RELEASE_DIR)/cluster-template.yaml $(E2E_TEMPLATE_DIR)/kustomization/base/cluster-template.yaml
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build $(E2E_TEMPLATE_DIR)/kustomization/base > $(E2E_TEMPLATE_DIR)/cluster-template.yaml
+	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build $(E2E_TEMPLATE_DIR)/kustomization/storage-policy > $(E2E_TEMPLATE_DIR)/cluster-template-storage-policy.yaml
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build $(E2E_TEMPLATE_DIR)/kustomization/remote-management > $(E2E_TEMPLATE_DIR)/cluster-template-remote-management.yaml
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build $(E2E_TEMPLATE_DIR)/kustomization/conformance > $(E2E_TEMPLATE_DIR)/cluster-template-conformance.yaml
 	# Since CAPI uses different flavor names for KCP and MD remediation using MHC

--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -89,7 +89,7 @@ func VerifyAntiAffinity(ctx context.Context, input AntiAffinitySpecInput) {
 	Expect(namespace).NotTo(BeNil())
 
 	Byf("creating a workload cluster with")
-	configCluster := defaultConfigCluster(clusterName, namespace.Name, 1, input.WorkerNodeCount,
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, input.WorkerNodeCount,
 		input.Global)
 
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -50,9 +50,9 @@ type GlobalInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 }
 
-func defaultConfigCluster(clusterName, namespace string, controlPlaneNodeCount, workerNodeCount int64,
+func defaultConfigCluster(clusterName, namespace, flavor string, controlPlaneNodeCount, workerNodeCount int64,
 	input GlobalInput) clusterctl.ConfigClusterInput {
-	return clusterctl.ConfigClusterInput{
+	configClusterInput := clusterctl.ConfigClusterInput{
 		LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
 		ClusterctlConfigPath:     input.ClusterctlConfigPath,
 		KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
@@ -64,4 +64,8 @@ func defaultConfigCluster(clusterName, namespace string, controlPlaneNodeCount, 
 		ControlPlaneMachineCount: pointer.Int64(controlPlaneNodeCount),
 		WorkerMachineCount:       pointer.Int64(workerNodeCount),
 	}
+	if flavor != "" {
+		configClusterInput.Flavor = flavor
+	}
+	return configClusterInput
 }

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -114,11 +114,12 @@ providers:
           # Add a cluster template
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-conformance.yaml"
-          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-pci.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-storage-policy.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml"
           - sourcePath: "../../../metadata.yaml"

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -119,11 +119,12 @@ providers:
           # Add a cluster template
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-conformance.yaml"
-          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-md-remediation.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-node-drain.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-pci.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-remote-management.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-storage-policy.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/cluster-template-topology.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/clusterclass-quick-start.yaml"
           - sourcePath: "../../../metadata.yaml"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/base/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/base/kustomization.yaml
@@ -7,3 +7,7 @@ patchesStrategicMerge:
   - ../commons/cluster-resource-set-label.yaml
   - ../commons/cluster-network-CIDR.yaml
   - ../commons/cluster-resource-set-csi-insecure.yaml
+patches:
+  - target:
+      kind: VSphereMachineTemplate
+    path: ../commons/remove-storage-policy.yaml

--- a/test/e2e/data/infrastructure-vsphere/kustomization/commons/remove-storage-policy.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/commons/remove-storage-policy.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/storagePolicyName

--- a/test/e2e/data/infrastructure-vsphere/kustomization/storage-policy/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/storage-policy/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: VSphereMachineTemplate
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/datastore
+      - op: add
+        path: /spec/template/spec/storagePolicyName
+        value: '${VSPHERE_STORAGE_POLICY}'

--- a/test/e2e/node_labeling_test.go
+++ b/test/e2e/node_labeling_test.go
@@ -76,7 +76,7 @@ func VerifyNodeLabeling(ctx context.Context, input NodeLabelingSpecInput) {
 
 	clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 	By("creating a workload cluster")
-	configCluster := defaultConfigCluster(clusterName, namespace.Name, 1, 1, input.Global)
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, 1, input.Global)
 
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 		ClusterProxy:                 input.Global.BootstrapClusterProxy,

--- a/test/e2e/storage_policy_test.go
+++ b/test/e2e/storage_policy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -24,7 +25,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
 	"github.com/vmware/govmomi/pbm/types"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -34,8 +35,15 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
+type StoragePolicySpecInput struct {
+	InfraClients
+	Global     GlobalInput
+	Namespace  *corev1.Namespace
+	Datacenter string
+}
+
 var _ = Describe("Cluster creation with storage policy", func() {
-	var namespace *v1.Namespace
+	var namespace *corev1.Namespace
 
 	BeforeEach(func() {
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -47,65 +55,89 @@ var _ = Describe("Cluster creation with storage policy", func() {
 	})
 
 	It("should create a cluster successfully", func() {
-		clusterName := fmt.Sprintf("cluster-%s", util.RandomString(6))
-		Expect(namespace).NotTo(BeNil())
-
-		By("creating a workload cluster")
-		configCluster := defaultConfigCluster(clusterName, namespace.Name, 1, 0, GlobalInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			ClusterctlConfigPath:  clusterctlConfigPath,
-			E2EConfig:             e2eConfig,
-			ArtifactFolder:        artifactFolder,
+		VerifyStoragePolicy(ctx, StoragePolicySpecInput{
+			Namespace:  namespace,
+			Datacenter: vsphereDatacenter,
+			InfraClients: InfraClients{
+				Client:     vsphereClient,
+				RestClient: restClient,
+				Finder:     vsphereFinder,
+			},
+			Global: GlobalInput{
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				E2EConfig:             e2eConfig,
+				ArtifactFolder:        artifactFolder,
+			},
 		})
-
-		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-			ClusterProxy:                 bootstrapClusterProxy,
-			ConfigCluster:                configCluster,
-			WaitForClusterIntervals:      e2eConfig.GetIntervals("", "wait-cluster"),
-			WaitForControlPlaneIntervals: e2eConfig.GetIntervals("", "wait-control-plane"),
-			WaitForMachineDeployments:    e2eConfig.GetIntervals("", "wait-worker-nodes"),
-		}, &clusterctl.ApplyClusterTemplateAndWaitResult{})
-
-		pbmClient, err := pbm.NewClient(ctx, vsphereClient.Client)
-		Expect(err).NotTo(HaveOccurred())
-		var res []types.PbmServerObjectRef
-		if pbmClient != nil {
-			spName := e2eConfig.GetVariable(VsphereStoragePolicy)
-			if spName == "" {
-				Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
-			}
-
-			spID, err := pbmClient.ProfileIDByName(ctx, spName)
-			Expect(err).NotTo(HaveOccurred())
-
-			res, err = pbmClient.QueryAssociatedEntity(ctx, types.PbmProfileId{UniqueId: spID}, "virtualMachine")
-			Expect(err).NotTo(HaveOccurred())
-		}
-		Expect(len(res)).To(BeNumerically(">", 0))
-
-		vms := getVSphereVMsForCluster(clusterName, namespace.Name)
-		Expect(len(vms.Items)).To(BeNumerically(">", 0))
-
-		datacenter, err := vsphereFinder.DatacenterOrDefault(ctx, vsphereDatacenter)
-		Expect(err).ShouldNot(HaveOccurred())
-		By("verifying storage policy is used by VMs")
-		for _, vm := range vms.Items {
-			si := object.NewSearchIndex(vsphereClient.Client)
-			ref, err := si.FindByUuid(ctx, datacenter, vm.Spec.BiosUUID, true, pointer.BoolPtr(false))
-			Expect(err).NotTo(HaveOccurred())
-			found := false
-
-			for _, o := range res {
-				if ref.Reference().Value == o.Key {
-					found = true
-					break
-				}
-			}
-
-			Expect(found).To(BeTrue(), "failed to find vm in list of vms using storage policy")
-		}
 	})
 })
+
+func VerifyStoragePolicy(ctx context.Context, input StoragePolicySpecInput) {
+	var (
+		specName         = "storage-policy"
+		namespace        = input.Namespace
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	)
+
+	clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+	Expect(namespace).NotTo(BeNil())
+
+	By("creating a workload cluster")
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, specName, 1, 0, GlobalInput{
+		BootstrapClusterProxy: bootstrapClusterProxy,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		E2EConfig:             e2eConfig,
+		ArtifactFolder:        artifactFolder,
+	})
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 input.Global.BootstrapClusterProxy,
+		ConfigCluster:                configCluster,
+		WaitForClusterIntervals:      input.Global.E2EConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: input.Global.E2EConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+
+	pbmClient, err := pbm.NewClient(ctx, input.Client.Client)
+	Expect(err).NotTo(HaveOccurred())
+	var res []types.PbmServerObjectRef
+	if pbmClient != nil {
+		spName := input.Global.E2EConfig.GetVariable(VsphereStoragePolicy)
+		if spName == "" {
+			Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
+		}
+
+		spID, err := pbmClient.ProfileIDByName(ctx, spName)
+		Expect(err).NotTo(HaveOccurred())
+
+		res, err = pbmClient.QueryAssociatedEntity(ctx, types.PbmProfileId{UniqueId: spID}, "virtualMachine")
+		Expect(err).NotTo(HaveOccurred())
+	}
+	Expect(len(res)).To(BeNumerically(">", 0))
+
+	vms := getVSphereVMsForCluster(clusterName, namespace.Name)
+	Expect(len(vms.Items)).To(BeNumerically(">", 0))
+
+	datacenter, err := vsphereFinder.DatacenterOrDefault(ctx, input.Datacenter)
+	Expect(err).ShouldNot(HaveOccurred())
+	By("verifying storage policy is used by VMs")
+	for _, vm := range vms.Items {
+		si := object.NewSearchIndex(input.Client.Client)
+		ref, err := si.FindByUuid(ctx, datacenter, vm.Spec.BiosUUID, true, pointer.Bool(false))
+		Expect(err).NotTo(HaveOccurred())
+		found := false
+
+		for _, o := range res {
+			if ref.Reference().Value == o.Key {
+				found = true
+				break
+			}
+		}
+
+		Expect(found).To(BeTrue(), "failed to find vm in list of vms using storage policy")
+	}
+}
 
 func getVSphereVMsForCluster(clusterName, namespace string) *infrav1.VSphereVMList {
 	var vms infrav1.VSphereVMList


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch removes the usage of storage policy for all e2e tests and instead makes provisions to use it for the storage policy e2e test only.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes storage policy usage from all e2e tests
```

/kind cleanup