### PR TITLE
🌱 [CI]: Updates CI template to k8s 1.27.3

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -131,8 +131,8 @@ providers:
           - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.25.6"
-  CPI_IMAGE_K8S_VERSION: "v1.25.0"
+  KUBERNETES_VERSION: "v1.27.3"
+  CPI_IMAGE_K8S_VERSION: "v1.27.0"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
@@ -147,8 +147,8 @@ variables:
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"
-  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
-  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3374.2.4-kube-v1.25.6"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.27.3"
+  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3510.2.4-kube-v1.27.3"
   VSPHERE_INSECURE_CSI: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -134,8 +134,8 @@ providers:
           - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.25.6"
-  CPI_IMAGE_K8S_VERSION: "v1.25.0"
+  KUBERNETES_VERSION: "v1.27.3"
+  CPI_IMAGE_K8S_VERSION: "v1.27.0"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
@@ -152,8 +152,8 @@ variables:
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "network-1"
-  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
-  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3374.2.4-kube-v1.25.6"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.27.3"
+  FLATCAR_VSPHERE_TEMPLATE: "flatcar-stable-3510.2.4-kube-v1.27.3"
   # WORKLOAD_CONTROL_PLANE_ENDPOINT_IP:
   # Also following variables are required but it is recommended to use env variables to avoid disclosure of sensitive data
   # VSPHERE_SSH_AUTHORIZED_KEY:
@@ -175,7 +175,7 @@ variables:
   VSPHERE2_SERVER: "vcenter2.vmware.com"
   VSPHERE2_TLS_THUMBPRINT: "AA:BB:CC:DD:11:22:33:44:EE:FF"
   VSPHERE2_RESOURCE_POOL: "ResourcePool"
-  VSPHERE2_TEMPLATE: "ubuntu-2004-kube-v1.25.6"
+  VSPHERE2_TEMPLATE: "ubuntu-2004-kube-v1.27.3"
   # Dedicated IP to be used by kube-vip
   VSPHERE2_CONTROL_PLANE_ENDPOINT_IP:
   # Following variables are also required and please use env variables to avoid disclosure of sensitive data


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates CI template to k8s 1.27.3

**Which issue(s) this PR fixes**:
To confirm whether CAPV works with `1.27.0`

**Release note**:
```release-note
NONE
```