### PR TITLE
✨ Introduces parameter for control plane zone selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export GO111MODULE := on
 #
 # Kubebuilder.
 #
-export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.23.3
+export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.25.0
 
 # Directories
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))

--- a/apis/v1alpha3/conversion_test.go
+++ b/apis/v1alpha3/conversion_test.go
@@ -80,6 +80,7 @@ func overrideVSphereClusterSpecFieldsFuncs(codecs runtimeserializer.CodecFactory
 		func(in *nextver.VSphereClusterSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(in)
 			in.ClusterModules = nil
+			in.FailureDomainSelector = nil
 		},
 	}
 }
@@ -99,7 +100,7 @@ func CustomObjectMetaFuzzFunc(_ runtimeserializer.CodecFactory) []interface{} {
 	}
 }
 
-//nolint
+// nolint
 func CustomObjectMetaFuzzer(in *clusterv1.ObjectMeta, c fuzz.Continue) {
 	c.FuzzNoCustom(in)
 

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -986,6 +986,7 @@ func autoConvert_v1beta1_VSphereClusterSpec_To_v1alpha3_VSphereClusterSpec(in *v
 	}
 	out.IdentityRef = (*VSphereIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	// WARNING: in.ClusterModules requires manual conversion: does not exist in peer-type
+	// WARNING: in.FailureDomainSelector requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1028,6 +1028,7 @@ func autoConvert_v1beta1_VSphereClusterSpec_To_v1alpha4_VSphereClusterSpec(in *v
 	}
 	out.IdentityRef = (*VSphereIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	// WARNING: in.ClusterModules requires manual conversion: does not exist in peer-type
+	// WARNING: in.FailureDomainSelector requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/apis/v1beta1/vspherecluster_types.go
+++ b/apis/v1beta1/vspherecluster_types.go
@@ -58,6 +58,12 @@ type VSphereClusterSpec struct {
 	// for each of the objects responsible for creation of VM objects belonging to the cluster.
 	// +optional
 	ClusterModules []ClusterModule `json:"clusterModules,omitempty"`
+
+	// FailureDomainSelector is the label selector to use for failure domain selection
+	// for the control plane nodes of the cluster.
+	// An empty value for the selector includes all the related failure domains.
+	// +optional
+	FailureDomainSelector *metav1.LabelSelector `json:"failureDomainSelector,omitempty"`
 }
 
 // ClusterModule holds the anti affinity construct `ClusterModule` identifier

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
@@ -576,6 +577,11 @@ func (in *VSphereClusterSpec) DeepCopyInto(out *VSphereClusterSpec) {
 		in, out := &in.ClusterModules, &out.ClusterModules
 		*out = make([]ClusterModule, len(*in))
 		copy(*out, *in)
+	}
+	if in.FailureDomainSelector != nil {
+		in, out := &in.FailureDomainSelector, &out.FailureDomainSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -644,6 +644,53 @@ spec:
                 - host
                 - port
                 type: object
+              failureDomainSelector:
+                description: FailureDomainSelector is the label selector to use for
+                  failure domain selection for the control plane nodes of the cluster.
+                  An empty value for the selector includes all the related failure
+                  domains.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               identityRef:
                 description: IdentityRef is a reference to either a Secret or VSphereClusterIdentity
                   that contains the identity to use when reconciling the cluster.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -167,6 +167,54 @@ spec:
                         - host
                         - port
                         type: object
+                      failureDomainSelector:
+                        description: FailureDomainSelector is the label selector to
+                          use for failure domain selection for the control plane nodes
+                          of the cluster. An empty value for the selector includes
+                          all the related failure domains.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       identityRef:
                         description: IdentityRef is a reference to either a Secret
                           or VSphereClusterIdentity that contains the identity to

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -27,9 +27,11 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -358,15 +360,29 @@ func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext)
 	failureDomains := clusterv1.FailureDomains{}
 	for _, zone := range deploymentZoneList.Items {
 		if zone.Spec.Server == ctx.VSphereCluster.Spec.Server {
+			// This should never fail, validating webhook should catch this first
+			if ctx.VSphereCluster.Spec.FailureDomainSelector != nil {
+				selector, err := metav1.LabelSelectorAsSelector(ctx.VSphereCluster.Spec.FailureDomainSelector)
+				if err != nil {
+					return false, errors.Wrapf(err, "zone label selector is misconfigured")
+				}
+
+				// An empty selector allows the zone to be selected
+				if !selector.Empty() && !selector.Matches(labels.Set(zone.GetLabels())) {
+					r.Logger.V(5).Info("skipping the deployment zone due to label mismatch", "name", zone.Name)
+					continue
+				}
+			}
+
 			if zone.Status.Ready == nil {
 				readyNotReported++
 				failureDomains[zone.Name] = clusterv1.FailureDomainSpec{
-					ControlPlane: *zone.Spec.ControlPlane,
+					ControlPlane: pointer.BoolDeref(zone.Spec.ControlPlane, true),
 				}
 			} else {
 				if *zone.Status.Ready {
 					failureDomains[zone.Name] = clusterv1.FailureDomainSpec{
-						ControlPlane: *zone.Spec.ControlPlane,
+						ControlPlane: pointer.BoolDeref(zone.Spec.ControlPlane, true),
 					}
 				} else {
 					notReady++


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch introduces a new parameter for selecting zones for control plane nodes.
In the past, all zones having the same vCenter URL in the spec.server would be associated to a vSphereCluster object with the same vCenter URL set in the spec.server.
Now the vSphereCluster spec exposes a label based selection which can be used to choose the zones for control plane node placement. The label selector follows the same rules as described on the label selector types in https://pkg.go.dev/k8s.io/apimachinery@v0.26.1/pkg/apis/meta/v1#LabelSelector

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduces parameter for control plane zone selection
```