### PR TITLE
⚠️ Re-introduce the keep alive flag on the CAPV manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,7 @@ spec:
       - args:
         - --leader-elect
         - --v=4
+        - --enable-keep-alive
         - "--feature-gates=NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false}"
         image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
         imagePullPolicy: IfNotPresent

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -321,6 +321,7 @@ func (r clusterReconciler) reconcileVCenterConnectivity(ctx *context.ClusterCont
 		WithServer(ctx.VSphereCluster.Spec.Server).
 		WithThumbprint(ctx.VSphereCluster.Spec.Thumbprint).
 		WithFeatures(session.Feature{
+			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -226,6 +226,7 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx *context.VSphereD
 		WithDatacenter(ctx.VSphereFailureDomain.Spec.Topology.Datacenter).
 		WithUserInfo(r.ControllerContext.Username, r.ControllerContext.Password).
 		WithFeatures(session.Feature{
+			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -539,6 +539,7 @@ func (r vmReconciler) retrieveVcenterSession(ctx goctx.Context, vsphereVM *infra
 		WithUserInfo(r.ControllerContext.Username, r.ControllerContext.Password).
 		WithThumbprint(vsphereVM.Spec.Thumbprint).
 		WithFeatures(session.Feature{
+			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, vsphereVM.ObjectMeta)

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&managerOpts.EnableKeepAlive,
 		"enable-keep-alive",
 		defaultEnableKeepAlive,
-		"DEPRECATED: feature to enable keep alive handler in vsphere sessions. This functionality is enabled by default now")
+		"feature to enable keep alive handler in vsphere sessions. This functionality is enabled by default.")
 	flag.DurationVar(
 		&managerOpts.KeepAliveDuration,
 		"keep-alive-duration",

--- a/pkg/clustermodule/session.go
+++ b/pkg/clustermodule/session.go
@@ -44,6 +44,7 @@ func newParams(ctx context.ClusterContext) *session.Params {
 		WithServer(ctx.VSphereCluster.Spec.Server).
 		WithThumbprint(ctx.VSphereCluster.Spec.Thumbprint).
 		WithFeatures(session.Feature{
+			EnableKeepAlive:   ctx.EnableKeepAlive,
 			KeepAliveDuration: ctx.KeepAliveDuration,
 		})
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,8 +51,8 @@ const (
 	// cluster are in maintenance mode.
 	MaintenanceAnnotationLabel = "capv." + v1alpha3.GroupName + "/maintenance"
 
-	// DefaultEnableKeepAlive is false by default.
-	DefaultEnableKeepAlive = false
+	// DefaultEnableKeepAlive is true by default.
+	DefaultEnableKeepAlive = true
 
 	// KeepaliveDuration unit minutes.
 	DefaultKeepAliveDuration = time.Minute * 5

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -38,6 +38,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 )
 
 var (
@@ -58,11 +59,14 @@ type Session struct {
 }
 
 type Feature struct {
+	EnableKeepAlive   bool
 	KeepAliveDuration time.Duration
 }
 
 func DefaultFeature() Feature {
-	return Feature{}
+	return Feature{
+		EnableKeepAlive: constants.DefaultEnableKeepAlive,
+	}
 }
 
 type Params struct {
@@ -194,20 +198,16 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	vimClient.RoundTripper = session.KeepAliveHandler(vimClient.RoundTripper, feature.KeepAliveDuration, func(tripper soap.RoundTripper) error {
-		// we tried implementing
-		// c.Login here but the client once logged out
-		// keeps errong in invalid username or password
-		// we tried with cached username and password in session still the error persisted
-		// hence we just clear the cache and expect the client to
-		// be recreated in next GetOrCreate call
-		_, err := methods.GetCurrentTime(ctx, tripper)
-		if err != nil {
-			logger.Error(err, "failed to keep alive govmomi client")
-			clearCache(logger, sessionKey)
-		}
-		return err
-	})
+	if feature.EnableKeepAlive {
+		vimClient.RoundTripper = session.KeepAliveHandler(vimClient.RoundTripper, feature.KeepAliveDuration, func(tripper soap.RoundTripper) error {
+			_, err := methods.GetCurrentTime(ctx, vimClient)
+			if err != nil {
+				logger.Error(err, "failed to keep alive govmomi client")
+				clearCache(logger, sessionKey)
+			}
+			return err
+		})
+	}
 
 	if err := c.Login(ctx, url.User); err != nil {
 		return nil, err
@@ -231,19 +231,21 @@ func clearCache(logger logr.Logger, sessionKey string) {
 // newManager creates a Manager that encompasses the REST Client for the VSphere tagging API.
 func newManager(ctx context.Context, logger logr.Logger, sessionKey string, client *vim25.Client, user *url.Userinfo, feature Feature) (*tags.Manager, error) {
 	rc := rest.NewClient(client)
-	rc.Transport = keepalive.NewHandlerREST(rc, feature.KeepAliveDuration, func() error {
-		s, err := rc.Session(ctx)
-		if err != nil {
-			return err
-		}
-		if s != nil {
-			return nil
-		}
+	if feature.EnableKeepAlive {
+		rc.Transport = keepalive.NewHandlerREST(rc, feature.KeepAliveDuration, func() error {
+			s, err := rc.Session(ctx)
+			if err != nil {
+				return err
+			}
+			if s != nil {
+				return nil
+			}
 
-		logger.Info("rest client session expired, clearing cache")
-		clearCache(logger, sessionKey)
-		return errors.New("rest client session expired")
-	})
+			logger.Info("rest client session expired, clearing cache")
+			clearCache(logger, sessionKey)
+			return errors.New("rest client session expired")
+		})
+	}
 	if err := rc.Login(ctx, user); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Thie patch re-introduces the keep alive flag on the CAPV manager. The flag is by enabled default so there are no breaking changes after upgrades.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1896 

**Special notes for your reviewer**:
This leads to the `--enable-keep-alive` flag being exposed on the CAPV manifest.

**Release note**:
```release-note
Re-introduce the keep alive flag on the CAPV manager
```