### PR TITLE
[WIP] :sparkles: Create kube-state-metrics configuration from markers

### DIFF
--- a/apis/v1beta1/vspherecluster_types.go
+++ b/apis/v1beta1/vspherecluster_types.go
@@ -91,6 +91,8 @@ type VSphereClusterStatus struct {
 
 	// Conditions defines current service state of the VSphereCluster.
 	// +optional
+	// +Metrics:stateset:name="status_condition",help="The condition of a vspherecluster.",labelName="status",JSONPath=".status",list={"True","False","Unknown"},labelsFromPath={"type":".type"}
+	// +Metrics:gauge:name="status_condition_last_transition_time",help="The condition last transition time of a vspherecluster.",valueFrom=.lastTransitionTime,labelsFromPath={"type":".type","status":".status"}
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
 	// FailureDomains is a list of failure domain objects synced from the infrastructure provider.
@@ -110,6 +112,15 @@ type VSphereClusterStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API
+// +Metrics:gvk:namePrefix="capi_vspherecluster"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vspherecluster is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vspherecluster.",labelsFromPath={status_vsphere_version:.status.vCenterVersion,spec_server:.spec.server,identity_reference_kind:".spec.identityRef.kind",identity_reference_name:".spec.identityRef.name"}
 type VSphereCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1beta1/vsphereclusteridentity_types.go
+++ b/apis/v1beta1/vsphereclusteridentity_types.go
@@ -45,6 +45,8 @@ type VSphereClusterIdentityStatus struct {
 
 	// Conditions defines current service state of the VSphereCluster.
 	// +optional
+	// +Metrics:stateset:name="status_condition",help="The condition of a vsphereclusteridentity.",labelName="status",JSONPath=".status",list={"True","False","Unknown"},labelsFromPath={"type":".type"}
+	// +Metrics:gauge:name="status_condition_last_transition_time",help="The condition last transition time of a vsphereclusteridentity.",valueFrom=.lastTransitionTime,labelsFromPath={"type":".type","status":".status"}
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 }
 
@@ -85,6 +87,15 @@ func (c *VSphereClusterIdentity) SetConditions(conditions clusterv1.Conditions) 
 // +kubebuilder:subresource:status
 
 // VSphereClusterIdentity defines the account to be used for reconciling clusters
+// +Metrics:gvk:namePrefix="capi_vsphereclusteridentity"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vsphereclusteridentity is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vsphereclusteridentity.",labelsFromPath={name:.metadata.name}
 type VSphereClusterIdentity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1beta1/vspheredeploymentzone_types.go
+++ b/apis/v1beta1/vspheredeploymentzone_types.go
@@ -81,6 +81,8 @@ type VSphereDeploymentZoneStatus struct {
 
 	// Conditions defines current service state of the VSphereMachine.
 	// +optional
+	// +Metrics:stateset:name="status_condition",help="The condition of a vspheredeploymentzone.",labelName="status",JSONPath=".status",list={"True","False","Unknown"},labelsFromPath={"type":".type"}
+	// +Metrics:gauge:name="status_condition_last_transition_time",help="The condition last transition time of a vspheredeploymentzone.",valueFrom=.lastTransitionTime,labelsFromPath={"type":".type","status":".status"}
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 }
 
@@ -90,6 +92,15 @@ type VSphereDeploymentZoneStatus struct {
 // +kubebuilder:subresource:status
 
 // VSphereDeploymentZone is the Schema for the vspheredeploymentzones API
+// +Metrics:gvk:namePrefix="capi_vspheredeploymentzone"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vspheredeploymentzone is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vspheredeploymentzone.",labelsFromPath={name:.metadata.name}
 type VSphereDeploymentZone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1beta1/vspherefailuredomain_types.go
+++ b/apis/v1beta1/vspherefailuredomain_types.go
@@ -95,6 +95,15 @@ type FailureDomainHosts struct {
 // +kubebuilder:resource:path=vspherefailuredomains,scope=Cluster,categories=cluster-api
 
 // VSphereFailureDomain is the Schema for the vspherefailuredomains API
+// +Metrics:gvk:namePrefix="capi_vspherefailuredomain"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vspherefailuredomain is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vspherefailuredomain.",labelsFromPath={name:.metadata.name}
 type VSphereFailureDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1beta1/vspheremachine_types.go
+++ b/apis/v1beta1/vspheremachine_types.go
@@ -78,6 +78,7 @@ type VSphereMachineStatus struct {
 	Ready bool `json:"ready"`
 
 	// Addresses contains the VSphere instance associated addresses.
+	// +Metrics:info:name="status_addresses",help="Address information about a vspheremachine.",labelsFromPath={address:".address",type:".type"}
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// Network returns the network status for each of the machine's configured
@@ -125,6 +126,8 @@ type VSphereMachineStatus struct {
 
 	// Conditions defines current service state of the VSphereMachine.
 	// +optional
+	// +Metrics:stateset:name="status_condition",help="The condition of a vspheremachine.",labelName="status",JSONPath=".status",list={"True","False","Unknown"},labelsFromPath={"type":".type"}
+	// +Metrics:gauge:name="status_condition_last_transition_time",help="The condition last transition time of a vspheremachine.",valueFrom=.lastTransitionTime,labelsFromPath={"type":".type","status":".status"}
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 }
 
@@ -139,6 +142,15 @@ type VSphereMachineStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereMachine is the Schema for the vspheremachines API
+// +Metrics:gvk:namePrefix="capi_vspheremachine"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vspheremachine is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vspheremachine.",labelsFromPath={provider_id:.spec.providerID}
 type VSphereMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1beta1/vspherevm_types.go
+++ b/apis/v1beta1/vspherevm_types.go
@@ -104,6 +104,7 @@ type VSphereVMStatus struct {
 	// This field is required at runtime for other controllers that read
 	// this CRD as unstructured data.
 	// +optional
+	// +Metrics:info:name="status_addresses",help="Address information about a vspherevm.",labelsFromPath={address:"."}
 	Addresses []string `json:"addresses,omitempty"`
 
 	// CloneMode is the type of clone operation used to clone this VM. Since
@@ -165,6 +166,8 @@ type VSphereVMStatus struct {
 
 	// Conditions defines current service state of the VSphereVM.
 	// +optional
+	// +Metrics:stateset:name="status_condition",help="The condition of a vspherevm.",labelName="status",JSONPath=".status",list={"True","False","Unknown"},labelsFromPath={"type":".type"}
+	// +Metrics:gauge:name="status_condition_last_transition_time",help="The condition last transition time of a vspherevm.",valueFrom=.lastTransitionTime,labelsFromPath={"type":".type","status":".status"}
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
 	// ModuleUUID is the unique identifier for the vCenter cluster module construct
@@ -187,6 +190,15 @@ type VSphereVMStatus struct {
 // +kubebuilder:subresource:status
 
 // VSphereVM is the Schema for the vspherevms API
+// +Metrics:gvk:namePrefix="capi_vspherevm"
+// +Metrics:labelFromPath:name="name",JSONPath=".metadata.name"
+// +Metrics:labelFromPath:name="namespace",JSONPath=".metadata.namespace"
+// +Metrics:labelFromPath:name="uid",JSONPath=".metadata.uid"
+// +Metrics:gauge:name="created",JSONPath=".metadata.creationTimestamp",help="Unix creation timestamp."
+// +Metrics:info:name="annotation_paused",JSONPath=.metadata.annotations['cluster\.x-k8s\.io/paused'],help="Whether the vspherevm is paused and any of its resources will not be processed by the controllers.",labelsFromPath={paused_value:"."}
+// +Metrics:info:name="owner",JSONPath=".metadata.ownerReferences",help="Owner references.",labelsFromPath={owner_is_controller:".controller",owner_kind:".kind",owner_name:".name",owner_uid:".uid"}
+// +Metrics:labelFromPath:name="cluster_name",JSONPath=.metadata.labels.cluster\.x-k8s\.io/cluster-name
+// +Metrics:info:name="info",help="Information about a vspherevm.",labelsFromPath={status_clonemode:.status.cloneMode,bootstrap_reference_kind:".spec.bootstrapRef.kind",bootstrap_reference_name:".spec.bootstrapRef.name",status_vmref:".status.vmRef"}
 type VSphereVM struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/hack/go-tools-build.sh
+++ b/hack/go-tools-build.sh
@@ -37,7 +37,10 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-CAPI_HACK_TOOLS="sigs.k8s.io/cluster-api/hack/tools"
+export GOWORK="off"
+
+GOMOD_REPLACE=${GOMOD_REPLACE:=}
+GOMOD_REQUIRE=${GOMOD_REQUIRE:=}
 
 rm -f "${GOBIN}/${2}"* || true
 
@@ -52,8 +55,13 @@ cd "${TMP_MODULE_DIR}"
 
 # Initialize a go module and place a tools.go file for building the binary.
 go mod init "tools"
-# Set require for "sigs.k8s.io/cluster-api" to let go resolve the tools version via the CAPI version.
-go mod edit -require "${CAPI_HACK_TOOLS}@${3}"
+
+for PARAM in ${GOMOD_REPLACE}; do
+  eval go mod edit -replace "${PARAM}"
+done
+for PARAM in ${GOMOD_REQUIRE}; do
+  eval go mod edit -require "${PARAM}"
+done
 
 # Create go file which imports the required package and resolve dependencies.
 cat << EOF > tools.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Makes use of kube-state-metrics PR https://github.com/kubernetes/kube-state-metrics/pull/2014 to generate the configuration for the CRD metrics.

TODO:
- [ ] wait for https://github.com/kubernetes/kube-state-metrics/pull/2014 to merge
- [ ] squash

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2061
