### PR TITLE
🌱 Add verify-import-restrictions to enforce import restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,11 @@ KIND_BIN := kind
 KIND := $(abspath $(TOOLS_BIN_DIR)/$(KIND_BIN)-$(KIND_VER))
 KIND_PKG := sigs.k8s.io/kind
 
+IMPORT_BOSS_BIN := import-boss
+IMPORT_BOSS_VER := v0.28.1
+IMPORT_BOSS := $(abspath $(TOOLS_BIN_DIR)/$(IMPORT_BOSS_BIN))
+IMPORT_BOSS_PKG := k8s.io/code-generator/cmd/import-boss
+
 CAPI_HACK_TOOLS_VER := 4abf44cd85c4590602e4c10543d53cd4ec914845 # Note: this is the commit ID of the dependend CAPI release tag, currently v1.5.0
 
 CONVERSION_VERIFIER_VER := $(CAPI_HACK_TOOLS_VER)
@@ -337,7 +342,7 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences
 	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
-ALL_VERIFY_CHECKS = licenses boilerplate shellcheck modules gen conversions doctoc flavors
+ALL_VERIFY_CHECKS = licenses boilerplate shellcheck modules gen conversions doctoc flavors import-restrictions
 
 .PHONY: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
@@ -407,6 +412,9 @@ verify-flavors: $(FLAVOR_DIR) generate-flavors ## Verify generated flavors
 		echo "flavor files in templates directory are out of date"; exit 1; \
 	fi
 
+.PHONY: verify-import-restrictions
+verify-import-restrictions: $(IMPORT_BOSS) ## Verify import restrictions with import-boss
+	./hack/verify-import-restrictions.sh
 
 ## --------------------------------------
 ## Build
@@ -769,6 +777,8 @@ $(GOVC_BIN): $(GOVC) ## Build a local copy of govc.
 .PHONY: $(KIND_BIN)
 $(KIND_BIN): $(KIND) ## Build a local copy of kind.
 
+.PHONY: $(IMPORT_BOSS_BIN)
+$(IMPORT_BOSS_BIN): $(IMPORT_BOSS)
 
 .PHONY: $(RELEASE_NOTES_BIN)
 $(RELEASE_NOTES_BIN): $(RELEASE_NOTES) ## Build a local copy of release-notes.
@@ -821,6 +831,8 @@ $(GOVC): # Build GOVC.
 $(KIND): # Build kind.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(KIND_PKG) $(KIND_BIN) $(KIND_VER)
 
+$(IMPORT_BOSS): # Build import-boss
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(IMPORT_BOSS_PKG) $(IMPORT_BOSS_BIN) $(IMPORT_BOSS_VER)
 
 $(RELEASE_NOTES): # Build release-notes.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_TOOLS_BUILD) $(RELEASE_NOTES_PKG) $(RELEASE_NOTES_BIN) $(RELEASE_NOTES_VER)

--- a/apis/.import-restrictions
+++ b/apis/.import-restrictions
@@ -1,0 +1,5 @@
+rules:
+  - selectorRegexp: sigs[.]k8s[.]io/controller-runtime
+    allowedPrefixes:
+      - "sigs.k8s.io/controller-runtime/pkg/conversion"
+    forbiddenPrefixes: []

--- a/apis/v1beta1/.import-restrictions
+++ b/apis/v1beta1/.import-restrictions
@@ -1,0 +1,5 @@
+rules:
+  - selectorRegexp: sigs[.]k8s[.]io/controller-runtime
+    allowedPrefixes: []
+    forbiddenPrefixes:
+      - "sigs.k8s.io/controller-runtime"

--- a/apis/vmware/v1beta1/.import-restrictions
+++ b/apis/vmware/v1beta1/.import-restrictions
@@ -1,0 +1,5 @@
+rules:
+  - selectorRegexp: sigs[.]k8s[.]io/controller-runtime
+    allowedPrefixes: []
+    forbiddenPrefixes:
+      - "sigs.k8s.io/controller-runtime"

--- a/hack/verify-import-restrictions.sh
+++ b/hack/verify-import-restrictions.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks import restrictions. The script looks for a file called
+# `.import-restrictions` in each directory, then all imports of the package are
+# checked against each "rule" in the file.
+# Usage: `hack/verify-import-restrictions.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+sub_packages=(
+  "apis"
+)
+
+packages=()
+visit() {
+  local count=0
+  for file in "$1"/* ; do
+    if [ -d "$file" ]; then
+      visit "$file"
+    elif [ -f "$file" ]; then
+      ((count += 1))
+    fi
+  done
+  if [ "$count" -gt 0 ]; then
+    # import-boss may not accept directories without any sources
+    packages+=("./$1")
+  fi
+}
+for d in "${sub_packages[@]}"; do
+  visit "$d"
+done
+
+INPUT_DIRS="$(IFS=, ; echo "${packages[*]}")"
+echo "Enforcing imports in source codes under the following directories: ${INPUT_DIRS}"
+
+# Make sure GOPATH is unset to avoid behavior inconsistency
+# as import-boss will go through the sources
+unset GOPATH
+import-boss --include-test-files=true --verify-only --input-dirs "${INPUT_DIRS}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new make target `verify-import-restrictions` to verify imports in source codes
to prevent regression mentioned in #2159.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2159
