### PR TITLE
:seedling: Bump Trivy to v0.45.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
 SHELLCHECK_VER := v0.9.0
 
-TRIVY_VER := 0.44.1
+TRIVY_VER := 0.45.0
 
 KPROMO_VER := v4.0.4
 KPROMO_BIN := kpromo


### PR DESCRIPTION
Release notes here: https://github.com/aquasecurity/trivy/releases/tag/v0.45.0