### PR TITLE
🌱 Updates dependabot config to ignore CAPI test dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
   # together with controller-runtime and CAPI dependencies.
   - dependency-name: "k8s.io/*"
   - dependency-name: "sigs.k8s.io/*"
+  - dependency-name: "sigs.k8s.io/cluster-api/test"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the dependabot configuration to ignore the cluster-api/test dependency

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```