### PR TITLE
🌱 Enable powerOffMode trySoft in cluster-templates and CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ generate-doctoc:
 	TRACE=$(TRACE) ./hack/generate-doctoc.sh
 
 .PHONY: generate-e2e-templates
-generate-e2e-templates: ## Generate e2e cluster templates
+generate-e2e-templates: $(KUSTOMIZE) ## Generate e2e cluster templates
 	$(MAKE) release-flavors
 
 	cp $(RELEASE_DIR)/cluster-template.yaml $(E2E_TEMPLATE_DIR)/kustomization/base/cluster-template.yaml

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -259,7 +259,7 @@ func newVSphereMachineTemplate(templateName string) infrav1.VSphereMachineTempla
 func defaultVirtualMachineSpec() infrav1.VSphereMachineSpec {
 	return infrav1.VSphereMachineSpec{
 		VirtualMachineCloneSpec: defaultVirtualMachineCloneSpec(),
-		PowerOffMode:            infrav1.VirtualMachinePowerOpModeHard,
+		PowerOffMode:            infrav1.VirtualMachinePowerOpModeTrySoft,
 	}
 }
 
@@ -312,7 +312,7 @@ func newNodeIPAMVSphereMachineTemplate(templateName string) infrav1.VSphereMachi
 func nodeIPAMVirtualMachineSpec() infrav1.VSphereMachineSpec {
 	return infrav1.VSphereMachineSpec{
 		VirtualMachineCloneSpec: nodeIPAMVirtualMachineCloneSpec(),
-		PowerOffMode:            infrav1.VirtualMachinePowerOpModeHard,
+		PowerOffMode:            infrav1.VirtualMachinePowerOpModeTrySoft,
 	}
 }
 

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -55,7 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -82,7 +82,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -55,7 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -60,7 +60,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -92,7 +92,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -55,7 +55,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -82,7 +82,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -178,7 +178,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
@@ -205,7 +205,7 @@ spec:
           networkName: '${VSPHERE_NETWORK}'
       numCPUs: 2
       os: Linux
-      powerOffMode: hard
+      powerOffMode: trySoft
       resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       storagePolicyName: '${VSPHERE_STORAGE_POLICY}'


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We introduced powerOffMode in CAPV v1.8. We ensured that the default behavior doesn't change by using "hard" as default on the CRDs. 

I think it's reasonable now to start using trySoft in our cluster-templates and in CI. It's the ideal value and just changing the value in the cluster-templates doesn't break our API behavior in any way.

Also the VM's now have a chance to "return" their DHCP leases during shutdown, which is helpful for CI stability.

P.S. I don't want to cherry-pick this change as I don't want to change the field in cluster-templates in a CAPV v1.8 patch release

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
