### PR TITLE
:book: Improve godoc of the ipAddrs field

### DIFF
--- a/apis/v1alpha3/types.go
+++ b/apis/v1alpha3/types.go
@@ -237,7 +237,8 @@ type NetworkDeviceSpec struct {
 	Gateway6 string `json:"gateway6,omitempty"`
 
 	// IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
-	// to this device.
+	// to this device. IP addresses must also specify the segment length in
+	// CIDR notation.
 	// Required when DHCP4 and DHCP6 are both false.
 	// +optional
 	IPAddrs []string `json:"ipAddrs,omitempty"`

--- a/apis/v1alpha4/types.go
+++ b/apis/v1alpha4/types.go
@@ -237,7 +237,8 @@ type NetworkDeviceSpec struct {
 	Gateway6 string `json:"gateway6,omitempty"`
 
 	// IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
-	// to this device.
+	// to this device. IP addresses must also specify the segment length in
+	// CIDR notation.
 	// Required when DHCP4 and DHCP6 are both false.
 	// +optional
 	IPAddrs []string `json:"ipAddrs,omitempty"`

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -313,7 +313,8 @@ type NetworkDeviceSpec struct {
 	Gateway6 string `json:"gateway6,omitempty"`
 
 	// IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
-	// to this device.
+	// to this device.  IP addresses must also specify the segment length in
+	// CIDR notation.
 	// Required when DHCP4 and DHCP6 are both false.
 	// +optional
 	IPAddrs []string `json:"ipAddrs,omitempty"`

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_haproxyloadbalancers.yaml
@@ -132,8 +132,9 @@ spec:
                               type: string
                             ipAddrs:
                               description: IPAddrs is a list of one or more IPv4 and/or
-                                IPv6 addresses to assign to this device. Required
-                                when DHCP4 and DHCP6 are both false.
+                                IPv6 addresses to assign to this device. IP addresses
+                                must also specify the segment length in CIDR notation.
+                                Required when DHCP4 and DHCP6 are both false.
                               items:
                                 type: string
                               type: array

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -140,8 +140,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device. IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array
@@ -535,8 +536,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device. IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array
@@ -1085,8 +1087,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device.  IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -241,7 +241,9 @@ spec:
                                 ipAddrs:
                                   description: IPAddrs is a list of one or more IPv4
                                     and/or IPv6 addresses to assign to this device.
-                                    Required when DHCP4 and DHCP6 are both false.
+                                    IP addresses must also specify the segment length
+                                    in CIDR notation. Required when DHCP4 and DHCP6
+                                    are both false.
                                   items:
                                     type: string
                                   type: array
@@ -529,7 +531,9 @@ spec:
                                 ipAddrs:
                                   description: IPAddrs is a list of one or more IPv4
                                     and/or IPv6 addresses to assign to this device.
-                                    Required when DHCP4 and DHCP6 are both false.
+                                    IP addresses must also specify the segment length
+                                    in CIDR notation. Required when DHCP4 and DHCP6
+                                    are both false.
                                   items:
                                     type: string
                                   type: array
@@ -988,8 +992,10 @@ spec:
                                   type: string
                                 ipAddrs:
                                   description: IPAddrs is a list of one or more IPv4
-                                    and/or IPv6 addresses to assign to this device.
-                                    Required when DHCP4 and DHCP6 are both false.
+                                    and/or IPv6 addresses to assign to this device.  IP
+                                    addresses must also specify the segment length
+                                    in CIDR notation. Required when DHCP4 and DHCP6
+                                    are both false.
                                   items:
                                     type: string
                                   type: array

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -157,8 +157,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device. IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array
@@ -568,8 +569,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device. IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array
@@ -1134,8 +1136,9 @@ spec:
                           type: string
                         ipAddrs:
                           description: IPAddrs is a list of one or more IPv4 and/or
-                            IPv6 addresses to assign to this device. Required when
-                            DHCP4 and DHCP6 are both false.
+                            IPv6 addresses to assign to this device.  IP addresses
+                            must also specify the segment length in CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
                           items:
                             type: string
                           type: array


### PR DESCRIPTION

#### What this PR does / why we need it:
When reading the API specs, it was not obvious to me what the syntax of the field was. This PR updates the description of the ipAddrs field to prevent ambiguity when specifying the IP address.

#### Which issue(s) this PR fixes
Resolves a minor issue I found in the [troubleshooting guide](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/troubleshooting.md?rgh-link-date=2023-03-17T18%3A28%3A49Z#a-static-ip-address-must-include-the-segment-length).

This is a manual minor fixup of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1828 - thanks @rvanderp3!
