### PR TITLE
🐛 Refine finalizer handling

### DIFF
--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -417,7 +417,9 @@ var _ = Describe("Reconciliation tests", func() {
 			By("Expect a ResourcePolicy to exist")
 			rpKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
 			resourcePolicy := &vmoprv1.VirtualMachineSetResourcePolicy{}
-			Expect(k8sClient.Get(ctx, rpKey, resourcePolicy)).To(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, rpKey, resourcePolicy)
+			}, time.Second*30).Should(Succeed())
 			Expect(len(resourcePolicy.Spec.ClusterModules)).To(BeEquivalentTo(2))
 
 			By("Create the CAPI Machine and wait for it to exist")

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -255,6 +255,12 @@ func (r *machineReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl
 		return reconcile.Result{}, nil
 	}
 
+	// If the VSphereMachine doesn't have our finalizer, add it.
+	// Requeue immediately after adding finalizer to avoid the race condition between init and delete
+	if !ctrlutil.ContainsFinalizer(machineContext.GetVSphereMachine(), infrav1.MachineFinalizer) {
+		ctrlutil.AddFinalizer(machineContext.GetVSphereMachine(), infrav1.MachineFinalizer)
+		return reconcile.Result{}, nil
+	}
 	// Handle non-deleted machines
 	return r.reconcileNormal(machineContext)
 }
@@ -288,9 +294,6 @@ func (r *machineReconciler) reconcileNormal(ctx context.MachineContext) (reconci
 		ctx.GetLogger().Info("Error state detected, skipping reconciliation")
 		return reconcile.Result{}, nil
 	}
-
-	// If the VSphereMachine doesn't have our finalizer, add it.
-	ctrlutil.AddFinalizer(ctx.GetVSphereMachine(), infrav1.MachineFinalizer)
 
 	//nolint:gocritic
 	if r.supervisorBased {

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -279,6 +279,15 @@ func (r vmReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Res
 		}
 	}
 
+	if vsphereVM.ObjectMeta.DeletionTimestamp.IsZero() {
+		// If the VSphereVM doesn't have our finalizer, add it.
+		// Requeue immediately to avoid the race condition between init and delete
+		if !ctrlutil.ContainsFinalizer(vsphereVM, infrav1.VMFinalizer) {
+			ctrlutil.AddFinalizer(vsphereVM, infrav1.VMFinalizer)
+			return reconcile.Result{}, nil
+		}
+	}
+
 	return r.reconcile(vmContext, fetchClusterModuleInput{
 		VSphereCluster: vsphereCluster,
 		Machine:        machine,
@@ -371,8 +380,6 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 		r.Logger.Info("VM is failed, won't reconcile", "namespace", ctx.VSphereVM.Namespace, "name", ctx.VSphereVM.Name)
 		return reconcile.Result{}, nil
 	}
-	// If the VSphereVM doesn't have our finalizer, add it.
-	ctrlutil.AddFinalizer(ctx.VSphereVM, infrav1.VMFinalizer)
 
 	if r.isWaitingForStaticIPAllocation(ctx) {
 		conditions.MarkFalse(ctx.VSphereVM, infrav1.VMProvisionedCondition, infrav1.WaitingForStaticIPAllocationReason, clusterv1.ConditionSeverityInfo, "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

- Add finalizer if not existed
- Requeue immediately after adding finalizer to avoid the race condition between init and delete
Please find more details in #2039 description.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2039 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refine finalizer handling
```