### PR TITLE
:seedling: OWNERS: Refresh of owners as per meeting of 2023/06/22

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - cluster-api-admins
   - cluster-api-maintainers
   - cluster-api-vsphere-maintainers
   - sig-cluster-lifecycle-leads
+  - sig-cluster-lifecycle-tech-leads
 
 reviewers:
   - cluster-api-vsphere-maintainers
   - cluster-api-vsphere-reviewers
-
-emeritus_approvers:
-  - gab-satchi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,21 +5,26 @@ aliases:
     - fabriziopandini
     - justinsb
     - neolit123
-  cluster-api-admins:
+  sig-cluster-lifecycle-tech-leads:
     - CecileRobertMichon
     - vincepri
   cluster-api-maintainers:
     - CecileRobertMichon
+    - enxebre
     - fabriziopandini
+    - killianmuldoon
+    - sbueringer
     - vincepri
   cluster-api-vsphere-maintainers:
-    - frapposelli
     - randomvariable
     - srm09
     - yastij
+    - gab-satchi
+    - chrischdi
   cluster-api-vsphere-reviewers:
     - maxrink
     - vrabbi
+    - zhanggbj
   cluster-api-vsphere-emeritus-maintainers:
     - akutz
     - andrewsykim
@@ -27,3 +32,4 @@ aliases:
     - frapposelli
     - ncdc
     - sidharthsurana
+    - frapposelli


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Refresh of OWNERS to reflect current folk as per the meeting of 2023/06/22

Related PRs:
* https://github.com/kubernetes/test-infra/pull/30190
* https://github.com/kubernetes/org/pull/4345
* https://github.com/kubernetes/k8s.io/pull/5621


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```