### PR TITLE
🐛 pkg/session fix used RoundTripper inside anonymous func for KeepAliveHandler

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -217,7 +217,7 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 
 	if feature.EnableKeepAlive {
 		vimClient.RoundTripper = session.KeepAliveHandler(vimClient.RoundTripper, feature.KeepAliveDuration, func(tripper soap.RoundTripper) error {
-			_, err := methods.GetCurrentTime(ctx, vimClient)
+			_, err := methods.GetCurrentTime(ctx, tripper)
 			if err != nil {
 				logger.Error(err, "failed to keep alive govmomi client")
 				logger.Info("clearing the session", "key", sessionKey)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes the used RoundTripper inside the KeepAliveHander function to use the one provided by the function arguments.

Got introduced in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1897

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Cherry-picking this to release-1.7, because the change got cherry-picked by accident in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2027.

https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/commit/a32439152edaea5a9e4b145c86d6d5c0b4068b47#diff-59fbb0bb5dfeeb4f123f1e9e0a3d12c38a60b839e113b29868cb905755639e13R202-R203

/cherry-pick release-1.7

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes the used RoundTripper inside the sessions KeepAliveHandler function
```