### PR TITLE
🌱 lint: enable containedctx lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
-  # - containedctx
+  - containedctx
   - dogsled
   - dupword
   - durationcheck

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -33,7 +33,7 @@ import (
 // ControllerManagerContext is the context of the controller that owns the
 // controllers.
 type ControllerManagerContext struct {
-	context.Context
+	context.Context //nolint:containedctx
 
 	// Namespace is the namespace in which the resource is located responsible
 	// for running the controller manager.

--- a/pkg/services/govmomi/cluster/cluster_suite_test.go
+++ b/pkg/services/govmomi/cluster/cluster_suite_test.go
@@ -33,8 +33,8 @@ func TestCluster(t *testing.T) {
 }
 
 type testComputeClusterCtx struct {
-	context.Context
-	finder *find.Finder
+	context.Context //nolint:containedctx
+	finder          *find.Finder
 }
 
 func (t testComputeClusterCtx) GetSession() *session.Session {

--- a/pkg/util/fetch_object.go
+++ b/pkg/util/fetch_object.go
@@ -28,7 +28,7 @@ import (
 )
 
 type FetchObjectInput struct {
-	context.Context
+	context.Context //nolint:containedctx
 	ctrlclient.Client
 	Object ctrlclient.Object
 }

--- a/test/helpers/vmware/intg_test_context.go
+++ b/test/helpers/vmware/intg_test_context.go
@@ -41,7 +41,7 @@ import (
 // IntegrationTestContext is used for integration testing
 // Supervisor controllers.
 type IntegrationTestContext struct {
-	context.Context
+	context.Context   //nolint:containedctx
 	Client            client.Client
 	GuestClient       client.Client
 	Namespace         string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Enable containedctx lint for future code checking, but exclude current failures as we have a separate issue to track the whole refactoring of capv controller context #2295


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2058 
