### PR TITLE
:seedling: Deflake verify-crd test

### DIFF
--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -38,7 +38,7 @@ echo "verify-crds: comparing crds"
 while IFS= read -r -d '' dst_file; do
   src_file="${dst_file#"${_output_dir}/"}"
   echo "  config/${src_file}"
-  diff "${dst_file}" "./config/${src_file}" >"${_diff_log}" || _exit_code="${?}"
+  diff <(yq -P 'sort_keys(..)' "${dst_file}") <(yq -P 'sort_keys(..)' "./config/${src_file}") >"${_diff_log}" || _exit_code="${?}"
   if [ "${_exit_code}" -ne "0" ]; then
     echo "config/${src_file}" 1>&2
     cat "${_diff_log}" 1>&2


### PR DESCRIPTION
**What this PR does / why we need it**:
verify-crd is flaky. This is because the yaml files can be generated out of order sometimes, getting differences. 
This approach (as recommended on [yq](https://mikefarah.gitbook.io/yq/usage/tips-and-tricks#comparing-yaml-files) will check the consistency of the CRD yaml file, not only the diffs

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```