### PR TITLE
🌱 fix YML unmarshal error at test code

### DIFF
--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -19,7 +19,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"time"
 
@@ -208,16 +207,6 @@ func updateClusterInfraRef(cluster *clusterv1.Cluster, infraCluster client.Objec
 }
 
 func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
-	contentFmt := `username: '%s'
-	password: '%s'
-	`
-	tmpFile, err := os.CreateTemp("", "creds")
-	Expect(err).NotTo(HaveOccurred())
-
-	content := fmt.Sprintf(contentFmt, cfg.Username, cfg.Password)
-	_, err = tmpFile.Write([]byte(content))
-	Expect(err).NotTo(HaveOccurred())
-
 	opts := manager.Options{
 		Options: ctrlmgr.Options{
 			Scheme: scheme.Scheme,
@@ -230,7 +219,6 @@ func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
 		},
 		KubeConfig:      cfg,
 		NetworkProvider: networkProvider,
-		CredentialsFile: tmpFile.Name(),
 	}
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Fix the YML unmarshal error caused by an incorrect credential format string. (Remove the credential-related code as discussed.)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2320 
