### PR TITLE
[release-1.5] 🌱 hack/tools: use go-install.sh for installing controller-gen for 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,13 @@ MANAGER := $(BIN_DIR)/manager
 CLUSTERCTL := $(BIN_DIR)/clusterctl
 
 # Tooling binaries
-CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
+GO_INSTALL := ./hack/go-install.sh
+
+CONTROLLER_GEN_VER := v0.12.1
+CONTROLLER_GEN_BIN := controller-gen
+CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER))
+CONTROLLER_GEN_PKG := sigs.k8s.io/controller-tools/cmd/controller-gen
+
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
@@ -66,7 +72,7 @@ SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/setup-envtest)
 CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/conversion-verifier)
 GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
 RELEASE_NOTES := $(TOOLS_BIN_DIR)/release-notes
-TOOLING_BINARIES := $(CONTROLLER_GEN) $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF) $(RELEASE_NOTES)
+TOOLING_BINARIES := $(CONVERSION_GEN) $(GINKGO) $(GOLANGCI_LINT) $(GOVC) $(KIND) $(KUSTOMIZE) $(CONVERSION_VERIFIER) $(GO_APIDIFF) $(RELEASE_NOTES)
 ARTIFACTS_PATH := $(ROOT_DIR)/_artifacts
 
 # Set --output-base for conversion-gen if we are not within GOPATH
@@ -217,6 +223,12 @@ tools: $(TOOLING_BINARIES) ## Build tooling binaries
 .PHONY: $(TOOLING_BINARIES)
 $(TOOLING_BINARIES):
 	make -C $(TOOLS_DIR) $(@F)
+
+$(CONTROLLER_GEN): # Build CONTROLLER_GEN from tools folder.
+	CGO_ENABLED=0 GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(CONTROLLER_GEN_PKG) $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
+
+.PHONY: $(CONTROLLER_GEN_BIN)
+$(CONTROLLER_GEN_BIN): $(CONTROLLER_GEN) ## Build a local copy of controller-gen.
 
 ## --------------------------------------
 ## Linting and fixing linter errors

--- a/apis/v1beta1/vspherevm_types.go
+++ b/apis/v1beta1/vspherevm_types.go
@@ -142,7 +142,7 @@ type VSphereVMStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=vspherevms,scope=Namespaced
+// +kubebuilder:resource:path=vspherevms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: haproxyloadbalancers.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -104,7 +102,7 @@ spec:
                       devices:
                         description: Devices is the list of network devices used by
                           the virtual machine. TODO(akutz) Make sure at least one
-                          network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                          network matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                         items:
                           description: NetworkDeviceSpec defines the network configuration
                             for a virtual machine's network device.
@@ -294,9 +292,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -88,6 +86,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretName:
                 description: SecretName references a Secret inside the controller
@@ -219,6 +218,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretName:
                 description: SecretName references a Secret inside the controller
@@ -350,6 +350,7 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               secretName:
                 description: SecretName references a Secret inside the controller
@@ -412,9 +413,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -116,9 +114,9 @@ spec:
                           may be found. This may used in the event that: 1. It is
                           not desirable to use the K8s API to watch changes to secrets
                           2. The cloud controller manager is not running in a K8s
-                          environment,    such as DC/OS. For example, the container
-                          storage interface (CSI) is    container orcehstrator (CO)
-                          agnostic, and should support non-K8s COs. Defaults to /etc/cloud/credentials.'
+                          environment, such as DC/OS. For example, the container storage
+                          interface (CSI) is container orcehstrator (CO) agnostic,
+                          and should support non-K8s COs. Defaults to /etc/cloud/credentials.'
                         type: string
                       serviceAccount:
                         description: ServiceAccount is the Kubernetes service account
@@ -323,6 +321,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               server:
                 description: Server is the address of the vSphere endpoint.
                 type: string
@@ -752,9 +751,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -206,9 +204,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheredeploymentzones.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -331,9 +329,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspherefailuredomains.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -380,9 +378,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -112,7 +110,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -507,7 +505,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -917,7 +915,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -948,6 +946,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         deviceName:
                           description: DeviceName may be used to explicitly assign
@@ -1382,9 +1381,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -150,6 +148,7 @@ spec:
                           - name
                           - uid
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                     type: object
                   spec:
@@ -209,7 +208,7 @@ spec:
                           devices:
                             description: Devices is the list of network devices used
                               by the virtual machine. TODO(akutz) Make sure at least
-                              one network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                              one network matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                             items:
                               description: NetworkDeviceSpec defines the network configuration
                                 for a virtual machine's network device.
@@ -497,7 +496,7 @@ spec:
                           devices:
                             description: Devices is the list of network devices used
                               by the virtual machine. TODO(akutz) Make sure at least
-                              one network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                              one network matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                             items:
                               description: NetworkDeviceSpec defines the network configuration
                                 for a virtual machine's network device.
@@ -802,7 +801,7 @@ spec:
                           devices:
                             description: Devices is the list of network devices used
                               by the virtual machine. TODO(akutz) Make sure at least
-                              one network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                              one network matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                             items:
                               description: NetworkDeviceSpec defines the network configuration
                                 for a virtual machine's network device.
@@ -836,6 +835,7 @@ spec:
                                     - kind
                                     - name
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                                 deviceName:
                                   description: DeviceName may be used to explicitly
@@ -1167,9 +1167,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspherevms.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -82,6 +80,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least
@@ -128,7 +127,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -492,6 +491,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least
@@ -538,7 +538,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -910,6 +910,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cloneMode:
                 description: CloneMode specifies the type of clone operation. The
                   LinkedClone mode is only support for templates that have at least
@@ -963,7 +964,7 @@ spec:
                   devices:
                     description: Devices is the list of network devices used by the
                       virtual machine. TODO(akutz) Make sure at least one network
-                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                      matches the ClusterSpec.CloudProviderConfiguration.Network.Name
                     items:
                       description: NetworkDeviceSpec defines the network configuration
                         for a virtual machine's network device.
@@ -994,6 +995,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         deviceName:
                           description: DeviceName may be used to explicitly assign
@@ -1437,9 +1439,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentlibraryproviders.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -56,9 +54,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentsourcebindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -52,9 +50,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: contentsources.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -66,9 +64,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineclassbindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -59,9 +57,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineclasses.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -202,9 +200,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -237,9 +235,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachines.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -307,10 +305,9 @@ spec:
                     persistentVolumeClaim:
                       description: "PersistentVolumeClaim represents a reference to
                         a PersistentVolumeClaim in the same namespace. The PersistentVolumeClaim
-                        must match one of the following: \n   * A volume provisioned
-                        (either statically or dynamically) by the     cluster's CSI
-                        provider. \n   * An instance volume with a lifecycle coupled
-                        to the VM."
+                        must match one of the following: \n * A volume provisioned
+                        (either statically or dynamically) by the cluster's CSI provider.
+                        \n * An instance volume with a lifecycle coupled to the VM."
                       properties:
                         claimName:
                           description: 'claimName is the name of a PersistentVolumeClaim
@@ -522,9 +519,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachineservices.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -179,9 +177,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: virtualmachinesetresourcepolicies.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -128,9 +126,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: webconsolerequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -69,9 +67,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_providerserviceaccounts.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_providerserviceaccounts.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: providerserviceaccounts.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io
@@ -89,6 +87,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               rules:
                 description: Rules specifies the privileges that need to be granted
                   to the service account.
@@ -159,9 +158,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclusters.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io
@@ -137,9 +135,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vsphereclustertemplates.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io
@@ -71,9 +69,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachines.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io
@@ -218,9 +216,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: vspheremachinetemplates.vmware.infrastructure.cluster.x-k8s.io
 spec:
   group: vmware.infrastructure.cluster.x-k8s.io
@@ -110,9 +108,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -90,12 +88,10 @@ webhooks:
     resources:
     - vspherevms
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${1}" ]; then
+  echo "must provide module as first parameter"
+  exit 1
+fi
+
+if [ -z "${2}" ]; then
+  echo "must provide binary name as second parameter"
+  exit 1
+fi
+
+if [ -z "${3}" ]; then
+  echo "must provide version as third parameter"
+  exit 1
+fi
+
+if [ -z "${GOBIN}" ]; then
+  echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
+  exit 1
+fi
+
+rm -f "${GOBIN}/${2}"* || true
+
+# install the golang module specified as the first argument
+go install "${1}@${3}"
+mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
+ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -35,7 +35,6 @@ BIN_DIR := bin
 SRCS := go.mod go.sum
 
 # Binaries.
-CONTROLLER_GEN := $(BIN_DIR)/controller-gen
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 KUSTOMIZE := $(BIN_DIR)/kustomize
 CONVERSION_GEN := $(BIN_DIR)/conversion-gen
@@ -56,10 +55,6 @@ help: ## Display this help
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------
-
-controller-gen: $(CONTROLLER_GEN) $(SRCS) ## Build controller-gen
-$(CONTROLLER_GEN): go.mod
-	go build -tags=tools -o $@ sigs.k8s.io/controller-tools/cmd/controller-gen
 
 conversion-gen: $(CONVERSION_GEN) $(SRCS) ## Build conversion-gen
 $(CONVERSION_GEN): go.mod

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -10,7 +10,6 @@ require (
 	k8s.io/code-generator v0.22.2
 	sigs.k8s.io/cluster-api/hack/tools v0.0.0-20211104153216-fb1f86267fed
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20211025141024-c73b143dc503
-	sigs.k8s.io/controller-tools v0.7.0
 	sigs.k8s.io/kind v0.7.0
 	sigs.k8s.io/kubebuilder-release-tools/notes v0.0.0-20220428224951-d8a44c7aef35
 	sigs.k8s.io/kustomize/kustomize/v4 v4.4.0
@@ -244,6 +243,7 @@ require (
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442 // indirect
+	sigs.k8s.io/controller-tools v0.7.0 // indirect
 	sigs.k8s.io/kustomize/api v0.10.0 // indirect
 	sigs.k8s.io/kustomize/cmd/config v0.10.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.12.0 // indirect

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -29,7 +29,6 @@ import (
 	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "sigs.k8s.io/cluster-api/hack/tools"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
-	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"
 	_ "sigs.k8s.io/kubebuilder-release-tools/notes"
 	_ "sigs.k8s.io/kustomize/kustomize/v4"


### PR DESCRIPTION
This is a manual cherry-pick of #2005

**What this PR does / why we need it**:

As follow-up of #2004

Adjusts the targets for `controller-gen` to use `hack/go-install.sh` instead so we are able to cherry-pick the new version to the release branches of 1.5, 1.6 and 1.7. We do this to make `verify-crds` deterministic on this branches again.

Note: this would not be possible on the release branches by just bumping in `hack/tools/go.mod` because other binaries won't compile then anymore.
