### PR TITLE
:seedling:Update the deprecated vm-operator API to the new repository location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		output:crd:dir=$(SUPERVISOR_CRD_ROOT)
 	# vm-operator crds are loaded to be used for integration tests.
 	$(CONTROLLER_GEN) \
-		paths=github.com/vmware-tanzu/vm-operator-api/api/... \
+		paths=github.com/vmware-tanzu/vm-operator/api/... \
 		crd:crdVersions=v1 \
 		output:crd:dir=$(VMOP_CRD_ROOT)
 

--- a/apis/v1beta1/vspheremachine_webhook.go
+++ b/apis/v1beta1/vspheremachine_webhook.go
@@ -69,6 +69,7 @@ func (m *VSphereMachine) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+//
 //nolint:forcetypeassert
 func (m *VSphereMachine) ValidateUpdate(old runtime.Object) error {
 	newVSphereMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(m)

--- a/apis/v1beta1/vspherevm_webhook.go
+++ b/apis/v1beta1/vspherevm_webhook.go
@@ -75,6 +75,7 @@ func (r *VSphereVM) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+//
 //nolint:forcetypeassert
 func (r *VSphereVM) ValidateUpdate(old runtime.Object) error {
 	newVSphereVM, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -6,17 +6,18 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
-  name: virtualmachineimages.vmoperator.vmware.com
+  name: clustervirtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
   names:
-    kind: VirtualMachineImage
-    listKind: VirtualMachineImageList
-    plural: virtualmachineimages
+    kind: ClusterVirtualMachineImage
+    listKind: ClusterVirtualMachineImageList
+    plural: clustervirtualmachineimages
     shortNames:
-    - vmi
-    - vmimage
-    singular: virtualmachineimage
+    - cvmi
+    - cvmimage
+    - clustervmimage
+    singular: clustervirtualmachineimage
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -48,11 +49,9 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VirtualMachineImage is the Schema for the virtualmachineimages
-          API A VirtualMachineImage represents a VirtualMachine image (e.g. VM template)
-          that can be used as the base image for creating a VirtualMachine instance.  The
-          VirtualMachineImage is a required field of the VirtualMachine spec.  Currently,
-          VirtualMachineImages are immutable to end users.
+        description: ClusterVirtualMachineImage is the schema for the clustervirtualmachineimage
+          API A ClusterVirtualMachineImage represents the desired specification and
+          the observed status of a ClusterVirtualMachineImage instance.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -19,13 +19,13 @@ spec:
   - additionalPrinterColumns:
     - description: UUID of the vSphere content library
       jsonPath: .spec.uuid
-      name: Content Library UUID
+      name: Content-Library-UUID
       type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ContentLibraryProvider is the Schema for the contentlibraryproviders
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -40,7 +40,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ContentLibraryProviderSpec defines the desired state of ContentLibraryProvider
+            description: ContentLibraryProviderSpec defines the desired state of ContentLibraryProvider.
             properties:
               uuid:
                 description: UUID describes the UUID of a vSphere content library.
@@ -50,7 +50,7 @@ spec:
           status:
             description: ContentLibraryProviderStatus defines the observed state of
               ContentLibraryProvider Can include fields indicating when was the last
-              time VM images were updated from a library
+              time VM images were updated from a library.
             type: object
         type: object
     served: true

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
@@ -36,7 +36,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ContentSourceSpec defines the desired state of ContentSource
+            description: ContentSourceSpec defines the desired state of ContentSource.
             properties:
               providerRef:
                 description: ProviderRef is a reference to a content provider object
@@ -61,7 +61,7 @@ spec:
                 type: object
             type: object
           status:
-            description: ContentSourceStatus defines the observed state of ContentSource
+            description: ContentSourceStatus defines the observed state of ContentSource.
             type: object
         type: object
     served: true

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -26,7 +26,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: VirtualMachineClassBinding is a binding object responsible for
-          defining a VirtualMachineClass and a Namespace associated with it
+          defining a VirtualMachineClass and a Namespace associated with it.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -29,11 +29,11 @@ spec:
       name: Age
       type: date
     - jsonPath: .spec.hardware.devices.vgpuDevices[*].profileName
-      name: VGPUDevicesProfileNames
+      name: VGPU-Devices-Profile-Names
       priority: 1
       type: string
     - jsonPath: .spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID
-      name: PassthroughDeviceIDs
+      name: Passthrough-DeviceIDs
       priority: 1
       type: string
     name: v1alpha1
@@ -59,8 +59,17 @@ spec:
           metadata:
             type: object
           spec:
-            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
             properties:
+              configSpec:
+                description: ConfigSpec may specify additional virtual machine configuration
+                  settings including hardware specifications for a VirtualMachine
+                properties:
+                  xml:
+                    description: XML contains a vim.vm.ConfigSpec object that has
+                      been serialized to XML and base64-encoded.
+                    type: string
+                type: object
               description:
                 description: Description describes the configuration of the VirtualMachineClass
                   which is not related to virtual hardware or infrastructure policy.

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -1,0 +1,303 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: virtualmachinepublishrequests.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachinePublishRequest
+    listKind: VirtualMachinePublishRequestList
+    plural: virtualmachinepublishrequests
+    shortNames:
+    - vmpub
+    singular: virtualmachinepublishrequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachinePublishRequest defines the information necessary
+          to publish a VirtualMachine as a VirtualMachineImage to an image registry.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "VirtualMachinePublishRequestSpec defines the desired state
+              of a VirtualMachinePublishRequest. \n All the fields in this spec are
+              optional. This is especially useful when a DevOps persona wants to publish
+              a VM without doing anything more than applying a VirtualMachinePublishRequest
+              resource that has the same name as said VM in the same namespace as
+              said VM."
+            properties:
+              source:
+                description: "Source is the source of the publication request, ex.
+                  a VirtualMachine resource. \n If this value is omitted then the
+                  publication controller checks to see if there is a resource with
+                  the same name as this VirtualMachinePublishRequest resource, an
+                  API version equal to spec.source.apiVersion, and a kind equal to
+                  spec.source.kind. If such a resource exists, then it is the source
+                  of the publication."
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: "Name is the name of the referenced object. \n If
+                      omitted this value defaults to the name of the VirtualMachinePublishRequest
+                      resource."
+                    type: string
+                type: object
+              target:
+                description: "Target is the target of the publication request, ex.
+                  item information and a ContentLibrary resource. \n If this value
+                  is omitted, the controller uses spec.source.name + \"-image\" as
+                  the name of the published item. Additionally, when omitted the controller
+                  attempts to identify the target location by matching a resource
+                  with an API version equal to spec.target.location.apiVersion, a
+                  kind equal to spec.target.location.kind, w/ the label \"imageregistry.vmware.com/default\".
+                  \n Please note that while optional, if a VirtualMachinePublishRequest
+                  sans target information is applied to a namespace without a default
+                  publication target, then the VirtualMachinePublishRequest resource
+                  will be marked in error."
+                properties:
+                  item:
+                    description: "Item contains information about the name of the
+                      object to which the VM is published. \n Please note this value
+                      is optional and if omitted, the controller will use spec.source.name
+                      + \"-image\" as the name of the published item."
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: "Name is the name of the published object. \n
+                          If the spec.target.location.apiVersion equals imageregistry.vmware.com/v1alpha1
+                          and the spec.target.location.kind equals ContentLibrary,
+                          then this should be the name that will show up in vCenter
+                          Content Library, not the custom resource name in the namespace.
+                          \n If omitted then the controller will use spec.source.name
+                          + \"-image\"."
+                        type: string
+                    type: object
+                  location:
+                    description: Location contains information about the location
+                      to which to publish the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: "Name is the name of the referenced object. \n
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+                          \n A default publication target is a resource with an API
+                          version equal to spec.target.location.apiVersion, a kind
+                          equal to spec.target.location.kind, and has the label \"imageregistry.vmware.com/default\"."
+                        type: string
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: "TTLSecondsAfterFinished is the time-to-live duration
+                  for how long this resource will be allowed to exist once the publication
+                  operation completes. After the TTL expires, the resource will be
+                  automatically deleted without the user having to take any direct
+                  action. \n If this field is unset then the request resource will
+                  not be automatically deleted. If this field is set to zero then
+                  the request resource is eligible for deletion immediately after
+                  it finishes."
+                format: int64
+                type: integer
+            type: object
+          status:
+            description: VirtualMachinePublishRequestStatus defines the observed state
+              of a VirtualMachinePublishRequest.
+            properties:
+              attempts:
+                description: Attempts represents the number of times the request to
+                  publish the VM has been attempted.
+                format: int64
+                type: integer
+              completionTime:
+                description: "CompletionTime represents time when the request was
+                  completed. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and
+                  is in UTC. \n The value of this field should be equal to the value
+                  of the LastTransitionTime for the status condition Type=Complete."
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions is a list of the latest, available observations
+                  of the request's current state.
+                items:
+                  description: Condition defines an observation of a VM Operator API
+                    resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to disambiguate
+                        is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: "ImageName is the name of the VirtualMachineImage resource
+                  that is eventually realized in the same namespace as the VM and
+                  publication request after the publication operation completes. \n
+                  This field will not be set until the VirtualMachineImage resource
+                  is realized."
+                type: string
+              lastAttemptTime:
+                description: LastAttemptTime represents the time when the latest request
+                  was sent.
+                format: date-time
+                type: string
+              ready:
+                description: "Ready is set to true only when the VM has been published
+                  successfully and the new VirtualMachineImage resource is ready.
+                  \n Readiness is determined by waiting until there is status condition
+                  Type=Complete and ensuring it and all other status conditions present
+                  have a Status=True. The conditions present will be: \n   * SourceValid
+                  \  * TargetValid   * Uploaded   * ImageAvailable   * Complete"
+                type: boolean
+              sourceRef:
+                description: SourceRef is the reference to the source of the publication
+                  request, ex. a VirtualMachine resource.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: "Name is the name of the referenced object. \n If
+                      omitted this value defaults to the name of the VirtualMachinePublishRequest
+                      resource."
+                    type: string
+                type: object
+              startTime:
+                description: StartTime represents time when the request was acknowledged
+                  by the controller. It is not guaranteed to be set in happens-before
+                  order across separate operations. It is represented in RFC3339 form
+                  and is in UTC.
+                format: date-time
+                type: string
+              targetRef:
+                description: TargetRef is the reference to the target of the publication
+                  request, ex. item information and a ContentLibrary resource.
+                properties:
+                  item:
+                    description: "Item contains information about the name of the
+                      object to which the VM is published. \n Please note this value
+                      is optional and if omitted, the controller will use spec.source.name
+                      + \"-image\" as the name of the published item."
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: "Name is the name of the published object. \n
+                          If the spec.target.location.apiVersion equals imageregistry.vmware.com/v1alpha1
+                          and the spec.target.location.kind equals ContentLibrary,
+                          then this should be the name that will show up in vCenter
+                          Content Library, not the custom resource name in the namespace.
+                          \n If omitted then the controller will use spec.source.name
+                          + \"-image\"."
+                        type: string
+                    type: object
+                  location:
+                    description: Location contains information about the location
+                      to which to publish the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: "Name is the name of the referenced object. \n
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+                          \n A default publication target is a resource with an API
+                          version equal to spec.target.location.apiVersion, a kind
+                          equal to spec.target.location.kind, and has the label \"imageregistry.vmware.com/default\"."
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
@@ -20,7 +20,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.powerState
-      name: PowerState
+      name: Power-State
       type: string
     - jsonPath: .spec.className
       name: Class
@@ -58,7 +58,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: VirtualMachineSpec defines the desired state of a VirtualMachine
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine.
             properties:
               advancedOptions:
                 description: AdvancedOptions describes a set of optional, advanced
@@ -285,6 +285,7 @@ spec:
                     enum:
                     - ExtraConfig
                     - OvfEnv
+                    - vAppConfig
                     - CloudInit
                     type: string
                 type: object
@@ -423,8 +424,8 @@ spec:
                       description: Type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources
                         like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                        (see .node.status.conditions), the ability to disambiguate
+                        is important.
                       type: string
                   required:
                   - status
@@ -446,7 +447,7 @@ spec:
                 items:
                   description: NetworkInterfaceStatus defines the observed state of
                     network interfaces attached to the VirtualMachine as seen by the
-                    Guest OS and VMware tools
+                    Guest OS and VMware tools.
                   properties:
                     connected:
                       description: Connected represents whether the network interface
@@ -516,6 +517,11 @@ spec:
                   - name
                   type: object
                 type: array
+              zone:
+                description: Zone describes the availability zone where the VirtualMachine
+                  has been scheduled. Please note this field may be empty when the
+                  cluster is not zone-aware.
+                type: string
             type: object
         type: object
     served: true

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -145,7 +145,7 @@ spec:
             type: object
           status:
             description: VirtualMachineServiceStatus defines the observed state of
-              VirtualMachineService
+              VirtualMachineService.
             properties:
               loadBalancer:
                 description: LoadBalancer contains the current status of the load

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -36,7 +36,7 @@ spec:
             type: object
           spec:
             description: VirtualMachineSetResourcePolicySpec defines the desired state
-              of VirtualMachineSetResourcePolicy
+              of VirtualMachineSetResourcePolicy.
             properties:
               clustermodules:
                 items:
@@ -54,7 +54,7 @@ spec:
                   type: object
                 type: array
               folder:
-                description: Folder defines a Folder
+                description: FolderSpec defines a Folder.
                 properties:
                   name:
                     description: Name describes the name of the Folder
@@ -105,7 +105,7 @@ spec:
             type: object
           status:
             description: VirtualMachineSetResourcePolicyStatus defines the observed
-              state of VirtualMachineSetResourcePolicy
+              state of VirtualMachineSetResourcePolicy.
             properties:
               clustermodules:
                 items:

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707
-	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff
+	github.com/vmware-tanzu/vm-operator/api v0.0.0-20221121185334-8c4d5ac76c83
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f
 	github.com/vmware/govmomi v0.27.1

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4x
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707 h1:2onys8tWlQh7DFiOz6+68AwJdW9EBOEv6RTKzwh1x7A=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20210401185409-b0dc6c297707/go.mod h1:pDB0pUiFYufuP3lUkQX9fZ67PYnKvqBpDcJN3mSrw5U=
-github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff h1:ThuEcNdWY5aXymrx0iOYhkIDwAQhZnOwXyEQ776lepI=
-github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211029224930-6ec913d11bff/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
+github.com/vmware-tanzu/vm-operator/api v0.0.0-20221121185334-8c4d5ac76c83 h1:sCnIye9vMtR4JNcHBQV678ZTbeoY9/NokRus8NSYPyk=
+github.com/vmware-tanzu/vm-operator/api v0.0.0-20221121185334-8c4d5ac76c83/go.mod h1:fsqKK8tWRDbsuOkH/mwIsW25wBnmGxHiTj0yLiTQH74=
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f h1:RUuS5lh25citvQoXmDSfxJ1BB72LXOjD5cXvJETJ7Cc=
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f h1:wwYUf16/g8bLywQMQJB5VHbDtuf6aOFH24Ar2/yA7+I=

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -19,7 +19,7 @@ package fake
 import (
 	goctx "context"
 
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientrecord "k8s.io/client-go/tools/record"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"gopkg.in/fsnotify.v1"

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -17,7 +17,7 @@ limitations under the License.
 package services
 
 import (
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -17,7 +17,7 @@ limitations under the License.
 package network
 
 import (
-	vmopv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"

--- a/pkg/services/network/netop_provider.go
+++ b/pkg/services/network/netop_provider.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmopv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	netopv1alpha1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	"github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	"github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/services/network/nsxt_provider.go
+++ b/pkg/services/network/nsxt_provider.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	vmopv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -452,6 +452,7 @@ func (v *VimMachineService) createOrPatchVSPhereVM(ctx *context.VIMMachineContex
 
 // generateOverrideFunc returns a function which can override the values in the VSphereVM Spec
 // with the values from the FailureDomain (if any) set on the owner CAPI machine.
+//
 //nolint:nestif
 func (v *VimMachineService) generateOverrideFunc(ctx *context.VIMMachineContext) (func(vm *infrav1.VSphereVM), bool) {
 	failureDomainName := ctx.Machine.Spec.FailureDomain

--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"

--- a/pkg/services/vmoperator/control_plane_endpoint_test.go
+++ b/pkg/services/vmoperator/control_plane_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/services/vmoperator/resource_policy.go
+++ b/pkg/services/vmoperator/resource_policy.go
@@ -18,7 +18,7 @@ package vmoperator
 
 import (
 	"github.com/pkg/errors"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -549,8 +549,9 @@ func getVMLabels(ctx *vmware.SupervisorMachineContext, vmLabels map[string]strin
 // getTopologyLabels returns the labels related to a VM's topology.
 //
 // TODO(akutz): Currently this function just returns the availability zone,
-//              and thus the code is optimized as such. However, in the future
-//              this function may return a more diverse topology.
+//
+//	and thus the code is optimized as such. However, in the future
+//	this function may return a more diverse topology.
 func getTopologyLabels(ctx *vmware.SupervisorMachineContext) map[string]string {
 	if fd := ctx.VSphereMachine.Spec.FailureDomain; fd != nil && *fd != "" {
 		return map[string]string{

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -20,7 +20,7 @@ import (
 	goctx "context"
 
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"

--- a/test/helpers/vmware/unit_test_context.go
+++ b/test/helpers/vmware/unit_test_context.go
@@ -19,7 +19,7 @@ package vmware
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/integration/sanity_test.go
+++ b/test/integration/sanity_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	vmoprv1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

**What this PR does / why we need it**:
Update the deprecated vm-operator API to the new repository location

Deprecated: `https://github.com/vmware-tanzu/vm-operator-api`
New: `https://github.com/vmware-tanzu/vm-operator`

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1698

**Special notes for your reviewer**:

None

**Release note**:
```release-note
None
```