### PR TITLE
:seedling: Align github actions with upstream CAPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,34 +11,23 @@ updates:
       prefix: ":seedling:"
   labels:
     - "ok-to-test"
+
 # Go
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "monday"
   ignore:
-  # Ignore k8s modules as they are upgraded manually
-  # together with controller-runtime and CAPI dependencies.
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-  - dependency-name: "sigs.k8s.io/*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - dependency-name: "sigs.k8s.io/cluster-api/test"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "ok-to-test"
-
-- package-ecosystem: "gomod"
-  directory: "/hack/tools"
-  schedule:
-    interval: "weekly"
-  ignore:
-    # Ignore k8s modules as they are upgraded manually
-    # together with controller-runtime and CAPI dependencies.
-    - dependency-name: "k8s.io/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    - dependency-name: "sigs.k8s.io/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
   labels:

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: PR golangci-lint
 
 on:
   pull_request:

--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -1,0 +1,23 @@
+name: PR check Markdown links
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - '**.md'
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  markdown-link-check:
+    name: Broken Links
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # tag=v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: .markdownlinkcheck.json
+        check-modified-files-only: 'yes'
+        base-branch: main

--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -1,4 +1,4 @@
-name: Verify PR
+name: PR Verify
 
 on:
   pull_request_target:
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: Verifier action
         id: verifier
-        uses: kubernetes-sigs/kubebuilder-release-tools@v0.3.0
+        uses: kubernetes-sigs/kubebuilder-release-tools@4f3d1085b4458a49ed86918b4b55505716715b77 # tag=v0.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-image-scan.yaml
+++ b/.github/workflows/weekly-image-scan.yaml
@@ -1,4 +1,4 @@
-name: scan-images
+name: Weekly image scan
 
 on:
   schedule:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.7, release-1.6, release-1.5 ]
+        branch: [ main, release-1.8, release-1.7, release-1.6, release-1.5 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +25,7 @@ jobs:
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1 # tag=v3.5.0
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # tag=v4.0.1
         with:
           go-version: ${{ steps.vars.outputs.go_version }}
       - name: Run verify container script

--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -1,0 +1,26 @@
+name: Weekly check all Markdown links
+
+on:
+  schedule:
+    # Cron for every Monday at 12:00 UTC.
+    - cron: "0 12 * * 1"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  markdown-link-check:
+    name: Broken Links
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ main, release-1.8, release-1.7, release-1.6, release-1.5 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+        with:
+          ref: ${{ matrix.branch }}
+      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # tag=v1
+        with:
+          use-quiet-mode: 'yes'
+          config-file: .markdownlinkcheck.json

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -1,0 +1,40 @@
+name: Weekly release test
+
+# Note: This workflow does not build for releases. It attempts to build release binaries periodically to ensure the repo
+# release machinery is in a good state.
+
+on:
+  schedule:
+    # Cron for every day at 12:00 UTC.
+    - cron: "0 12 * * *"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  weekly-test-release:
+    name: Test release
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ main, release-1.8, release-1.7, release-1.6, release-1.5 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+      - name: Set env
+        run:  echo "RELEASE_TAG=v9.9.9-fake" >> $GITHUB_ENV
+      - name: Set fake tag for release
+        run: |
+          git tag ${{ env.RELEASE_TAG }}
+      - name: Calculate go version
+        run: echo "go_version=$(make go-version)" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # tag=v4.0.1
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Test release
+        run: |
+          make release

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [{
+        "pattern": "^http://localhost"
+    }],
+    "httpHeaders": [{
+        "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",
+        "urls": ["https://docs.github.com/"],
+        "headers": {
+            "Accept-Encoding": "zstd, br, gzip, deflate"
+        }
+    }],
+    "timeout": "10s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ GINKGO := $(abspath $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINGKO_VER))
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
 
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT_VER := $(shell cat .github/workflows/golangci-lint.yaml | grep [[:space:]]version: | sed 's/.*version: //')
+GOLANGCI_LINT_VER := $(shell cat .github/workflows/pr-golangci-lint.yaml | grep [[:space:]]version: | sed 's/.*version: //')
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -108,7 +108,7 @@ From this point forward changes which should land in the release have to be cher
          - Adjust branches: `^main$` => `^release-1.8$`.
 5. Remove tests for old release branches if necessary
 6. Verify the jobs and dashboards a day later by taking a look at [testgrid](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-vsphere)
-7. Update `.github/workflows/scan.yaml` - to set up Trivy scanning for the currently supported branches.
+7. Update `.github/workflows/weekly-image-scan.yaml` - to setup Trivy scanning - `.github/workflows/weekly-md-link-check.yaml` - to setup link checking in the CAPI book - and `.github/workflows/weekly-test-release.yaml` - to verify the release target is working - for the currently supported branches.
 
 ## Cut a release
 


### PR DESCRIPTION
Aligns the github actions used in this repo with those used in upstream Cluster API c/f https://github.com/kubernetes-sigs/cluster-api/tree/main/.github/workflows

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2059
