### PR TITLE
:bug: Renaming the Windows VM name on creation

### DIFF
--- a/apis/v1beta1/vspherevm_webhook.go
+++ b/apis/v1beta1/vspherevm_webhook.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,11 +42,6 @@ func (r *VSphereVM) Default() {
 	// Set Linux as default OS value
 	if r.Spec.OS == "" {
 		r.Spec.OS = Linux
-	}
-
-	// Windows hostnames must be < 16 characters in length
-	if r.Spec.OS == Windows && len(r.Name) > 15 {
-		r.Name = strings.TrimSuffix(r.Name[0:9], "-") + "-" + r.Name[len(r.Name)-5:]
 	}
 }
 

--- a/apis/v1beta1/vspherevm_webhook_test.go
+++ b/apis/v1beta1/vspherevm_webhook_test.go
@@ -45,10 +45,6 @@ func TestVSphereVM_Default(t *testing.T) {
 	g.Expect(LinuxVM.Spec.OS).To(Equal(Linux))
 	g.Expect(WindowsVM.Spec.OS).To(Equal(Windows))
 	g.Expect(NoOSVM.Spec.OS).To(Equal(Linux))
-
-	// WindowsVM gets name updated to be 15 characters. Linux remains unchanged
-	g.Expect(WindowsVM.Name).To(Equal("cluster-m-2qj6q"))
-	g.Expect(LinuxVM.Name).To(Equal("linux-control-plane-qkkbv"))
 }
 
 //nolint
@@ -81,7 +77,7 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "name too long for Linux VM",
+			name:      "no error with name too long for Linux VM",
 			vSphereVM: createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
 			wantErr:   false,
 		},

--- a/pkg/context/fake/fake_machine_context.go
+++ b/pkg/context/fake/fake_machine_context.go
@@ -52,13 +52,18 @@ func NewMachineContext(ctx *context.ClusterContext) *context.VIMMachineContext {
 }
 
 func newMachineV1a4() clusterv1.Machine {
+	dataSecretName := "fake-name"
 	return clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: Namespace,
 			Name:      Clusterv1a2Name,
 			UID:       Clusterv1a2UUID,
 		},
-		Spec: clusterv1.MachineSpec{},
+		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: &dataSecretName,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Renaming the vsphereVM object in the Webhook will cause wrong patching in the controller later, fixing the bug and renaming it directly in the controller on creation time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes Windows vspherevm rename when VSphereMachine OS is Windows.
```