### PR TITLE
✨ Add VMRef moID to Object status

### DIFF
--- a/apis/v1alpha3/conversion_test.go
+++ b/apis/v1alpha3/conversion_test.go
@@ -133,4 +133,5 @@ func CustomStatusNewFieldFuzzer(in *nextver.VSphereVMStatus, c fuzz.Continue) {
 
 	in.Host = ""
 	in.ModuleUUID = nil
+	in.VMRef = ""
 }

--- a/apis/v1alpha3/types.go
+++ b/apis/v1alpha3/types.go
@@ -340,6 +340,9 @@ type VirtualMachine struct {
 
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
+
+	// VMRef is the the VM's Managed Object Reference on vSphere.
+	VMRef string `json:"vmRef"`
 }
 
 // SSHUser is granted remote access to a system.

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1610,6 +1610,7 @@ func autoConvert_v1beta1_VSphereVMStatus_To_v1alpha3_VSphereVMStatus(in *v1beta1
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha3.Conditions)(unsafe.Pointer(&in.Conditions))
 	// WARNING: in.ModuleUUID requires manual conversion: does not exist in peer-type
+	// WARNING: in.VMRef requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -1618,6 +1619,7 @@ func autoConvert_v1alpha3_VirtualMachine_To_v1beta1_VirtualMachine(in *VirtualMa
 	out.BiosUUID = in.BiosUUID
 	out.State = v1beta1.VirtualMachineState(in.State)
 	out.Network = *(*[]v1beta1.NetworkStatus)(unsafe.Pointer(&in.Network))
+	out.VMRef = in.VMRef
 	return nil
 }
 
@@ -1631,6 +1633,7 @@ func autoConvert_v1beta1_VirtualMachine_To_v1alpha3_VirtualMachine(in *v1beta1.V
 	out.BiosUUID = in.BiosUUID
 	out.State = VirtualMachineState(in.State)
 	out.Network = *(*[]NetworkStatus)(unsafe.Pointer(&in.Network))
+	out.VMRef = in.VMRef
 	return nil
 }
 

--- a/apis/v1alpha4/types.go
+++ b/apis/v1alpha4/types.go
@@ -340,6 +340,9 @@ type VirtualMachine struct {
 
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
+
+	// VMRef is the the VM's Managed Object Reference on vSphere.
+	VMRef string `json:"vmRef"`
 }
 
 // SSHUser is granted remote access to a system.

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1768,6 +1768,7 @@ func autoConvert_v1beta1_VSphereVMStatus_To_v1alpha4_VSphereVMStatus(in *v1beta1
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
 	// WARNING: in.ModuleUUID requires manual conversion: does not exist in peer-type
+	// WARNING: in.VMRef requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -1776,6 +1777,7 @@ func autoConvert_v1alpha4_VirtualMachine_To_v1beta1_VirtualMachine(in *VirtualMa
 	out.BiosUUID = in.BiosUUID
 	out.State = v1beta1.VirtualMachineState(in.State)
 	out.Network = *(*[]v1beta1.NetworkStatus)(unsafe.Pointer(&in.Network))
+	out.VMRef = in.VMRef
 	return nil
 }
 
@@ -1789,6 +1791,7 @@ func autoConvert_v1beta1_VirtualMachine_To_v1alpha4_VirtualMachine(in *v1beta1.V
 	out.BiosUUID = in.BiosUUID
 	out.State = VirtualMachineState(in.State)
 	out.Network = *(*[]NetworkStatus)(unsafe.Pointer(&in.Network))
+	out.VMRef = in.VMRef
 	return nil
 }
 

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -459,6 +459,9 @@ type VirtualMachine struct {
 
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
+
+	// VMRef is the the VM's Managed Object Reference on vSphere.
+	VMRef string `json:"vmRef"`
 }
 
 // SSHUser is granted remote access to a system.

--- a/apis/v1beta1/vspherevm_types.go
+++ b/apis/v1beta1/vspherevm_types.go
@@ -139,6 +139,12 @@ type VSphereVMStatus struct {
 	// the VMs on separate hosts.
 	// +optional
 	ModuleUUID *string `json:"moduleUUID,omitempty"`
+
+	// VMRef is the the VM's Managed Object Reference on vSphere. It can be used by consumers
+	// to programatically get this VM representation on vSphere in case of the need to retrieve informations.
+	// This field is set once the machine is created and should not be changed
+	// +optional
+	VMRef string `json:"vmRef,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1430,6 +1430,12 @@ spec:
                   to the machine. This value is set automatically at runtime and should
                   not be set or modified by users.
                 type: string
+              vmRef:
+                description: VMRef is the the VM's Managed Object Reference on vSphere.
+                  It can be used by consumers to programatically get this VM representation
+                  on vSphere in case of the need to retrieve informations. This field
+                  is set once the machine is created and should not be changed
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -411,6 +411,11 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 		return reconcile.Result{}, errors.Errorf("bios uuid is empty while VM is ready")
 	}
 
+	// VMRef should be set just once. It is not supposed to change!
+	if vm.VMRef != "" && ctx.VSphereVM.Status.VMRef == "" {
+		ctx.VSphereVM.Status.VMRef = vm.VMRef
+	}
+
 	// Update the VSphereVM's network status.
 	r.reconcileNetwork(ctx, vm)
 

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -569,6 +569,7 @@ func Test_reconcile(t *testing.T) {
 				Name:     vsphereVM.Name,
 				BiosUUID: "265104de-1472-547c-b873-6dc7883fb6cb",
 				State:    infrav1.VirtualMachineStateReady,
+				VMRef:    "VirtualMachine:vm-129",
 			}, nil)
 
 			r := setupReconciler(fakeVMSvc, objsWithHierarchy...)
@@ -583,6 +584,7 @@ func Test_reconcile(t *testing.T) {
 
 			g := NewWithT(t)
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(vsphereVM.Status.VMRef).To(Equal("VirtualMachine:vm-129"))
 		})
 	})
 

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -122,6 +122,7 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 		Ref:       vmRef,
 		State:     &vm,
 	}
+	vm.VMRef = vmRef.String()
 
 	vms.reconcileUUID(vmCtx)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new status field to vspherevms resources, representing the fetched moid/vmref from reconciliation process.

This information is desired on situations where you create a cluster, and later may want to query on vCenter directly information about the nodes (for observability reasons, metrics collection, datastore usage, etc).

vmRef/Moid is an immutable information, so as soon as a virtual machine is created it is allocated and will persist during VM lifecycle, while biosUUID can change on specific situations (see https://kb.vmware.com/s/article/2002506).

Having biosUUID should be enough to query a virtual machine VMRef, but this needs a bunch of machinery (https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/5a027e203ceae96c9721a691e75751adec005ea0/pkg/services/govmomi/util.go#L54) while having the vmref generated during machine provisioning is desired, enough and easier to correlate vspherevms with real objects on vCenter

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Issue virtual machine reference/moid on vspherevm status
```