### PR TITLE
:seedling: Add release-1.7 to Trivy scan

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.6, release-1.5 ]
+        branch: [ main, release-1.7, release-1.6, release-1.5 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add the `release-1.7` branch to the trivy scan for CVEs in images.

```release-note
NONE
```