### PR TITLE
🌱 Adds junit reporter to the ginkgo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/conversion-verifier)
 GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
 RELEASE_NOTES := $(TOOLS_BIN_DIR)/release-notes
 TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF) $(RELEASE_NOTES)
-ARTIFACTS_PATH := $(ROOT_DIR)/_artifacts
+ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 
 # Set --output-base for conversion-gen if we are not within GOPATH
 ifneq ($(abspath $(ROOT_DIR)),$(shell go env GOPATH)/src/sigs.k8s.io/cluster-api-provider-vsphere)
@@ -162,7 +162,7 @@ e2e-templates: ## Generate e2e cluster templates
 .PHONY: test-integration
 test-integration: e2e-image
 test-integration: $(GINKGO) $(KUSTOMIZE) $(KIND)
-	time $(GINKGO) -v ./test/integration -- --config="$(INTEGRATION_CONF_FILE)" --artifacts-folder="$(ARTIFACTS_PATH)"
+	time $(GINKGO) -v ./test/integration -- --config="$(INTEGRATION_CONF_FILE)" --artifacts-folder="$(ARTIFACTS)"
 
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
@@ -181,9 +181,10 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-	time $(GINKGO) -v -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -timeout=$(GINKGO_TEST_TIMEOUT) ./test/e2e -- \
+	time $(GINKGO) -v -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -timeout=$(GINKGO_TEST_TIMEOUT) \
+		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" ./test/e2e -- \
 		--e2e.config="$(E2E_CONF_FILE)" \
-		--e2e.artifacts-folder="$(ARTIFACTS_PATH)" \
+		--e2e.artifacts-folder="$(ARTIFACTS)" \
 		--e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
 		--e2e.use-existing-cluster="$(USE_EXISTING_CLUSTER)"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Ginkgo 2.0 removed the support of custom reporters when running the test suite, and instead provided it as a command line argument on the command itself. This patch makes sure that the report of the test suite gets created in the artifacts folder.

**Which issue(s) this PR fixes**
n/a

**Special notes for your reviewer**:
Before Gingko 2.0 test grid reported the test runs as following
<img width="1450" alt="image" src="https://user-images.githubusercontent.com/8758225/222245210-962c3e32-5854-4353-b515-3275930ae639.png">

After the upgrade, the test grid report shows as below:
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/8758225/222245320-4a85e4a9-2696-4cd5-b675-4ef1c87124c0.png">


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```