### PR TITLE
:bug: Allow ipv6 gateway to be optional when DHCPv6 is disabled.

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -281,7 +281,6 @@ type NetworkDeviceSpec struct {
 	Gateway4 string `json:"gateway4,omitempty"`
 
 	// Gateway4 is the IPv4 gateway used by this device.
-	// Required when DHCP6 is false.
 	// +optional
 	Gateway6 string `json:"gateway6,omitempty"`
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1075,7 +1075,6 @@ spec:
                           type: string
                         gateway6:
                           description: Gateway4 is the IPv4 gateway used by this device.
-                            Required when DHCP6 is false.
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -976,7 +976,7 @@ spec:
                                   type: string
                                 gateway6:
                                   description: Gateway4 is the IPv4 gateway used by
-                                    this device. Required when DHCP6 is false.
+                                    this device.
                                   type: string
                                 ipAddrs:
                                   description: IPAddrs is a list of one or more IPv4

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1122,7 +1122,6 @@ spec:
                           type: string
                         gateway6:
                           description: Gateway4 is the IPv4 gateway used by this device.
-                            Required when DHCP6 is false.
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or

--- a/pkg/services/govmomi/ipam/status.go
+++ b/pkg/services/govmomi/ipam/status.go
@@ -77,10 +77,12 @@ func BuildState(ctx context.VMContext, networkStatus []infrav1.NetworkStatus) (m
 				continue
 			}
 
-			if gatewayAddr.Is4() {
-				ipamDeviceConfig.IPAMConfigGateway4 = ipamAddress.Spec.Gateway
-			} else {
-				ipamDeviceConfig.IPAMConfigGateway6 = ipamAddress.Spec.Gateway
+			if gatewayAddr != nil {
+				if gatewayAddr.Is4() {
+					ipamDeviceConfig.IPAMConfigGateway4 = ipamAddress.Spec.Gateway
+				} else {
+					ipamDeviceConfig.IPAMConfigGateway6 = ipamAddress.Spec.Gateway
+				}
 			}
 
 			addressWithPrefixes = append(addressWithPrefixes, addressWithPrefix)

--- a/pkg/services/govmomi/ipam/status_test.go
+++ b/pkg/services/govmomi/ipam/status_test.go
@@ -716,6 +716,28 @@ func Test_BuildState(t *testing.T) {
 			g.Expect(err).To(gomega.MatchError("IPAddress my-namespace/vsphereVM1-0-0 has invalid ip address: \"10.0.1.50/200\""))
 		})
 
+		t.Run("when a provider assigns an IPv4 IPAddress without a Gateway field", func(_ *testing.T) {
+			beforeWithClaimsAndAddressCreated()
+
+			address1.Spec.Gateway = ""
+			g.Expect(ctx.Client.Update(ctx, address1)).NotTo(gomega.HaveOccurred())
+
+			_, err := BuildState(ctx, networkStatus)
+			g.Expect(err).To(gomega.HaveOccurred())
+			g.Expect(err).To(gomega.MatchError("IPAddress my-namespace/vsphereVM1-0-0 has invalid gateway: \"\""))
+		})
+
+		t.Run("when a provider assigns an IPv6 IPAddress without a Gateway field", func(_ *testing.T) {
+			beforeWithClaimsAndAddressCreated()
+
+			address1.Spec.Address = "fd00:dddd::1"
+			address1.Spec.Gateway = ""
+			g.Expect(ctx.Client.Update(ctx, address1)).NotTo(gomega.HaveOccurred())
+
+			_, err := BuildState(ctx, networkStatus)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		t.Run("when a provider assigns an IPAddress with an invalid value in the Gateway field", func(_ *testing.T) {
 			beforeWithClaimsAndAddressCreated()
 			// Simulate an invalid gateway was provided: the gateway is an invalid ip


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows ipv6 gateway to be optional. In the case of using IPAM for nodes the IPAddress can have an ipv6 address without a gateway and it will configure the machine's metadata appropriately. The comment on gateway6 says it is required when DHCPv6 is disabled. This comment was removed, but there was no logic enforcing it except in the case of Node IPAM were it would always try to parse the gateway from the `IPAddress` resource.

**Which issue(s) this PR fixes**:
Fixes #1861

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow IPv6 Gateways to be optional when DHCPv6 is disabled.
```