### PR TITLE
:seedling: Add powerOffMode to templates

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -259,6 +259,7 @@ func newVSphereMachineTemplate(templateName string) infrav1.VSphereMachineTempla
 func defaultVirtualMachineSpec() infrav1.VSphereMachineSpec {
 	return infrav1.VSphereMachineSpec{
 		VirtualMachineCloneSpec: defaultVirtualMachineCloneSpec(),
+		PowerOffMode:            infrav1.VirtualMachinePowerOpModeHard,
 	}
 }
 
@@ -311,6 +312,7 @@ func newNodeIPAMVSphereMachineTemplate(templateName string) infrav1.VSphereMachi
 func nodeIPAMVirtualMachineSpec() infrav1.VSphereMachineSpec {
 	return infrav1.VSphereMachineSpec{
 		VirtualMachineCloneSpec: nodeIPAMVirtualMachineCloneSpec(),
+		PowerOffMode:            infrav1.VirtualMachinePowerOpModeHard,
 	}
 }
 

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -55,6 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -81,6 +82,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -55,6 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -60,6 +60,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -91,6 +92,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -55,6 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -81,6 +82,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -178,6 +178,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -204,6 +205,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
+      powerOffMode: hard
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `powerOffMode` to the current templates to serve as documentation to control the VM power off behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #