### PR TITLE
🌱 Rename controller context and golang context

### DIFF
--- a/controllers/serviceaccount_controller_suite_test.go
+++ b/controllers/serviceaccount_controller_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -46,27 +46,27 @@ const (
 
 var truePointer = true
 
-func createTestResource(ctx goctx.Context, ctrlClient client.Client, obj client.Object) {
+func createTestResource(ctx context.Context, ctrlClient client.Client, obj client.Object) {
 	Expect(ctrlClient.Create(ctx, obj)).To(Succeed())
 }
 
-func deleteTestResource(ctx goctx.Context, ctrlClient client.Client, obj client.Object) {
+func deleteTestResource(ctx context.Context, ctrlClient client.Client, obj client.Object) {
 	Expect(ctrlClient.Delete(ctx, obj)).To(Succeed())
 }
 
-func createTargetSecretWithInvalidToken(ctx goctx.Context, guestClient client.Client, namespace string) {
+func createTargetSecretWithInvalidToken(ctx context.Context, guestClient client.Client, namespace string) {
 	secret := getTestTargetSecretWithInvalidToken(namespace)
 	Expect(guestClient.Create(ctx, secret)).To(Succeed())
 }
 
-func assertEventuallyExistsInNamespace(ctx goctx.Context, c client.Client, namespace, name string, obj client.Object) {
+func assertEventuallyExistsInNamespace(ctx context.Context, c client.Client, namespace, name string, obj client.Object) {
 	EventuallyWithOffset(2, func() error {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		return c.Get(ctx, key, obj)
 	}).Should(Succeed())
 }
 
-func assertNoEntities(ctx goctx.Context, ctrlClient client.Client, namespace string) {
+func assertNoEntities(ctx context.Context, ctrlClient client.Client, namespace string) {
 	Consistently(func() int {
 		var serviceAccountList corev1.ServiceAccountList
 		err := ctrlClient.List(ctx, &serviceAccountList, client.InNamespace(namespace))
@@ -89,7 +89,7 @@ func assertNoEntities(ctx goctx.Context, ctrlClient client.Client, namespace str
 	}, time.Second*3).Should(Equal(0))
 }
 
-func assertServiceAccountAndUpdateSecret(ctx goctx.Context, ctrlClient client.Client, namespace, name string) {
+func assertServiceAccountAndUpdateSecret(ctx context.Context, ctrlClient client.Client, namespace, name string) {
 	svcAccount := &corev1.ServiceAccount{}
 	assertEventuallyExistsInNamespace(ctx, ctrlClient, namespace, name, svcAccount)
 	secret := &corev1.Secret{}
@@ -102,7 +102,7 @@ func assertServiceAccountAndUpdateSecret(ctx goctx.Context, ctrlClient client.Cl
 	Expect(ctrlClient.Update(ctx, secret)).To(Succeed())
 }
 
-func assertTargetSecret(ctx goctx.Context, guestClient client.Client, namespace, name string) {
+func assertTargetSecret(ctx context.Context, guestClient client.Client, namespace, name string) {
 	secret := &corev1.Secret{}
 	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, secret)
 	EventuallyWithOffset(2, func() []byte {
@@ -145,7 +145,7 @@ func assertRoleBinding(_ *helpers.UnitTestContextForController, ctrlClient clien
 	opts := &client.ListOptions{
 		Namespace: namespace,
 	}
-	err := ctrlClient.List(goctx.TODO(), &roleBindingList, opts)
+	err := ctrlClient.List(context.TODO(), &roleBindingList, opts)
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(roleBindingList.Items).To(HaveLen(1))
 	Expect(roleBindingList.Items[0].Name).To(Equal(name))

--- a/controllers/vmware/test/controllers_suite_test.go
+++ b/controllers/vmware/test/controllers_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	goctx "context"
+	"context"
 	"encoding/json"
 	"os/exec"
 	"path"
@@ -43,7 +43,7 @@ import (
 var (
 	testEnv       *envtest.Environment
 	restConfig    *rest.Config
-	ctx, cancel   = goctx.WithCancel(goctx.Background())
+	ctx, cancel   = context.WithCancel(context.Background())
 	clusterAPIDir = findModuleDir("sigs.k8s.io/cluster-api")
 )
 

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -39,7 +39,7 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/controllers/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
@@ -57,7 +57,7 @@ import (
 
 // AddClusterControllerToManager adds the cluster controller to the provided
 // manager.
-func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr manager.Manager, clusterControlledType client.Object, options controller.Options) error {
+func AddClusterControllerToManager(controllerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterControlledType client.Object, options controller.Options) error {
 	supervisorBased, err := util.IsSupervisorType(clusterControlledType)
 	if err != nil {
 		return err
@@ -67,24 +67,24 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		clusterControlledTypeName = reflect.TypeOf(clusterControlledType).Elem().Name()
 		clusterControlledTypeGVK  = infrav1.GroupVersion.WithKind(clusterControlledTypeName)
 		controllerNameShort       = fmt.Sprintf("%s-controller", strings.ToLower(clusterControlledTypeName))
-		controllerNameLong        = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+		controllerNameLong        = fmt.Sprintf("%s/%s/%s", controllerCtx.Namespace, controllerCtx.Name, controllerNameShort)
 	)
 	if supervisorBased {
 		clusterControlledTypeGVK = vmwarev1.GroupVersion.WithKind(clusterControlledTypeName)
 		controllerNameShort = fmt.Sprintf("%s-supervisor-controller", strings.ToLower(clusterControlledTypeName))
-		controllerNameLong = fmt.Sprintf("%s/%s/%s", ctx.Namespace, ctx.Name, controllerNameShort)
+		controllerNameLong = fmt.Sprintf("%s/%s/%s", controllerCtx.Namespace, controllerCtx.Name, controllerNameShort)
 	}
 
 	// Build the controller context.
-	controllerContext := &context.ControllerContext{
-		ControllerManagerContext: ctx,
+	controllerContext := &capvcontext.ControllerContext{
+		ControllerManagerContext: controllerCtx,
 		Name:                     controllerNameShort,
 		Recorder:                 record.New(mgr.GetEventRecorderFor(controllerNameLong)),
-		Logger:                   ctx.Logger.WithName(controllerNameShort),
+		Logger:                   controllerCtx.Logger.WithName(controllerNameShort),
 	}
 
 	if supervisorBased {
-		networkProvider, err := inframanager.GetNetworkProvider(ctx)
+		networkProvider, err := inframanager.GetNetworkProvider(controllerCtx)
 		if err != nil {
 			return errors.Wrap(err, "failed to create a network provider")
 		}
@@ -102,7 +102,7 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 				&vmwarev1.VSphereMachine{},
 				handler.EnqueueRequestsFromMapFunc(reconciler.VSphereMachineToCluster),
 			).
-			WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), ctx.WatchFilterValue)).
+			WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(controllerCtx), controllerCtx.WatchFilterValue)).
 			Complete(reconciler)
 	}
 
@@ -110,7 +110,7 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		ControllerContext:       controllerContext,
 		clusterModuleReconciler: NewReconciler(controllerContext),
 	}
-	clusterToInfraFn := clusterToInfrastructureMapFunc(ctx)
+	clusterToInfraFn := clusterToInfrastructureMapFunc(controllerCtx)
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		// Watch the controlled, infrastructure resource.
 		For(clusterControlledType).
@@ -118,7 +118,7 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		// Watch the CAPI resource that owns this infrastructure resource.
 		Watches(
 			&clusterv1.Cluster{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx goctx.Context, o client.Object) []reconcile.Request {
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 				requests := clusterToInfraFn(ctx, o)
 				if requests == nil {
 					return nil
@@ -157,10 +157,10 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 		// should cause a resource to be synchronized, such as a goroutine
 		// waiting on some asynchronous, external task to complete.
 		WatchesRawSource(
-			&source.Channel{Source: ctx.GetGenericEventChannelFor(clusterControlledTypeGVK)},
+			&source.Channel{Source: controllerCtx.GetGenericEventChannelFor(clusterControlledTypeGVK)},
 			&handler.EnqueueRequestForObject{},
 		).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), ctx.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(controllerCtx), controllerCtx.WatchFilterValue)).
 		WithEventFilter(predicates.ResourceIsNotExternallyManaged(reconciler.Logger)).
 		Build(reconciler)
 	if err != nil {
@@ -173,7 +173,7 @@ func AddClusterControllerToManager(ctx *context.ControllerManagerContext, mgr ma
 	return nil
 }
 
-func clusterToInfrastructureMapFunc(managerContext *context.ControllerManagerContext) handler.MapFunc {
+func clusterToInfrastructureMapFunc(controllerCtx *capvcontext.ControllerManagerContext) handler.MapFunc {
 	gvk := infrav1.GroupVersion.WithKind(reflect.TypeOf(&infrav1.VSphereCluster{}).Elem().Name())
-	return clusterutilv1.ClusterToInfrastructureMapFunc(managerContext, gvk, managerContext.Client, &infrav1.VSphereCluster{})
+	return clusterutilv1.ClusterToInfrastructureMapFunc(controllerCtx, gvk, controllerCtx.Client, &infrav1.VSphereCluster{})
 }

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -18,7 +18,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -44,7 +44,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
@@ -55,13 +55,13 @@ import (
 const legacyIdentityFinalizer string = "identity/infrastructure.cluster.x-k8s.io"
 
 type clusterReconciler struct {
-	*context.ControllerContext
+	*capvcontext.ControllerContext
 
 	clusterModuleReconciler Reconciler
 }
 
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
-func (r clusterReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r clusterReconciler) Reconcile(_ context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	// Get the VSphereCluster resource for this request.
 	vsphereCluster := &infrav1.VSphereCluster{}
 	if err := r.Client.Get(r, req.NamespacedName, vsphereCluster); err != nil {
@@ -99,7 +99,7 @@ func (r clusterReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.
 	}
 
 	// Create the cluster context for this request.
-	clusterContext := &context.ClusterContext{
+	clusterContext := &capvcontext.ClusterContext{
 		ControllerContext: r.ControllerContext,
 		Cluster:           cluster,
 		VSphereCluster:    vsphereCluster,
@@ -138,13 +138,13 @@ func (r clusterReconciler) Reconcile(_ goctx.Context, req ctrl.Request) (_ ctrl.
 	return r.reconcileNormal(clusterContext)
 }
 
-func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconcile.Result, error) {
-	ctx.Logger.Info("Reconciling VSphereCluster delete")
+func (r clusterReconciler) reconcileDelete(clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {
+	clusterCtx.Logger.Info("Reconciling VSphereCluster delete")
 
-	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(ctx, ctx.Client, ctx.Cluster.Namespace, ctx.Cluster.Name)
+	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(clusterCtx, clusterCtx.Client, clusterCtx.Cluster.Namespace, clusterCtx.Cluster.Name)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err,
-			"unable to list VSphereMachines part of VSphereCluster %s/%s", ctx.VSphereCluster.Namespace, ctx.VSphereCluster.Name)
+			"unable to list VSphereMachines part of VSphereCluster %s/%s", clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
 	}
 
 	machineDeletionCount := 0
@@ -153,16 +153,16 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 		// If the VSphereMachine is not owned by the CAPI Machine object because the machine object was deleted
 		// before setting the owner references, then proceed with the deletion of the VSphereMachine object.
 		// This is required until CAPI has a solution for https://github.com/kubernetes-sigs/cluster-api/issues/5483
-		if clusterutilv1.IsOwnedByObject(vsphereMachine, ctx.VSphereCluster) && len(vsphereMachine.OwnerReferences) == 1 {
+		if clusterutilv1.IsOwnedByObject(vsphereMachine, clusterCtx.VSphereCluster) && len(vsphereMachine.OwnerReferences) == 1 {
 			machineDeletionCount++
 			// Remove the finalizer since VM creation wouldn't proceed
 			r.Logger.Info("Removing finalizer from VSphereMachine", "namespace", vsphereMachine.Namespace, "name", vsphereMachine.Name)
 			ctrlutil.RemoveFinalizer(vsphereMachine, infrav1.MachineFinalizer)
-			if err := r.Client.Update(ctx, vsphereMachine); err != nil {
+			if err := r.Client.Update(clusterCtx, vsphereMachine); err != nil {
 				return reconcile.Result{}, err
 			}
-			if err := r.Client.Delete(ctx, vsphereMachine); err != nil && !apierrors.IsNotFound(err) {
-				ctx.Logger.Error(err, "Failed to delete for VSphereMachine", "namespace", vsphereMachine.Namespace, "name", vsphereMachine.Name)
+			if err := r.Client.Delete(clusterCtx, vsphereMachine); err != nil && !apierrors.IsNotFound(err) {
+				clusterCtx.Logger.Error(err, "Failed to delete for VSphereMachine", "namespace", vsphereMachine.Namespace, "name", vsphereMachine.Name)
 				deletionErrors = append(deletionErrors, err)
 			}
 		}
@@ -172,29 +172,29 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 	}
 
 	if len(vsphereMachines)-machineDeletionCount > 0 {
-		ctx.Logger.Info("Waiting for VSphereMachines to be deleted", "count", len(vsphereMachines)-machineDeletionCount)
+		clusterCtx.Logger.Info("Waiting for VSphereMachines to be deleted", "count", len(vsphereMachines)-machineDeletionCount)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// The cluster module info needs to be reconciled before the secret deletion
 	// since it needs access to the vCenter instance to be able to perform LCM operations
 	// on the cluster modules.
-	affinityReconcileResult, err := r.reconcileClusterModules(ctx)
+	affinityReconcileResult, err := r.reconcileClusterModules(clusterCtx)
 	if err != nil {
 		return affinityReconcileResult, err
 	}
 
 	// Remove finalizer on Identity Secret
-	if identity.IsSecretIdentity(ctx.VSphereCluster) {
+	if identity.IsSecretIdentity(clusterCtx.VSphereCluster) {
 		secret := &corev1.Secret{}
 		secretKey := client.ObjectKey{
-			Namespace: ctx.VSphereCluster.Namespace,
-			Name:      ctx.VSphereCluster.Spec.IdentityRef.Name,
+			Namespace: clusterCtx.VSphereCluster.Namespace,
+			Name:      clusterCtx.VSphereCluster.Spec.IdentityRef.Name,
 		}
-		err := ctx.Client.Get(ctx, secretKey, secret)
+		err := clusterCtx.Client.Get(clusterCtx, secretKey, secret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				ctrlutil.RemoveFinalizer(ctx.VSphereCluster, infrav1.ClusterFinalizer)
+				ctrlutil.RemoveFinalizer(clusterCtx.VSphereCluster, infrav1.ClusterFinalizer)
 				return reconcile.Result{}, nil
 			}
 			return reconcile.Result{}, err
@@ -207,90 +207,90 @@ func (r clusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconci
 		if ctrlutil.ContainsFinalizer(secret, legacyIdentityFinalizer) {
 			ctrlutil.RemoveFinalizer(secret, legacyIdentityFinalizer)
 		}
-		if err := ctx.Client.Update(ctx, secret); err != nil {
+		if err := clusterCtx.Client.Update(clusterCtx, secret); err != nil {
 			return reconcile.Result{}, err
 		}
-		if err := ctx.Client.Delete(ctx, secret); err != nil {
+		if err := clusterCtx.Client.Delete(clusterCtx, secret); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
 	// Cluster is deleted so remove the finalizer.
-	ctrlutil.RemoveFinalizer(ctx.VSphereCluster, infrav1.ClusterFinalizer)
+	ctrlutil.RemoveFinalizer(clusterCtx.VSphereCluster, infrav1.ClusterFinalizer)
 
 	return reconcile.Result{}, nil
 }
 
-func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconcile.Result, error) {
-	ctx.Logger.Info("Reconciling VSphereCluster")
+func (r clusterReconciler) reconcileNormal(clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {
+	clusterCtx.Logger.Info("Reconciling VSphereCluster")
 
-	ok, err := r.reconcileDeploymentZones(ctx)
+	ok, err := r.reconcileDeploymentZones(clusterCtx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	if !ok {
-		ctx.Logger.Info("waiting for failure domains to be reconciled")
+		clusterCtx.Logger.Info("waiting for failure domains to be reconciled")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	if err := r.reconcileIdentitySecret(ctx); err != nil {
-		conditions.MarkFalse(ctx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
+	if err := r.reconcileIdentitySecret(clusterCtx); err != nil {
+		conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, err
 	}
 
-	vcenterSession, err := r.reconcileVCenterConnectivity(ctx)
+	vcenterSession, err := r.reconcileVCenterConnectivity(clusterCtx)
 	if err != nil {
-		conditions.MarkFalse(ctx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
+		conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.VCenterAvailableCondition, infrav1.VCenterUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrapf(err,
-			"unexpected error while probing vcenter for %s", ctx)
+			"unexpected error while probing vcenter for %s", clusterCtx)
 	}
-	conditions.MarkTrue(ctx.VSphereCluster, infrav1.VCenterAvailableCondition)
+	conditions.MarkTrue(clusterCtx.VSphereCluster, infrav1.VCenterAvailableCondition)
 
-	err = r.reconcileVCenterVersion(ctx, vcenterSession)
-	if err != nil || ctx.VSphereCluster.Status.VCenterVersion == "" {
-		conditions.MarkFalse(ctx.VSphereCluster, infrav1.ClusterModulesAvailableCondition, infrav1.MissingVCenterVersionReason, clusterv1.ConditionSeverityWarning, "vCenter API version not set")
-		ctx.Logger.Error(err, "could not reconcile vCenter version")
+	err = r.reconcileVCenterVersion(clusterCtx, vcenterSession)
+	if err != nil || clusterCtx.VSphereCluster.Status.VCenterVersion == "" {
+		conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition, infrav1.MissingVCenterVersionReason, clusterv1.ConditionSeverityWarning, "vCenter API version not set")
+		clusterCtx.Logger.Error(err, "could not reconcile vCenter version")
 	}
 
-	affinityReconcileResult, err := r.reconcileClusterModules(ctx)
+	affinityReconcileResult, err := r.reconcileClusterModules(clusterCtx)
 	if err != nil {
-		conditions.MarkFalse(ctx.VSphereCluster, infrav1.ClusterModulesAvailableCondition, infrav1.ClusterModuleSetupFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+		conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition, infrav1.ClusterModuleSetupFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 		return affinityReconcileResult, err
 	}
 
-	ctx.VSphereCluster.Status.Ready = true
+	clusterCtx.VSphereCluster.Status.Ready = true
 
 	// Ensure the VSphereCluster is reconciled when the API server first comes online.
 	// A reconcile event will only be triggered if the Cluster is not marked as
 	// ControlPlaneInitialized.
-	r.reconcileVSphereClusterWhenAPIServerIsOnline(ctx)
-	if ctx.VSphereCluster.Spec.ControlPlaneEndpoint.IsZero() {
-		ctx.Logger.Info("control plane endpoint is not reconciled")
+	r.reconcileVSphereClusterWhenAPIServerIsOnline(clusterCtx)
+	if clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.IsZero() {
+		clusterCtx.Logger.Info("control plane endpoint is not reconciled")
 		return reconcile.Result{}, nil
 	}
 
 	// If the cluster is deleted, that's mean that the workload cluster is being deleted and so the CCM/CSI instances
-	if !ctx.Cluster.DeletionTimestamp.IsZero() {
+	if !clusterCtx.Cluster.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}
 
 	// Wait until the API server is online and accessible.
-	if !r.isAPIServerOnline(ctx) {
+	if !r.isAPIServerOnline(clusterCtx) {
 		return reconcile.Result{}, nil
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (r clusterReconciler) reconcileIdentitySecret(ctx *context.ClusterContext) error {
-	vsphereCluster := ctx.VSphereCluster
+func (r clusterReconciler) reconcileIdentitySecret(clusterCtx *capvcontext.ClusterContext) error {
+	vsphereCluster := clusterCtx.VSphereCluster
 	if identity.IsSecretIdentity(vsphereCluster) {
 		secret := &corev1.Secret{}
 		secretKey := client.ObjectKey{
 			Namespace: vsphereCluster.Namespace,
 			Name:      vsphereCluster.Spec.IdentityRef.Name,
 		}
-		err := ctx.Client.Get(ctx, secretKey, secret)
+		err := clusterCtx.Client.Get(clusterCtx, secretKey, secret)
 		if err != nil {
 			return err
 		}
@@ -312,7 +312,7 @@ func (r clusterReconciler) reconcileIdentitySecret(ctx *context.ClusterContext) 
 		if !ctrlutil.ContainsFinalizer(secret, infrav1.SecretIdentitySetFinalizer) {
 			ctrlutil.AddFinalizer(secret, infrav1.SecretIdentitySetFinalizer)
 		}
-		err = r.Client.Update(ctx, secret)
+		err = r.Client.Update(clusterCtx, secret)
 		if err != nil {
 			return err
 		}
@@ -321,53 +321,53 @@ func (r clusterReconciler) reconcileIdentitySecret(ctx *context.ClusterContext) 
 	return nil
 }
 
-func (r clusterReconciler) reconcileVCenterConnectivity(ctx *context.ClusterContext) (*session.Session, error) {
+func (r clusterReconciler) reconcileVCenterConnectivity(clusterCtx *capvcontext.ClusterContext) (*session.Session, error) {
 	params := session.NewParams().
-		WithServer(ctx.VSphereCluster.Spec.Server).
-		WithThumbprint(ctx.VSphereCluster.Spec.Thumbprint).
+		WithServer(clusterCtx.VSphereCluster.Spec.Server).
+		WithThumbprint(clusterCtx.VSphereCluster.Spec.Thumbprint).
 		WithFeatures(session.Feature{
 			EnableKeepAlive:   r.EnableKeepAlive,
 			KeepAliveDuration: r.KeepAliveDuration,
 		})
 
-	if ctx.VSphereCluster.Spec.IdentityRef != nil {
-		creds, err := identity.GetCredentials(ctx, r.Client, ctx.VSphereCluster, r.Namespace)
+	if clusterCtx.VSphereCluster.Spec.IdentityRef != nil {
+		creds, err := identity.GetCredentials(clusterCtx, r.Client, clusterCtx.VSphereCluster, r.Namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		params = params.WithUserInfo(creds.Username, creds.Password)
-		return session.GetOrCreate(ctx, params)
+		return session.GetOrCreate(clusterCtx, params)
 	}
 
-	params = params.WithUserInfo(ctx.Username, ctx.Password)
-	return session.GetOrCreate(ctx, params)
+	params = params.WithUserInfo(clusterCtx.Username, clusterCtx.Password)
+	return session.GetOrCreate(clusterCtx, params)
 }
 
-func (r clusterReconciler) reconcileVCenterVersion(ctx *context.ClusterContext, s *session.Session) error {
+func (r clusterReconciler) reconcileVCenterVersion(clusterCtx *capvcontext.ClusterContext, s *session.Session) error {
 	version, err := s.GetVersion()
 	if err != nil {
 		return err
 	}
-	ctx.VSphereCluster.Status.VCenterVersion = version
+	clusterCtx.VSphereCluster.Status.VCenterVersion = version
 	return nil
 }
 
-func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext) (bool, error) {
+func (r clusterReconciler) reconcileDeploymentZones(clusterCtx *capvcontext.ClusterContext) (bool, error) {
 	// If there is no failure domain selector, we should simply skip it
-	if ctx.VSphereCluster.Spec.FailureDomainSelector == nil {
+	if clusterCtx.VSphereCluster.Spec.FailureDomainSelector == nil {
 		return true, nil
 	}
 
 	var opts client.ListOptions
 	var err error
-	opts.LabelSelector, err = metav1.LabelSelectorAsSelector(ctx.VSphereCluster.Spec.FailureDomainSelector)
+	opts.LabelSelector, err = metav1.LabelSelectorAsSelector(clusterCtx.VSphereCluster.Spec.FailureDomainSelector)
 	if err != nil {
 		return false, errors.Wrapf(err, "zone label selector is misconfigured")
 	}
 
 	var deploymentZoneList infrav1.VSphereDeploymentZoneList
-	err = r.Client.List(ctx, &deploymentZoneList, &opts)
+	err = r.Client.List(clusterCtx, &deploymentZoneList, &opts)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to list deployment zones")
 	}
@@ -375,7 +375,7 @@ func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext)
 	readyNotReported, notReady := 0, 0
 	failureDomains := clusterv1.FailureDomains{}
 	for _, zone := range deploymentZoneList.Items {
-		if zone.Spec.Server != ctx.VSphereCluster.Spec.Server {
+		if zone.Spec.Server != clusterCtx.VSphereCluster.Spec.Server {
 			continue
 		}
 
@@ -396,21 +396,21 @@ func (r clusterReconciler) reconcileDeploymentZones(ctx *context.ClusterContext)
 		notReady++
 	}
 
-	ctx.VSphereCluster.Status.FailureDomains = failureDomains
+	clusterCtx.VSphereCluster.Status.FailureDomains = failureDomains
 	if readyNotReported > 0 {
-		conditions.MarkFalse(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition, infrav1.WaitingForFailureDomainStatusReason, clusterv1.ConditionSeverityInfo, "waiting for failure domains to report ready status")
+		conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.FailureDomainsAvailableCondition, infrav1.WaitingForFailureDomainStatusReason, clusterv1.ConditionSeverityInfo, "waiting for failure domains to report ready status")
 		return false, nil
 	}
 
 	if len(failureDomains) > 0 {
 		if notReady > 0 {
-			conditions.MarkFalse(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition, infrav1.FailureDomainsSkippedReason, clusterv1.ConditionSeverityInfo, "one or more failure domains are not ready")
+			conditions.MarkFalse(clusterCtx.VSphereCluster, infrav1.FailureDomainsAvailableCondition, infrav1.FailureDomainsSkippedReason, clusterv1.ConditionSeverityInfo, "one or more failure domains are not ready")
 		} else {
-			conditions.MarkTrue(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
+			conditions.MarkTrue(clusterCtx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
 		}
 	} else {
 		// Remove the condition if failure domains do not exist
-		conditions.Delete(ctx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
+		conditions.Delete(clusterCtx.VSphereCluster, infrav1.FailureDomainsAvailableCondition)
 	}
 	return true, nil
 }
@@ -422,46 +422,46 @@ var (
 	apiServerTriggersMu sync.Mutex
 )
 
-func (r clusterReconciler) reconcileVSphereClusterWhenAPIServerIsOnline(ctx *context.ClusterContext) {
-	if conditions.IsTrue(ctx.Cluster, clusterv1.ControlPlaneInitializedCondition) {
-		ctx.Logger.Info("skipping reconcile when API server is online",
+func (r clusterReconciler) reconcileVSphereClusterWhenAPIServerIsOnline(clusterCtx *capvcontext.ClusterContext) {
+	if conditions.IsTrue(clusterCtx.Cluster, clusterv1.ControlPlaneInitializedCondition) {
+		clusterCtx.Logger.Info("skipping reconcile when API server is online",
 			"reason", "controlPlaneInitialized")
 		return
 	}
 	apiServerTriggersMu.Lock()
 	defer apiServerTriggersMu.Unlock()
-	if _, ok := apiServerTriggers[ctx.Cluster.UID]; ok {
-		ctx.Logger.Info("skipping reconcile when API server is online",
+	if _, ok := apiServerTriggers[clusterCtx.Cluster.UID]; ok {
+		clusterCtx.Logger.Info("skipping reconcile when API server is online",
 			"reason", "alreadyPolling")
 		return
 	}
-	apiServerTriggers[ctx.Cluster.UID] = struct{}{}
+	apiServerTriggers[clusterCtx.Cluster.UID] = struct{}{}
 	go func() {
 		// Block until the target API server is online.
-		ctx.Logger.Info("start polling API server for online check")
-		wait.PollUntilContextCancel(goctx.Background(), time.Second*1, true, func(goctx.Context) (bool, error) { return r.isAPIServerOnline(ctx), nil }) //nolint:errcheck
-		ctx.Logger.Info("stop polling API server for online check")
-		ctx.Logger.Info("triggering GenericEvent", "reason", "api-server-online")
-		eventChannel := ctx.GetGenericEventChannelFor(ctx.VSphereCluster.GetObjectKind().GroupVersionKind())
+		clusterCtx.Logger.Info("start polling API server for online check")
+		wait.PollUntilContextCancel(context.Background(), time.Second*1, true, func(context.Context) (bool, error) { return r.isAPIServerOnline(clusterCtx), nil }) //nolint:errcheck
+		clusterCtx.Logger.Info("stop polling API server for online check")
+		clusterCtx.Logger.Info("triggering GenericEvent", "reason", "api-server-online")
+		eventChannel := clusterCtx.GetGenericEventChannelFor(clusterCtx.VSphereCluster.GetObjectKind().GroupVersionKind())
 		eventChannel <- event.GenericEvent{
-			Object: ctx.VSphereCluster,
+			Object: clusterCtx.VSphereCluster,
 		}
 
 		// Once the control plane has been marked as initialized it is safe to
 		// remove the key from the map that prevents multiple goroutines from
 		// polling the API server to see if it is online.
-		ctx.Logger.Info("start polling for control plane initialized")
-		wait.PollUntilContextCancel(goctx.Background(), time.Second*1, true, func(goctx.Context) (bool, error) { return r.isControlPlaneInitialized(ctx), nil }) //nolint:errcheck
-		ctx.Logger.Info("stop polling for control plane initialized")
+		clusterCtx.Logger.Info("start polling for control plane initialized")
+		wait.PollUntilContextCancel(context.Background(), time.Second*1, true, func(context.Context) (bool, error) { return r.isControlPlaneInitialized(clusterCtx), nil }) //nolint:errcheck
+		clusterCtx.Logger.Info("stop polling for control plane initialized")
 		apiServerTriggersMu.Lock()
-		delete(apiServerTriggers, ctx.Cluster.UID)
+		delete(apiServerTriggers, clusterCtx.Cluster.UID)
 		apiServerTriggersMu.Unlock()
 	}()
 }
 
-func (r clusterReconciler) isAPIServerOnline(ctx *context.ClusterContext) bool {
-	if kubeClient, err := infrautilv1.NewKubeClient(ctx, ctx.Client, ctx.Cluster); err == nil {
-		if _, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
+func (r clusterReconciler) isAPIServerOnline(clusterCtx *capvcontext.ClusterContext) bool {
+	if kubeClient, err := infrautilv1.NewKubeClient(clusterCtx, clusterCtx.Client, clusterCtx.Cluster); err == nil {
+		if _, err := kubeClient.CoreV1().Nodes().List(clusterCtx, metav1.ListOptions{}); err == nil {
 			// The target cluster is online. To make sure the correct control
 			// plane endpoint information is logged, it is necessary to fetch
 			// an up-to-date Cluster resource. If this fails, then set the
@@ -469,14 +469,14 @@ func (r clusterReconciler) isAPIServerOnline(ctx *context.ClusterContext) bool {
 			// VSphereCluster resource, as it must have the correct information
 			// if the API server is online.
 			cluster := &clusterv1.Cluster{}
-			clusterKey := client.ObjectKey{Namespace: ctx.Cluster.Namespace, Name: ctx.Cluster.Name}
-			if err := ctx.Client.Get(ctx, clusterKey, cluster); err != nil {
-				cluster = ctx.Cluster.DeepCopy()
-				cluster.Spec.ControlPlaneEndpoint.Host = ctx.VSphereCluster.Spec.ControlPlaneEndpoint.Host
-				cluster.Spec.ControlPlaneEndpoint.Port = ctx.VSphereCluster.Spec.ControlPlaneEndpoint.Port
-				ctx.Logger.Error(err, "failed to get updated cluster object while checking if API server is online")
+			clusterKey := client.ObjectKey{Namespace: clusterCtx.Cluster.Namespace, Name: clusterCtx.Cluster.Name}
+			if err := clusterCtx.Client.Get(clusterCtx, clusterKey, cluster); err != nil {
+				cluster = clusterCtx.Cluster.DeepCopy()
+				cluster.Spec.ControlPlaneEndpoint.Host = clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.Host
+				cluster.Spec.ControlPlaneEndpoint.Port = clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.Port
+				clusterCtx.Logger.Error(err, "failed to get updated cluster object while checking if API server is online")
 			}
-			ctx.Logger.Info(
+			clusterCtx.Logger.Info(
 				"API server is online",
 				"controlPlaneEndpoint", cluster.Spec.ControlPlaneEndpoint.String())
 			return true
@@ -485,30 +485,30 @@ func (r clusterReconciler) isAPIServerOnline(ctx *context.ClusterContext) bool {
 	return false
 }
 
-func (r clusterReconciler) isControlPlaneInitialized(ctx *context.ClusterContext) bool {
+func (r clusterReconciler) isControlPlaneInitialized(clusterCtx *capvcontext.ClusterContext) bool {
 	cluster := &clusterv1.Cluster{}
-	clusterKey := client.ObjectKey{Namespace: ctx.Cluster.Namespace, Name: ctx.Cluster.Name}
-	if err := ctx.Client.Get(ctx, clusterKey, cluster); err != nil {
+	clusterKey := client.ObjectKey{Namespace: clusterCtx.Cluster.Namespace, Name: clusterCtx.Cluster.Name}
+	if err := clusterCtx.Client.Get(clusterCtx, clusterKey, cluster); err != nil {
 		if !apierrors.IsNotFound(err) {
-			ctx.Logger.Error(err, "failed to get updated cluster object while checking if control plane is initialized")
+			clusterCtx.Logger.Error(err, "failed to get updated cluster object while checking if control plane is initialized")
 			return false
 		}
-		ctx.Logger.Info("exiting early because cluster no longer exists")
+		clusterCtx.Logger.Info("exiting early because cluster no longer exists")
 		return true
 	}
-	return conditions.IsTrue(ctx.Cluster, clusterv1.ControlPlaneInitializedCondition)
+	return conditions.IsTrue(clusterCtx.Cluster, clusterv1.ControlPlaneInitializedCondition)
 }
 
-func setOwnerRefsOnVsphereMachines(ctx *context.ClusterContext) error {
-	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(ctx, ctx.Client, ctx.Cluster.Namespace, ctx.Cluster.Name)
+func setOwnerRefsOnVsphereMachines(clusterCtx *capvcontext.ClusterContext) error {
+	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(clusterCtx, clusterCtx.Client, clusterCtx.Cluster.Namespace, clusterCtx.Cluster.Name)
 	if err != nil {
 		return errors.Wrapf(err,
-			"unable to list VSphereMachines part of VSphereCluster %s/%s", ctx.VSphereCluster.Namespace, ctx.VSphereCluster.Name)
+			"unable to list VSphereMachines part of VSphereCluster %s/%s", clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
 	}
 
 	var patchErrors []error
 	for _, vsphereMachine := range vsphereMachines {
-		patchHelper, err := patch.NewHelper(vsphereMachine, ctx.Client)
+		patchHelper, err := patch.NewHelper(vsphereMachine, clusterCtx.Client)
 		if err != nil {
 			patchErrors = append(patchErrors, err)
 			continue
@@ -517,22 +517,22 @@ func setOwnerRefsOnVsphereMachines(ctx *context.ClusterContext) error {
 		vsphereMachine.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(
 			vsphereMachine.OwnerReferences,
 			metav1.OwnerReference{
-				APIVersion: ctx.VSphereCluster.APIVersion,
-				Kind:       ctx.VSphereCluster.Kind,
-				Name:       ctx.VSphereCluster.Name,
-				UID:        ctx.VSphereCluster.UID,
+				APIVersion: clusterCtx.VSphereCluster.APIVersion,
+				Kind:       clusterCtx.VSphereCluster.Kind,
+				Name:       clusterCtx.VSphereCluster.Name,
+				UID:        clusterCtx.VSphereCluster.UID,
 			}))
 
-		if err := patchHelper.Patch(ctx, vsphereMachine); err != nil {
+		if err := patchHelper.Patch(clusterCtx, vsphereMachine); err != nil {
 			patchErrors = append(patchErrors, err)
 		}
 	}
 	return kerrors.NewAggregate(patchErrors)
 }
 
-func (r clusterReconciler) reconcileClusterModules(ctx *context.ClusterContext) (reconcile.Result, error) {
+func (r clusterReconciler) reconcileClusterModules(clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {
 	if feature.Gates.Enabled(feature.NodeAntiAffinity) {
-		return r.clusterModuleReconciler.Reconcile(ctx)
+		return r.clusterModuleReconciler.Reconcile(clusterCtx)
 	}
 	return reconcile.Result{}, nil
 }
@@ -540,7 +540,7 @@ func (r clusterReconciler) reconcileClusterModules(ctx *context.ClusterContext) 
 // controlPlaneMachineToCluster is a handler.ToRequestsFunc to be used
 // to enqueue requests for reconciliation for VSphereCluster to update
 // its status.apiEndpoints field.
-func (r clusterReconciler) controlPlaneMachineToCluster(ctx goctx.Context, o client.Object) []ctrl.Request {
+func (r clusterReconciler) controlPlaneMachineToCluster(ctx context.Context, o client.Object) []ctrl.Request {
 	vsphereMachine, ok := o.(*infrav1.VSphereMachine)
 	if !ok {
 		r.Logger.Error(nil, fmt.Sprintf("expected a VSphereMachine but got a %T", o))
@@ -602,7 +602,7 @@ func (r clusterReconciler) controlPlaneMachineToCluster(ctx goctx.Context, o cli
 	}}
 }
 
-func (r clusterReconciler) deploymentZoneToCluster(ctx goctx.Context, o client.Object) []ctrl.Request {
+func (r clusterReconciler) deploymentZoneToCluster(ctx context.Context, o client.Object) []ctrl.Request {
 	var requests []ctrl.Request
 	obj, ok := o.(*infrav1.VSphereDeploymentZone)
 	if !ok {

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,7 +31,7 @@ import (
 )
 
 var _ = Describe("VSphereClusterIdentity Reconciler", func() {
-	ctx := goctx.Background()
+	ctx := context.Background()
 	controllerNamespace := testEnv.Manager.GetContext().Namespace
 
 	Context("Reconcile Normal", func() {

--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -24,107 +24,107 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/cluster"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/metadata"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/taggable"
 )
 
-func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(ctx *context.VSphereDeploymentZoneContext) error {
-	logger := ctrl.LoggerFrom(ctx).WithValues("failure domain", ctx.VSphereFailureDomain.Name)
+func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext) error {
+	logger := ctrl.LoggerFrom(deploymentZoneCtx).WithValues("failure domain", deploymentZoneCtx.VSphereFailureDomain.Name)
 
 	// verify the failure domain for the region
-	if err := r.reconcileInfraFailureDomain(ctx, ctx.VSphereFailureDomain.Spec.Region); err != nil {
-		conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.RegionMisconfiguredReason, clusterv1.ConditionSeverityError, err.Error())
+	if err := r.reconcileInfraFailureDomain(deploymentZoneCtx, deploymentZoneCtx.VSphereFailureDomain.Spec.Region); err != nil {
+		conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.RegionMisconfiguredReason, clusterv1.ConditionSeverityError, err.Error())
 		logger.Error(err, "region is not configured correctly")
 		return errors.Wrapf(err, "region is not configured correctly")
 	}
 
 	// verify the failure domain for the zone
-	if err := r.reconcileInfraFailureDomain(ctx, ctx.VSphereFailureDomain.Spec.Zone); err != nil {
-		conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ZoneMisconfiguredReason, clusterv1.ConditionSeverityError, err.Error())
+	if err := r.reconcileInfraFailureDomain(deploymentZoneCtx, deploymentZoneCtx.VSphereFailureDomain.Spec.Zone); err != nil {
+		conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ZoneMisconfiguredReason, clusterv1.ConditionSeverityError, err.Error())
 		logger.Error(err, "zone is not configured correctly")
 		return errors.Wrapf(err, "zone is not configured correctly")
 	}
 
-	if computeCluster := ctx.VSphereFailureDomain.Spec.Topology.ComputeCluster; computeCluster != nil {
-		if err := r.reconcileComputeCluster(ctx); err != nil {
+	if computeCluster := deploymentZoneCtx.VSphereFailureDomain.Spec.Topology.ComputeCluster; computeCluster != nil {
+		if err := r.reconcileComputeCluster(deploymentZoneCtx); err != nil {
 			logger.Error(err, "compute cluster is not configured correctly", "name", *computeCluster)
 			return errors.Wrap(err, "compute cluster is not configured correctly")
 		}
 	}
 
-	if err := r.reconcileTopology(ctx); err != nil {
+	if err := r.reconcileTopology(deploymentZoneCtx); err != nil {
 		logger.Error(err, "topology is not configured correctly")
 		return errors.Wrap(err, "topology is not configured correctly")
 	}
 	return nil
 }
 
-func (r vsphereDeploymentZoneReconciler) reconcileInfraFailureDomain(ctx *context.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
+func (r vsphereDeploymentZoneReconciler) reconcileInfraFailureDomain(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
 	if *failureDomain.AutoConfigure {
-		return r.createAndAttachMetadata(ctx, failureDomain)
+		return r.createAndAttachMetadata(deploymentZoneCtx, failureDomain)
 	}
-	return r.verifyFailureDomain(ctx, failureDomain)
+	return r.verifyFailureDomain(deploymentZoneCtx, failureDomain)
 }
 
-func (r vsphereDeploymentZoneReconciler) reconcileTopology(ctx *context.VSphereDeploymentZoneContext) error {
-	topology := ctx.VSphereFailureDomain.Spec.Topology
+func (r vsphereDeploymentZoneReconciler) reconcileTopology(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext) error {
+	topology := deploymentZoneCtx.VSphereFailureDomain.Spec.Topology
 	if datastore := topology.Datastore; datastore != "" {
-		if _, err := ctx.AuthSession.Finder.Datastore(ctx, datastore); err != nil {
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.DatastoreNotFoundReason, clusterv1.ConditionSeverityError, "datastore %s is misconfigured", datastore)
+		if _, err := deploymentZoneCtx.AuthSession.Finder.Datastore(deploymentZoneCtx, datastore); err != nil {
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.DatastoreNotFoundReason, clusterv1.ConditionSeverityError, "datastore %s is misconfigured", datastore)
 			return errors.Wrapf(err, "unable to find datastore %s", datastore)
 		}
 	}
 
 	for _, network := range topology.Networks {
-		if _, err := ctx.AuthSession.Finder.Network(ctx, network); err != nil {
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.NetworkNotFoundReason, clusterv1.ConditionSeverityError, "network %s is misconfigured", network)
+		if _, err := deploymentZoneCtx.AuthSession.Finder.Network(deploymentZoneCtx, network); err != nil {
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.NetworkNotFoundReason, clusterv1.ConditionSeverityError, "network %s is misconfigured", network)
 			return errors.Wrapf(err, "unable to find network %s", network)
 		}
 	}
 
 	if hostPlacementInfo := topology.Hosts; hostPlacementInfo != nil {
-		rule, err := cluster.VerifyAffinityRule(ctx, *topology.ComputeCluster, hostPlacementInfo.HostGroupName, hostPlacementInfo.VMGroupName)
+		rule, err := cluster.VerifyAffinityRule(deploymentZoneCtx, *topology.ComputeCluster, hostPlacementInfo.HostGroupName, hostPlacementInfo.VMGroupName)
 		switch {
 		case err != nil:
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.HostsMisconfiguredReason, clusterv1.ConditionSeverityError, "vm host affinity does not exist")
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.HostsMisconfiguredReason, clusterv1.ConditionSeverityError, "vm host affinity does not exist")
 			return err
 		case rule.Disabled():
-			ctrl.LoggerFrom(ctx).V(4).Info("warning: vm-host rule for the failure domain is disabled", "hostgroup", hostPlacementInfo.HostGroupName, "vmGroup", hostPlacementInfo.VMGroupName)
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.HostsAffinityMisconfiguredReason, clusterv1.ConditionSeverityWarning, "vm host affinity is disabled")
+			ctrl.LoggerFrom(deploymentZoneCtx).V(4).Info("warning: vm-host rule for the failure domain is disabled", "hostgroup", hostPlacementInfo.HostGroupName, "vmGroup", hostPlacementInfo.VMGroupName)
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.HostsAffinityMisconfiguredReason, clusterv1.ConditionSeverityWarning, "vm host affinity is disabled")
 		default:
-			conditions.MarkTrue(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+			conditions.MarkTrue(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
 		}
 	}
 	return nil
 }
 
-func (r vsphereDeploymentZoneReconciler) reconcileComputeCluster(ctx *context.VSphereDeploymentZoneContext) error {
-	computeCluster := ctx.VSphereFailureDomain.Spec.Topology.ComputeCluster
+func (r vsphereDeploymentZoneReconciler) reconcileComputeCluster(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext) error {
+	computeCluster := deploymentZoneCtx.VSphereFailureDomain.Spec.Topology.ComputeCluster
 	if computeCluster == nil {
 		return nil
 	}
 
-	ccr, err := ctx.AuthSession.Finder.ClusterComputeResource(ctx, *computeCluster)
+	ccr, err := deploymentZoneCtx.AuthSession.Finder.ClusterComputeResource(deploymentZoneCtx, *computeCluster)
 	if err != nil {
-		conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ComputeClusterNotFoundReason, clusterv1.ConditionSeverityError, "compute cluster %s not found", *computeCluster)
+		conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ComputeClusterNotFoundReason, clusterv1.ConditionSeverityError, "compute cluster %s not found", *computeCluster)
 		return errors.Wrap(err, "compute cluster not found")
 	}
 
-	if resourcePool := ctx.VSphereDeploymentZone.Spec.PlacementConstraint.ResourcePool; resourcePool != "" {
-		rp, err := ctx.AuthSession.Finder.ResourcePool(ctx, resourcePool)
+	if resourcePool := deploymentZoneCtx.VSphereDeploymentZone.Spec.PlacementConstraint.ResourcePool; resourcePool != "" {
+		rp, err := deploymentZoneCtx.AuthSession.Finder.ResourcePool(deploymentZoneCtx, resourcePool)
 		if err != nil {
 			return errors.Wrapf(err, "unable to find resource pool")
 		}
 
-		ref, err := rp.Owner(ctx)
+		ref, err := rp.Owner(deploymentZoneCtx)
 		if err != nil {
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ComputeClusterNotFoundReason, clusterv1.ConditionSeverityError, "resource pool owner not found")
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ComputeClusterNotFoundReason, clusterv1.ConditionSeverityError, "resource pool owner not found")
 			return errors.Wrap(err, "unable to find owner compute resource")
 		}
 		if ref.Reference() != ccr.Reference() {
-			conditions.MarkFalse(ctx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ResourcePoolNotFoundReason, clusterv1.ConditionSeverityError, "resource pool is not owned by compute cluster")
+			conditions.MarkFalse(deploymentZoneCtx.VSphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition, infrav1.ResourcePoolNotFoundReason, clusterv1.ConditionSeverityError, "resource pool is not owned by compute cluster")
 			return errors.Errorf("compute cluster %s does not own resource pool %s", *computeCluster, resourcePool)
 		}
 	}
@@ -133,19 +133,19 @@ func (r vsphereDeploymentZoneReconciler) reconcileComputeCluster(ctx *context.VS
 
 // verifyFailureDomain verifies the Failure Domain. It verifies the existence of tag and category specified and
 // checks whether the specified tags exist on the DataCenter or Compute Cluster or Hosts (in a HostGroup).
-func (r vsphereDeploymentZoneReconciler) verifyFailureDomain(ctx *context.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
-	if _, err := ctx.AuthSession.TagManager.GetTagForCategory(ctx, failureDomain.Name, failureDomain.TagCategory); err != nil {
+func (r vsphereDeploymentZoneReconciler) verifyFailureDomain(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
+	if _, err := deploymentZoneCtx.AuthSession.TagManager.GetTagForCategory(deploymentZoneCtx, failureDomain.Name, failureDomain.TagCategory); err != nil {
 		return errors.Wrapf(err, "failed to verify tag %s and category %s", failureDomain.Name, failureDomain.TagCategory)
 	}
 
-	objects, err := taggable.GetObjects(ctx, failureDomain.Type)
+	objects, err := taggable.GetObjects(deploymentZoneCtx, failureDomain.Type)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find object")
 	}
 
 	// All the objects should be associated to the tag
 	for _, obj := range objects {
-		hasTag, err := obj.HasTag(ctx, failureDomain.Name)
+		hasTag, err := obj.HasTag(deploymentZoneCtx, failureDomain.Name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to verify tag association")
 		}
@@ -156,21 +156,21 @@ func (r vsphereDeploymentZoneReconciler) verifyFailureDomain(ctx *context.VSpher
 	return nil
 }
 
-func (r vsphereDeploymentZoneReconciler) createAndAttachMetadata(ctx *context.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
-	logger := ctrl.LoggerFrom(ctx, "tag", failureDomain.Name, "category", failureDomain.TagCategory)
-	categoryID, err := metadata.CreateCategory(ctx, failureDomain.TagCategory, failureDomain.Type)
+func (r vsphereDeploymentZoneReconciler) createAndAttachMetadata(deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
+	logger := ctrl.LoggerFrom(deploymentZoneCtx, "tag", failureDomain.Name, "category", failureDomain.TagCategory)
+	categoryID, err := metadata.CreateCategory(deploymentZoneCtx, failureDomain.TagCategory, failureDomain.Type)
 	if err != nil {
 		logger.V(4).Error(err, "category creation failed")
 		return errors.Wrapf(err, "failed to create category %s", failureDomain.TagCategory)
 	}
-	err = metadata.CreateTag(ctx, failureDomain.Name, categoryID)
+	err = metadata.CreateTag(deploymentZoneCtx, failureDomain.Name, categoryID)
 	if err != nil {
 		logger.V(4).Error(err, "tag creation failed")
 		return errors.Wrapf(err, "failed to create tag %s", failureDomain.Name)
 	}
 
 	logger = logger.WithValues("type", failureDomain.Type)
-	objects, err := taggable.GetObjects(ctx, failureDomain.Type)
+	objects, err := taggable.GetObjects(deploymentZoneCtx, failureDomain.Type)
 	if err != nil {
 		logger.V(4).Error(err, "failed to find object")
 		return err
@@ -179,7 +179,7 @@ func (r vsphereDeploymentZoneReconciler) createAndAttachMetadata(ctx *context.VS
 	var errList []error
 	for _, obj := range objects {
 		logger.V(4).Info("attaching tag to object")
-		err := obj.AttachTag(ctx, failureDomain.Name)
+		err := obj.AttachTag(deploymentZoneCtx, failureDomain.Name)
 		if err != nil {
 			logger.V(4).Error(err, "failed to find object")
 			errList = append(errList, errors.Wrapf(err, "failed to attach tag"))

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
@@ -92,7 +92,7 @@ func ForComputeClusterZone(t *testing.T) {
 		},
 	}
 
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+	deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 		ControllerContext:    controllerCtx,
 		VSphereFailureDomain: vsphereFailureDomain,
 		Logger:               logr.Discard(),
@@ -176,7 +176,7 @@ func ForHostGroupZone(t *testing.T) {
 		},
 	}
 
-	deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+	deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 		ControllerContext:    controllerCtx,
 		VSphereFailureDomain: vsphereFailureDomain,
 		Logger:               logr.Discard(),
@@ -287,7 +287,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			Spec: tests[0].vsphereFailureDomainSpec,
 		}
 
-		deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:    controllerCtx,
 			VSphereFailureDomain: vsphereFailureDomain,
 			Logger:               logr.Discard(),
@@ -308,7 +308,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			Spec: tests[1].vsphereFailureDomainSpec,
 		}
 
-		deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:    controllerCtx,
 			VSphereFailureDomain: vsphereFailureDomain,
 			Logger:               logr.Discard(),
@@ -329,7 +329,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			Spec: tests[2].vsphereFailureDomainSpec,
 		}
 
-		deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:    controllerCtx,
 			VSphereFailureDomain: vsphereFailureDomain,
 			Logger:               logr.Discard(),

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vcsim"
 )
@@ -43,7 +43,7 @@ import (
 var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 	var (
 		simr *vcsim.Simulator
-		ctx  goctx.Context
+		ctx  context.Context
 
 		failureDomainKey, deploymentZoneKey client.ObjectKey
 
@@ -74,7 +74,7 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 			Expect(simr.Run(op, gbytes.NewBuffer(), gbytes.NewBuffer())).To(Succeed())
 		}
 
-		ctx = goctx.Background()
+		ctx = context.Background()
 	})
 
 	BeforeEach(func() {
@@ -555,7 +555,7 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 
 			controllerCtx := fake.NewControllerContext(mgmtContext)
 
-			deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext: controllerCtx,
 				VSphereDeploymentZone: &infrav1.VSphereDeploymentZone{Spec: infrav1.VSphereDeploymentZoneSpec{
 					Server:              simr.ServerURL().Host,
@@ -615,7 +615,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		t.Run("should block deletion", func(t *testing.T) {
 			mgmtContext := fake.NewControllerManagerContext(machineUsingDeplZone, vsphereFailureDomain)
 			controllerCtx := fake.NewControllerContext(mgmtContext)
-			deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
 				VSphereFailureDomain:  vsphereFailureDomain,
@@ -637,7 +637,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			mgmtContext := fake.NewControllerManagerContext(machineUsingDeplZone, vsphereFailureDomain)
 			controllerCtx := fake.NewControllerContext(mgmtContext)
-			deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
 				VSphereFailureDomain:  vsphereFailureDomain,
@@ -656,7 +656,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		machineNotUsingDeplZone := createMachine("machine-1", "cluster-1", "ns", false)
 		mgmtContext := fake.NewControllerManagerContext(machineNotUsingDeplZone, vsphereFailureDomain)
 		controllerCtx := fake.NewControllerContext(mgmtContext)
-		deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:     controllerCtx,
 			VSphereDeploymentZone: vsphereDeploymentZone,
 			VSphereFailureDomain:  vsphereFailureDomain,
@@ -673,7 +673,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 	t.Run("when no machines are present", func(t *testing.T) {
 		mgmtContext := fake.NewControllerManagerContext(vsphereFailureDomain)
 		controllerCtx := fake.NewControllerContext(mgmtContext)
-		deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:     controllerCtx,
 			VSphereDeploymentZone: vsphereDeploymentZone,
 			VSphereFailureDomain:  vsphereFailureDomain,
@@ -697,7 +697,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		t.Run("not used by other deployment zones", func(t *testing.T) {
 			mgmtContext := fake.NewControllerManagerContext(vsphereFailureDomain)
 			controllerCtx := fake.NewControllerContext(mgmtContext)
-			deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
 				VSphereFailureDomain:  vsphereFailureDomain,
@@ -719,7 +719,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			mgmtContext := fake.NewControllerManagerContext(vsphereFailureDomain)
 			controllerCtx := fake.NewControllerContext(mgmtContext)
-			deploymentZoneCtx := &context.VSphereDeploymentZoneContext{
+			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
 				VSphereFailureDomain:  vsphereFailureDomain,
@@ -732,7 +732,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			fetchedFailureDomain := &infrav1.VSphereFailureDomain{}
-			g.Expect(mgmtContext.Client.Get(goctx.Background(), client.ObjectKey{Name: vsphereFailureDomain.Name}, fetchedFailureDomain)).To(Succeed())
+			g.Expect(mgmtContext.Client.Get(context.Background(), client.ObjectKey{Name: vsphereFailureDomain.Name}, fetchedFailureDomain)).To(Succeed())
 			g.Expect(fetchedFailureDomain.OwnerReferences).To(HaveLen(1))
 		})
 	})

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
@@ -203,7 +203,7 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		controllerMgrContext.Password = password
 		controllerMgrContext.Username = simr.ServerURL().User.Username()
 
-		controllerContext := &context.ControllerContext{
+		controllerContext := &capvcontext.ControllerContext{
 			ControllerManagerContext: controllerMgrContext,
 			Recorder:                 record.New(apirecord.NewFakeRecorder(100)),
 			Logger:                   log.Log,
@@ -230,13 +230,13 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 			Network:  nil,
 		}, nil)
 		r := setupReconciler(fakeVMSvc)
-		_, err = r.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g := NewWithT(t)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(goctx.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
 
 		g.Expect(conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
 		vmProvisionCondition := conditions.Get(vm, infrav1.VMProvisionedCondition)
@@ -263,13 +263,13 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 			}},
 		}, nil)
 		r := setupReconciler(fakeVMSvc)
-		_, err = r.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g := NewWithT(t)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(goctx.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
 
 		g.Expect(conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
 		vmProvisionCondition := conditions.Get(vm, infrav1.VMProvisionedCondition)
@@ -311,16 +311,16 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 
 		g := NewWithT(t)
 
-		_, err := r.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).To(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(apierrors.IsNotFound(r.Client.Get(goctx.Background(), vmKey, vm))).To(BeTrue())
+		g.Expect(apierrors.IsNotFound(r.Client.Get(context.Background(), vmKey, vm))).To(BeTrue())
 
 		claim := &ipamv1.IPAddressClaim{}
 		ipacKey := util.ObjectKey(ipAddressClaim)
-		g.Expect(r.Client.Get(goctx.Background(), ipacKey, claim)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(context.Background(), ipacKey, claim)).NotTo(HaveOccurred())
 		g.Expect(claim.ObjectMeta.Finalizers).NotTo(ContainElement(infrav1.IPAddressClaimFinalizer))
 	})
 }
@@ -483,20 +483,20 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 		initObjs = append(initObjs, secret, vsphereVM, vsphereMachine, machine, cluster, vsphereCluster)
 		controllerMgrContext := fake.NewControllerManagerContext(initObjs...)
 
-		controllerContext := &context.ControllerContext{
+		controllerContext := &capvcontext.ControllerContext{
 			ControllerManagerContext: controllerMgrContext,
 			Recorder:                 record.New(apirecord.NewFakeRecorder(100)),
 			Logger:                   log.Log,
 		}
 		r := vmReconciler{ControllerContext: controllerContext}
 
-		_, err = r.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g := NewWithT(t)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(goctx.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
 		g.Expect(conditions.Has(vm, infrav1.VCenterAvailableCondition)).To(BeTrue())
 		vCenterCondition := conditions.Get(vm, infrav1.VCenterAvailableCondition)
 		g.Expect(vCenterCondition.Status).To(Equal(corev1.ConditionTrue))
@@ -519,14 +519,14 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 		initObjs = append(initObjs, secret, vsphereVM, vsphereMachine, machine, cluster, vsphereCluster)
 		controllerMgrContext := fake.NewControllerManagerContext(initObjs...)
 
-		controllerContext := &context.ControllerContext{
+		controllerContext := &capvcontext.ControllerContext{
 			ControllerManagerContext: controllerMgrContext,
 			Recorder:                 record.New(apirecord.NewFakeRecorder(100)),
 			Logger:                   log.Log,
 		}
 		r := vmReconciler{ControllerContext: controllerContext}
 
-		_, err = r.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g := NewWithT(t)
 		g.Expect(err).To(HaveOccurred())
 	},
@@ -570,7 +570,7 @@ func Test_reconcile(t *testing.T) {
 
 	setupReconciler := func(vmService services.VirtualMachineService, initObjs ...client.Object) vmReconciler {
 		return vmReconciler{
-			ControllerContext: &context.ControllerContext{
+			ControllerContext: &capvcontext.ControllerContext{
 				ControllerManagerContext: fake.NewControllerManagerContext(initObjs...),
 				Recorder:                 record.New(apirecord.NewFakeRecorder(100)),
 				Logger:                   log.Log,
@@ -590,7 +590,7 @@ func Test_reconcile(t *testing.T) {
 					State:    infrav1.VirtualMachineStateReady,
 				}, nil)
 				r := setupReconciler(fakeVMSvc, initObjs...)
-				_, err := r.reconcile(&context.VMContext{
+				_, err := r.reconcile(&capvcontext.VMContext{
 					ControllerContext: r.ControllerContext,
 					VSphereVM:         vsphereVM,
 					Logger:            r.Logger,
@@ -606,7 +606,7 @@ func Test_reconcile(t *testing.T) {
 			t.Run("when anti affinity feature gate is turned on", func(t *testing.T) {
 				_ = feature.MutableGates.Set("NodeAntiAffinity=true")
 				r := setupReconciler(new(fake_svc.VMService), initObjs...)
-				_, err := r.reconcile(&context.VMContext{
+				_, err := r.reconcile(&capvcontext.VMContext{
 					ControllerContext: r.ControllerContext,
 					VSphereVM:         vsphereVM,
 					Logger:            r.Logger,
@@ -632,7 +632,7 @@ func Test_reconcile(t *testing.T) {
 			}, nil)
 
 			r := setupReconciler(fakeVMSvc, objsWithHierarchy...)
-			_, err := r.reconcile(&context.VMContext{
+			_, err := r.reconcile(&capvcontext.VMContext{
 				ControllerContext: r.ControllerContext,
 				VSphereVM:         vsphereVM,
 				Logger:            r.Logger,
@@ -665,7 +665,7 @@ func Test_reconcile(t *testing.T) {
 			objsWithHierarchy = append(objsWithHierarchy, createMachineOwnerHierarchy(machine)...)
 
 			r := setupReconciler(fakeVMSvc, objsWithHierarchy...)
-			_, err := r.reconcile(&context.VMContext{
+			_, err := r.reconcile(&capvcontext.VMContext{
 				ControllerContext: r.ControllerContext,
 				VSphereVM:         deletedVM,
 				Logger:            r.Logger,
@@ -680,7 +680,7 @@ func Test_reconcile(t *testing.T) {
 
 		t.Run("when info cannot be fetched", func(t *testing.T) {
 			r := setupReconciler(fakeVMSvc, initObjs...)
-			_, err := r.reconcile(&context.VMContext{
+			_, err := r.reconcile(&capvcontext.VMContext{
 				ControllerContext: r.ControllerContext,
 				VSphereVM:         deletedVM,
 				Logger:            r.Logger,

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	goctx "context"
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -32,16 +32,16 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 	name, namespace := "test-vm", "my-namespace"
-	setup := func(vsphereVM *infrav1.VSphereVM, initObjects ...client.Object) *context.VMContext {
+	setup := func(vsphereVM *infrav1.VSphereVM, initObjects ...client.Object) *capvcontext.VMContext {
 		ctx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
-		return &context.VMContext{
+		return &capvcontext.VMContext{
 			ControllerContext: ctx,
 			VSphereVM:         vsphereVM,
 			Logger:            logr.Discard(),
@@ -84,7 +84,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(goctx.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
 			g.Expect(ipAddrClaimList.Items).To(gomega.HaveLen(3))
 
 			for idx := range ipAddrClaimList.Items {
@@ -133,7 +133,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(claimedCondition.Message).To(gomega.Equal("3/3 claims being processed"))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(goctx.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
 
 			for idx := range ipAddrClaimList.Items {
 				claim := ipAddrClaimList.Items[idx]
@@ -167,7 +167,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionTrue))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(goctx.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
 
 			for idx := range ipAddrClaimList.Items {
 				claim := ipAddrClaimList.Items[idx]

--- a/pkg/clustermodule/session.go
+++ b/pkg/clustermodule/session.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clustermodule
 
 import (
-	goctx "context"
+	"context"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -26,45 +26,45 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
-func fetchSessionForObject(ctx *context.ClusterContext, template *infrav1.VSphereMachineTemplate) (*session.Session, error) {
-	params := newParams(*ctx)
+func fetchSessionForObject(clusterCtx *capvcontext.ClusterContext, template *infrav1.VSphereMachineTemplate) (*session.Session, error) {
+	params := newParams(*clusterCtx)
 	// Datacenter is necessary since we use the finder.
 	params = params.WithDatacenter(template.Spec.Template.Spec.Datacenter)
 
-	return fetchSession(ctx, params)
+	return fetchSession(clusterCtx, params)
 }
 
-func newParams(ctx context.ClusterContext) *session.Params {
+func newParams(clusterCtx capvcontext.ClusterContext) *session.Params {
 	return session.NewParams().
-		WithServer(ctx.VSphereCluster.Spec.Server).
-		WithThumbprint(ctx.VSphereCluster.Spec.Thumbprint).
+		WithServer(clusterCtx.VSphereCluster.Spec.Server).
+		WithThumbprint(clusterCtx.VSphereCluster.Spec.Thumbprint).
 		WithFeatures(session.Feature{
-			EnableKeepAlive:   ctx.EnableKeepAlive,
-			KeepAliveDuration: ctx.KeepAliveDuration,
+			EnableKeepAlive:   clusterCtx.EnableKeepAlive,
+			KeepAliveDuration: clusterCtx.KeepAliveDuration,
 		})
 }
 
-func fetchSession(ctx *context.ClusterContext, params *session.Params) (*session.Session, error) {
-	if ctx.VSphereCluster.Spec.IdentityRef != nil {
-		creds, err := identity.GetCredentials(ctx, ctx.Client, ctx.VSphereCluster, ctx.Namespace)
+func fetchSession(clusterCtx *capvcontext.ClusterContext, params *session.Params) (*session.Session, error) {
+	if clusterCtx.VSphereCluster.Spec.IdentityRef != nil {
+		creds, err := identity.GetCredentials(clusterCtx, clusterCtx.Client, clusterCtx.VSphereCluster, clusterCtx.Namespace)
 		if err != nil {
 			return nil, err
 		}
 
 		params = params.WithUserInfo(creds.Username, creds.Password)
-		return session.GetOrCreate(ctx, params)
+		return session.GetOrCreate(clusterCtx, params)
 	}
 
-	params = params.WithUserInfo(ctx.Username, ctx.Password)
-	return session.GetOrCreate(ctx, params)
+	params = params.WithUserInfo(clusterCtx.Username, clusterCtx.Password)
+	return session.GetOrCreate(clusterCtx, params)
 }
 
-func fetchTemplateRef(ctx goctx.Context, c client.Client, input Wrapper) (*corev1.ObjectReference, error) {
+func fetchTemplateRef(ctx context.Context, c client.Client, input Wrapper) (*corev1.ObjectReference, error) {
 	obj := new(unstructured.Unstructured)
 	obj.SetAPIVersion(input.GetObjectKind().GroupVersionKind().GroupVersion().String())
 	obj.SetKind(input.GetObjectKind().GroupVersionKind().Kind)
@@ -81,9 +81,9 @@ func fetchTemplateRef(ctx goctx.Context, c client.Client, input Wrapper) (*corev
 	return &objRef, nil
 }
 
-func fetchMachineTemplate(ctx *context.ClusterContext, input Wrapper, templateName string) (*infrav1.VSphereMachineTemplate, error) {
+func fetchMachineTemplate(clusterCtx *capvcontext.ClusterContext, input Wrapper, templateName string) (*infrav1.VSphereMachineTemplate, error) {
 	template := &infrav1.VSphereMachineTemplate{}
-	if err := ctx.Client.Get(ctx, client.ObjectKey{
+	if err := clusterCtx.Client.Get(clusterCtx, client.ObjectKey{
 		Name:      templateName,
 		Namespace: input.GetNamespace(),
 	}, template); err != nil {

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fake
 
 import (
-	goctx "context"
+	"context"
 
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +32,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 )
 
@@ -40,7 +40,7 @@ import (
 // testing reconcilers and webhooks with a fake client. You can choose to
 // initialize it with a slice of runtime.Object.
 
-func NewControllerManagerContext(initObjects ...client.Object) *context.ControllerManagerContext {
+func NewControllerManagerContext(initObjects ...client.Object) *capvcontext.ControllerManagerContext {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
@@ -55,8 +55,8 @@ func NewControllerManagerContext(initObjects ...client.Object) *context.Controll
 		&vmwarev1.VSphereCluster{},
 	).WithObjects(initObjects...).Build()
 
-	return &context.ControllerManagerContext{
-		Context:                 goctx.Background(),
+	return &capvcontext.ControllerManagerContext{
+		Context:                 context.Background(),
 		Client:                  clientWithObjects,
 		Logger:                  ctrllog.Log.WithName(ControllerManagerName),
 		Scheme:                  scheme,

--- a/pkg/identity/identity_suite_test.go
+++ b/pkg/identity/identity_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package identity
 
 import (
-	goctx "context"
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -44,7 +44,7 @@ var (
 	scheme    = runtime.NewScheme()
 	env       *envtest.Environment
 	k8sclient client.Client
-	ctx       goctx.Context
+	ctx       context.Context
 )
 
 func getTestEnv() *envtest.Environment {
@@ -75,7 +75,7 @@ func TestIdentity(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	By("Creating new test environment")
-	ctx = goctx.Background()
+	ctx = context.Background()
 	env = getTestEnv()
 	cfg, err := env.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/services/fake/vmservice.go
+++ b/pkg/services/fake/vmservice.go
@@ -28,12 +28,12 @@ type VMService struct {
 	mock.Mock
 }
 
-func (v *VMService) ReconcileVM(ctx *context.VMContext) (infrav1.VirtualMachine, error) {
-	args := v.Called(ctx)
+func (v *VMService) ReconcileVM(vmCtx *context.VMContext) (infrav1.VirtualMachine, error) {
+	args := v.Called(vmCtx)
 	return args.Get(0).(infrav1.VirtualMachine), args.Error(1)
 }
 
-func (v *VMService) DestroyVM(ctx *context.VMContext) (reconcile.Result, infrav1.VirtualMachine, error) {
-	args := v.Called(ctx)
+func (v *VMService) DestroyVM(vmCtx *context.VMContext) (reconcile.Result, infrav1.VirtualMachine, error) {
+	args := v.Called(vmCtx)
 	return args.Get(0).(reconcile.Result), args.Get(1).(infrav1.VirtualMachine), args.Error(2)
 }

--- a/pkg/services/govmomi/power_test.go
+++ b/pkg/services/govmomi/power_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package govmomi
 
 import (
-	goctx "context"
+	"context"
 	"testing"
 	"time"
 
@@ -147,7 +147,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())
@@ -176,7 +176,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())
@@ -213,7 +213,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())
@@ -250,7 +250,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())
@@ -287,7 +287,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())
@@ -315,7 +315,7 @@ func TestTriggerSoftPowerOff(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package govmomi
 
 import (
-	goctx "context"
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -31,16 +31,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 func emptyVirtualMachineContext() *virtualMachineContext {
 	return &virtualMachineContext{
-		VMContext: context.VMContext{
+		VMContext: capvcontext.VMContext{
 			Logger: logr.Discard(),
-			ControllerContext: &context.ControllerContext{
-				ControllerManagerContext: &context.ControllerManagerContext{
-					Context: goctx.TODO(),
+			ControllerContext: &capvcontext.ControllerContext{
+				ControllerManagerContext: &capvcontext.ControllerManagerContext{
+					Context: context.TODO(),
 				},
 			},
 		},
@@ -63,7 +63,7 @@ func Test_reconcilePCIDevices(t *testing.T) {
 		g = NewWithT(t)
 		before()
 
-		simulator.Run(func(ctx goctx.Context, c *vim25.Client) error {
+		simulator.Run(func(ctx context.Context, c *vim25.Client) error {
 			finder := find.NewFinder(c)
 			vm, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
 			g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -17,7 +17,7 @@ limitations under the License.
 package services
 
 import (
-	goctx "context"
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -37,21 +37,21 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 type VimMachineService struct{}
 
-func (v *VimMachineService) FetchVSphereMachine(c client.Client, name types.NamespacedName) (context.MachineContext, error) {
+func (v *VimMachineService) FetchVSphereMachine(c client.Client, name types.NamespacedName) (capvcontext.MachineContext, error) {
 	vsphereMachine := &infrav1.VSphereMachine{}
-	err := c.Get(goctx.Background(), name, vsphereMachine)
+	err := c.Get(context.Background(), name, vsphereMachine)
 
-	return &context.VIMMachineContext{VSphereMachine: vsphereMachine}, err
+	return &capvcontext.VIMMachineContext{VSphereMachine: vsphereMachine}, err
 }
 
-func (v *VimMachineService) FetchVSphereCluster(c client.Client, cluster *clusterv1.Cluster, machineContext context.MachineContext) (context.MachineContext, error) {
-	ctx, ok := machineContext.(*context.VIMMachineContext)
+func (v *VimMachineService) FetchVSphereCluster(c client.Client, cluster *clusterv1.Cluster, machineContext capvcontext.MachineContext) (capvcontext.MachineContext, error) {
+	vimMachineCtx, ok := machineContext.(*capvcontext.VIMMachineContext)
 	if !ok {
 		return nil, errors.New("received unexpected VIMMachineContext type")
 	}
@@ -60,19 +60,19 @@ func (v *VimMachineService) FetchVSphereCluster(c client.Client, cluster *cluste
 		Namespace: machineContext.GetObjectMeta().Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
-	err := c.Get(goctx.Background(), vsphereClusterName, vsphereCluster)
+	err := c.Get(context.Background(), vsphereClusterName, vsphereCluster)
 
-	ctx.VSphereCluster = vsphereCluster
-	return ctx, err
+	vimMachineCtx.VSphereCluster = vsphereCluster
+	return vimMachineCtx, err
 }
 
-func (v *VimMachineService) ReconcileDelete(c context.MachineContext) error {
-	ctx, ok := c.(*context.VIMMachineContext)
+func (v *VimMachineService) ReconcileDelete(machineCtx capvcontext.MachineContext) error {
+	vimMachineCtx, ok := machineCtx.(*capvcontext.VIMMachineContext)
 	if !ok {
 		return errors.New("received unexpected VIMMachineContext type")
 	}
 
-	vm, err := v.findVSphereVM(ctx)
+	vm, err := v.findVSphereVM(vimMachineCtx)
 	// Attempt to find the associated VSphereVM resource.
 	if err != nil {
 		return err
@@ -81,49 +81,49 @@ func (v *VimMachineService) ReconcileDelete(c context.MachineContext) error {
 	if vm != nil && vm.GetDeletionTimestamp().IsZero() {
 		// If the VSphereVM was found and it's not already enqueued for
 		// deletion, go ahead and attempt to delete it.
-		if err := ctx.Client.Delete(ctx, vm); err != nil {
+		if err := vimMachineCtx.Client.Delete(vimMachineCtx, vm); err != nil {
 			return err
 		}
 	}
 
 	// VSphereMachine wraps a VMSphereVM, so we are mirroring status from the underlying VMSphereVM
 	// in order to provide evidences about machine deletion.
-	conditions.SetMirror(ctx.VSphereMachine, infrav1.VMProvisionedCondition, vm)
+	conditions.SetMirror(vimMachineCtx.VSphereMachine, infrav1.VMProvisionedCondition, vm)
 	return nil
 }
 
-func (v *VimMachineService) SyncFailureReason(c context.MachineContext) (bool, error) {
-	ctx, ok := c.(*context.VIMMachineContext)
+func (v *VimMachineService) SyncFailureReason(machineCtx capvcontext.MachineContext) (bool, error) {
+	vimMachineCtx, ok := machineCtx.(*capvcontext.VIMMachineContext)
 	if !ok {
 		return false, errors.New("received unexpected VIMMachineContext type")
 	}
 
-	vsphereVM, err := v.findVSphereVM(ctx)
+	vsphereVM, err := v.findVSphereVM(vimMachineCtx)
 	if err != nil {
 		return false, err
 	}
 	if vsphereVM != nil {
 		// Reconcile VSphereMachine's failures
-		ctx.VSphereMachine.Status.FailureReason = vsphereVM.Status.FailureReason
-		ctx.VSphereMachine.Status.FailureMessage = vsphereVM.Status.FailureMessage
+		vimMachineCtx.VSphereMachine.Status.FailureReason = vsphereVM.Status.FailureReason
+		vimMachineCtx.VSphereMachine.Status.FailureMessage = vsphereVM.Status.FailureMessage
 	}
 
-	return ctx.VSphereMachine.Status.FailureReason != nil || ctx.VSphereMachine.Status.FailureMessage != nil, err
+	return vimMachineCtx.VSphereMachine.Status.FailureReason != nil || vimMachineCtx.VSphereMachine.Status.FailureMessage != nil, err
 }
 
-func (v *VimMachineService) ReconcileNormal(c context.MachineContext) (bool, error) {
-	ctx, ok := c.(*context.VIMMachineContext)
+func (v *VimMachineService) ReconcileNormal(machineCtx capvcontext.MachineContext) (bool, error) {
+	vimMachineCtx, ok := machineCtx.(*capvcontext.VIMMachineContext)
 	if !ok {
 		return false, errors.New("received unexpected VIMMachineContext type")
 	}
-	vsphereVM, err := v.findVSphereVM(ctx)
+	vsphereVM, err := v.findVSphereVM(vimMachineCtx)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
 
-	vm, err := v.createOrPatchVSphereVM(ctx, vsphereVM)
+	vm, err := v.createOrPatchVSphereVM(vimMachineCtx, vsphereVM)
 	if err != nil {
-		ctx.Logger.Error(err, "error creating or patching VM", "vsphereVM", vsphereVM)
+		vimMachineCtx.Logger.Error(err, "error creating or patching VM", "vsphereVM", vsphereVM)
 		return false, err
 	}
 
@@ -140,50 +140,50 @@ func (v *VimMachineService) ReconcileNormal(c context.MachineContext) (bool, err
 	vmObj.SetKind(vm.GetObjectKind().GroupVersionKind().Kind)
 
 	// Waits the VM's ready state.
-	if ok, err := v.waitReadyState(ctx, vmObj); !ok {
+	if ok, err := v.waitReadyState(vimMachineCtx, vmObj); !ok {
 		if err != nil {
-			return false, errors.Wrapf(err, "unexpected error while reconciling ready state for %s", ctx)
+			return false, errors.Wrapf(err, "unexpected error while reconciling ready state for %s", vimMachineCtx)
 		}
-		ctx.Logger.Info("waiting for ready state")
+		vimMachineCtx.Logger.Info("waiting for ready state")
 		// VSphereMachine wraps a VMSphereVM, so we are mirroring status from the underlying VMSphereVM
 		// in order to provide evidences about machine provisioning while provisioning is actually happening.
-		conditions.SetMirror(ctx.VSphereMachine, infrav1.VMProvisionedCondition, conditions.UnstructuredGetter(vmObj))
+		conditions.SetMirror(vimMachineCtx.VSphereMachine, infrav1.VMProvisionedCondition, conditions.UnstructuredGetter(vmObj))
 		return true, nil
 	}
 
 	// Reconcile the VSphereMachine's provider ID using the VM's BIOS UUID.
-	if ok, err := v.reconcileProviderID(ctx, vmObj); !ok {
+	if ok, err := v.reconcileProviderID(vimMachineCtx, vmObj); !ok {
 		if err != nil {
-			return false, errors.Wrapf(err, "unexpected error while reconciling provider ID for %s", ctx)
+			return false, errors.Wrapf(err, "unexpected error while reconciling provider ID for %s", vimMachineCtx)
 		}
-		ctx.Logger.Info("provider ID is not reconciled")
+		vimMachineCtx.Logger.Info("provider ID is not reconciled")
 		return true, nil
 	}
 
 	// Reconcile the VSphereMachine's node addresses from the VM's IP addresses.
-	if ok, err := v.reconcileNetwork(ctx, vmObj); !ok {
+	if ok, err := v.reconcileNetwork(vimMachineCtx, vmObj); !ok {
 		if err != nil {
-			return false, errors.Wrapf(err, "unexpected error while reconciling network for %s", ctx)
+			return false, errors.Wrapf(err, "unexpected error while reconciling network for %s", vimMachineCtx)
 		}
-		ctx.Logger.Info("network is not reconciled")
-		conditions.MarkFalse(ctx.VSphereMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForNetworkAddressesReason, clusterv1.ConditionSeverityInfo, "")
+		vimMachineCtx.Logger.Info("network is not reconciled")
+		conditions.MarkFalse(vimMachineCtx.VSphereMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForNetworkAddressesReason, clusterv1.ConditionSeverityInfo, "")
 		return true, nil
 	}
 
-	ctx.VSphereMachine.Status.Ready = true
+	vimMachineCtx.VSphereMachine.Status.Ready = true
 	return false, nil
 }
 
-func (v *VimMachineService) GetHostInfo(c context.MachineContext) (string, error) {
-	ctx, ok := c.(*context.VIMMachineContext)
+func (v *VimMachineService) GetHostInfo(c capvcontext.MachineContext) (string, error) {
+	vimMachineCtx, ok := c.(*capvcontext.VIMMachineContext)
 	if !ok {
 		return "", errors.New("received unexpected VIMMachineContext type")
 	}
 
 	vsphereVM := &infrav1.VSphereVM{}
-	if err := ctx.Client.Get(ctx, client.ObjectKey{
-		Namespace: ctx.VSphereMachine.Namespace,
-		Name:      generateVMObjectName(ctx, ctx.Machine.Name),
+	if err := vimMachineCtx.Client.Get(vimMachineCtx, client.ObjectKey{
+		Namespace: vimMachineCtx.VSphereMachine.Namespace,
+		Name:      generateVMObjectName(vimMachineCtx, vimMachineCtx.Machine.Name),
 	}, vsphereVM); err != nil {
 		return "", err
 	}
@@ -191,25 +191,25 @@ func (v *VimMachineService) GetHostInfo(c context.MachineContext) (string, error
 	if conditions.IsTrue(vsphereVM, infrav1.VMProvisionedCondition) {
 		return vsphereVM.Status.Host, nil
 	}
-	ctx.Logger.V(4).Info("VMProvisionedCondition is set to false", "vsphereVM", vsphereVM.Name)
+	vimMachineCtx.Logger.V(4).Info("VMProvisionedCondition is set to false", "vsphereVM", vsphereVM.Name)
 	return "", nil
 }
 
-func (v *VimMachineService) findVSphereVM(ctx *context.VIMMachineContext) (*infrav1.VSphereVM, error) {
+func (v *VimMachineService) findVSphereVM(vimMachineCtx *capvcontext.VIMMachineContext) (*infrav1.VSphereVM, error) {
 	// Get ready to find the associated VSphereVM resource.
 	vm := &infrav1.VSphereVM{}
 	vmKey := types.NamespacedName{
-		Namespace: ctx.VSphereMachine.Namespace,
-		Name:      generateVMObjectName(ctx, ctx.Machine.Name),
+		Namespace: vimMachineCtx.VSphereMachine.Namespace,
+		Name:      generateVMObjectName(vimMachineCtx, vimMachineCtx.Machine.Name),
 	}
 	// Attempt to find the associated VSphereVM resource.
-	if err := ctx.Client.Get(ctx, vmKey, vm); err != nil {
+	if err := vimMachineCtx.Client.Get(vimMachineCtx, vmKey, vm); err != nil {
 		return nil, err
 	}
 	return vm, nil
 }
 
-func (v *VimMachineService) waitReadyState(ctx *context.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
+func (v *VimMachineService) waitReadyState(vimMachineCtx *capvcontext.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
 	ready, ok, err := unstructured.NestedBool(vm.Object, "status", "ready")
 	if !ok {
 		if err != nil {
@@ -218,16 +218,16 @@ func (v *VimMachineService) waitReadyState(ctx *context.VIMMachineContext, vm *u
 				vm.GroupVersionKind(),
 				vm.GetNamespace(),
 				vm.GetName(),
-				ctx)
+				vimMachineCtx)
 		}
-		ctx.Logger.Info("status.ready not found",
+		vimMachineCtx.Logger.Info("status.ready not found",
 			"vmGVK", vm.GroupVersionKind().String(),
 			"vmNamespace", vm.GetNamespace(),
 			"vmName", vm.GetName())
 		return false, nil
 	}
 	if !ready {
-		ctx.Logger.Info("status.ready is false",
+		vimMachineCtx.Logger.Info("status.ready is false",
 			"vmGVK", vm.GroupVersionKind().String(),
 			"vmNamespace", vm.GetNamespace(),
 			"vmName", vm.GetName())
@@ -237,7 +237,7 @@ func (v *VimMachineService) waitReadyState(ctx *context.VIMMachineContext, vm *u
 	return true, nil
 }
 
-func (v *VimMachineService) reconcileProviderID(ctx *context.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
+func (v *VimMachineService) reconcileProviderID(vimMachineCtx *capvcontext.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
 	biosUUID, ok, err := unstructured.NestedString(vm.Object, "spec", "biosUUID")
 	if !ok {
 		if err != nil {
@@ -246,16 +246,16 @@ func (v *VimMachineService) reconcileProviderID(ctx *context.VIMMachineContext, 
 				vm.GroupVersionKind(),
 				vm.GetNamespace(),
 				vm.GetName(),
-				ctx)
+				vimMachineCtx)
 		}
-		ctx.Logger.Info("spec.biosUUID not found",
+		vimMachineCtx.Logger.Info("spec.biosUUID not found",
 			"vmGVK", vm.GroupVersionKind().String(),
 			"vmNamespace", vm.GetNamespace(),
 			"vmName", vm.GetName())
 		return false, nil
 	}
 	if biosUUID == "" {
-		ctx.Logger.Info("spec.biosUUID is empty",
+		vimMachineCtx.Logger.Info("spec.biosUUID is empty",
 			"vmGVK", vm.GroupVersionKind().String(),
 			"vmNamespace", vm.GetNamespace(),
 			"vmName", vm.GetName())
@@ -269,24 +269,24 @@ func (v *VimMachineService) reconcileProviderID(ctx *context.VIMMachineContext, 
 			vm.GroupVersionKind(),
 			vm.GetNamespace(),
 			vm.GetName(),
-			ctx)
+			vimMachineCtx)
 	}
-	if ctx.VSphereMachine.Spec.ProviderID == nil || *ctx.VSphereMachine.Spec.ProviderID != providerID {
-		ctx.VSphereMachine.Spec.ProviderID = &providerID
-		ctx.Logger.Info("updated provider ID", "provider-id", providerID)
+	if vimMachineCtx.VSphereMachine.Spec.ProviderID == nil || *vimMachineCtx.VSphereMachine.Spec.ProviderID != providerID {
+		vimMachineCtx.VSphereMachine.Spec.ProviderID = &providerID
+		vimMachineCtx.Logger.Info("updated provider ID", "provider-id", providerID)
 	}
 
 	return true, nil
 }
 
 //nolint:nestif
-func (v *VimMachineService) reconcileNetwork(ctx *context.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
+func (v *VimMachineService) reconcileNetwork(vimMachineCtx *capvcontext.VIMMachineContext, vm *unstructured.Unstructured) (bool, error) {
 	var errs []error
 	if networkStatusListOfIfaces, ok, _ := unstructured.NestedSlice(vm.Object, "status", "network"); ok {
 		var networkStatusList []infrav1.NetworkStatus
 		for i, networkStatusListMemberIface := range networkStatusListOfIfaces {
 			if buf, err := json.Marshal(networkStatusListMemberIface); err != nil {
-				ctx.Logger.Error(err,
+				vimMachineCtx.Logger.Error(err,
 					"unsupported data for member of status.network list",
 					"index", i)
 				errs = append(errs, err)
@@ -298,7 +298,7 @@ func (v *VimMachineService) reconcileNetwork(ctx *context.VIMMachineContext, vm 
 					errs = append(errs, err)
 				}
 				if err != nil {
-					ctx.Logger.Error(err,
+					vimMachineCtx.Logger.Error(err,
 						"unsupported data for member of status.network list",
 						"index", i, "data", string(buf))
 					errs = append(errs, err)
@@ -307,7 +307,7 @@ func (v *VimMachineService) reconcileNetwork(ctx *context.VIMMachineContext, vm 
 				}
 			}
 		}
-		ctx.VSphereMachine.Status.Network = networkStatusList
+		vimMachineCtx.VSphereMachine.Status.Network = networkStatusList
 	}
 
 	if addresses, ok, _ := unstructured.NestedStringSlice(vm.Object, "status", "addresses"); ok {
@@ -318,23 +318,23 @@ func (v *VimMachineService) reconcileNetwork(ctx *context.VIMMachineContext, vm 
 				Address: addr,
 			})
 		}
-		ctx.VSphereMachine.Status.Addresses = machineAddresses
+		vimMachineCtx.VSphereMachine.Status.Addresses = machineAddresses
 	}
 
-	if len(ctx.VSphereMachine.Status.Addresses) == 0 {
-		ctx.Logger.Info("waiting on IP addresses")
+	if len(vimMachineCtx.VSphereMachine.Status.Addresses) == 0 {
+		vimMachineCtx.Logger.Info("waiting on IP addresses")
 		return false, kerrors.NewAggregate(errs)
 	}
 
 	return true, nil
 }
 
-func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContext, vsphereVM *infrav1.VSphereVM) (runtime.Object, error) {
+func (v *VimMachineService) createOrPatchVSphereVM(vimMachineCtx *capvcontext.VIMMachineContext, vsphereVM *infrav1.VSphereVM) (runtime.Object, error) {
 	// Create or update the VSphereVM resource.
 	vm := &infrav1.VSphereVM{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ctx.VSphereMachine.Namespace,
-			Name:      generateVMObjectName(ctx, ctx.Machine.Name),
+			Namespace: vimMachineCtx.VSphereMachine.Namespace,
+			Name:      generateVMObjectName(vimMachineCtx, vimMachineCtx.Machine.Name),
 		},
 	}
 	mutateFn := func() (err error) {
@@ -342,10 +342,10 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 		vm.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(
 			vm.OwnerReferences,
 			metav1.OwnerReference{
-				APIVersion: ctx.VSphereMachine.APIVersion,
-				Kind:       ctx.VSphereMachine.Kind,
-				Name:       ctx.VSphereMachine.Name,
-				UID:        ctx.VSphereMachine.UID,
+				APIVersion: vimMachineCtx.VSphereMachine.APIVersion,
+				Kind:       vimMachineCtx.VSphereMachine.Kind,
+				Name:       vimMachineCtx.VSphereMachine.Name,
+				UID:        vimMachineCtx.VSphereMachine.UID,
 			}))
 
 		// Instruct the VSphereVM to use the CAPI bootstrap data resource.
@@ -353,8 +353,8 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 		vm.Spec.BootstrapRef = &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Secret",
-			Name:       *ctx.Machine.Spec.Bootstrap.DataSecretName,
-			Namespace:  ctx.Machine.ObjectMeta.Namespace,
+			Name:       *vimMachineCtx.Machine.Spec.Bootstrap.DataSecretName,
+			Namespace:  vimMachineCtx.Machine.ObjectMeta.Namespace,
 		}
 
 		// Initialize the VSphereVM's labels map if it is nil.
@@ -364,20 +364,20 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 
 		// Ensure the VSphereVM has a label that can be used when searching for
 		// resources associated with the target cluster.
-		vm.Labels[clusterv1.ClusterNameLabel] = ctx.Machine.Labels[clusterv1.ClusterNameLabel]
+		vm.Labels[clusterv1.ClusterNameLabel] = vimMachineCtx.Machine.Labels[clusterv1.ClusterNameLabel]
 
 		// For convenience, add a label that makes it easy to figure out if the
 		// VSphereVM resource is part of some control plane.
-		if val, ok := ctx.Machine.Labels[clusterv1.MachineControlPlaneLabel]; ok {
+		if val, ok := vimMachineCtx.Machine.Labels[clusterv1.MachineControlPlaneLabel]; ok {
 			vm.Labels[clusterv1.MachineControlPlaneLabel] = val
 		}
 
 		// Copy the VSphereMachine's VM clone spec into the VSphereVM's
 		// clone spec.
-		ctx.VSphereMachine.Spec.VirtualMachineCloneSpec.DeepCopyInto(&vm.Spec.VirtualMachineCloneSpec)
+		vimMachineCtx.VSphereMachine.Spec.VirtualMachineCloneSpec.DeepCopyInto(&vm.Spec.VirtualMachineCloneSpec)
 
 		// If Failure Domain is present on CAPI machine, use that to override the vm clone spec.
-		if overrideFunc, ok := v.generateOverrideFunc(ctx); ok {
+		if overrideFunc, ok := v.generateOverrideFunc(vimMachineCtx); ok {
 			overrideFunc(vm)
 		}
 
@@ -388,16 +388,16 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 		//   2. From the VSphereMachine.Spec (the DeepCopyInto above)
 		//   3. From the VSphereCluster.Spec
 		if vm.Spec.Server == "" {
-			vm.Spec.Server = ctx.VSphereCluster.Spec.Server
+			vm.Spec.Server = vimMachineCtx.VSphereCluster.Spec.Server
 		}
 		if vm.Spec.Thumbprint == "" {
-			vm.Spec.Thumbprint = ctx.VSphereCluster.Spec.Thumbprint
+			vm.Spec.Thumbprint = vimMachineCtx.VSphereCluster.Spec.Thumbprint
 		}
 		if vsphereVM != nil {
 			vm.Spec.BiosUUID = vsphereVM.Spec.BiosUUID
 		}
-		vm.Spec.PowerOffMode = ctx.VSphereMachine.Spec.PowerOffMode
-		vm.Spec.GuestSoftPowerOffTimeout = ctx.VSphereMachine.Spec.GuestSoftPowerOffTimeout
+		vm.Spec.PowerOffMode = vimMachineCtx.VSphereMachine.Spec.PowerOffMode
+		vm.Spec.GuestSoftPowerOffTimeout = vimMachineCtx.VSphereMachine.Spec.GuestSoftPowerOffTimeout
 		return nil
 	}
 
@@ -405,9 +405,9 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 		Namespace: vm.Namespace,
 		Name:      vm.Name,
 	}
-	result, err := ctrlutil.CreateOrPatch(ctx, ctx.Client, vm, mutateFn)
+	result, err := ctrlutil.CreateOrPatch(vimMachineCtx, vimMachineCtx.Client, vm, mutateFn)
 	if err != nil {
-		ctx.Logger.Error(
+		vimMachineCtx.Logger.Error(
 			err,
 			"failed to CreateOrPatch VSphereVM",
 			"namespace",
@@ -419,31 +419,31 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 	}
 	switch result {
 	case ctrlutil.OperationResultNone:
-		ctx.Logger.Info(
+		vimMachineCtx.Logger.Info(
 			"no update required for vm",
 			"vm",
 			vmKey,
 		)
 	case ctrlutil.OperationResultCreated:
-		ctx.Logger.Info(
+		vimMachineCtx.Logger.Info(
 			"created vm",
 			"vm",
 			vmKey,
 		)
 	case ctrlutil.OperationResultUpdated:
-		ctx.Logger.Info(
+		vimMachineCtx.Logger.Info(
 			"updated vm",
 			"vm",
 			vmKey,
 		)
 	case ctrlutil.OperationResultUpdatedStatus:
-		ctx.Logger.Info(
+		vimMachineCtx.Logger.Info(
 			"updated vm and vm status",
 			"vm",
 			vmKey,
 		)
 	case ctrlutil.OperationResultUpdatedStatusOnly:
-		ctx.Logger.Info(
+		vimMachineCtx.Logger.Info(
 			"updated vm status",
 			"vm",
 			vmKey,
@@ -455,9 +455,9 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx *context.VIMMachineContex
 
 // generateVMObjectName returns a new VM object name in specific cases, otherwise return the same
 // passed in the parameter.
-func generateVMObjectName(ctx *context.VIMMachineContext, machineName string) string {
+func generateVMObjectName(vimMachineCtx *capvcontext.VIMMachineContext, machineName string) string {
 	// Windows VM names must have 15 characters length at max.
-	if ctx.VSphereMachine.Spec.OS == infrav1.Windows && len(machineName) > 15 {
+	if vimMachineCtx.VSphereMachine.Spec.OS == infrav1.Windows && len(machineName) > 15 {
 		return strings.TrimSuffix(machineName[0:9], "-") + "-" + machineName[len(machineName)-5:]
 	}
 	return machineName
@@ -467,22 +467,22 @@ func generateVMObjectName(ctx *context.VIMMachineContext, machineName string) st
 // with the values from the FailureDomain (if any) set on the owner CAPI machine.
 //
 //nolint:nestif
-func (v *VimMachineService) generateOverrideFunc(ctx *context.VIMMachineContext) (func(vm *infrav1.VSphereVM), bool) {
-	failureDomainName := ctx.Machine.Spec.FailureDomain
+func (v *VimMachineService) generateOverrideFunc(vimMachineCtx *capvcontext.VIMMachineContext) (func(vm *infrav1.VSphereVM), bool) {
+	failureDomainName := vimMachineCtx.Machine.Spec.FailureDomain
 	if failureDomainName == nil {
 		return nil, false
 	}
 
 	// Use the failureDomain name to fetch the vSphereDeploymentZone object
 	var vsphereDeploymentZone infrav1.VSphereDeploymentZone
-	if err := ctx.Client.Get(ctx, client.ObjectKey{Name: *failureDomainName}, &vsphereDeploymentZone); err != nil {
-		ctx.Logger.Error(err, "unable to fetch vsphere deployment zone", "name", *failureDomainName)
+	if err := vimMachineCtx.Client.Get(vimMachineCtx, client.ObjectKey{Name: *failureDomainName}, &vsphereDeploymentZone); err != nil {
+		vimMachineCtx.Logger.Error(err, "unable to fetch vsphere deployment zone", "name", *failureDomainName)
 		return nil, false
 	}
 
 	var vsphereFailureDomain infrav1.VSphereFailureDomain
-	if err := ctx.Client.Get(ctx, client.ObjectKey{Name: vsphereDeploymentZone.Spec.FailureDomain}, &vsphereFailureDomain); err != nil {
-		ctx.Logger.Error(err, "unable to fetch failure domain", "name", vsphereDeploymentZone.Spec.FailureDomain)
+	if err := vimMachineCtx.Client.Get(vimMachineCtx, client.ObjectKey{Name: vsphereDeploymentZone.Spec.FailureDomain}, &vsphereFailureDomain); err != nil {
+		vimMachineCtx.Logger.Error(err, "unable to fetch failure domain", "name", vsphereDeploymentZone.Spec.FailureDomain)
 		return nil, false
 	}
 

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -17,7 +17,7 @@ limitations under the License.
 package util
 
 import (
-	goctx "context"
+	"context"
 
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
@@ -33,7 +33,7 @@ import (
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
 )
 
@@ -151,8 +151,8 @@ func createScheme() *runtime.Scheme {
 
 func CreateClusterContext(cluster *clusterv1.Cluster, vsphereCluster *vmwarev1.VSphereCluster) *vmware.ClusterContext {
 	scheme := createScheme()
-	controllerManagerContext := &context.ControllerManagerContext{
-		Context: goctx.Background(),
+	controllerManagerContext := &capvcontext.ControllerManagerContext{
+		Context: context.Background(),
 		Logger:  klog.Background().WithName("controller-manager-logger"),
 		Scheme:  scheme,
 		Client: testclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
@@ -162,7 +162,7 @@ func CreateClusterContext(cluster *clusterv1.Cluster, vsphereCluster *vmwarev1.V
 	}
 
 	// Build the controller context.
-	controllerContext := &context.ControllerContext{
+	controllerContext := &capvcontext.ControllerContext{
 		ControllerManagerContext: controllerManagerContext,
 		Logger:                   controllerManagerContext.Logger.WithName("controller-logger"),
 	}
@@ -180,7 +180,7 @@ func CreateMachineContext(clusterContext *vmware.ClusterContext, machine *cluste
 	vsphereMachine *vmwarev1.VSphereMachine) *vmware.SupervisorMachineContext {
 	// Build the machine context.
 	return &vmware.SupervisorMachineContext{
-		BaseMachineContext: &context.BaseMachineContext{
+		BaseMachineContext: &capvcontext.BaseMachineContext{
 			Logger:  clusterContext.Logger.WithName(vsphereMachine.Name),
 			Machine: machine,
 			Cluster: clusterContext.Cluster,

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helpers
 
 import (
-	goctx "context"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -33,7 +33,7 @@ import (
 // Util functions to interact with the clusterctl e2e framework.
 
 func LoadE2EConfig(configPath string) (*clusterctl.E2EConfig, error) {
-	config := clusterctl.LoadE2EConfig(goctx.TODO(), clusterctl.LoadE2EConfigInput{ConfigPath: configPath})
+	config := clusterctl.LoadE2EConfig(context.TODO(), clusterctl.LoadE2EConfigInput{ConfigPath: configPath})
 	if config == nil {
 		return nil, fmt.Errorf("cannot load E2E config found at %s", configPath)
 	}
@@ -58,7 +58,7 @@ func CreateClusterctlLocalRepository(config *clusterctl.E2EConfig, repositoryFol
 		createRepositoryInput.RegisterClusterResourceSetConfigMapTransformation(cniPath, capi_e2e.CNIResources)
 	}
 
-	clusterctlConfig := clusterctl.CreateRepository(goctx.TODO(), createRepositoryInput)
+	clusterctlConfig := clusterctl.CreateRepository(context.TODO(), createRepositoryInput)
 	if _, err := os.Stat(clusterctlConfig); err != nil {
 		return "", fmt.Errorf("the clusterctl config file does not exists in the local repository %s", repositoryFolder)
 	}
@@ -69,7 +69,7 @@ func SetupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 	var clusterProvider bootstrap.ClusterProvider
 	kubeconfigPath := ""
 	if !useExistingCluster {
-		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(goctx.TODO(), bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
+		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(context.TODO(), bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
@@ -87,7 +87,7 @@ func SetupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 }
 
 func InitBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy, config *clusterctl.E2EConfig, clusterctlConfig, artifactFolder string) {
-	clusterctl.InitManagementClusterAndWatchControllerLogs(goctx.TODO(), clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+	clusterctl.InitManagementClusterAndWatchControllerLogs(context.TODO(), clusterctl.InitManagementClusterAndWatchControllerLogsInput{
 		ClusterProxy:            bootstrapClusterProxy,
 		ClusterctlConfigPath:    clusterctlConfig,
 		InfrastructureProviders: config.InfrastructureProviders(),
@@ -97,9 +97,9 @@ func InitBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy, config *
 
 func TearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClusterProxy framework.ClusterProxy) {
 	if bootstrapClusterProxy != nil {
-		bootstrapClusterProxy.Dispose(goctx.TODO())
+		bootstrapClusterProxy.Dispose(context.TODO())
 	}
 	if bootstrapClusterProvider != nil {
-		bootstrapClusterProvider.Dispose(goctx.TODO())
+		bootstrapClusterProvider.Dispose(context.TODO())
 	}
 }

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package integration
 
 import (
-	goctx "context"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -69,7 +69,7 @@ const (
 var (
 	testClusterName        string
 	dummyKubernetesVersion = "1.15.0+vmware.1"
-	ctx                    goctx.Context
+	ctx                    context.Context
 	k8sClient              dynamic.Interface
 )
 
@@ -246,7 +246,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By("Initializing the bootstrap cluster")
 	helpers.InitBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
-	ctx = goctx.Background()
+	ctx = context.Background()
 	return []byte(
 		strings.Join([]string{
 			artifactFolder,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This is part of the story: refactor capv controller context #2295. Currently working on this incrementally. In this PR, just rename controller context to make it more readable and differentiate from golang context, to be more specific
- name package sigs.k8s.io/cluster-api-provider-vsphere/pkg/contex  as `capvcontext`
- remove package alias `goctx "context"` and just use `context`
- in function signature, rename customized context from `ctx` to `xxxxCtx` (Leave ctx for golang context as the first parameter, which will be added in future PR )

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2295 
