### PR TITLE
🌱 Remove NodeLabeling feature gate

### DIFF
--- a/docs/proposal/node-affinity-and-anti-affinity.md
+++ b/docs/proposal/node-affinity-and-anti-affinity.md
@@ -260,7 +260,7 @@ A new controller is added which is responsible for propagating the labels with a
 Two new feature flags are introduced to control the availability of these new behaviors:
 
 1. **NodeAntiAffinity** which is set to `false` by default. This controls the creation of cluster modules to dictate anti affinity for VM placement.
-2. **NodeLabeling** which is set to `false` by default. This controls the propagation of labels with a special prefix from Machine to Node objects. Starting from v1.7.0 release, this feature flag is deprecated and this functionality will not be provided by CAPV. CAPI v1.4.0 natively supports this feature.
+2. **NodeLabeling** which is set to `false` by default. This controls the propagation of labels with a special prefix from Machine to Node objects. Starting from v1.7.0 release, this feature flag is deprecated and this functionality will not be provided by CAPV. CAPI v1.4.0 natively supports this feature. Starting with v1.8.0 the feature gate has been removed.
 
 ## Upgrade Strategy
 

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -32,19 +32,6 @@ const (
 	//
 	// alpha: v1.4
 	NodeAntiAffinity featuregate.Feature = "NodeAntiAffinity"
-
-	//nolint: gocritic
-	// NodeLabeling is a feature gate for the functionality to propagate Machine labels
-	// with the prefix to the Node objects.
-	// This is a stop-gap measure which will be removed when we have this functionality
-	// present in CAPI.
-	// See https://github.com/kubernetes-sigs/cluster-api/pull/6255
-	// Since this is natively supported in CAPI with the v1.4 release, this feature is being
-	// deprecated.
-	//
-	// alpha: v1.4
-	// deprecated: v1.7
-	NodeLabeling featuregate.Feature = "NodeLabeling"
 )
 
 func init() {
@@ -56,5 +43,4 @@ func init() {
 var defaultCAPVFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
 	NodeAntiAffinity: {Default: false, PreRelease: featuregate.Alpha},
-	NodeLabeling:     {Default: false, PreRelease: featuregate.Deprecated},
 }

--- a/main.go
+++ b/main.go
@@ -300,16 +300,8 @@ func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Man
 	if err := controllers.AddVsphereClusterIdentityControllerToManager(ctx, mgr); err != nil {
 		return err
 	}
-	if err := controllers.AddVSphereDeploymentZoneControllerToManager(ctx, mgr); err != nil {
-		return err
-	}
 
-	if feature.Gates.Enabled(feature.NodeLabeling) {
-		setupLog.Info("Use of this feature flag is deprecated. Please consider unsetting this feature flag."+
-			"This flag does not enable the node labeling feature anymore. Consider using the cluster-api node labeling functionality instead.",
-			"flag", feature.NodeLabeling, "value", "true")
-	}
-	return nil
+	return controllers.AddVSphereDeploymentZoneControllerToManager(ctx, mgr)
 }
 
 func setupSupervisorControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The feature gate was already deprecated / disabled with v1.7. This PR now removes the feature gate. The difference for users should only be that we don't emit the log anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```