### PR TITLE
🌱 Introduce --clustercachetracker-concurrency flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ var (
 	webhookOpts                 webhook.Options
 	watchNamespace              string
 
+	clusterCacheTrackerConcurrency    int
 	vSphereClusterConcurrency         int
 	vSphereMachineConcurrency         int
 	providerServiceAccountConcurrency int
@@ -102,6 +103,9 @@ func InitFlags(fs *pflag.FlagSet) {
 		"leader-election-id",
 		defaultLeaderElectionID,
 		"Name of the config map to use as the locking resource when configuring leader election.")
+
+	fs.IntVar(&clusterCacheTrackerConcurrency, "clustercachetracker-concurrency", 10,
+		"Number of clusters to process simultaneously")
 
 	fs.IntVar(&vSphereClusterConcurrency, "vspherecluster-concurrency", 10,
 		"Number of vSphere clusters to process simultaneously")
@@ -447,7 +451,7 @@ func setupRemoteClusterCacheTracker(ctx *context.ControllerManagerContext, mgr c
 		Client:           mgr.GetClient(),
 		Tracker:          tracker,
 		WatchFilterValue: managerOpts.WatchFilterValue,
-	}).SetupWithManager(ctx, mgr, concurrency(10)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(clusterCacheTrackerConcurrency)); err != nil {
 		return nil, perrors.Wrapf(err, "unable to create ClusterCacheReconciler controller")
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We kept the flag in core CAPI, so let's also introduce it here

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
