### PR TITLE
🐛  CAPV CSI driver isn't passing TLS thumbprint

### DIFF
--- a/packaging/flavorgen/flavors/crs/csi.go
+++ b/packaging/flavorgen/flavors/crs/csi.go
@@ -129,7 +129,6 @@ func ConfigForCSI() *types.CPIConfig {
 
 	config.Global.ClusterID = fmt.Sprintf("%s/%s", env.NamespaceVar, env.ClusterNameVar)
 	config.Global.Thumbprint = env.VSphereThumbprint
-	config.Global.Insecure = env.VSphereInsecure
 	config.Network.Name = env.VSphereNetworkVar
 
 	config.VCenter = map[string]types.CPIVCenterConfig{

--- a/packaging/flavorgen/flavors/env/envsubts_consts.go
+++ b/packaging/flavorgen/flavors/env/envsubts_consts.go
@@ -51,5 +51,4 @@ const (
 	VSphereUsername              = "${VSPHERE_USERNAME}"
 	VSpherePassword              = "${VSPHERE_PASSWORD}" /* #nosec */
 	ClusterResourceSetNameSuffix = "-crs-0"
-	VSphereInsecure              = true
 )

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -390,7 +390,6 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        insecure-flag = true
         thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
         cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
 

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -533,7 +533,6 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        insecure-flag = true
         thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
         cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
 

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -456,6 +456,7 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
+        thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
         cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
 
         [VirtualCenter "${VSPHERE_SERVER}"]

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -285,7 +285,6 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        insecure-flag = true
         thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
         cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
 

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -446,7 +446,6 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        insecure-flag = true
         thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
         cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR I changed a few lines of code.

`packaging/flavorgen/flavors/crs/csi.go`
```
config.Global.Thumbprint = env.VSphereThumbprint
config.Global.Insecure = env.VSphereInsecure
```

`packaging/flavorgen/flavors/env/envsubts_consts.go`
```
VSphereInsecure              = true
```

With this, I was able to create a new 'cluster-template.yaml' inside .cluster-api/overrides... where the Global-Section of the csi-vsphere-config Secret gets the thumbprint and insecure flag passed.

```
  stringData:
     csi-vsphere.conf: |+
        [Global]
        insecure-flag = true
        thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
        cluster-id = "${NAMESPACE}/${CLUSTER_NAME}"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1162

**Special notes for your reviewer**:

Newly created PR, since on my last one(PR 1812) , I encountered some Issues with my CLA.

Notes from the last PR:

> Since the Insecure-Flag is defined as a bool inside packaging/flavorgen/flavors/crs/types/cloudprovider_types.go
at line 88, I was not able to make this Insecure-Flag configurable via the clusterctl.yaml under ~/.clusterctl-api.

> Changing it to a string, would make it configurable.
Like so: `Insecure string `gcfg:"insecure-flag,omitempty" json:"insecure,omitempty"`` but comes with the side-effect, that the file packaging/flavorgen/flavors/crs/types/cloudprovider_encoding_test.go throws me an error `cannot use true (untyped bool constant) as string...`
Since changing the type of the Insecure-Flag causes some impact on the testing file (And I am not sure, which side-effects this could lead to) I did not changed the typed and let it remain as a bool.
Maybe a maintainer could have a look at this and maybe help me out with this 😄 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Passing Thumbprint and Insecure-Flag (set as true in default) to the generated Cluster-Manifests file
```