### PR TITLE
:seedling: Deprecate v1alpha3 and v1alpha4 apiVersions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,11 @@ issues:
     - linters:
       - staticcheck
       text: "SA1019: failureDomain.AutoConfigure is deprecated"
+    # Specific exclude rules for deprecated packages that are still part of the codebase. These
+    # should be removed as the referenced deprecated packages are removed from the project.
+    - linters:
+        - staticcheck
+      text: "SA1019: .* is deprecated: This package will be removed in one of the next releases."
     - path: "test/e2e/*"
       linters:
         - gosec

--- a/apis/v1alpha3/doc.go
+++ b/apis/v1alpha3/doc.go
@@ -18,4 +18,6 @@ limitations under the License.
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/apis/v1alpha3/haproxyloadbalancer_types.go
+++ b/apis/v1alpha3/haproxyloadbalancer_types.go
@@ -62,11 +62,13 @@ type HAProxyLoadBalancerStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=haproxyloadbalancers,scope=Namespaced
 // +kubebuilder:subresource:status
 
 // HAProxyLoadBalancer is the Schema for the haproxyloadbalancers API
-// DEPRECATED: will be removed in v1alpha4
+//
+// Deprecated: This type will be removed in v1alpha4.
 type HAProxyLoadBalancer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -78,6 +80,8 @@ type HAProxyLoadBalancer struct {
 // +kubebuilder:object:root=true
 
 // HAProxyLoadBalancerList contains a list of HAProxyLoadBalancer
+//
+// Deprecated: This type will be removed in one of the next releases.
 type HAProxyLoadBalancerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspherecluster_types.go
+++ b/apis/v1alpha3/vspherecluster_types.go
@@ -84,6 +84,7 @@ type VSphereClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vsphereclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
@@ -92,6 +93,8 @@ type VSphereClusterStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -111,6 +114,8 @@ func (m *VSphereCluster) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereClusterList contains a list of VSphereCluster
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vsphereclusteridentity_types.go
+++ b/apis/v1alpha3/vsphereclusteridentity_types.go
@@ -79,10 +79,13 @@ func (c *VSphereClusterIdentity) SetConditions(conditions clusterv1.Conditions) 
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vsphereclusteridentities,scope=Cluster,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereClusterIdentity defines the account to be used for reconciling clusters
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterIdentity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -93,6 +96,8 @@ type VSphereClusterIdentity struct {
 
 // +kubebuilder:object:root=true
 // VSphereClusterIdentityList contains a list of VSphereClusterIdentity
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterIdentityList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspheredeploymentzone_types.go
+++ b/apis/v1alpha3/vspheredeploymentzone_types.go
@@ -78,10 +78,13 @@ type VSphereDeploymentZoneStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheredeploymentzones,scope=Cluster,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereDeploymentZone is the Schema for the vspheredeploymentzones API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereDeploymentZone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -93,6 +96,8 @@ type VSphereDeploymentZone struct {
 // +kubebuilder:object:root=true
 
 // VSphereDeploymentZoneList contains a list of VSphereDeploymentZone
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereDeploymentZoneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspherefailuredomain_types.go
+++ b/apis/v1alpha3/vspherefailuredomain_types.go
@@ -89,9 +89,12 @@ type FailureDomainHosts struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspherefailuredomains,scope=Cluster,categories=cluster-api
 
 // VSphereFailureDomain is the Schema for the vspherefailuredomains API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereFailureDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -102,6 +105,8 @@ type VSphereFailureDomain struct {
 // +kubebuilder:object:root=true
 
 // VSphereFailureDomainList contains a list of VSphereFailureDomain
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereFailureDomainList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspheremachine_types.go
+++ b/apis/v1alpha3/vspheremachine_types.go
@@ -102,6 +102,7 @@ type VSphereMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this VSphereMachine belongs"
@@ -111,6 +112,8 @@ type VSphereMachineStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereMachine is the Schema for the vspheremachines API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -130,6 +133,8 @@ func (m *VSphereMachine) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereMachineList contains a list of VSphereMachine
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspheremachinetemplate_types.go
+++ b/apis/v1alpha3/vspheremachinetemplate_types.go
@@ -27,9 +27,12 @@ type VSphereMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheremachinetemplates,scope=Namespaced,categories=cluster-api
 
 // VSphereMachineTemplate is the Schema for the vspheremachinetemplates API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +43,8 @@ type VSphereMachineTemplate struct {
 // +kubebuilder:object:root=true
 
 // VSphereMachineTemplateList contains a list of VSphereMachineTemplate
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha3/vspherevm_types.go
+++ b/apis/v1alpha3/vspherevm_types.go
@@ -126,10 +126,13 @@ type VSphereVMStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspherevms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereVM is the Schema for the vspherevms API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereVM struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -149,6 +152,8 @@ func (m *VSphereVM) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereVMList contains a list of VSphereVM
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereVMList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/doc.go
+++ b/apis/v1alpha4/doc.go
@@ -18,4 +18,6 @@ limitations under the License.
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/apis/v1alpha4/vspherecluster_types.go
+++ b/apis/v1alpha4/vspherecluster_types.go
@@ -62,6 +62,7 @@ type VSphereClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vsphereclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
@@ -70,6 +71,8 @@ type VSphereClusterStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -89,6 +92,8 @@ func (c *VSphereCluster) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereClusterList contains a list of VSphereCluster
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vsphereclusteridentity_types.go
+++ b/apis/v1alpha4/vsphereclusteridentity_types.go
@@ -79,10 +79,13 @@ func (c *VSphereClusterIdentity) SetConditions(conditions clusterv1.Conditions) 
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vsphereclusteridentities,scope=Cluster,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereClusterIdentity defines the account to be used for reconciling clusters
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterIdentity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -93,6 +96,8 @@ type VSphereClusterIdentity struct {
 
 // +kubebuilder:object:root=true
 // VSphereClusterIdentityList contains a list of VSphereClusterIdentity
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterIdentityList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vsphereclustertemplate_types.go
+++ b/apis/v1alpha4/vsphereclustertemplate_types.go
@@ -27,9 +27,12 @@ type VSphereClusterTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vsphereclustertemplates,scope=Namespaced,categories=cluster-api
 
 // VSphereClusterTemplate is the Schema for the vsphereclustertemplates API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +43,8 @@ type VSphereClusterTemplate struct {
 // +kubebuilder:object:root=true
 
 // VSphereClusterTemplateList contains a list of VSphereClusterTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereClusterTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vspheredeploymentzone_types.go
+++ b/apis/v1alpha4/vspheredeploymentzone_types.go
@@ -78,10 +78,13 @@ type VSphereDeploymentZoneStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheredeploymentzones,scope=Cluster,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereDeploymentZone is the Schema for the vspheredeploymentzones API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereDeploymentZone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -101,6 +104,8 @@ func (z *VSphereDeploymentZone) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereDeploymentZoneList contains a list of VSphereDeploymentZone
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereDeploymentZoneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vspherefailuredomain_types.go
+++ b/apis/v1alpha4/vspherefailuredomain_types.go
@@ -90,9 +90,12 @@ type FailureDomainHosts struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspherefailuredomains,scope=Cluster,categories=cluster-api
 
 // VSphereFailureDomain is the Schema for the vspherefailuredomains API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereFailureDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -103,6 +106,8 @@ type VSphereFailureDomain struct {
 // +kubebuilder:object:root=true
 
 // VSphereFailureDomainList contains a list of VSphereFailureDomain
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereFailureDomainList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vspheremachine_types.go
+++ b/apis/v1alpha4/vspheremachine_types.go
@@ -102,6 +102,7 @@ type VSphereMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this VSphereMachine belongs"
@@ -111,6 +112,8 @@ type VSphereMachineStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereMachine is the Schema for the vspheremachines API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -130,6 +133,8 @@ func (m *VSphereMachine) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereMachineList contains a list of VSphereMachine
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vspheremachinetemplate_types.go
+++ b/apis/v1alpha4/vspheremachinetemplate_types.go
@@ -27,9 +27,12 @@ type VSphereMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspheremachinetemplates,scope=Namespaced,categories=cluster-api
 
 // VSphereMachineTemplate is the Schema for the vspheremachinetemplates API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +43,8 @@ type VSphereMachineTemplate struct {
 // +kubebuilder:object:root=true
 
 // VSphereMachineTemplateList contains a list of VSphereMachineTemplate
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha4/vspherevm_types.go
+++ b/apis/v1alpha4/vspherevm_types.go
@@ -126,10 +126,13 @@ type VSphereVMStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +kubebuilder:resource:path=vspherevms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
 // VSphereVM is the Schema for the vspherevms API
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereVM struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -149,6 +152,8 @@ func (r *VSphereVM) SetConditions(conditions clusterv1.Conditions) {
 // +kubebuilder:object:root=true
 
 // VSphereVMList contains a list of VSphereVM
+//
+// Deprecated: This type will be removed in one of the next releases.
 type VSphereVMList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -14,11 +14,12 @@ spec:
     singular: haproxyloadbalancer
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: 'HAProxyLoadBalancer is the Schema for the haproxyloadbalancers
-          API DEPRECATED: will be removed in v1alpha4'
+        description: "HAProxyLoadBalancer is the Schema for the haproxyloadbalancers
+          API \n Deprecated: This type will be removed in v1alpha4."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -16,11 +16,12 @@ spec:
     singular: vsphereclusteridentity
   scope: Cluster
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereClusterIdentity defines the account to be used for reconciling
-          clusters
+        description: "VSphereClusterIdentity defines the account to be used for reconciling
+          clusters \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -148,11 +149,12 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereClusterIdentity defines the account to be used for reconciling
-          clusters
+        description: "VSphereClusterIdentity defines the account to be used for reconciling
+          clusters \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -34,10 +34,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereCluster is the Schema for the vsphereclusters API
+        description: "VSphereCluster is the Schema for the vsphereclusters API \n
+          Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -424,10 +426,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereCluster is the Schema for the vsphereclusters API
+        description: "VSphereCluster is the Schema for the vsphereclusters API \n
+          Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -16,11 +16,12 @@ spec:
     singular: vsphereclustertemplate
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
-          API
+        description: "VSphereClusterTemplate is the Schema for the vsphereclustertemplates
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -16,11 +16,12 @@ spec:
     singular: vspheredeploymentzone
   scope: Cluster
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
-          API
+        description: "VSphereDeploymentZone is the Schema for the vspheredeploymentzones
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -120,11 +121,12 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
-          API
+        description: "VSphereDeploymentZone is the Schema for the vspheredeploymentzones
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -16,11 +16,12 @@ spec:
     singular: vspherefailuredomain
   scope: Cluster
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereFailureDomain is the Schema for the vspherefailuredomains
-          API
+        description: "VSphereFailureDomain is the Schema for the vspherefailuredomains
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -137,11 +138,12 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereFailureDomain is the Schema for the vspherefailuredomains
-          API
+        description: "VSphereFailureDomain is the Schema for the vspherefailuredomains
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -38,10 +38,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereMachine is the Schema for the vspheremachines API
+        description: "VSphereMachine is the Schema for the vspheremachines API \n
+          Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -433,10 +435,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereMachine is the Schema for the vspheremachines API
+        description: "VSphereMachine is the Schema for the vspheremachines API \n
+          Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -16,11 +16,12 @@ spec:
     singular: vspheremachinetemplate
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
-          API
+        description: "VSphereMachineTemplate is the Schema for the vspheremachinetemplates
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -393,11 +394,12 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
-          API
+        description: "VSphereMachineTemplate is the Schema for the vspheremachinetemplates
+          API \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -16,10 +16,12 @@ spec:
     singular: vspherevm
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: VSphereVM is the Schema for the vspherevms API
+        description: "VSphereVM is the Schema for the vspherevms API \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -427,10 +429,12 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha4
+  - deprecated: true
+    name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VSphereVM is the Schema for the vspherevms API
+        description: "VSphereVM is the Schema for the vspherevms API \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -19,7 +19,7 @@ package constants
 import (
 	"time"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 )
 
 const (
@@ -45,11 +45,11 @@ const (
 
 	// MachineReadyAnnotationLabel is the annotation used to indicate that a
 	// machine is ready.
-	MachineReadyAnnotationLabel = "capv." + v1alpha3.GroupName + "/machine-ready"
+	MachineReadyAnnotationLabel = "capv." + v1beta1.GroupName + "/machine-ready"
 
 	// MaintenanceAnnotationLabel is the annotation used to indicate a machine and/or
 	// cluster are in maintenance mode.
-	MaintenanceAnnotationLabel = "capv." + v1alpha3.GroupName + "/maintenance"
+	MaintenanceAnnotationLabel = "capv." + v1beta1.GroupName + "/maintenance"
 
 	// DefaultEnableKeepAlive is true by default.
 	DefaultEnableKeepAlive = true


### PR DESCRIPTION
Deprecate v1alpha3 and v1alpha4 apiVersions by:

1) Adding a Go deprecrated marker to each package and each root API type in packages `v1alpha3` and `v1alpha4`
2) Add a kubebuilder marker to set `deprecated: true` on the openAPI definition.


Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2165