### PR TITLE
:bug: Fix toleration config on templates

### DIFF
--- a/pkg/services/cloudprovider/cloud-controller-manager.go
+++ b/pkg/services/cloudprovider/cloud-controller-manager.go
@@ -106,9 +106,6 @@ func CloudControllerManagerDaemonSet(image string, args []string) *appsv1.Daemon
 					},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"node-role.kubernetes.io/master": "",
-					},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: int64ptr(0),
 					},
@@ -120,6 +117,10 @@ func CloudControllerManagerDaemonSet(image string, args []string) *appsv1.Daemon
 						},
 						{
 							Key:    "node-role.kubernetes.io/master",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:    "node-role.kubernetes.io/control-plane",
 							Effect: corev1.TaintEffectNoSchedule,
 						},
 						{

--- a/pkg/services/cloudprovider/csi.go
+++ b/pkg/services/cloudprovider/csi.go
@@ -406,13 +406,14 @@ func CSIControllerDeployment(storageConfig *types.CPIStorageConfig) *appsv1.Depl
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: CSIControllerName,
-					NodeSelector: map[string]string{
-						"node-role.kubernetes.io/master": "",
-					},
 					Tolerations: []corev1.Toleration{
-
 						{
 							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -664,6 +664,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -899,6 +902,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -807,6 +807,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1042,6 +1045,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -559,6 +559,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -794,6 +797,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -720,6 +720,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -955,6 +958,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
In k8s v1.25, the control-plane node role label is not "master" anymore, but "control-plane".

This turns into vsphere-cloud-provider to never be able to progress, because vsphere-cloud-controller can never run on nodes with only control-planes and never set the proper nodeID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/3279

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
Add the right tolerations for Kubernetes v1.25+
```