### PR TITLE
🐛 Handles cluster owner ref error for node controller

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -111,11 +111,13 @@ func (r nodeLabelReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ c
 	}
 
 	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, machine.ObjectMeta)
-	if err == nil {
-		if annotations.IsPaused(cluster, machine) {
-			logger.V(4).Info("Machine linked to a cluster that is paused")
-			return reconcile.Result{}, nil
-		}
+	if err != nil {
+		logger.Error(err, "Could not fetch cluster data", "machine", key)
+		return reconcile.Result{}, nil
+	}
+	if annotations.IsPaused(cluster, machine) {
+		logger.V(4).Info("Machine linked to a cluster that is paused")
+		return reconcile.Result{}, nil
 	}
 
 	if !machine.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
**What this PR does / why we need it**:
During B/R operations, the cluster owner ref is somethimes not present immediately. This might throw an error which when unhandled causes the controller to crash.
This patch handles the error case and requeues the reconcile request for a later time.

The main motivation behind fixing this is to make sure a backport can be made to the `release-1.6` and `release-1.5` branches, the last active branches which will have support for CAPV based node labeling.

**Which issue(s) this PR fixes**:
Fixes #1884 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```