### PR TITLE
🌱 lint: fix duplicated words via dupword linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
   - bodyclose
   # - containedctx
   - dogsled
-  # - dupword
+  - dupword
   - durationcheck
   - errcheck
   # - errchkjson

--- a/apis/v1alpha3/types.go
+++ b/apis/v1alpha3/types.go
@@ -342,7 +342,7 @@ type VirtualMachine struct {
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
 
-	// VMRef is the the VM's Managed Object Reference on vSphere.
+	// VMRef is the VM's Managed Object Reference on vSphere.
 	VMRef string `json:"vmRef"`
 }
 

--- a/apis/v1alpha3/vspherevm_types.go
+++ b/apis/v1alpha3/vspherevm_types.go
@@ -41,7 +41,7 @@ type VSphereVMSpec struct {
 	// +optional
 	BootstrapRef *corev1.ObjectReference `json:"bootstrapRef,omitempty"`
 
-	// BiosUUID is the the VM's BIOS UUID that is assigned at runtime after
+	// BiosUUID is the VM's BIOS UUID that is assigned at runtime after
 	// the VM has been created.
 	// This field is required at runtime for other controllers that read
 	// this CRD as unstructured data.

--- a/apis/v1alpha4/types.go
+++ b/apis/v1alpha4/types.go
@@ -342,7 +342,7 @@ type VirtualMachine struct {
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
 
-	// VMRef is the the VM's Managed Object Reference on vSphere.
+	// VMRef is the VM's Managed Object Reference on vSphere.
 	VMRef string `json:"vmRef"`
 }
 

--- a/apis/v1alpha4/vspherevm_types.go
+++ b/apis/v1alpha4/vspherevm_types.go
@@ -41,7 +41,7 @@ type VSphereVMSpec struct {
 	// +optional
 	BootstrapRef *corev1.ObjectReference `json:"bootstrapRef,omitempty"`
 
-	// BiosUUID is the the VM's BIOS UUID that is assigned at runtime after
+	// BiosUUID is the VM's BIOS UUID that is assigned at runtime after
 	// the VM has been created.
 	// This field is required at runtime for other controllers that read
 	// this CRD as unstructured data.

--- a/apis/v1beta1/condition_consts.go
+++ b/apis/v1beta1/condition_consts.go
@@ -92,7 +92,7 @@ const (
 	// retry the operation, but a user intervention might be required to fix the problem.
 	TaskFailure = "TaskFailure"
 
-	// WaitingForNetworkAddressesReason (Severity=Info) documents a VSphereMachine waiting for the the machine network
+	// WaitingForNetworkAddressesReason (Severity=Info) documents a VSphereMachine waiting for the machine network
 	// settings to be reported after machine being powered on.
 	//
 	// NOTE: This reason does not apply to VSphereVM (this state happens after the VSphereVM is in ready state).

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -489,7 +489,7 @@ type VirtualMachine struct {
 	// Network is the status of the VM's network devices.
 	Network []NetworkStatus `json:"network"`
 
-	// VMRef is the the VM's Managed Object Reference on vSphere.
+	// VMRef is the VM's Managed Object Reference on vSphere.
 	VMRef string `json:"vmRef"`
 }
 

--- a/apis/v1beta1/vspherevm_types.go
+++ b/apis/v1beta1/vspherevm_types.go
@@ -52,7 +52,7 @@ type VSphereVMSpec struct {
 	// +optional
 	BootstrapRef *corev1.ObjectReference `json:"bootstrapRef,omitempty"`
 
-	// BiosUUID is the the VM's BIOS UUID that is assigned at runtime after
+	// BiosUUID is the VM's BIOS UUID that is assigned at runtime after
 	// the VM has been created.
 	// This field is required at runtime for other controllers that read
 	// this CRD as unstructured data.
@@ -174,7 +174,7 @@ type VSphereVMStatus struct {
 	// +optional
 	ModuleUUID *string `json:"moduleUUID,omitempty"`
 
-	// VMRef is the the VM's Managed Object Reference on vSphere. It can be used by consumers
+	// VMRef is the VM's Managed Object Reference on vSphere. It can be used by consumers
 	// to programatically get this VM representation on vSphere in case of the need to retrieve informations.
 	// This field is set once the machine is created and should not be changed
 	// +optional

--- a/apis/vmware/v1beta1/conditions_consts.go
+++ b/apis/vmware/v1beta1/conditions_consts.go
@@ -64,10 +64,10 @@ const (
 	VMProvisionStartedReason = "VMProvisionStarted"
 	// PoweringOnReason documents (Severity=Info) a Virtual Machine currently executing the power on sequence.
 	PoweringOnReason = "PoweringOn"
-	// WaitingForNetworkAddressReason (Severity=Info) documents a VSphereMachine waiting for the the machine network
+	// WaitingForNetworkAddressReason (Severity=Info) documents a VSphereMachine waiting for the machine network
 	// settings to be reported after machine being powered on.
 	WaitingForNetworkAddressReason = "WaitingForNetworkAddress"
-	// WaitingForBIOSUUIDReason (Severity=Info) documents a VSphereMachine waiting for the the machine to have a BIOS UUID.
+	// WaitingForBIOSUUIDReason (Severity=Info) documents a VSphereMachine waiting for the machine to have a BIOS UUID.
 	WaitingForBIOSUUIDReason = "WaitingForBIOSUUID"
 )
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -39,10 +39,9 @@ spec:
             description: VSphereVMSpec defines the desired state of VSphereVM.
             properties:
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -453,10 +452,9 @@ spec:
             description: VSphereVMSpec defines the desired state of VSphereVM.
             properties:
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -873,10 +871,9 @@ spec:
                   type: integer
                 type: array
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -1463,7 +1460,7 @@ spec:
                   not be set or modified by users.
                 type: string
               vmRef:
-                description: VMRef is the the VM's Managed Object Reference on vSphere.
+                description: VMRef is the VM's Managed Object Reference on vSphere.
                   It can be used by consumers to programatically get this VM representation
                   on vSphere in case of the need to retrieve informations. This field
                   is set once the machine is created and should not be changed

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 This is a guide on how to get started with Cluster API Provider vSphere. To learn more about cluster API in more
-depth, check out the the [Cluster API book][cluster-api-book].
+depth, check out the [Cluster API book][cluster-api-book].
 
 - [Getting Started](#getting-started)
   - [Install Requirements](#install-requirements)

--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func main() {
 	addToManager := func(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 		tracker, err := setupRemoteClusterCacheTracker(ctx, mgr)
 		if err != nil {
-			return perrors.Wrapf(err, "unable to create remote cluster tracker tracker")
+			return perrors.Wrapf(err, "unable to create remote cluster cache tracker")
 		}
 
 		// Check for non-supervisor VSphereCluster and start controller if found

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -68,7 +68,7 @@ var (
 	// with the providers specified in the configPath.
 	clusterctlConfigPath string
 
-	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// bootstrapClusterProvider manages provisioning of the bootstrap cluster to be used for the e2e tests.
 	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
 	bootstrapClusterProvider bootstrap.ClusterProvider
 

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -203,7 +203,7 @@ var (
 	// with the providers specified in the configPath.
 	clusterctlConfigPath string
 
-	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// bootstrapClusterProvider manages provisioning of the bootstrap cluster to be used for the e2e tests.
 	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
 	bootstrapClusterProvider bootstrap.ClusterProvider
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Check the duplicate words in the code via linter configuration, and fix it. 
Enable `dupword` check in `.golangci.yml` configuration file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of [#2058 ](url)
