### PR TITLE
🌱 Fixes logger output for legacy network label

### DIFF
--- a/pkg/services/network/netop_provider.go
+++ b/pkg/services/network/netop_provider.go
@@ -55,7 +55,7 @@ func (np *netopNetworkProvider) getDefaultClusterNetwork(ctx *vmware.ClusterCont
 		return networkWithLabel, nil
 	}
 
-	ctx.Logger.Info("falling back to legacy label %s to identify default network", legacyDefaultNetworkLabel)
+	ctx.Logger.Info("falling back to legacy label to identify default network", "label", legacyDefaultNetworkLabel)
 	return np.getDefaultClusterNetworkWithLabel(ctx, legacyDefaultNetworkLabel)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes logger output for legacy network label

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```