### PR TITLE
🌱 Bump Go to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GOLANG_VERSION=golang:1.19.3
+ARG GOLANG_VERSION=golang:1.20.6
 FROM --platform=${BUILDPLATFORM} ${GOLANG_VERSION} as builder
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SHELL := /usr/bin/env bash
 
 VERSION ?= $(shell cat clusterctl-settings.json | jq .config.nextVersion -r)
 
-GO_VERSION ?=1.19.3
+GO_VERSION ?=1.20.6
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq (,$(strip $(GOPROXY)))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-vsphere
 
-go 1.19
+go 1.20
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.0-rc.0
 

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 # MIN_GO_VERSION is the minimum, supported Go version.
-MIN_GO_VERSION="go${MIN_GO_VERSION:-1.12.1}"
+MIN_GO_VERSION="go${MIN_GO_VERSION:-1.20.6}"
 
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-vsphere/hack/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/joelanford/go-apidiff v0.6.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Bumps Go to the latest supported 1.20.6 to be on the same version as CAPI and k8s v1.27 / v1.28

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Go to 1.20.6
```