### PR TITLE
🐛 Reorder PCI device attachment operation

### DIFF
--- a/apis/v1beta1/condition_consts.go
+++ b/apis/v1beta1/condition_consts.go
@@ -93,8 +93,19 @@ const (
 	// NOTE: This reason does not apply to VSphereVM (this state happens after the VSphereVM is in ready state).
 	WaitingForNetworkAddressesReason = "WaitingForNetworkAddresses"
 
-	// TagsAttachmentFailedReason (Severity=Error) documents a VSPhereMachine/VSphereVM tags attachment failure.
+	// TagsAttachmentFailedReason (Severity=Error) documents a VSphereMachine/VSphereVM tags attachment failure.
 	TagsAttachmentFailedReason = "TagsAttachmentFailed"
+
+	// PCIDevicesDetachedCondition documents the status of the attached PCI devices on the VSphereVM.
+	// It is a negative condition to notify the user that the device(s) is no longer attached to
+	// the underlying VM and would require manual intervention to fix the situation.
+	//
+	// NOTE: This condition does not apply to VSphereMachine.
+	PCIDevicesDetachedCondition clusterv1.ConditionType = "PCIDevicesDetached"
+
+	// NotFoundReason (Severity=Warning) documents the VSphereVM not having the PCI device attached during VM startup.
+	// This would indicate that the PCI devices were removed out of band by an external entity.
+	NotFoundReason = "NotFound"
 )
 
 // Conditions and Reasons related to utilizing a VSphereIdentity to make connections to a VCenter.

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,11 @@ require (
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-20221204041501-ec03d8bb733c
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f
-	github.com/vmware/govmomi v0.27.1
+	github.com/vmware/govmomi v0.30.2
 	golang.org/x/crypto v0.5.0
 	golang.org/x/exp v0.0.0-20221002003631-540bb7301a08
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	golang.org/x/net v0.5.0
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 	golang.org/x/text v0.6.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -55,7 +56,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
-	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,6 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -144,7 +143,6 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892/go.mod h1:CTDl0pzVzE5DEzZhPfvhY/9sPFMQIxaJ9VAMs9AagrE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
@@ -320,7 +318,6 @@ github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -624,9 +621,8 @@ github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20211209213435-0f4ab286f64f/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f h1:wwYUf16/g8bLywQMQJB5VHbDtuf6aOFH24Ar2/yA7+I=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20211209213435-0f4ab286f64f/go.mod h1:dfYrWS8DMRN+XZfhu8M4LVHmeGvYB29Ipd7j4uIq+mU=
-github.com/vmware/govmomi v0.27.1 h1:Rf3o1btFrkJa9be5KtgJ4CyOO8mbFnBxmNtAVHNyFes=
-github.com/vmware/govmomi v0.27.1/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
-github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
+github.com/vmware/govmomi v0.30.2 h1:zPMmLTtAfBgOVsTgwKOzVVahQIOC4A2oyFQFSsn/0ag=
+github.com/vmware/govmomi v0.30.2/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/pkg/services/govmomi/pci/device.go
+++ b/pkg/services/govmomi/pci/device.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+)
+
+func CalculateDevicesToBeAdded(ctx context.Context, vm *object.VirtualMachine, deviceSpecs []infrav1.PCIDeviceSpec) ([]infrav1.PCIDeviceSpec, error) {
+	// store the number of expected devices for each deviceID + vendorID combo
+	deviceVendorIDComboMap := map[string]int{}
+	for _, spec := range deviceSpecs {
+		key := constructKey(spec)
+		if _, ok := deviceVendorIDComboMap[key]; !ok {
+			deviceVendorIDComboMap[key] = 1
+		} else {
+			deviceVendorIDComboMap[key]++
+		}
+	}
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	specsToBeAdded := []infrav1.PCIDeviceSpec{}
+	for _, spec := range deviceSpecs {
+		key := constructKey(spec)
+		pciDeviceList := devices.SelectByBackingInfo(createBackingInfo(spec))
+		expectedDeviceLen := deviceVendorIDComboMap[key]
+		if expectedDeviceLen-len(pciDeviceList) > 0 {
+			specsToBeAdded = append(specsToBeAdded, spec)
+			deviceVendorIDComboMap[key]--
+		}
+	}
+	return specsToBeAdded, nil
+}
+
+func ConstructDeviceSpecs(pciDeviceSpecs []infrav1.PCIDeviceSpec) []types.BaseVirtualDevice {
+	pciDevices := []types.BaseVirtualDevice{}
+	deviceKey := int32(-200)
+
+	for _, pciDevice := range pciDeviceSpecs {
+		backingInfo := createBackingInfo(pciDevice)
+		pciDevices = append(pciDevices, &types.VirtualPCIPassthrough{
+			VirtualDevice: types.VirtualDevice{
+				Key:     deviceKey,
+				Backing: backingInfo,
+			},
+		})
+		deviceKey--
+	}
+	return pciDevices
+}
+
+func createBackingInfo(spec infrav1.PCIDeviceSpec) *types.VirtualPCIPassthroughDynamicBackingInfo {
+	return &types.VirtualPCIPassthroughDynamicBackingInfo{
+		AllowedDevice: []types.VirtualPCIPassthroughAllowedDevice{
+			{
+				VendorId: *spec.VendorID,
+				DeviceId: *spec.DeviceID,
+			},
+		},
+	}
+}
+
+func constructKey(pciDeviceSpec infrav1.PCIDeviceSpec) string {
+	return fmt.Sprintf("%d-%d", *pciDeviceSpec.DeviceID, *pciDeviceSpec.VendorID)
+}

--- a/pkg/services/govmomi/pci/device_test.go
+++ b/pkg/services/govmomi/pci/device_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pci
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"k8s.io/utils/pointer"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+)
+
+func Test_CalculateDevicesToBeAdded(t *testing.T) {
+	type input struct {
+		name                      string
+		expectedLen               int
+		existingDeviceSpecIndexes []int
+		pciDeviceSpecs            []infrav1.PCIDeviceSpec
+		assertFunc                func(g *gomega.WithT, actual []infrav1.PCIDeviceSpec)
+	}
+
+	testFunc := func(t *testing.T, i input) {
+		t.Helper()
+		t.Run(i.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			simulator.Run(func(ctx context.Context, client *vim25.Client) error {
+				finder := find.NewFinder(client)
+				vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
+				if err != nil {
+					return err
+				}
+
+				if len(i.existingDeviceSpecIndexes) > 0 {
+					existingDevices := []infrav1.PCIDeviceSpec{}
+					for _, idx := range i.existingDeviceSpecIndexes {
+						existingDevices = append(existingDevices, i.pciDeviceSpecs[idx])
+					}
+					g.Expect(vm.AddDevice(ctx,
+						ConstructDeviceSpecs(existingDevices)...)).ToNot(gomega.HaveOccurred())
+				}
+				toBeAdded, err := CalculateDevicesToBeAdded(ctx, vm, i.pciDeviceSpecs)
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(toBeAdded).To(gomega.HaveLen(i.expectedLen))
+				if i.assertFunc != nil {
+					i.assertFunc(g, toBeAdded)
+				}
+				return nil
+			})
+		})
+	}
+
+	t.Run("when no PCI devices exist on the VM", func(t *testing.T) {
+		inputs := []input{
+			{
+				name:        "when adding a single PCI device of each type",
+				expectedLen: 2,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(4321), VendorID: pointer.Int32(8765)},
+				},
+				assertFunc: func(g *gomega.WithT, actual []infrav1.PCIDeviceSpec) {
+					g.Expect(*actual[0].DeviceID).To(gomega.Equal(int32(1234)))
+					g.Expect(*actual[0].VendorID).To(gomega.Equal(int32(5678)))
+					g.Expect(*actual[1].DeviceID).To(gomega.Equal(int32(4321)))
+					g.Expect(*actual[1].VendorID).To(gomega.Equal(int32(8765)))
+				},
+			},
+			{
+				name:        "when adding multiple PCI devices of a type",
+				expectedLen: 2,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+				},
+				assertFunc: func(g *gomega.WithT, actual []infrav1.PCIDeviceSpec) {
+					g.Expect(*actual[0].DeviceID).To(gomega.Equal(int32(1234)))
+					g.Expect(*actual[0].VendorID).To(gomega.Equal(int32(5678)))
+					g.Expect(*actual[1].DeviceID).To(gomega.Equal(int32(1234)))
+					g.Expect(*actual[1].VendorID).To(gomega.Equal(int32(5678)))
+				},
+			},
+		}
+		for _, tt := range inputs {
+			testFunc(t, tt)
+		}
+	})
+
+	t.Run("when all PCI devices exist on the VM", func(t *testing.T) {
+		inputs := []input{
+			{
+				name:        "when adding a single PCI device of each type",
+				expectedLen: 0,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(4321), VendorID: pointer.Int32(8765)},
+				},
+				existingDeviceSpecIndexes: []int{0, 1},
+			},
+			{
+				name:        "when adding multiple PCI devices of a type",
+				expectedLen: 0,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+				},
+				existingDeviceSpecIndexes: []int{0, 1},
+			},
+		}
+		for _, tt := range inputs {
+			testFunc(t, tt)
+		}
+	})
+
+	t.Run("when some PCI devices exist on the VM", func(t *testing.T) {
+		inputs := []input{
+			{
+				name:        "when adding a single PCI device of each type",
+				expectedLen: 1,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(4321), VendorID: pointer.Int32(8765)},
+				},
+				existingDeviceSpecIndexes: []int{0},
+				assertFunc: func(g *gomega.WithT, actual []infrav1.PCIDeviceSpec) {
+					g.Expect(*actual[0].DeviceID).To(gomega.Equal(int32(4321)))
+					g.Expect(*actual[0].VendorID).To(gomega.Equal(int32(8765)))
+				},
+			},
+			{
+				name:        "when adding multiple PCI devices of a type",
+				expectedLen: 2,
+				pciDeviceSpecs: []infrav1.PCIDeviceSpec{
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+					{DeviceID: pointer.Int32(4321), VendorID: pointer.Int32(8765)},
+				},
+				existingDeviceSpecIndexes: []int{0},
+				assertFunc: func(g *gomega.WithT, actual []infrav1.PCIDeviceSpec) {
+					g.Expect(*actual[0].DeviceID).To(gomega.Equal(int32(1234)))
+					g.Expect(*actual[0].VendorID).To(gomega.Equal(int32(5678)))
+					g.Expect(*actual[1].DeviceID).To(gomega.Equal(int32(4321)))
+					g.Expect(*actual[1].VendorID).To(gomega.Equal(int32(8765)))
+				},
+			},
+		}
+		for _, tt := range inputs {
+			testFunc(t, tt)
+		}
+	})
+}

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/clustermodules"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/extra"
 	govmominet "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/net"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/pci"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
@@ -131,7 +132,11 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 
 	vms.reconcileUUID(vmCtx)
 
-	if err := vms.reconcileHardwareVersion(vmCtx); err != nil {
+	if ok, err := vms.reconcileHardwareVersion(vmCtx); err != nil || !ok {
+		return vm, err
+	}
+
+	if err := vms.reconcilePCIDevices(vmCtx); err != nil {
 		return vm, err
 	}
 
@@ -590,28 +595,65 @@ func (vms *VMService) reconcileUUID(ctx *virtualMachineContext) {
 	ctx.State.BiosUUID = ctx.Obj.UUID(ctx)
 }
 
-func (vms *VMService) reconcileHardwareVersion(ctx *virtualMachineContext) error {
-	if ctx.VSphereVM.Spec.HardwareVersion == "" {
-		return nil
-	}
-
-	var virtualMachine mo.VirtualMachine
-	if err := ctx.Obj.Properties(ctx, ctx.Obj.Reference(), []string{"config.version"}, &virtualMachine); err != nil {
-		return errors.Wrapf(err, "error getting guestInfo version information from VM %s", ctx.VSphereVM.Name)
-	}
-	toUpgrade, err := util.LessThan(virtualMachine.Config.Version, ctx.VSphereVM.Spec.HardwareVersion)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse hardware version")
-	}
-	if toUpgrade {
-		ctx.Logger.Info("upgrading hardware version",
-			"from", virtualMachine.Config.Version,
-			"to", ctx.VSphereVM.Spec.HardwareVersion)
-		task, err := ctx.Obj.UpgradeVM(ctx, ctx.VSphereVM.Spec.HardwareVersion)
-		if err != nil {
-			return errors.Wrapf(err, "error trigging upgrade op for machine %s", ctx)
+func (vms *VMService) reconcileHardwareVersion(ctx *virtualMachineContext) (bool, error) {
+	if ctx.VSphereVM.Spec.HardwareVersion != "" {
+		var virtualMachine mo.VirtualMachine
+		if err := ctx.Obj.Properties(ctx, ctx.Obj.Reference(), []string{"config.version"}, &virtualMachine); err != nil {
+			return false, errors.Wrapf(err, "error getting guestInfo version information from VM %s", ctx.VSphereVM.Name)
 		}
-		ctx.VSphereVM.Status.TaskRef = task.Reference().Value
+		toUpgrade, err := util.LessThan(virtualMachine.Config.Version, ctx.VSphereVM.Spec.HardwareVersion)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to parse hardware version")
+		}
+		if toUpgrade {
+			ctx.Logger.Info("upgrading hardware version",
+				"from", virtualMachine.Config.Version,
+				"to", ctx.VSphereVM.Spec.HardwareVersion)
+			task, err := ctx.Obj.UpgradeVM(ctx, ctx.VSphereVM.Spec.HardwareVersion)
+			if err != nil {
+				return false, errors.Wrapf(err, "error trigging upgrade op for machine %s", ctx)
+			}
+			ctx.VSphereVM.Status.TaskRef = task.Reference().Value
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (vms *VMService) reconcilePCIDevices(ctx *virtualMachineContext) error {
+	if expectedPciDevices := ctx.VSphereVM.Spec.VirtualMachineCloneSpec.PciDevices; len(expectedPciDevices) != 0 {
+		specsToBeAdded, err := pci.CalculateDevicesToBeAdded(ctx, ctx.Obj, expectedPciDevices)
+		if err != nil {
+			return err
+		}
+
+		if len(specsToBeAdded) == 0 {
+			if conditions.Has(ctx.VSphereVM, infrav1.PCIDevicesDetachedCondition) {
+				conditions.Delete(ctx.VSphereVM, infrav1.PCIDevicesDetachedCondition)
+			}
+			ctx.Logger.V(5).Info("no new PCI devices to be added")
+			return nil
+		}
+
+		powerState, err := ctx.Obj.PowerState(ctx)
+		if err != nil {
+			return err
+		}
+		if powerState == types.VirtualMachinePowerStatePoweredOn {
+			// This would arise only when the PCI device is manually removed from
+			// the VM post creation.
+			ctx.Logger.Info("PCI device cannot be attached in powered on state")
+			conditions.MarkFalse(ctx.VSphereVM,
+				infrav1.PCIDevicesDetachedCondition,
+				infrav1.NotFoundReason,
+				clusterv1.ConditionSeverityWarning,
+				"PCI devices removed after VM was powered on")
+			return errors.Errorf("missing PCI devices")
+		}
+		ctx.Logger.Info("PCI devices to be added", "number", len(specsToBeAdded))
+		if err := ctx.Obj.AddDevice(ctx, pci.ConstructDeviceSpecs(specsToBeAdded)...); err != nil {
+			return errors.Wrapf(err, "error adding pci devices for %q", ctx)
+		}
 	}
 	return nil
 }

--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -17,14 +17,20 @@ limitations under the License.
 package govmomi
 
 import (
+	goctx "context"
 	"testing"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	ipamv1a1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -700,7 +706,9 @@ func emptyVirtualMachineContext() *virtualMachineContext {
 		VMContext: context.VMContext{
 			Logger: logr.Discard(),
 			ControllerContext: &context.ControllerContext{
-				ControllerManagerContext: &context.ControllerManagerContext{},
+				ControllerManagerContext: &context.ControllerManagerContext{
+					Context: goctx.TODO(),
+				},
 			},
 		},
 	}
@@ -713,4 +721,59 @@ func emptyVMContext() *context.VMContext {
 			ControllerManagerContext: &context.ControllerManagerContext{},
 		},
 	}
+}
+
+func Test_reconcilePCIDevices(t *testing.T) {
+	var vmCtx *virtualMachineContext
+	var g *WithT
+	var vms *VMService
+
+	before := func() {
+		vmCtx = emptyVirtualMachineContext()
+		vmCtx.Client = fake.NewClientBuilder().Build()
+
+		vms = &VMService{}
+	}
+
+	t.Run("when powered off VM has no PCI devices", func(t *testing.T) {
+		g = NewWithT(t)
+		before()
+
+		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+			finder := find.NewFinder(c)
+			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
+			g.Expect(err).ToNot(HaveOccurred())
+			_, err = vm.PowerOff(ctx)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			vmCtx.Obj = vm
+			vmCtx.VSphereVM = &infrav1.VSphereVM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vsphereVM1",
+					Namespace: "my-namespace",
+				},
+				Spec: infrav1.VSphereVMSpec{
+					VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
+						PciDevices: []infrav1.PCIDeviceSpec{
+							{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+							{DeviceID: pointer.Int32(1234), VendorID: pointer.Int32(5678)},
+						},
+					},
+				},
+			}
+
+			g.Expect(vms.reconcilePCIDevices(vmCtx)).ToNot(HaveOccurred())
+
+			// get the VM's virtual device list
+			devices, err := vm.Device(ctx)
+			g.Expect(err).ToNot(HaveOccurred())
+			// filter the device with the given backing info
+			pciDevices := devices.SelectByBackingInfo(&types.VirtualPCIPassthroughDynamicBackingInfo{
+				AllowedDevice: []types.VirtualPCIPassthroughAllowedDevice{
+					{DeviceId: 1234, VendorId: 5678},
+				}})
+			g.Expect(pciDevices).To(HaveLen(2))
+			return nil
+		})
+	})
 }

--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestGetDiskSpec(t *testing.T) {
-	defaultSizeGiB := int32(5)
+	defaultSizeGiB := int32(20)
 
 	model, session, server := initSimulator(t)
 	t.Cleanup(model.Remove)
@@ -80,7 +80,7 @@ func TestGetDiskSpec(t *testing.T) {
 			name:          "Fail to clone template with lower disk requirements then on template",
 			disks:         defaultDisks,
 			cloneDiskSize: defaultSizeGiB - 1,
-			err:           "Error getting disk config spec for primary disk: can't resize template disk down, initial capacity is larger: 6291456KiB > 4194304KiB",
+			err:           "Error getting disk config spec for primary disk: can't resize template disk down, initial capacity is larger: 22020096KiB > 19922944KiB",
 		},
 		{
 			name:  "Fail to clone template without disk devices",
@@ -100,7 +100,7 @@ func TestGetDiskSpec(t *testing.T) {
 			disks:                    append(defaultDisks, defaultDisks...),
 			cloneDiskSize:            defaultSizeGiB + 2,
 			additionalCloneDiskSizes: []int32{defaultSizeGiB},
-			err:                      "Error getting disk config spec for additional disk: can't resize template disk down, initial capacity is larger: 7340032KiB > 5242880KiB",
+			err:                      "Error getting disk config spec for additional disk: can't resize template disk down, initial capacity is larger: 23068672KiB > 20971520KiB",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch reorders the process of attaching PCI devices to the VM. Previously, the PCI devices were attached during the VM cloning operation, but the PCI device attachment requires a minimum hardware version of vmx-17.
Instead of forcing the template to be hardcoded with a minimum hardware version, CAPV introduced the capability of upgrading the hardware version of the VM post clone operation succeeds. This would mean that the PCI devices need to be attached after the upgrade hardware VM task is finished and the hardware version of the VM has been successfully upgraded to some compatible version specified by the user.

**Which issue(s) this PR fixes**:
Fixes #1749

**Special notes for your reviewer**:
The govmomi dependency has been updated to v0.30.2, which is the latest version released at this time, since v0.30.0 is necessary for unit test support for this reordering.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Reorder PCI device attachment operation
```