### PR TITLE
🌱 Removes unnecessary import golang.org/x/net

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	golang.org/x/crypto v0.6.0
 	golang.org/x/exp v0.0.0-20221002003631-540bb7301a08
 	golang.org/x/mod v0.9.0
-	golang.org/x/net v0.8.0
 	golang.org/x/oauth2 v0.6.0
 	golang.org/x/text v0.8.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -58,6 +57,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/pkg/services/govmomi/pci/device.go
+++ b/pkg/services/govmomi/pci/device.go
@@ -17,11 +17,11 @@ limitations under the License.
 package pci
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the import statement to use the correct `context` package from the standard go library.

**Which issue(s) this PR fixes**:
Fixes #1836 

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Removes unnecessary import golang.org/x/net
```