### PR TITLE
🌱 Updates image links for integration test job

### DIFF
--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -11,11 +11,11 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: k8s.gcr.io/cluster-api/cluster-api-controller:v1.1.0
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.1.0
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.1.0
     loadBehavior: tryLoad
-  - name: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.1.0
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.1.0
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad


### PR DESCRIPTION
**What this PR does / why we need it**:
Move over from `k8s.gcr.io` to `registry.k8s.io` registry links for the integration tests job

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```