### PR TITLE
🌱 lint: fix the JSON encoding check error via errchkjson linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
   - dupword
   - durationcheck
   - errcheck
-  # - errchkjson
+  - errchkjson
   - exportloopref
   - gci
   # - ginkgolinter

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -55,7 +55,10 @@ func ClusterClassTemplateWithKubeVIP() []runtime.Object {
 }
 
 func ClusterTopologyTemplateKubeVIP() []runtime.Object {
-	cluster := newClusterClassCluster()
+	cluster, err := newClusterTopologyCluster()
+	if err != nil {
+		return nil
+	}
 	identitySecret := newIdentitySecret()
 	clusterResourceSet := newClusterResourceSet(cluster)
 	crsResourcesCSI := crs.CreateCrsResourceObjectsCSI(&clusterResourceSet)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Fix the checked error by errchkjson linter. (remove the safe returns of errors from `json.Marshal`)
2. Enable `errchkjson` check in `.golangci.yml` configuration file.
3. Enable `linters-settings.errchkjson.check-error-free-encoding`. With it set to true, errchkjson does not report about the errors from json encoding functions that are safe to be ignored, because they are not possible to happen.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2058 
