### PR TITLE
🌱 LDFLAGS defined once for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ ifeq ($(SELINUX_ENABLED),1)
 endif
 
 # Set build time variables including version details
-LDFLAGS := $(shell hack/version.sh)
+LDFLAGS ?= $(shell hack/version.sh)
 
 # Additional CAPV vars (everything else is ~ kept in sync with core CAPI)
 # Allow overriding manifest generation destination directory

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -119,6 +119,7 @@ export WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
 echo "Acquired Workload Cluster Control Plane IP: $WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"
 
 # save the docker image locally
+export LDFLAGS=""
 make e2e-image
 mkdir -p "$ARTIFACTS"/tempContainers
 docker save gcr.io/k8s-staging-cluster-api/capv-manager:e2e -o "$DOCKER_IMAGE_TAR"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -119,7 +119,6 @@ export WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
 echo "Acquired Workload Cluster Control Plane IP: $WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"
 
 # save the docker image locally
-export LDFLAGS=""
 make e2e-image
 mkdir -p "$ARTIFACTS"/tempContainers
 docker save gcr.io/k8s-staging-cluster-api/capv-manager:e2e -o "$DOCKER_IMAGE_TAR"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -50,6 +50,9 @@ The first step to running the e2e tests is setting up the required environment v
 Run the following command to execute the CAPV e2e tests:
 
 ```shell
+# For local testing, uncomment the line below to turn off traceability in the built image.
+# export LDFLAGS="" 
+
 make e2e
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR intends to define `LDFLAGS` only once for Makefile, which makes `e2e-image` use Docker cache instead of building a new image from scratch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1354
