### PR TITLE
🌱 Add args to golangci-lint to show lines number

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,3 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # tag=v3.6.0
         with:
           version: v1.53.3
+          args: --out-format=colored-line-number


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Right now the error doesn't show exact line that has issue.
With this fix, then the error log will be more descriptive.
Example: here https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/actions/runs/5791075333/job/15695267905?pr=2171
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.53.3-linux-amd64/golangci-lint run --out-format=line-number,github-actions] in [] ...
  Error: pkg/session/session.go:335:67: unnecessary conversion (unconvert)
  		logger.V(4).Info("Session.LoginByToken with certificate", string(userCert))
  		                                                                ^
  pkg/session/session.go:347: unnecessary trailing newline (whitespace)
  
  }
  Error: unnecessary conversion (unconvert)
  Error: unnecessary trailing newline (whitespace)
  
  Error: issues found
  Ran golangci-lint in 2717ms
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2058
