### PR TITLE
🌱 Fixes dependenabot config to exclude CAPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,9 @@ updates:
     interval: "weekly"
   ignore:
   # Ignore k8s modules as they are upgraded manually
-  # together with controller-runtime.
+  # together with controller-runtime and CAPI dependencies.
   - dependency-name: "k8s.io/*"
-  - dependency-name: "sigs.k8s.io/controller-runtime"
+  - dependency-name: "sigs.k8s.io/*"
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes dependenabot config to exclude CAPI and other `sigs.k8s.io` modules like `kind` and `cluster-api/test` which we handle manually.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```