### PR TITLE
🐛 ServiceAccount Controller: Forcefully set controller ownership on resources being reconciled

### DIFF
--- a/pkg/util/supervisor.go
+++ b/pkg/util/supervisor.go
@@ -20,6 +20,12 @@ import (
 	"fmt"
 	"reflect"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 )
@@ -33,4 +39,61 @@ func IsSupervisorType(input interface{}) (bool, error) {
 	default:
 		return false, fmt.Errorf("unexpected type %s", reflect.TypeOf(input))
 	}
+}
+
+// SetControllerReferenceWithOverride sets owner as a Controller OwnerReference on controlled.
+// This is used for garbage collection of the controlled object and for
+// reconciling the owner object on changes to controlled (with a Watch + EnqueueRequestForOwner).
+// Since only one OwnerReference can be a controller, it returns an error if
+// there is another OwnerReference with Controller flag set unless it was a legacy controller owner.
+func SetControllerReferenceWithOverride(owner, controlled metav1.Object, scheme *runtime.Scheme) error {
+	// Validate the owner.
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a runtime.Object, cannot call SetControllerReference", owner)
+	}
+
+	// Create a new controller ref.
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return err
+	}
+	ref := metav1.OwnerReference{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
+		Name:       owner.GetName(),
+	}
+
+	deleteAllControllerRefs(controlled, ref)
+
+	return controllerutil.SetControllerReference(owner, controlled, scheme)
+}
+
+// deleteAllControllerRefs Removes existing controller reference from controlled object.
+func deleteAllControllerRefs(controlled metav1.Object, ref metav1.OwnerReference) {
+	owners := controlled.GetOwnerReferences()
+	for i := range owners {
+		// We don't want controller references to be removed if they are the same object, to avoid
+		// unnecessary patches.
+		if owners[i].Controller != nil && *owners[i].Controller && !referSameObject(owners[i], ref) {
+			owners = append(owners[:i], owners[i+1:]...)
+			break
+		}
+	}
+	controlled.SetOwnerReferences(owners)
+}
+
+// Returns true if a and b point to the same object.
+func referSameObject(a, b metav1.OwnerReference) bool {
+	aGV, err := schema.ParseGroupVersion(a.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	bGV, err := schema.ParseGroupVersion(b.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
 }

--- a/pkg/util/supervisor_test.go
+++ b/pkg/util/supervisor_test.go
@@ -20,12 +20,17 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 )
 
-type testCase struct {
+type isSupervisorTestCase struct {
 	name         string
 	input        interface{}
 	expectedResp bool
@@ -35,7 +40,7 @@ type testCase struct {
 func TestIsSupervisorType(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	cases := []testCase{
+	cases := []isSupervisorTestCase{
 		{
 			name:         "VSphereCluster",
 			input:        &infrav1.VSphereCluster{},
@@ -79,6 +84,162 @@ func TestIsSupervisorType(t *testing.T) {
 			}
 
 			g.Expect(actualResp).To(Equal(tc.expectedResp))
+		})
+	}
+}
+
+type controllerReferenceTestCase struct {
+	name                   string
+	controlled             client.Object
+	newOwner               client.Object
+	expectedNumberOfOwners int
+	expectErr              bool
+}
+
+func TestSetControllerReferenceWithOverride(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cases := []controllerReferenceTestCase{
+		{
+			name: "no existing owners",
+			controlled: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "no-owner-secret",
+				},
+			},
+			newOwner: &vmwarev1.ProviderServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "ProviderServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owner",
+				},
+			},
+			expectedNumberOfOwners: 1,
+			expectErr:              false,
+		},
+		{
+			name: "1 existing non controller owner",
+			controlled: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "no-owner-secret",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "ProviderServiceAccount",
+							Name: "non-controller-owner",
+						},
+					},
+				},
+			},
+			newOwner: &vmwarev1.ProviderServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "ProviderServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owner",
+				},
+			},
+			expectedNumberOfOwners: 2,
+			expectErr:              false,
+		},
+		{
+			name: "1 existing controller owner",
+			controlled: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "no-owner-secret",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ProviderServiceAccount",
+							Name:       "non-controller-owner",
+							Controller: pointer.Bool(true),
+						},
+					},
+				},
+			},
+			newOwner: &vmwarev1.ProviderServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "ProviderServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owner",
+				},
+			},
+			expectedNumberOfOwners: 1,
+			expectErr:              false,
+		},
+		{
+			name: "cluster-scoped owner of namespaced owner",
+			controlled: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-owner-secret",
+				},
+			},
+			newOwner: &vmwarev1.ProviderServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owner",
+				},
+			},
+			expectedNumberOfOwners: 0,
+			expectErr:              true,
+		},
+		{
+			name: "no change of owner",
+			controlled: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "no-owner-secret",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ProviderServiceAccount",
+							Name:       "owner",
+							Controller: pointer.Bool(true),
+						},
+					},
+				},
+			},
+			newOwner: &vmwarev1.ProviderServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "ProviderServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owner",
+				},
+			},
+			expectedNumberOfOwners: 1,
+			expectErr:              false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := fake.NewControllerContext(fake.NewControllerManagerContext(tc.controlled))
+			actualErr := SetControllerReferenceWithOverride(tc.newOwner, tc.controlled, ctx.Scheme)
+			if tc.expectErr {
+				g.Expect(actualErr).To(HaveOccurred())
+			} else {
+				g.Expect(actualErr).NotTo(HaveOccurred())
+				controller := metav1.GetControllerOf(tc.controlled)
+				newOwnerRef := &metav1.OwnerReference{
+					APIVersion: tc.newOwner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+					Kind:       tc.newOwner.GetObjectKind().GroupVersionKind().Kind,
+					Name:       tc.newOwner.GetName(),
+				}
+				g.Expect(referSameObject(*controller, *newOwnerRef)).To(BeTrue(), "Expect controller to be: %v, got: %v", newOwnerRef, controller)
+			}
+			g.Expect(len(tc.controlled.GetOwnerReferences())).To(Equal(tc.expectedNumberOfOwners))
 		})
 	}
 }

--- a/test/helpers/vmware/intg_test_context.go
+++ b/test/helpers/vmware/intg_test_context.go
@@ -46,6 +46,7 @@ type IntegrationTestContext struct {
 	GuestClient       client.Client
 	Namespace         string
 	VSphereCluster    *vmwarev1.VSphereCluster
+	Cluster           *clusterv1.Cluster
 	VSphereClusterKey client.ObjectKey
 	envTest           *envtest.Environment
 }
@@ -100,10 +101,10 @@ func NewIntegrationTestContextWithClusters(goctx context.Context, integrationTes
 	})
 
 	vsphereClusterName := capiutil.RandomString(6)
-	cluster := createCluster(goctx, integrationTestClient, ctx.Namespace, vsphereClusterName)
+	ctx.Cluster = createCluster(goctx, integrationTestClient, ctx.Namespace, vsphereClusterName)
 
 	By("Create a vsphere cluster and wait for it to exist", func() {
-		ctx.VSphereCluster = createVSphereCluster(goctx, integrationTestClient, ctx.Namespace, vsphereClusterName, cluster.GetName())
+		ctx.VSphereCluster = createVSphereCluster(goctx, integrationTestClient, ctx.Namespace, vsphereClusterName, ctx.Cluster.GetName())
 		ctx.VSphereClusterKey = client.ObjectKeyFromObject(ctx.VSphereCluster)
 	})
 
@@ -136,13 +137,13 @@ func NewIntegrationTestContextWithClusters(goctx context.Context, integrationTes
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
-				Name:      fmt.Sprintf("%s-kubeconfig", cluster.Name),
+				Name:      fmt.Sprintf("%s-kubeconfig", ctx.Cluster.Name),
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: cluster.APIVersion,
-						Kind:       cluster.Kind,
-						Name:       cluster.Name,
-						UID:        cluster.UID,
+						APIVersion: ctx.Cluster.APIVersion,
+						Kind:       ctx.Cluster.Kind,
+						Name:       ctx.Cluster.Name,
+						UID:        ctx.Cluster.UID,
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1927

As part of this, had to implement pause support for the integration tests.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPV forces setting controller ownership of resources reconciled by the Service Account controller, which may have stale references when upgrading from vSphere 7.
```