### PR TITLE
⚠️ webhook: prevent changes to an already set VSphereVM.spec.biosUUID

### DIFF
--- a/apis/v1beta1/vspherevm_webhook_test.go
+++ b/apis/v1beta1/vspherevm_webhook_test.go
@@ -191,6 +191,18 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "BB:CC:DD:EE:FF", []string{"192.168.0.1/32"}, nil, Linux, VirtualMachinePowerOpModeSoft, nil),
 			wantErr:      false,
 		},
+		{
+			name:         "biosUUID can be set to a value",
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "", "", "AA:BB:CC:DD:EE", []string{"192.168.0.1/32"}, nil, Linux, VirtualMachinePowerOpModeTrySoft, nil),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "AA:BB:CC:DD:EE", []string{"192.168.0.1/32"}, nil, Linux, VirtualMachinePowerOpModeTrySoft, nil),
+			wantErr:      false,
+		},
+		{
+			name:         "biosUUID cannot be updated to a different value",
+			oldVSphereVM: createVSphereVM("vsphere-vm-1", "foo.com", "old-uuid", "", "AA:BB:CC:DD:EE", []string{"192.168.0.1/32"}, nil, Linux, VirtualMachinePowerOpModeTrySoft, nil),
+			vSphereVM:    createVSphereVM("vsphere-vm-1", "foo.com", biosUUID, "", "AA:BB:CC:DD:EE", []string{"192.168.0.1/32"}, nil, Linux, VirtualMachinePowerOpModeTrySoft, nil),
+			wantErr:      true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR improves the validation for VSphereVM objects by adjusting the webhook to:
* only allow changes to `VSphereVM.spec.biosUUID` if it is not already set
* prevent updates which try to change the biosUUID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Identified during discussions around #2102
