### PR TITLE
✨: Add guestinfo.hostname to config of a VM

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -124,7 +124,7 @@ func AddMachineControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles})
 
-	r := machineReconciler{
+	r := &machineReconciler{
 		ControllerContext: controllerContext,
 		VMService:         &services.VimMachineService{},
 		supervisorBased:   supervisorBased,
@@ -179,7 +179,7 @@ type machineReconciler struct {
 }
 
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
-func (r machineReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r *machineReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	var machineContext context.MachineContext
 	logger := r.Logger.WithName(req.Namespace).WithName(req.Name)
 	logger.V(3).Info("Starting Reconcile VSphereMachine")
@@ -259,7 +259,7 @@ func (r machineReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.
 	return r.reconcileNormal(machineContext)
 }
 
-func (r machineReconciler) reconcileDelete(ctx context.MachineContext) (reconcile.Result, error) {
+func (r *machineReconciler) reconcileDelete(ctx context.MachineContext) (reconcile.Result, error) {
 	ctx.GetLogger().Info("Handling deleted VSphereMachine")
 	conditions.MarkFalse(ctx.GetVSphereMachine(), infrav1.VMProvisionedCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 
@@ -277,7 +277,7 @@ func (r machineReconciler) reconcileDelete(ctx context.MachineContext) (reconcil
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (r machineReconciler) reconcileNormal(ctx context.MachineContext) (reconcile.Result, error) {
+func (r *machineReconciler) reconcileNormal(ctx context.MachineContext) (reconcile.Result, error) {
 	machineFailed, err := r.VMService.SyncFailureReason(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, err

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -318,6 +318,10 @@ func (v *VimMachineService) reconcileNetwork(ctx *context.VIMMachineContext, vm 
 				Address: addr,
 			})
 		}
+		machineAddresses = append(machineAddresses, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalDNS,
+			Address: vm.GetName(),
+		})
 		ctx.VSphereMachine.Status.Addresses = machineAddresses
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The VMs in the vCenter are currently without a DNSName (they don't have a config data at key guestinfo.hostname) while using an ignition to set the VM up.  With setting this field up, we can also append an internal DNS address to the list of machine's addresses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2013

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set a DNSName for VMs to a corresponding machine's name.
```