### PR TITLE
✨ reconcile IPAddressClaims earlier

### DIFF
--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -40,12 +40,12 @@ func Test_reconcileIPAddressClaims_ShouldGenerateIPAddressClaims(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = ipamv1a1.AddToScheme(scheme)
 
-	var ctx *virtualMachineContext
+	var ctx *context.VMContext
 	var g *WithT
 	var vms *VMService
 
 	before := func() {
-		ctx = emptyVirtualMachineContext()
+		ctx = emptyVMContext()
 		ctx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		vms = &VMService{}
@@ -702,6 +702,15 @@ func emptyVirtualMachineContext() *virtualMachineContext {
 			ControllerContext: &context.ControllerContext{
 				ControllerManagerContext: &context.ControllerManagerContext{},
 			},
+		},
+	}
+}
+
+func emptyVMContext() *context.VMContext {
+	return &context.VMContext{
+		Logger: logr.Discard(),
+		ControllerContext: &context.ControllerContext{
+			ControllerManagerContext: &context.ControllerManagerContext{},
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
IPAddressClaims must be fulfilled before a VM can be powered on. This
could take some time depending on the IPAM Provider. By creating these
claims first we can give the provider time to fulfill these while the VM
is cloning, reducing the overall wait time for a VM to be ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1690 

**Special notes for your reviewer**:
We rebased on the e2e tests PR #1667 to validate this work, but dropped that commit before opening this PR

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```