### PR TITLE
✨ Support bare IPv6 vCenter server addresses

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -18,6 +18,8 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"net/netip"
 	"net/url"
 	"sync"
 	"time"
@@ -137,7 +139,17 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	}
 
 	clearCache(logger, sessionKey)
-	soapURL, err := soap.ParseURL(params.server)
+
+	// soap.ParseURL expects a valid URL. In the case of a bare, unbracketed
+	// IPv6 address (e.g fd00::1) ParseURL will fail. Surround unbracketed IPv6
+	// addresses with brackets.
+	urlSafeServer := params.server
+	ip, err := netip.ParseAddr(urlSafeServer)
+	if err == nil && ip.Is6() {
+		urlSafeServer = fmt.Sprintf("[%s]", urlSafeServer)
+	}
+
+	soapURL, err := soap.ParseURL(urlSafeServer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing vSphere URL %q", params.server)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR makes it possible to set `VsphereCluster.Spec.Server` as an unbracketed IPv6 address. This makes `Server` consistent with `VsphereCluster.Spec.ControlPlaneEndpoint`'s handling of IPv6 addresses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1997

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support unbracketed IPv6 addresses for `VsphereCluster.Spec.Server`
```