### PR TITLE
:bug: Check for bool ptrs before using it

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -358,15 +358,19 @@ func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext)
 	failureDomains := clusterv1.FailureDomains{}
 	for _, zone := range deploymentZoneList.Items {
 		if zone.Spec.Server == ctx.VSphereCluster.Spec.Server {
+			var isCP bool
+			if zone.Spec.ControlPlane != nil {
+				isCP = *zone.Spec.ControlPlane
+			}
 			if zone.Status.Ready == nil {
 				readyNotReported++
 				failureDomains[zone.Name] = clusterv1.FailureDomainSpec{
-					ControlPlane: *zone.Spec.ControlPlane,
+					ControlPlane: isCP,
 				}
 			} else {
 				if *zone.Status.Ready {
 					failureDomains[zone.Name] = clusterv1.FailureDomainSpec{
-						ControlPlane: *zone.Spec.ControlPlane,
+						ControlPlane: isCP,
 					}
 				} else {
 					notReady++

--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -62,7 +62,7 @@ func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(ctx *context.VSp
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileInfraFailureDomain(ctx *context.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
-	if *failureDomain.AutoConfigure {
+	if failureDomain.AutoConfigure != nil && *failureDomain.AutoConfigure {
 		return r.createAndAttachMetadata(ctx, failureDomain)
 	}
 	return r.verifyFailureDomain(ctx, failureDomain)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a check for boolean pointers before using it.

When a user is configuring failure domains, some fields can be specified as booleans. But those are pointers because "nil is different than false".

The controller assumes this pointer will always exists, are there are mutation webhooks that defaults this field to false when it is not set (and then the pointer starts to exists).

But in deployments were the webhook is not working properly, or no mutation happens, the object will be created with a nil pointer and controller will panic.

This fix adds a simple check on pointer existence, before allowing it to be referenced
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid null pointer on boolean pointer fields
```