### PR TITLE
:bug: Calculate default primary disk size from base template

### DIFF
--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
+
 	// run init func to register the tagging API endpoints.
 	_ "github.com/vmware/govmomi/vapi/simulator"
 	"github.com/vmware/govmomi/vim25/types"
@@ -74,6 +75,12 @@ func TestGetDiskSpec(t *testing.T) {
 			name:          "Successfully clone template and increase disk requirements",
 			disks:         defaultDisks,
 			cloneDiskSize: defaultSizeGiB + 1,
+			expectDevice:  true,
+		},
+		{
+			name:          "Successfully clone template with no explicit disk requirements",
+			disks:         defaultDisks,
+			cloneDiskSize: 0,
 			expectDevice:  true,
 		},
 		{
@@ -144,7 +151,10 @@ func TestGetDiskSpec(t *testing.T) {
 func validateDiskSpec(t *testing.T, device types.BaseVirtualDeviceConfigSpec, cloneDiskSize int32) {
 	t.Helper()
 	disk := device.GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk)
-	expectedSizeKB := int64(cloneDiskSize) * 1024 * 1024
+	expectedSizeKB := disk.CapacityInKB
+	if cloneDiskSize > 0 {
+		expectedSizeKB = int64(cloneDiskSize) * 1024 * 1024
+	}
 	if device.GetVirtualDeviceConfigSpec().Operation != types.VirtualDeviceConfigSpecOperationEdit {
 		t.Errorf("Disk operation does not match '%s', got: %s",
 			types.VirtualDeviceConfigSpecOperationEdit, device.GetVirtualDeviceConfigSpec().Operation)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The primary disk size is [optional](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/48a9daca388238ea942c407b0752c4eeaeb09204/apis/v1beta1/types.go#L151), according to the API.
    
Prior to this commit, if the user did not set an explicit primary disk size, VM creation would fail with a validation error.
    
This PR sets the primary disk size to the base template primary disk size when the user does not set an explicit primary disk size.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default the machine primary disk size to the base template disk size.
```