### PR TITLE
🌱 Add a e2e test case that validates the multiple vCenter support of CAPV

### DIFF
--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -112,8 +112,7 @@ providers:
         contract: v1beta1
         replacements:
           - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
-            # Tag the gcr.io/k8s-staging-cluster-api/capv-manager:e2e and push to projects.registry.vmware.com/tkgi/capv-manager:e2e so that move can be completed
-            new: projects.registry.vmware.com/tkgi/capv-manager:e2e
+            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
         files:
@@ -145,18 +144,16 @@ variables:
   IP_FAMILY: "IPv4"
   CLUSTER_CLASS_NAME: "quick-start"
   # Following CAPV variables should be set before testing
-  VSPHERE_TLS_THUMBPRINT: "10:CD:E8:AA:E5:67:8F:1B:6E:38:B3:60:58:06:9B:D2:A2:31:A3:85"
   VSPHERE_SERVER: "vcenter.vmware.com"
   VSPHERE_DATACENTER: "SDDC-Datacenter"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
-  VSPHERE_FOLDER: "/dc0/vm/"
-  VSPHERE_NETWORK: "VM Network"
-  VSPHERE_RESOURCE_POOL: "rp1"
-  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.23.10+vmware.1-tkg.2"
-  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3139.2.3-kube-v1.23.5"
-  VSPHERE_TLS_THUMBPRINT: "76:B5:C3:4A:9F:15:1D:F4:6D:37:1C:8B:C4:23:8C:C4:2D:4B:58:55"
-  CONTROL_PLANE_ENDPOINT_IP: "10.92.193.254"
+  VSPHERE_FOLDER: "FolderName"
+  VSPHERE_NETWORK: "network-1"
+  VSPHERE_RESOURCE_POOL: "ResourcePool"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
+  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3374.2.4-kube-v1.25.6"
+  VSPHERE_TLS_THUMBPRINT: "AA:BB:CC:DD:11:22:33:44:EE:FF"
   # WORKLOAD_CONTROL_PLANE_ENDPOINT_IP:
   # Also following variables are required but it is recommended to use env variables to avoid disclosure of sensitive data
   # VSPHERE_SSH_AUTHORIZED_KEY:
@@ -174,14 +171,17 @@ variables:
   # CAPV feature flags
   EXP_NODE_ANTI_AFFINITY: "true"
   EXP_NODE_LABELING: "true"
-  # 2nd VC
-  VSPHERE2_SERVER: "10.182.52.76"
-  VSPHERE2_TLS_THUMBPRINT: "2D:D5:9C:8D:D4:D8:EE:22:C3:A1:94:F1:8E:D4:65:1C:79:C1:10:A5"
-  #VSPHERE2_USERNAME: pass from env
-  # VSPHERE2_PASSWORD: pass from env
-  VSPHERE2_RESOURCE_POOL: "rp1"
-  VSPHERE2_TEMPLATE: "ubuntu-2004-kube-v1.23.10+vmware.1-tkg.2"
-  VSPHERE2_CONTROL_PLANE_ENDPOINT_IP: "10.182.48.110"
+  # Following CAPV variables is used for multivc_test.go. This is the second VSphere and should be set if multivc test is enabled.
+  VSPHERE2_SERVER: "vcenter2.vmware.com"
+  VSPHERE2_TLS_THUMBPRINT: "AA:BB:CC:DD:11:22:33:44:EE:FF"
+  VSPHERE2_RESOURCE_POOL: "ResourcePool"
+  VSPHERE2_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
+  # Dedicated IP to be used by kube-vip
+  VSPHERE2_CONTROL_PLANE_ENDPOINT_IP:
+  # Following variables are also required and please use env variables to avoid disclosure of sensitive data
+  VSPHERE2_USERNAME:
+  VSPHERE2_PASSWORD:
+
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -112,7 +112,8 @@ providers:
         contract: v1beta1
         replacements:
           - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
-            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+            # Tag the gcr.io/k8s-staging-cluster-api/capv-manager:e2e and push to projects.registry.vmware.com/tkgi/capv-manager:e2e so that move can be completed
+            new: projects.registry.vmware.com/tkgi/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
         files:
@@ -149,12 +150,13 @@ variables:
   VSPHERE_DATACENTER: "SDDC-Datacenter"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
-  VSPHERE_FOLDER: "FolderName"
-  VSPHERE_NETWORK: "network-1"
-  VSPHERE_RESOURCE_POOL: "ResourcePool"
-  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
-  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3374.2.4-kube-v1.25.6"
-  VSPHERE_TLS_THUMBPRINT: "AA:BB:CC:DD:11:22:33:44:EE:FF"
+  VSPHERE_FOLDER: "/dc0/vm/"
+  VSPHERE_NETWORK: "VM Network"
+  VSPHERE_RESOURCE_POOL: "rp1"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.23.10+vmware.1-tkg.2"
+  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3139.2.3-kube-v1.23.5"
+  VSPHERE_TLS_THUMBPRINT: "76:B5:C3:4A:9F:15:1D:F4:6D:37:1C:8B:C4:23:8C:C4:2D:4B:58:55"
+  CONTROL_PLANE_ENDPOINT_IP: "10.92.193.254"
   # WORKLOAD_CONTROL_PLANE_ENDPOINT_IP:
   # Also following variables are required but it is recommended to use env variables to avoid disclosure of sensitive data
   # VSPHERE_SSH_AUTHORIZED_KEY:
@@ -172,6 +174,14 @@ variables:
   # CAPV feature flags
   EXP_NODE_ANTI_AFFINITY: "true"
   EXP_NODE_LABELING: "true"
+  # 2nd VC
+  VSPHERE2_SERVER: "10.182.52.76"
+  VSPHERE2_TLS_THUMBPRINT: "2D:D5:9C:8D:D4:D8:EE:22:C3:A1:94:F1:8E:D4:65:1C:79:C1:10:A5"
+  #VSPHERE2_USERNAME: pass from env
+  # VSPHERE2_PASSWORD: pass from env
+  VSPHERE2_RESOURCE_POOL: "rp1"
+  VSPHERE2_TEMPLATE: "ubuntu-2004-kube-v1.23.10+vmware.1-tkg.2"
+  VSPHERE2_CONTROL_PLANE_ENDPOINT_IP: "10.182.48.110"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/multivc_test.go
+++ b/test/e2e/multivc_test.go
@@ -26,13 +26,14 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
 )
 
 type MultiVCenterSpecInput struct {
@@ -42,7 +43,7 @@ type MultiVCenterSpecInput struct {
 	Datacenter string
 }
 
-var _ = Describe("Cluster creation with multivc", func() {
+var _ = Describe("Cluster creation with multivc [specialized-infra]", func() {
 	var namespace *corev1.Namespace
 
 	BeforeEach(func() {
@@ -146,7 +147,7 @@ func VerifyMultiVC(ctx context.Context, input MultiVCenterSpecInput) {
 		ctx,
 		preMoveMachineList,
 		client.InNamespace(namespace.Name),
-		client.MatchingLabels{clusterv1.ClusterLabelName: clusterName},
+		client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName},
 	)
 	Expect(err).NotTo(HaveOccurred(), "Failed to list machines before move")
 
@@ -163,14 +164,14 @@ func VerifyMultiVC(ctx context.Context, input MultiVCenterSpecInput) {
 
 	wlClusterName := fmt.Sprintf("%s-%s", "wlcluster", util.RandomString(6))
 
-	os.Setenv("VSPHERE_SERVER", e2eConfig.GetVariable("VSPHERE2_SERVER"))
+	_ = os.Setenv("VSPHERE_SERVER", e2eConfig.GetVariable("VSPHERE2_SERVER"))
 
-	os.Setenv("VSPHERE_TLS_THUMBPRINT", e2eConfig.GetVariable("VSPHERE2_TLS_THUMBPRINT"))
-	os.Setenv("VSPHERE_USERNAME", os.Getenv("VSPHERE2_USERNAME"))
-	os.Setenv("VSPHERE_PASSWORD", os.Getenv("VSPHERE2_PASSWORD"))
-	os.Setenv("VSPHERE_RESOURCE_POOL", e2eConfig.GetVariable("VSPHERE2_RESOURCE_POOL"))
-	os.Setenv("VSPHERE_TEMPLATE", e2eConfig.GetVariable("VSPHERE2_TEMPLATE"))
-	os.Setenv("CONTROL_PLANE_ENDPOINT_IP", e2eConfig.GetVariable("VSPHERE2_CONTROL_PLANE_ENDPOINT_IP"))
+	_ = os.Setenv("VSPHERE_TLS_THUMBPRINT", e2eConfig.GetVariable("VSPHERE2_TLS_THUMBPRINT"))
+	_ = os.Setenv("VSPHERE_USERNAME", os.Getenv("VSPHERE2_USERNAME"))
+	_ = os.Setenv("VSPHERE_PASSWORD", os.Getenv("VSPHERE2_PASSWORD"))
+	_ = os.Setenv("VSPHERE_RESOURCE_POOL", e2eConfig.GetVariable("VSPHERE2_RESOURCE_POOL"))
+	_ = os.Setenv("VSPHERE_TEMPLATE", e2eConfig.GetVariable("VSPHERE2_TEMPLATE"))
+	_ = os.Setenv("CONTROL_PLANE_ENDPOINT_IP", e2eConfig.GetVariable("VSPHERE2_CONTROL_PLANE_ENDPOINT_IP"))
 
 	By("creating a workload cluster from vsphere hosted management cluster")
 	wlConfigCluster := defaultConfigCluster(wlClusterName, namespace.Name, specName, 1, 1, GlobalInput{
@@ -190,13 +191,10 @@ func VerifyMultiVC(ctx context.Context, input MultiVCenterSpecInput) {
 
 	vms = getVSphereVMs(mgmtClusterProxy, wlClusterName, namespace.Name)
 	Expect(len(vms.Items)).To(BeNumerically(">", 0))
-
 	if selfHostedCancelWatches != nil {
 		selfHostedCancelWatches()
 	}
-
 }
-
 func getVSphereVMs(clusterProxy framework.ClusterProxy, clusterName, namespace string) *infrav1.VSphereVMList {
 	var vms infrav1.VSphereVMList
 	err := clusterProxy.GetClient().List(
@@ -204,7 +202,7 @@ func getVSphereVMs(clusterProxy framework.ClusterProxy, clusterName, namespace s
 		&vms,
 		client.InNamespace(namespace),
 		client.MatchingLabels{
-			v1beta1.ClusterLabelName: clusterName,
+			clusterv1.ClusterNameLabel: clusterName,
 		},
 	)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multivc_test.go
+++ b/test/e2e/multivc_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MultiVCenterSpecInput struct {
+	InfraClients
+	Global     GlobalInput
+	Namespace  *corev1.Namespace
+	Datacenter string
+}
+
+var _ = Describe("Cluster creation with multivc", func() {
+	var namespace *corev1.Namespace
+
+	BeforeEach(func() {
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace = setupSpecNamespace("capv-e2e")
+	})
+
+	AfterEach(func() {
+		cleanupSpecNamespace(namespace)
+	})
+
+	It("should create a cluster successfully", func() {
+		VerifyMultiVC(ctx, MultiVCenterSpecInput{
+			Namespace:  namespace,
+			Datacenter: vsphereDatacenter,
+			InfraClients: InfraClients{
+				Client:     vsphereClient,
+				RestClient: restClient,
+				Finder:     vsphereFinder,
+			},
+			Global: GlobalInput{
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				E2EConfig:             e2eConfig,
+				ArtifactFolder:        artifactFolder,
+			},
+		})
+	})
+})
+
+func VerifyMultiVC(ctx context.Context, input MultiVCenterSpecInput) {
+	var (
+		specName         = "" // default template
+		namespace        = input.Namespace
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+
+		mgmtClusterProxy        framework.ClusterProxy
+		selfHostedNamespace     *corev1.Namespace
+		selfHostedCancelWatches context.CancelFunc
+	)
+
+	clusterName := fmt.Sprintf("%s-%s", "mgmtcluster", util.RandomString(6))
+	Expect(namespace).NotTo(BeNil())
+
+	By("creating a workload cluster")
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, specName, 1, 1, GlobalInput{
+		BootstrapClusterProxy: bootstrapClusterProxy,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		E2EConfig:             e2eConfig,
+		ArtifactFolder:        artifactFolder,
+	})
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 input.Global.BootstrapClusterProxy,
+		ConfigCluster:                configCluster,
+		WaitForClusterIntervals:      input.Global.E2EConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: input.Global.E2EConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+
+	vms := getVSphereVMsForCluster(clusterName, namespace.Name)
+	Expect(len(vms.Items)).To(BeNumerically(">", 0))
+
+	_, err := vsphereFinder.DatacenterOrDefault(ctx, input.Datacenter)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	By("Turning the workload cluster into a management cluster")
+
+	// Get a ClusterBroker so we can interact with the workload cluster
+	mgmtClusterProxy = input.Global.BootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterName)
+
+	Byf("Creating a namespace for hosting the %s test spec", specName)
+	selfHostedNamespace, selfHostedCancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+		Creator:   mgmtClusterProxy.GetClient(),
+		ClientSet: mgmtClusterProxy.GetClientSet(),
+		Name:      namespace.Name,
+		LogFolder: filepath.Join(artifactFolder, "clusters", "bootstrap"),
+	})
+
+	By("Initializing the workload cluster")
+	helpers.InitBootstrapCluster(mgmtClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
+
+	By("Ensure API servers are stable before doing move")
+	// Nb. This check was introduced to prevent doing move to self-hosted in an aggressive way and thus avoid flakes.
+	// More specifically, we were observing the test failing to get objects from the API server during move, so we
+	// are now testing the API servers are stable before starting move.
+	Consistently(func() error {
+		kubeSystem := &corev1.Namespace{}
+		return input.Global.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+	}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+	Consistently(func() error {
+		kubeSystem := &corev1.Namespace{}
+		return mgmtClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+	}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
+
+	// Get the machines of the workloadCluster before it is moved to become self-hosted to make sure that the move did not trigger
+	// any unexpected rollouts.
+	preMoveMachineList := &unstructured.UnstructuredList{}
+	preMoveMachineList.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("MachineList"))
+	err = input.Global.BootstrapClusterProxy.GetClient().List(
+		ctx,
+		preMoveMachineList,
+		client.InNamespace(namespace.Name),
+		client.MatchingLabels{clusterv1.ClusterLabelName: clusterName},
+	)
+	Expect(err).NotTo(HaveOccurred(), "Failed to list machines before move")
+
+	By("Moving the cluster to self hosted")
+	clusterctl.Move(ctx, clusterctl.MoveInput{
+		LogFolder:            filepath.Join(input.Global.ArtifactFolder, "clusters", "bootstrap"),
+		ClusterctlConfigPath: input.Global.ClusterctlConfigPath,
+		FromKubeconfigPath:   input.Global.BootstrapClusterProxy.GetKubeconfigPath(),
+		ToKubeconfigPath:     mgmtClusterProxy.GetKubeconfigPath(),
+		Namespace:            namespace.Name,
+	})
+
+	Expect(selfHostedNamespace.Name).ShouldNot(BeNil(), "namespace should have name")
+
+	wlClusterName := fmt.Sprintf("%s-%s", "wlcluster", util.RandomString(6))
+
+	os.Setenv("VSPHERE_SERVER", e2eConfig.GetVariable("VSPHERE2_SERVER"))
+
+	os.Setenv("VSPHERE_TLS_THUMBPRINT", e2eConfig.GetVariable("VSPHERE2_TLS_THUMBPRINT"))
+	os.Setenv("VSPHERE_USERNAME", os.Getenv("VSPHERE2_USERNAME"))
+	os.Setenv("VSPHERE_PASSWORD", os.Getenv("VSPHERE2_PASSWORD"))
+	os.Setenv("VSPHERE_RESOURCE_POOL", e2eConfig.GetVariable("VSPHERE2_RESOURCE_POOL"))
+	os.Setenv("VSPHERE_TEMPLATE", e2eConfig.GetVariable("VSPHERE2_TEMPLATE"))
+	os.Setenv("CONTROL_PLANE_ENDPOINT_IP", e2eConfig.GetVariable("VSPHERE2_CONTROL_PLANE_ENDPOINT_IP"))
+
+	By("creating a workload cluster from vsphere hosted management cluster")
+	wlConfigCluster := defaultConfigCluster(wlClusterName, namespace.Name, specName, 1, 1, GlobalInput{
+		BootstrapClusterProxy: mgmtClusterProxy,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		E2EConfig:             e2eConfig,
+		ArtifactFolder:        artifactFolder,
+	})
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 mgmtClusterProxy,
+		ConfigCluster:                wlConfigCluster,
+		WaitForClusterIntervals:      input.Global.E2EConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: input.Global.E2EConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+
+	vms = getVSphereVMs(mgmtClusterProxy, wlClusterName, namespace.Name)
+	Expect(len(vms.Items)).To(BeNumerically(">", 0))
+
+	if selfHostedCancelWatches != nil {
+		selfHostedCancelWatches()
+	}
+
+}
+
+func getVSphereVMs(clusterProxy framework.ClusterProxy, clusterName, namespace string) *infrav1.VSphereVMList {
+	var vms infrav1.VSphereVMList
+	err := clusterProxy.GetClient().List(
+		ctx,
+		&vms,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			v1beta1.ClusterLabelName: clusterName,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &vms
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This test case is to validate multiple vCenter support of CAPV, which means it will distribute management cluster in vCenter 1 and workload cluster in vCenter 2. So far it can only be run from downstream as it needs 2 vCenter to be pre-provisioned and I've verified the test case. And now this PR is ready for code review. Once the code review is complete, then anyone can leverage it to test multivc support downstream. Additionally, once the test infrastructure supports two vCenters, this test case can also be run upstream.

The original PR is https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1736, I've talked with @adam-jian-zhang  to use this PR to move forward.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a e2e test case that validates the multiple vCenter support of CAPV

```