### PR TITLE
✨ Improve session handling with a secure session key

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/netip"
 	"net/url"
@@ -113,14 +114,22 @@ func (p *Params) WithFeatures(feature Feature) *Params {
 // GetOrCreate gets a cached session or creates a new one if one does not
 // already exist.
 func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
-	logger := ctrl.LoggerFrom(ctx).WithName("session")
+	logger := ctrl.LoggerFrom(ctx).WithName("session").WithValues(
+		"server", params.server,
+		"datacenter", params.datacenter,
+		"username", params.userinfo.Username())
+
 	sessionMU.Lock()
 	defer sessionMU.Unlock()
 
-	sessionKey := params.server + params.userinfo.Username() + params.datacenter
+	userPassword, _ := params.userinfo.Password()
+	h := sha256.New()
+	h.Write([]byte(userPassword))
+	hashedUserPassword := h.Sum(nil)
+	sessionKey := fmt.Sprintf("%s#%s#%s#%x", params.server, params.datacenter, params.userinfo.Username(),
+		hashedUserPassword)
 	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
 		s := cachedSession.(*Session)
-		logger = logger.WithValues("server", params.server, "datacenter", params.datacenter)
 
 		vimSessionActive, err := s.SessionManager.SessionIsActive(ctx)
 		if err != nil {
@@ -220,7 +229,7 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 			_, err := methods.GetCurrentTime(ctx, tripper)
 			if err != nil {
 				logger.Error(err, "failed to keep alive govmomi client")
-				logger.Info("clearing the session", "key", sessionKey)
+				logger.Info("clearing the session")
 				sessionCache.Delete(sessionKey)
 			}
 			return err
@@ -247,7 +256,7 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
 				return nil
 			}
 
-			logger.Info("rest client session expired, clearing session", "key", sessionKey)
+			logger.Info("rest client session expired, clearing session")
 			sessionCache.Delete(sessionKey)
 			return errors.New("rest client session expired")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Improve session handling with a secure session key to avoid hijack.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
