### PR TITLE
[release-1.6] 🌱 hack/tools: use go-install.sh for installing controller-gen for 1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,16 @@ CLUSTERCTL := $(BIN_DIR)/clusterctl
 # Tooling binaries
 GO_INSTALL := ./hack/go-install.sh
 
+CONTROLLER_GEN_VER := v0.12.1
+CONTROLLER_GEN_BIN := controller-gen
+CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER))
+CONTROLLER_GEN_PKG := sigs.k8s.io/controller-tools/cmd/controller-gen
+
 GOVC_VER := $(shell cat go.mod | grep "github.com/vmware/govmomi" | awk '{print $$NF}')
 GOVC_BIN := govc
 GOVC := $(abspath $(TOOLS_BIN_DIR)/$(GOVC_BIN)-$(GOVC_VER))
 GOVC_PKG := github.com/vmware/govmomi/govc
 
-CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
@@ -72,7 +76,7 @@ SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/setup-envtest)
 CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/conversion-verifier)
 GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
 RELEASE_NOTES := $(TOOLS_BIN_DIR)/release-notes
-TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF) $(RELEASE_NOTES)
+TOOLING_BINARIES := $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF) $(RELEASE_NOTES)
 ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 
 # Set --output-base for conversion-gen if we are not within GOPATH
@@ -226,11 +230,18 @@ tools: $(TOOLING_BINARIES) ## Build tooling binaries
 $(TOOLING_BINARIES):
 	make -C $(TOOLS_DIR) $(@F)
 
+$(CONTROLLER_GEN): # Build CONTROLLER_GEN from tools folder.
+	CGO_ENABLED=0 GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(CONTROLLER_GEN_PKG) $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
+
+.PHONY: $(CONTROLLER_GEN_BIN)
+$(CONTROLLER_GEN_BIN): $(CONTROLLER_GEN) ## Build a local copy of controller-gen.
+
+
 $(GOVC): # Build GOVC from tools folder.
 	CGO_ENABLED=0 GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOVC_PKG) $(GOVC_BIN) $(GOVC_VER)
 
 .PHONY: $(GOVC_BIN)
-$(GOVC_BIN): $(GOVC) ## Build a local copy of kustomize.
+$(GOVC_BIN): $(GOVC) ## Build a local copy of govc.
 
 ## --------------------------------------
 ## Linting and fixing linter errors

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: haproxyloadbalancers.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -219,6 +218,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretName:
                 description: SecretName references a Secret inside the controller
@@ -350,6 +350,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretName:
                 description: SecretName references a Secret inside the controller

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheredeploymentzones.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspherefailuredomains.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -944,10 +943,10 @@ spec:
                                 description: Name is the name of resource being referenced
                                 type: string
                             required:
-                            - apiGroup
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         deviceName:
                           description: DeviceName may be used to explicitly assign

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -833,10 +832,10 @@ spec:
                                           being referenced
                                         type: string
                                     required:
-                                    - apiGroup
                                     - kind
                                     - name
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                                 deviceName:
                                   description: DeviceName may be used to explicitly

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspherevms.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -492,6 +491,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least
@@ -910,6 +910,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least
@@ -991,10 +992,10 @@ spec:
                                 description: Name is the name of resource being referenced
                                 type: string
                             required:
-                            - apiGroup
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         deviceName:
                           description: DeviceName may be used to explicitly assign

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: clustervirtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentlibraryproviders.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentsourcebindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentsources.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineclassbindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineclasses.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachinepublishrequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachines.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineservices.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachinesetresourcepolicies.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: webconsolerequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_providerserviceaccounts.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_providerserviceaccounts.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: providerserviceaccounts.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusters.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclustertemplates.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachines.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachinetemplates.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -93,7 +92,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -35,7 +35,6 @@ BIN_DIR := bin
 SRCS := go.mod go.sum
 
 # Binaries.
-CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 KUSTOMIZE := $(BIN_DIR)/kustomize
 CONVERSION_GEN := $(BIN_DIR)/conversion-gen
@@ -55,10 +54,6 @@ help: ## Display this help
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------
-
-controller-gen: $(CONTROLLER_GEN) $(SRCS) ## Build controller-gen
-$(CONTROLLER_GEN): go.mod
-	go build -tags=tools -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen
 
 conversion-gen: $(CONVERSION_GEN) $(SRCS) ## Build conversion-gen
 $(CONVERSION_GEN): go.mod

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -27,7 +27,6 @@ import (
 	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "sigs.k8s.io/cluster-api/hack/tools"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
-	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"
 	_ "sigs.k8s.io/kubebuilder-release-tools/notes"
 	_ "sigs.k8s.io/kustomize/kustomize/v4"


### PR DESCRIPTION
This is a manual cherry-pick of #2005

**What this PR does / why we need it**:

As follow-up of #2004

Adjusts the targets for `controller-gen` to use `hack/go-install.sh` instead so we are able to cherry-pick the new version to the release branches of 1.5, 1.6 and 1.7. We do this to make `verify-crds` deterministic on this branches again.

Note: this would not be possible on the release branches by just bumping in `hack/tools/go.mod` because other binaries won't compile then anymore.
