### PR TITLE
🐛 Allow thumbprint update on VSphereVM

### DIFF
--- a/apis/v1beta1/vspherevm_webhook.go
+++ b/apis/v1beta1/vspherevm_webhook.go
@@ -86,26 +86,22 @@ func (r *VSphereVM) ValidateUpdate(old runtime.Object) error {
 	newVSphereVMSpec := newVSphereVM["spec"].(map[string]interface{})
 	oldVSphereVMSpec := oldVSphereVM["spec"].(map[string]interface{})
 
-	// allow changes to biosUUID
-	delete(oldVSphereVMSpec, "biosUUID")
-	delete(newVSphereVMSpec, "biosUUID")
-
-	// allow changes to bootstrapRef
-	delete(oldVSphereVMSpec, "bootstrapRef")
-	delete(newVSphereVMSpec, "bootstrapRef")
+	// allow changes to biosUUID, bootstrapRef, thumbprint
+	keys := []string{"biosUUID", "bootstrapRef", "thumbprint"}
+	// allow changes to os only if the old spec has empty OS field
+	if _, ok := oldVSphereVMSpec["os"]; !ok {
+		keys = append(keys, "os")
+	}
+	r.deleteSpecKeys(oldVSphereVMSpec, keys)
+	r.deleteSpecKeys(newVSphereVMSpec, keys)
 
 	newVSphereVMNetwork := newVSphereVMSpec["network"].(map[string]interface{})
 	oldVSphereVMNetwork := oldVSphereVMSpec["network"].(map[string]interface{})
 
 	// allow changes to the network devices
-	delete(oldVSphereVMNetwork, "devices")
-	delete(newVSphereVMNetwork, "devices")
-
-	// allow changes to os only if the old spec has empty OS field
-	if _, ok := oldVSphereVMSpec["os"]; !ok {
-		delete(oldVSphereVMSpec, "os")
-		delete(newVSphereVMSpec, "os")
-	}
+	networkKeys := []string{"devices"}
+	r.deleteSpecKeys(oldVSphereVMNetwork, networkKeys)
+	r.deleteSpecKeys(newVSphereVMNetwork, networkKeys)
 
 	if !reflect.DeepEqual(oldVSphereVMSpec, newVSphereVMSpec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
@@ -117,4 +113,14 @@ func (r *VSphereVM) ValidateUpdate(old runtime.Object) error {
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereVM) ValidateDelete() error {
 	return nil
+}
+
+func (r *VSphereVM) deleteSpecKeys(spec map[string]interface{}, keys []string) {
+	if len(spec) == 0 || len(keys) == 0 {
+		return
+	}
+
+	for _, key := range keys {
+		delete(spec, key)
+	}
 }

--- a/apis/v1beta1/vspherevm_webhook_test.go
+++ b/apis/v1beta1/vspherevm_webhook_test.go
@@ -34,9 +34,9 @@ const (
 func TestVSphereVM_Default(t *testing.T) {
 	g := NewWithT(t)
 
-	WindowsVM := createVSphereVM(windowsVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows)
-	LinuxVM := createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux)
-	NoOSVM := createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, "")
+	WindowsVM := createVSphereVM(windowsVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows)
+	LinuxVM := createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux)
+	NoOSVM := createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, "")
 
 	WindowsVM.Default()
 	LinuxVM.Default()
@@ -58,27 +58,27 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 	}{
 		{
 			name:      "preferredAPIServerCIDR set on creation ",
-			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "192.168.0.1/32", []string{}, nil, Linux),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "192.168.0.1/32", "", []string{}, nil, Linux),
 			wantErr:   true,
 		},
 		{
 			name:      "IPs are not in CIDR format",
-			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3"}, nil, Linux),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3"}, nil, Linux),
 			wantErr:   true,
 		},
 		{
 			name:      "successful VSphereVM creation",
-			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
+			vSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
 			wantErr:   false,
 		},
 		{
 			name:      "name too long for Windows VM",
-			vSphereVM: createVSphereVM(windowsVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows),
+			vSphereVM: createVSphereVM(windowsVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Windows),
 			wantErr:   true,
 		},
 		{
 			name:      "no error with name too long for Linux VM",
-			vSphereVM: createVSphereVM(linuxVMName, "foo.com", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
+			vSphereVM: createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, Linux),
 			wantErr:   false,
 		},
 	}
@@ -106,39 +106,45 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:         "ProviderID can be updated",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
-			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32"}, nil, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "", []string{"192.168.0.1/32"}, nil, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating ips can be done",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
-			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating bootstrapRef can be done",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
-			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, &corev1.ObjectReference{}, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "", []string{"192.168.0.1/32", "192.168.0.10/32"}, &corev1.ObjectReference{}, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating server cannot be done",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
-			vSphereVM:    createVSphereVM("vsphere-vm-1", "bar.com", biosUUID, "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "bar.com", biosUUID, "", "", []string{"192.168.0.1/32", "192.168.0.10/32"}, nil, Linux),
 			wantErr:      true,
 		},
 		{
 			name:         "updating OS can be done only when empty",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, ""),
-			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, ""),
+			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
 			wantErr:      false,
 		},
 		{
 			name:         "updating OS cannot be done when alreadySet",
-			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Windows),
-			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", []string{"192.168.0.1/32"}, nil, Linux),
+			oldVSphereVM: createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Windows),
+			vSphereVM:    createVSphereVM("vsphere-vm-1-os", "foo.com", "", "", "", []string{"192.168.0.1/32"}, nil, Linux),
 			wantErr:      true,
+		},
+		{
+			name:         "updating thumbprint can be updated",
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "AA:BB:CC:DD:EE", []string{"192.168.0.1/32"}, nil, Linux),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "BB:CC:DD:EE:FF", []string{"192.168.0.1/32"}, nil, Linux),
+			wantErr:      false,
 		},
 	}
 	for _, tc := range tests {
@@ -153,7 +159,7 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createVSphereVM(name, server, biosUUID, preferredAPIServerCIDR string, ips []string, bootstrapRef *corev1.ObjectReference, os OS) *VSphereVM {
+func createVSphereVM(name, server, biosUUID, preferredAPIServerCIDR, thumbprint string, ips []string, bootstrapRef *corev1.ObjectReference, os OS) *VSphereVM {
 	VSphereVM := &VSphereVM{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -167,6 +173,7 @@ func createVSphereVM(name, server, biosUUID, preferredAPIServerCIDR string, ips 
 					PreferredAPIServerCIDR: preferredAPIServerCIDR,
 					Devices:                []NetworkDeviceSpec{},
 				},
+				Thumbprint: thumbprint,
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Updating thumbprint of VSphereCluster will cause reconcilererror for VSphereVM, to fix it
    - Relax the VSphereVM webhook to allow the thumbprint update.
    - Keep VSphereVM thumbprint consistent with VSphereCluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1718

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow thumbprint update on VSphereVM
```