### PR TITLE
🐛 Removes hard dependency on cluster module info for VM deletion

### DIFF
--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -50,11 +50,11 @@ func NewControllerManagerContext(initObjects ...client.Object) *context.Controll
 	_ = vmoprv1.AddToScheme(scheme)
 	_ = ipamv1.AddToScheme(scheme)
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+	clientWithObjects := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 	return &context.ControllerManagerContext{
 		Context:                 goctx.Background(),
-		Client:                  client,
+		Client:                  clientWithObjects,
 		Logger:                  ctrllog.Log.WithName(ControllerManagerName),
 		Scheme:                  scheme,
 		Namespace:               ControllerManagerNamespace,

--- a/pkg/services/fake/vmservice.go
+++ b/pkg/services/fake/vmservice.go
@@ -17,26 +17,22 @@ limitations under the License.
 package fake
 
 import (
+	"github.com/stretchr/testify/mock"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 )
 
-type vmService struct {
-	fakeMachine infrav1.VirtualMachine
-	err         error
+type VMService struct {
+	mock.Mock
 }
 
-func NewVMServiceWithVM(fakeMachine infrav1.VirtualMachine) services.VirtualMachineService {
-	return vmService{
-		fakeMachine: fakeMachine,
-	}
+func (v *VMService) ReconcileVM(ctx *context.VMContext) (infrav1.VirtualMachine, error) {
+	args := v.Called(ctx)
+	return args.Get(0).(infrav1.VirtualMachine), args.Error(1)
 }
 
-func (v vmService) ReconcileVM(_ *context.VMContext) (infrav1.VirtualMachine, error) {
-	return v.fakeMachine, v.err
-}
-
-func (v vmService) DestroyVM(ctx *context.VMContext) (infrav1.VirtualMachine, error) {
-	return v.fakeMachine, v.err
+func (v *VMService) DestroyVM(ctx *context.VMContext) (infrav1.VirtualMachine, error) {
+	args := v.Called(ctx)
+	return args.Get(0).(infrav1.VirtualMachine), args.Error(1)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch removes the hard dependency of finding the cluster module information when deleting a VM. If the information is missing, due to broken owner reference links, then we should let the controller proceed with VM deletion.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes hard dependency on cluster module info for VM deletion
```