### PR TITLE
✨ Updates kube-vip to v0.5.11

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -479,7 +479,7 @@ func kubeVIPPodSpec() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:            "kube-vip",
-					Image:           "ghcr.io/kube-vip/kube-vip:v0.5.5",
+					Image:           "ghcr.io/kube-vip/kube-vip:v0.5.11",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args: []string{
 						"manager",

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -106,7 +106,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.5
+            image: ghcr.io/kube-vip/kube-vip:v0.5.11
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -48,7 +48,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.5
+            image: ghcr.io/kube-vip/kube-vip:v0.5.11
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -132,7 +132,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.5
+            image: ghcr.io/kube-vip/kube-vip:v0.5.11
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the kube-vip version in templates to v0.5.11

**Which issue(s) this PR fixes**:
Fixes #1834 

**Special notes for your reviewer**:
Changes to the generated templates that will be shipped with the next release

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updates kube-vip to v0.5.11
```