### PR TITLE
🌱 test/e2e: add check at anti-affinity test to ensure enough hosts exist

### DIFF
--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -59,9 +59,9 @@ var _ = Describe("Cluster creation with anti affined nodes", func() {
 	})
 
 	It("should create a cluster with anti-affined nodes", func() {
-		// Since the upstream CI has five nodes, worker node count is set to 5
+		// Since the upstream CI has four nodes, worker node count is set to 4.
 		VerifyAntiAffinity(ctx, AntiAffinitySpecInput{
-			WorkerNodeCount: 5,
+			WorkerNodeCount: 4,
 			Namespace:       namespace,
 			InfraClients: InfraClients{
 				Client:     vsphereClient,
@@ -87,6 +87,11 @@ func VerifyAntiAffinity(ctx context.Context, input AntiAffinitySpecInput) {
 
 	clusterName := fmt.Sprintf("anti-affinity-%s", util.RandomString(6))
 	Expect(namespace).NotTo(BeNil())
+
+	By("checking if the target system has enough hosts")
+	hostSystems, err := input.Finder.HostSystemList(ctx, "*")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(hostSystems) >= int(input.WorkerNodeCount)).To(BeTrue(), "This test requires more or equal number of hosts compared to the WorkerNodeCount. Expected at least %d but only got %d hosts.", input.WorkerNodeCount, len(hostSystems))
 
 	Byf("creating a workload cluster %s", clusterName)
 	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, input.WorkerNodeCount,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds a check to the currently broken anti-affinity test to ensure enough hosts are available for the given anti-affinity test input.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1975

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/test help