### PR TITLE
🐛 Moves KCP watch population under feature flag

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -37,6 +37,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/controllers/vmware"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
@@ -163,8 +164,10 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		return err
 	}
 
-	// TODO (srm09): Need to figure out how to add the watches only when the anti-affinity feature flag is enabled.
-	return reconciler.clusterModuleReconciler.PopulateWatchesOnController(c)
+	if feature.Gates.Enabled(feature.NodeAntiAffinity) {
+		return reconciler.clusterModuleReconciler.PopulateWatchesOnController(c)
+	}
+	return nil
 }
 
 func clusterToInfrastructureMapFunc(managerContext *context.ControllerManagerContext) handler.MapFunc {


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch moves the watches on the `KubeadmControlPlane` object under the node anti affinity feature flag. These watches will now be set only when using the NodeAntiAffinity feature flag which implicitly depends upon the Kubeadm control plane provider. 

**Which issue(s) this PR fixes**:
Fixes #1863 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Moves KCP watch population under feature flag
```