### PR TITLE
:warning: Treating VSphereVM wasNotFoundByBIOSUUID as transient error

### DIFF
--- a/apis/v1beta1/condition_consts.go
+++ b/apis/v1beta1/condition_consts.go
@@ -83,6 +83,11 @@ const (
 	// are automatically re-tried by the controller.
 	PoweringOnFailedReason = "PoweringOnFailed"
 
+	// NotFoundByBIOSUUIDReason (Severity=Warning) documents a VSphereVM which can't be found by BIOS UUID.
+	// Those kind of errors could be transient sometimes and failed VSphereVM are automatically
+	// reconciled by the controller.
+	NotFoundByBIOSUUIDReason = "NotFoundByBIOSUUID"
+
 	// TaskFailure (Severity=Warning) documents a VSphereMachine/VSphere task failure; the reconcile look will automatically
 	// retry the operation, but a user intervention might be required to fix the problem.
 	TaskFailure = "TaskFailure"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We used to treate WasNotFoundByUUID as terminal error, and set `failureMessage` and `failureReason`, so VSphereVM won't be reconciled anymore. However, in some situation, this error is recoverable, for instance, if the storage was temporarily disconnected but later recovered, this error will be transient.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2102 
