### PR TITLE
:seedling: Update livenessprobe image to match vsphere-csi-driver

### DIFF
--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -35,7 +35,7 @@ const (
 	DefaultCSIAttacherImage       = "quay.io/k8scsi/csi-attacher:v3.0.0"
 	DefaultCSIProvisionerImage    = "quay.io/k8scsi/csi-provisioner:v2.0.0"
 	DefaultCSIMetadataSyncerImage = "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0"
-	DefaultCSILivenessProbeImage  = "quay.io/k8scsi/livenessprobe:v2.1.0"
+	DefaultCSILivenessProbeImage  = "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"
 	DefaultCSIRegistrarImage      = "quay.io/k8scsi/csi-node-driver-registrar:v2.0.1"
 	CSINamespace                  = metav1.NamespaceSystem
 	CSIControllerName             = "vsphere-csi-controller"

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -511,8 +511,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -617,11 +618,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -654,8 +654,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -760,11 +761,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -406,8 +406,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -512,11 +513,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -567,8 +567,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -673,11 +674,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha3/cluster-template.yaml
@@ -555,8 +555,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -661,11 +662,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:

--- a/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere/capi-upgrades/v1alpha4/cluster-template.yaml
@@ -542,8 +542,9 @@ data:
             - mountPath: /dev
               name: device-dir
           - args:
+            - --v=4
             - --csi-address=/csi/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -648,11 +649,12 @@ data:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           - args:
+            - --v=4
             - --csi-address=$(ADDRESS)
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: quay.io/k8scsi/livenessprobe:v2.1.0
+            image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
             name: liveness-probe
             resources: {}
             volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Update livenessprobe image to match vsphere-csi-driver, https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/347c5b39faa1d10d313fee43c2fcfa64e2152f6e

Also adds the verbose level 4 flag from upstream, this removes the following line that repeats every 5s:
`I1130 15:11:57.443865       1 connection.go:153] Connecting to unix:///csi/csi.sock`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update livenessprobe image to match vsphere-csi-drive
```