### PR TITLE
🐛 apis: fix missing categories marker for VShpereVM in v1alpha3 and v1alpha4

### DIFF
--- a/apis/v1alpha3/vspherevm_types.go
+++ b/apis/v1alpha3/vspherevm_types.go
@@ -126,7 +126,7 @@ type VSphereVMStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=vspherevms,scope=Namespaced
+// +kubebuilder:resource:path=vspherevms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereVM is the Schema for the vspherevms API

--- a/apis/v1alpha4/vspherevm_types.go
+++ b/apis/v1alpha4/vspherevm_types.go
@@ -126,7 +126,7 @@ type VSphereVMStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=vspherevms,scope=Namespaced
+// +kubebuilder:resource:path=vspherevms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereVM is the Schema for the vspherevms API


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds the missing `categories=cluster-api` marker to:
* `apis/v1alpha3/vspherevm_types.go`
* `apis/v1alpha4/vspherevm_types.go`

The missing markers result into inconsistent results for the generated CRD's.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #1928

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```