### PR TITLE
🐛 Update IPAddressClaim rbac for patch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -304,7 +304,7 @@ rules:
   - create
   - get
   - list
-  - update
+  - patch
   - watch
 - apiGroups:
   - ipam.cluster.x-k8s.io

--- a/controllers/vspherevm_ipaddress_reconciler.go
+++ b/controllers/vspherevm_ipaddress_reconciler.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
-// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;create;update;watch;list
+// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;create;patch;watch;list
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses,verbs=get;list;watch
 
 // reconcileIPAddressClaims ensures that VSphereVMs that are configured with .spec.network.devices.addressFromPools
@@ -69,6 +69,7 @@ func (r vmReconciler) reconcileIPAddressClaims(ctx *context.VMContext) error {
 			if err != nil {
 				ctx.Logger.Error(err, "createOrPatchIPAddressClaim failed", "name", ipAddrClaimName)
 				errList = append(errList, err)
+				continue
 			}
 			if created {
 				claimsCreated++


### PR DESCRIPTION
change update -> patch

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

During manual testing of IPAM features, a panic was encountered. The testing involved setting a label on a previously created IPAddressClaim. The controller failed to patch the claim, causing the claim to be nil. The claim became nil because the rbac permissions did not include patch. A previous incantation of the controller used udpate, and when the code was switched to patch, the rbac permissions has been left unchanged. This PR updates the controller's permissions to include patch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```