### PR TITLE
[release-1.8] :seedling:  Set base branch correctly for link checker

### DIFF
--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -20,4 +20,4 @@ jobs:
         use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json
         check-modified-files-only: 'yes'
-        base-branch: main
+        base-branch: release-1.8


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>


 Set base branch correctly for link checker