### PR TITLE
🐛 Fix vCenter session leaks

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/version"
 )
 
@@ -256,6 +257,7 @@ func main() {
 	defer func(watch *fsnotify.Watcher) {
 		_ = watch.Close()
 	}(watch)
+	defer session.Clear()
 }
 
 func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
On controller startup, the reconciliation loops for the VSphereCluster and VSphereVM objects make a call to the seesion.GetOrCreate function to look for existing sessions. Without the mutex guarding the access to the function, all the objects end up creating a session, and the last created session which gets saved in the cache gets used for future API calls and the other sessions are left to idle.
Also, altered the logout logic to destroy the session using the govmomi method calls directly.

Another improvement made here was to destroy the sessions on manager shutdown so that CAPV does not leave over any sessions on manager exit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1552 

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Fix vCenter session leaks
```