### PR TITLE
[release-1.5] 🐛 Don't call session logout for keepAliveHandler

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -132,9 +132,14 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 			logger.V(2).Info("found active cached vSphere client session")
 			return s, nil
 		}
-	}
 
-	clearCache(logger, sessionKey)
+		logger.V(2).Info("logout the session because it is inactive")
+		if err := s.Client.Logout(ctx); err != nil {
+			logger.Error(err, "unable to logout session")
+		} else {
+			logger.Info("logout session succeed")
+		}
+	}
 
 	// soap.ParseURL expects a valid URL. In the case of a bare, unbracketed
 	// IPv6 address (e.g fd00::1) ParseURL will fail. Surround unbracketed IPv6
@@ -206,16 +211,11 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 	}
 
 	vimClient.RoundTripper = session.KeepAliveHandler(vimClient.RoundTripper, feature.KeepAliveDuration, func(tripper soap.RoundTripper) error {
-		// we tried implementing
-		// c.Login here but the client once logged out
-		// keeps errong in invalid username or password
-		// we tried with cached username and password in session still the error persisted
-		// hence we just clear the cache and expect the client to
-		// be recreated in next GetOrCreate call
 		_, err := methods.GetCurrentTime(ctx, tripper)
 		if err != nil {
 			logger.Error(err, "failed to keep alive govmomi client")
-			clearCache(logger, sessionKey)
+			logger.Info("clearing the session", "key", sessionKey)
+			sessionCache.Delete(sessionKey)
 		}
 		return err
 	})
@@ -225,18 +225,6 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 	}
 
 	return c, nil
-}
-
-func clearCache(logger logr.Logger, sessionKey string) {
-	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
-		s := cachedSession.(*Session)
-
-		logger.Info("performing session log out and clearing session", "key", sessionKey)
-		if err := s.Logout(context.Background()); err != nil {
-			logger.Error(err, "unable to logout session")
-		}
-	}
-	sessionCache.Delete(sessionKey)
 }
 
 // newManager creates a Manager that encompasses the REST Client for the VSphere tagging API.
@@ -251,8 +239,8 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
 			return nil
 		}
 
-		logger.Info("rest client session expired, clearing cache")
-		clearCache(logger, sessionKey)
+		logger.Info("rest client session expired, clearing session", "key", sessionKey)
+		sessionCache.Delete(sessionKey)
 		return errors.New("rest client session expired")
 	})
 	if err := rc.Login(ctx, user); err != nil {


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1949

/assign sbueringer

```release-note
NONE
```