### PR TITLE
flavor-gen: fix error handling in ClusterTopologyTemplateKubeVIP

### DIFF
--- a/packaging/flavorgen/cmd/root.go
+++ b/packaging/flavorgen/cmd/root.go
@@ -132,7 +132,11 @@ func generateSingle(flavor string) (string, error) {
 	case flavors.ClusterClass:
 		objs = flavors.ClusterClassTemplateWithKubeVIP()
 	case flavors.ClusterTopology:
-		objs = flavors.ClusterTopologyTemplateKubeVIP()
+		var err error
+		objs, err = flavors.ClusterTopologyTemplateKubeVIP()
+		if err != nil {
+			return "", err
+		}
 		replacements = append(replacements, util.Replacement{
 			Kind:      "Cluster",
 			Name:      "${CLUSTER_NAME}",

--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -54,10 +54,10 @@ func ClusterClassTemplateWithKubeVIP() []runtime.Object {
 	return ClusterClassTemplate
 }
 
-func ClusterTopologyTemplateKubeVIP() []runtime.Object {
+func ClusterTopologyTemplateKubeVIP() ([]runtime.Object, error) {
 	cluster, err := newClusterTopologyCluster()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	identitySecret := newIdentitySecret()
 	clusterResourceSet := newClusterResourceSet(cluster)
@@ -70,7 +70,7 @@ func ClusterTopologyTemplateKubeVIP() []runtime.Object {
 	}
 	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCSI...)
 	MultiNodeTemplate = append(MultiNodeTemplate, crsResourcesCPI...)
-	return MultiNodeTemplate
+	return MultiNodeTemplate, nil
 }
 
 func MultiNodeTemplateWithKubeVIP() []runtime.Object {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixup for https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2273/files#r1304009214

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
