### PR TITLE
🌱 Rename findVMPre7 to findVSphereVM

### DIFF
--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -72,7 +72,7 @@ func (v *VimMachineService) ReconcileDelete(c context.MachineContext) error {
 		return errors.New("received unexpected VIMMachineContext type")
 	}
 
-	vm, err := v.findVMPre7(ctx)
+	vm, err := v.findVSphereVM(ctx)
 	// Attempt to find the associated VSphereVM resource.
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (v *VimMachineService) SyncFailureReason(c context.MachineContext) (bool, e
 		return false, errors.New("received unexpected VIMMachineContext type")
 	}
 
-	vsphereVM, err := v.findVMPre7(ctx)
+	vsphereVM, err := v.findVSphereVM(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -116,7 +116,7 @@ func (v *VimMachineService) ReconcileNormal(c context.MachineContext) (bool, err
 	if !ok {
 		return false, errors.New("received unexpected VIMMachineContext type")
 	}
-	vsphereVM, err := v.findVMPre7(ctx)
+	vsphereVM, err := v.findVSphereVM(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
@@ -195,7 +195,7 @@ func (v *VimMachineService) GetHostInfo(c context.MachineContext) (string, error
 	return "", nil
 }
 
-func (v *VimMachineService) findVMPre7(ctx *context.VIMMachineContext) (*infrav1.VSphereVM, error) {
+func (v *VimMachineService) findVSphereVM(ctx *context.VIMMachineContext) (*infrav1.VSphereVM, error) {
 	// Get ready to find the associated VSphereVM resource.
 	vm := &infrav1.VSphereVM{}
 	vmKey := types.NamespacedName{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Just want to rename the func to make it clear this works independent of the vCenter version.

The only restriction we have is that it is for the non-supervisor mode but that is clear because the func is a method on VimMachineService

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```