### PR TITLE
🌱 Set the ClusterName label on IP claims instead of setting the annotation

### DIFF
--- a/controllers/vspherevm_ipaddress_reconciler.go
+++ b/controllers/vspherevm_ipaddress_reconciler.go
@@ -147,10 +147,10 @@ func createOrPatchIPAddressClaim(ctx *context.VMContext, name string, poolRef co
 
 		ctrlutil.AddFinalizer(claim, infrav1.IPAddressClaimFinalizer)
 
-		if claim.Annotations == nil {
-			claim.Annotations = make(map[string]string)
+		if claim.Labels == nil {
+			claim.Labels = make(map[string]string)
 		}
-		claim.Annotations[clusterv1.ClusterNameAnnotation] = ctx.VSphereVM.ObjectMeta.Annotations[clusterv1.ClusterNameAnnotation]
+		claim.Labels[clusterv1.ClusterNameLabel] = ctx.VSphereVM.Labels[clusterv1.ClusterNameLabel]
 
 		claim.Spec.PoolRef.APIGroup = poolRef.APIGroup
 		claim.Spec.PoolRef.Kind = poolRef.Kind

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -53,8 +53,8 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
-				Annotations: map[string]string{
-					clusterv1.ClusterNameAnnotation: "my-cluster",
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: "my-cluster",
 				},
 			},
 			Spec: infrav1.VSphereVMSpec{
@@ -94,7 +94,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
-				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
+				g.Expect(claim.Labels).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameLabel, "my-cluster"))
 			}
 
 			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
@@ -142,7 +142,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
-				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
+				g.Expect(claim.Labels).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameLabel, "my-cluster"))
 			}
 		})
 
@@ -176,7 +176,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 
 				g.Expect(claim.OwnerReferences).To(gomega.HaveLen(1))
 				g.Expect(claim.OwnerReferences[0].Name).To(gomega.Equal(vsphereVM.Name))
-				g.Expect(claim.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameAnnotation, "my-cluster"))
+				g.Expect(claim.Labels).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameLabel, "my-cluster"))
 			}
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fixes error made in #1857 where we were previously setting the annotation on an IPAddressClaim based on a non-existent annotation on the VSphereVM.

This change uses labels which we have manually verified to be set correctly on a running kind cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```