### PR TITLE
🌱 Updates dependabot config to scan hack/tools directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,19 @@ updates:
     prefix: ":seedling:"
   labels:
     - "ok-to-test"
+
+- package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore k8s modules as they are upgraded manually
+    # together with controller-runtime and CAPI dependencies.
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    - dependency-name: "sigs.k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the dependencies under the hack/tools directory are managed by go.mod, we should instruct dependabot to also look for updates to those dependencies as well. Raised as a follow up to #1843 

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```