### PR TITLE
[WIP] ✨SAML token authentication support

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -336,11 +336,11 @@ func (r clusterReconciler) reconcileVCenterConnectivity(ctx *context.ClusterCont
 			return nil, err
 		}
 
-		params = params.WithUserInfo(creds.Username, creds.Password)
+		params = params.WithUserInfo(creds.Username, creds.Password).WithUserCertificate(creds.UserCert).WithUserKey(creds.UserKey)
 		return session.GetOrCreate(ctx, params)
 	}
 
-	params = params.WithUserInfo(ctx.Username, ctx.Password)
+	params = params.WithUserInfo(ctx.Username, ctx.Password).WithUserCertificate(ctx.UserCert).WithUserKey(ctx.UserKey)
 	return session.GetOrCreate(ctx, params)
 }
 

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -253,7 +253,7 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx *context.VSphereD
 				continue
 			}
 			logger.Info("using server credentials to create the authenticated session")
-			params = params.WithUserInfo(creds.Username, creds.Password)
+			params = params.WithUserInfo(creds.Username, creds.Password).WithUserCertificate(creds.UserCert).WithUserKey(creds.UserKey)
 			return session.GetOrCreate(r.Context,
 				params)
 		}

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -570,7 +570,9 @@ func (r vmReconciler) retrieveVcenterSession(ctx goctx.Context, vsphereVM *infra
 		WithFeatures(session.Feature{
 			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
-		})
+		}).
+		WithUserKey(r.ControllerContext.UserKey).
+		WithUserCertificate(r.ControllerContext.UserCert)
 	cluster, err := clusterutilv1.GetClusterFromMetadata(r.ControllerContext, r.Client, vsphereVM.ObjectMeta)
 	if err != nil {
 		r.Logger.Info("VsphereVM is missing cluster label or cluster does not exist")
@@ -595,7 +597,7 @@ func (r vmReconciler) retrieveVcenterSession(ctx goctx.Context, vsphereVM *infra
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to retrieve credentials from IdentityRef")
 		}
-		params = params.WithUserInfo(creds.Username, creds.Password)
+		params = params.WithUserInfo(creds.Username, creds.Password).WithUserCertificate(creds.UserCert).WithUserKey(creds.UserKey)
 		return session.GetOrCreate(r.Context,
 			params)
 	}

--- a/pkg/clustermodule/session.go
+++ b/pkg/clustermodule/session.go
@@ -60,7 +60,7 @@ func fetchSession(ctx *context.ClusterContext, params *session.Params) (*session
 		return session.GetOrCreate(ctx, params)
 	}
 
-	params = params.WithUserInfo(ctx.Username, ctx.Password)
+	params = params.WithUserInfo(ctx.Username, ctx.Password).WithUserCertificate(ctx.UserCert).WithUserKey(ctx.UserKey)
 	return session.GetOrCreate(ctx, params)
 }
 

--- a/pkg/clustermodule/session.go
+++ b/pkg/clustermodule/session.go
@@ -56,7 +56,7 @@ func fetchSession(ctx *context.ClusterContext, params *session.Params) (*session
 			return nil, err
 		}
 
-		params = params.WithUserInfo(creds.Username, creds.Password)
+		params = params.WithUserInfo(creds.Username, creds.Password).WithUserCertificate(creds.UserCert).WithUserKey(creds.UserKey)
 		return session.GetOrCreate(ctx, params)
 	}
 

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -74,6 +74,14 @@ type ControllerManagerContext struct {
 	// endpoints.
 	Password string
 
+	// UserCert is the user certificate for the account to access remote vSphere
+	// endpoints.
+	UserCert string
+
+	// UserKey is the user certificate for the account to access remote vSphere
+	// endpoints.
+	UserKey string
+
 	// EnableKeepAlive is a session feature to enable keep alive handler
 	// for better load management on vSphere api server
 	EnableKeepAlive bool

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -33,11 +33,15 @@ import (
 const (
 	UsernameKey = "username"
 	PasswordKey = "password"
+	UserCertKey = "userCertificate"
+	UserKeyKey  = "userKey"
 )
 
 type Credentials struct {
 	Username string
 	Password string
+	UserCert string
+	UserKey  string
 }
 
 func GetCredentials(ctx context.Context, c client.Client, cluster *infrav1.VSphereCluster, controllerNamespace string) (*Credentials, error) {
@@ -103,6 +107,8 @@ func GetCredentials(ctx context.Context, c client.Client, cluster *infrav1.VSphe
 	credentials := &Credentials{
 		Username: getData(secret, UsernameKey),
 		Password: getData(secret, PasswordKey),
+		UserCert: getData(secret, UserCertKey),
+		UserKey:  getData(secret, UserKeyKey),
 	}
 
 	return credentials, nil

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -90,6 +90,8 @@ var _ = Describe("GetCredentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(creds.Username).To(Equal(getData(credentialSecret, UsernameKey)))
 			Expect(creds.Password).To(Equal(getData(credentialSecret, PasswordKey)))
+			Expect(creds.UserCert).To(Equal(getData(credentialSecret, UserCertKey)))
+			Expect(creds.UserKey).To(Equal(getData(credentialSecret, UserKeyKey)))
 		})
 
 		It("should error if secret is not in the same namespace as the cluster", func() {
@@ -133,6 +135,8 @@ var _ = Describe("GetCredentials", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(creds.Username).To(Equal(getData(credentialSecret, UsernameKey)))
 			Expect(creds.Password).To(Equal(getData(credentialSecret, PasswordKey)))
+			Expect(creds.UserCert).To(Equal(getData(credentialSecret, UserCertKey)))
+			Expect(creds.UserKey).To(Equal(getData(credentialSecret, UserKeyKey)))
 		})
 
 		It("should error if allowedNamespaces is set to nil", func() {
@@ -262,6 +266,8 @@ func createSecret(namespace string) *corev1.Secret {
 		Data: map[string][]byte{
 			UsernameKey: []byte("user"),
 			PasswordKey: []byte("pass"),
+			UserCertKey: []byte("cert"),
+			UserKeyKey:  []byte("key"),
 		},
 	}
 	Expect(k8sclient.Create(ctx, credentialSecret)).To(Succeed())

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -95,6 +95,8 @@ func New(opts Options) (Manager, error) {
 		Scheme:                  opts.Scheme,
 		Username:                opts.Username,
 		Password:                opts.Password,
+		UserCert:                opts.UserCert,
+		UserKey:                 opts.UserKey,
 		EnableKeepAlive:         opts.EnableKeepAlive,
 		KeepAliveDuration:       opts.KeepAliveDuration,
 		NetworkProvider:         opts.NetworkProvider,

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -63,6 +63,14 @@ type Options struct {
 	// endpoints.
 	Password string
 
+	// UserCert is the user certificate for the account to access remote vSphere
+	// endpoints.
+	UserCert string
+
+	// UserKey is the user certificate for the account to access remote vSphere
+	// endpoints.
+	UserKey string
+
 	// KeepAliveDuration is the idle time interval in between send() requests
 	// in keepalive handler
 	KeepAliveDuration time.Duration
@@ -140,4 +148,6 @@ func (o *Options) readAndSetCredentials() {
 	credentials := o.getCredentials()
 	o.Username = credentials["username"]
 	o.Password = credentials["password"]
+	o.UserCert = credentials["userCert"]
+	o.UserKey = credentials["userKey"]
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -380,7 +380,7 @@ func signer(ctx context.Context, logger logr.Logger, client *vim25.Client, cert,
 		return nil, err
 	}
 
-	tokens, err := sts.NewClient(ctx, client)
+	stsc, err := sts.NewClient(ctx, client)
 	if err != nil {
 		logger.Error(err, "Failed to create STS client")
 		return nil, err
@@ -391,7 +391,7 @@ func signer(ctx context.Context, logger logr.Logger, client *vim25.Client, cert,
 		Delegatable: true,
 	}
 
-	signer, err := tokens.Issue(ctx, req)
+	signer, err := stsc.Issue(ctx, req)
 	if err != nil {
 		logger.Error(err, "Failed to issue SAML token")
 		return nil, err

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -341,7 +341,7 @@ func login(ctx context.Context, logger logr.Logger, client *govmomi.Client, user
 			logger.Info("Bother usrename/password and userCertificate/userKey are set. Using the userCertificate/userKey")
 		}
 
-		logger.V(4).Info("Session.LoginByToken with certificate", string(userCert))
+		logger.V(4).Info("Session.LoginByToken with certificate", userCert)
 		signer, err := signer(ctx, logger, client.Client, userCert, userKey)
 		if err != nil {
 			return err
@@ -353,7 +353,6 @@ func login(ctx context.Context, logger logr.Logger, client *govmomi.Client, user
 
 	// basic auth login
 	return client.Login(ctx, user)
-
 }
 
 func loginWithRestClient(ctx context.Context, logger logr.Logger, rc *rest.Client, client *vim25.Client, user *url.Userinfo, userCert, userKey string) error {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -141,11 +141,11 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	sessionMU.Lock()
 	defer sessionMU.Unlock()
 
-	if err := validateCredentials(ctx, logger, params); err != nil {
+	if err := validateCredentials(logger, params); err != nil {
 		return nil, err
 	}
 
-	sessionKey := generateSessionKey(ctx, logger, params)
+	sessionKey := generateSessionKey(logger, params)
 	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
 		s := cachedSession.(*Session)
 
@@ -400,7 +400,7 @@ func signer(ctx context.Context, logger logr.Logger, client *vim25.Client, cert,
 	return signer, nil
 }
 
-func validateCredentials(ctx context.Context, logger logr.Logger, params *Params) error {
+func validateCredentials(logger logr.Logger, params *Params) error {
 	if params.userCert != "" || params.userKey != "" {
 		if params.userCert == "" || params.userKey == "" {
 			return errors.New("one of userCert/userKey is empty")
@@ -412,7 +412,7 @@ func validateCredentials(ctx context.Context, logger logr.Logger, params *Params
 	return nil
 }
 
-func generateSessionKey(ctx context.Context, logger logr.Logger, params *Params) string {
+func generateSessionKey(logger logr.Logger, params *Params) string {
 	key1 := hash(params.userCert)
 	key2 := hash(params.userKey)
 	if params.userinfo.Username() != "" {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -335,8 +335,8 @@ func (s *Session) findByUUID(ctx context.Context, uuid string, findByInstanceUUI
 }
 
 func login(ctx context.Context, logger logr.Logger, client *govmomi.Client, user *url.Userinfo, userCert, userKey string) error {
+	// if certificate is configured, prefer using certificate
 	if len(userCert) > 0 || len(userKey) > 0 {
-		// if certificate is configured, prefer using certificate
 		if user != nil {
 			logger.Info("Bother usrename/password and userCertificate/userKey are set. Using the userCertificate/userKey")
 		}
@@ -349,14 +349,16 @@ func login(ctx context.Context, logger logr.Logger, client *govmomi.Client, user
 
 		header := soap.Header{Security: signer}
 		return client.SessionManager.LoginByToken(client.WithHeader(ctx, header))
-	} else {
-		return client.Login(ctx, user)
 	}
+
+	// basic auth login
+	return client.Login(ctx, user)
+
 }
 
 func loginWithRestClient(ctx context.Context, logger logr.Logger, rc *rest.Client, client *vim25.Client, user *url.Userinfo, userCert, userKey string) error {
+	// if certificate is configured, prefer using certificate
 	if len(userCert) > 0 || len(userKey) > 0 {
-		// if certificate is configured, prefer using certificate
 		if user != nil {
 			logger.Info("Bother usrename/password and userCertificate/userKey are set. Using the userCertificate/userKey")
 		}
@@ -365,9 +367,10 @@ func loginWithRestClient(ctx context.Context, logger logr.Logger, rc *rest.Clien
 			return err
 		}
 		return rc.LoginByToken(rc.WithSigner(ctx, signer))
-	} else {
-		return rc.Login(ctx, user)
 	}
+
+	// basic auth login
+	return rc.Login(ctx, user)
 }
 
 // signer returns an sts.Signer for use with SAML token auth if connection is configured for such.

--- a/test/helpers/vcsim/builder.go
+++ b/test/helpers/vcsim/builder.go
@@ -24,7 +24,10 @@ import (
 	"strings"
 
 	"github.com/onsi/gomega/gbytes"
+	_ "github.com/vmware/govmomi/lookup/simulator"
 	"github.com/vmware/govmomi/simulator"
+	_ "github.com/vmware/govmomi/sts/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 )
 
 type Builder struct {

--- a/test/helpers/vcsim/simulator.go
+++ b/test/helpers/vcsim/simulator.go
@@ -58,3 +58,37 @@ func (s Simulator) Password() string {
 	pwd, _ := s.server.URL.User.Password()
 	return pwd
 }
+
+func (s Simulator) UserKey() string {
+	return localhostKey
+}
+
+func (s Simulator) UserCert() string {
+	return localhostCert
+}
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//
+//	go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = `-----BEGIN CERTIFICATE-----
+MIIBjzCCATmgAwIBAgIRAKpi2WmTcFrVjxrl5n5YDUEwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgC
+QQC9fEbRszP3t14Gr4oahV7zFObBI4TfA5i7YnlMXeLinb7MnvT4bkfOJzE6zktn
+59zP7UiHs3l4YOuqrjiwM413AgMBAAGjaDBmMA4GA1UdDwEB/wQEAwICpDATBgNV
+HSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MC4GA1UdEQQnMCWCC2V4
+YW1wbGUuY29thwR/AAABhxAAAAAAAAAAAAAAAAAAAAABMA0GCSqGSIb3DQEBCwUA
+A0EAUsVE6KMnza/ZbodLlyeMzdo7EM/5nb5ywyOxgIOCf0OOLHsPS9ueGLQX9HEG
+//yjTXuhNcUugExIjM/AIwAZPQ==
+-----END CERTIFICATE-----`
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBAL18RtGzM/e3XgavihqFXvMU5sEjhN8DmLtieUxd4uKdvsye9Phu
+R84nMTrOS2fn3M/tSIezeXhg66quOLAzjXcCAwEAAQJBAKcRxH9wuglYLBdI/0OT
+BLzfWPZCEw1vZmMR2FF1Fm8nkNOVDPleeVGTWoOEcYYlQbpTmkGSxJ6ya+hqRi6x
+goECIQDx3+X49fwpL6B5qpJIJMyZBSCuMhH4B7JevhGGFENi3wIhAMiNJN5Q3UkL
+IuSvv03kaPR5XVQ99/UeEetUgGvBcABpAiBJSBzVITIVCGkGc7d+RCf49KTCIklv
+bGWObufAR8Ni4QIgWpILjW8dkGg8GOUZ0zaNA6Nvt6TIv2UWGJ4v5PoV98kCIQDx
+rIiZs5QbKdycsv9gQJzwQAogC8o04X3Zz3dsoX+h4A==
+-----END RSA PRIVATE KEY-----`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
SAML token authentication support

User can use username password to authenticate against vsphere. By setting `username` and `password` in secret referenced by `vsphereCluster.spec.identityRef`

User now can also use certificate/key pairs for a solution user to trigger SAML token authentication. By setting `userCert` and `userKey` in secret referenced by `vsphereCluster.spec.identityRef`

When both username and userCert are set, the SAML token authentication is preferred


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1959
