### PR TITLE
:seedling: Add license scan for pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,12 @@ Kubernetes projects require that you sign a Contributor License Agreement (CLA) 
         * 📖 (:book:, documentation or proposals)
         * 🌱 (:seedling:, minor or other)
 
-### Contributer Ladder
+## Dependency Licence Management
+
+Cluster API provider vSphere follows the [license policy of the CNCF](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md). This sets limits on which
+licenses dependencies and other artifacts use. For go dependencies only dependencies listed in the `go.mod` are considered dependencies. This is in line with [how dependencies are reviewed in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/vendor.md#reviewing-and-approving-dependency-changes).
+
+### Contributor Ladder
 
 We broadly follow the requirements from the [Kubernetes Community Membership](https://github.com/kubernetes/community/blob/master/community-membership.md).
 

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
 SHELLCHECK_VER := v0.9.0
 
+TRIVY_VER := 0.44.1
+
 KPROMO_VER := v4.0.4
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
@@ -334,7 +336,7 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences
 	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
-ALL_VERIFY_CHECKS = boilerplate shellcheck modules gen conversions doctoc flavors
+ALL_VERIFY_CHECKS = licenses boilerplate shellcheck modules gen conversions doctoc flavors
 
 .PHONY: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
@@ -378,7 +380,11 @@ verify-shellcheck: ## Verify shell files
 
 .PHONY: verify-container-images
 verify-container-images: ## Verify container images
-	TRACE=$(TRACE) ./hack/verify-container-images.sh
+	TRACE=$(TRACE) ./hack/verify-container-images.sh  $(TRIVY_VER)
+
+.PHONY: verify-licenses
+verify-licenses: ## Verify licenses
+	TRACE=$(TRACE) ./hack/verify-licenses.sh $(TRIVY_VER)
 
 .PHONY: verify-govulncheck
 verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities

--- a/hack/ensure-trivy.sh
+++ b/hack/ensure-trivy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+VERSION=${1}
+
+GO_OS="$(go env GOOS)"
+if [[ "${GO_OS}" == "linux" ]]; then
+  TRIVY_OS="Linux"
+elif [[ "${GO_OS}" == "darwin"* ]]; then
+  TRIVY_OS="macOS"
+fi
+
+GO_ARCH="$(go env GOARCH)"
+if [[ "${GO_ARCH}" == "amd" ]]; then
+  TRIVY_ARCH="32bit"
+elif [[ "${GO_ARCH}" == "amd64"* ]]; then
+  TRIVY_ARCH="64bit"
+elif [[ "${GO_ARCH}" == "arm" ]]; then
+  TRIVY_ARCH="ARM"
+elif [[ "${GO_ARCH}" == "arm64" ]]; then
+  TRIVY_ARCH="ARM64"
+fi
+
+TOOL_BIN=hack/tools/bin
+mkdir -p ${TOOL_BIN}
+
+TRIVY="${TOOL_BIN}/trivy/${VERSION}/trivy"
+
+# Downloads trivy scanner
+if [ ! -f "$TRIVY" ]; then
+  curl -L -o ${TOOL_BIN}/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
+  mkdir -p "$(dirname "$0")/tools/bin/trivy/${VERSION}"
+  tar -xf "${TOOL_BIN}/trivy.tar.gz" -C "${TOOL_BIN}/trivy/${VERSION}" trivy
+  chmod +x "${TOOL_BIN}/trivy/${VERSION}/trivy"
+  rm "${TOOL_BIN}/trivy.tar.gz"
+fi

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+# This list is from https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
+CNCF_LICENSE_ALLOWLIST=Apache-2.0,MIT,BSD-2-Clause,SD-2-Clause-FreeBSD,BSD-3-Clause,ISC,Python-2.0,PostgreSQL,X11,Zlib
+
+VERSION=${1}
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+"${REPO_ROOT}/hack/ensure-trivy.sh" "${VERSION}"
+
+
+TRIVY="${REPO_ROOT}/hack/tools/bin/trivy/${VERSION}/trivy"
+$TRIVY filesystem . --license-full --ignored-licenses ${CNCF_LICENSE_ALLOWLIST} --scanners license --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL -f json | \
+# Specifically ignore 'github.com/hashicorp/hcl'. This is a known indirect dependency that we should remove where possible.
+# This query ensures we only skip github.com/hashicorp/hcl for as long as the license remains MPL-2.0
+jq  '.Results[] | select( .Licenses[]?.PkgName == "github.com/hashicorp/hcl" and .Licenses[]?.Name == "MPL-2.0" | not) | if . == {} then .  else error(.) end'


### PR DESCRIPTION
Adds a licence scan inline with what is currently being added in the core Cluster API repo with https://github.com/kubernetes-sigs/cluster-api/pull/9184


Part of https://github.com/kubernetes-sigs/cluster-api/pull/9184