### PR TITLE
:seedling: Fix golang-lint call and pinning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILD
 
 .PHONY: test
 test: $(SETUP_ENVTEST) $(GOVC)
-	$(MAKE) generate lint-go
+	$(MAKE) generate
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" GOVC_BIN_PATH=$(GOVC) go test -v ./apis/... ./controllers/... ./pkg/... $(TEST_ARGS)
 
 

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -99,7 +99,7 @@ golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(REPO_ROOT)/.github/workflows/golangci-lint.yaml
 	$(REPO_ROOT)/hack/ensure-golangci-lint.sh \
 		-b $(BIN_DIR) \
-		$(shell cat .github/workflows/golangci-lint.yaml | grep version | sed 's/.*version: //')
+		$(shell cat $(REPO_ROOT)/.github/workflows/golangci-lint.yaml | grep [[:space:]]version: | sed 's/.*version: //')
 
 ## --------------------------------------
 ## Generate


### PR DESCRIPTION
**What this PR does / why we need it**:
Today golang-ci lint is called twice on PRs, one via Github Actions and the other on `make test`.

We can remove it from Makefile (as Core ClusterAPI)

Also, the current call is not considering the root of repository to access GH action version, and not considering that there may be other directives (like go-version) so this is fixing the current call for the linter version

```release-note
NONE
```