### PR TITLE
go.mod: pin cluster-api version to prevent dependabot from downgrading sigs.k8s.io/cluster-api/test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 
 go 1.19
 
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.0-rc.0
+
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/go-logr/logr v1.2.4
@@ -34,7 +36,7 @@ require (
 	k8s.io/component-base v0.27.2
 	k8s.io/klog/v2 v2.90.1
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
-	sigs.k8s.io/cluster-api v1.5.0-rc.0
+	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/cluster-api/test v1.5.0-rc.0
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/kind v0.20.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This fixes dependabot to not remove `sigs.k8s.io/cluster-api/test` when trying to upgrade dependencies.

Examples:
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2018
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2019

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```