### PR TITLE
:sparkles: ensure IPAddressClaims are created with a cluster annotation

### DIFF
--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -53,6 +53,9 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
+				Annotations: map[string]string{
+					clusterv1.ClusterNameAnnotation: "my-cluster",
+				},
 			},
 			Spec: infrav1.VSphereVMSpec{
 				VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
@@ -91,6 +94,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
+				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
 			}
 
 			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
@@ -138,6 +142,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
+				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
 			}
 		})
 
@@ -171,6 +176,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
+				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that IPAddressClaims get an annotation with a reference to the cluster they belong to. This will allow pausing of claim reconciliation when the cluster is paused, such as during a move from the bootstrap clusters to the management clusters.

This is related to https://github.com/telekom/cluster-api-ipam-provider-in-cluster/pull/105, which will use this annotation to check the cluster paused state when reconciling claims.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add cluster name label annotation to IPAddressClaims created by CAPV
```