### PR TITLE
✨ Set up golang context when initiating controller manager

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -61,7 +61,7 @@ func setup() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
 
-	testEnv = helpers.NewTestEnvironment()
+	testEnv = helpers.NewTestEnvironment(ctx)
 
 	secretCachingClient, err := client.New(testEnv.Manager.GetConfig(), client.Options{
 		HTTPClient: testEnv.Manager.GetHTTPClient(),
@@ -93,7 +93,7 @@ func setup() {
 		panic(fmt.Sprintf("unable to create ClusterCacheReconciler controller: %v", err))
 	}
 
-	if err := AddClusterControllerToManager(testEnv.GetContext(), testEnv.Manager, &infrav1.VSphereCluster{}, controllerOpts); err != nil {
+	if err := AddClusterControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, &infrav1.VSphereCluster{}, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereCluster controller: %v", err))
 	}
 	if err := AddMachineControllerToManager(testEnv.GetContext(), testEnv.Manager, &infrav1.VSphereMachine{}, controllerOpts); err != nil {

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -223,15 +223,15 @@ func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10}
 
-	opts.AddToManager = func(controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-		if err := controllers.AddClusterControllerToManager(controllerCtx, mgr, &vmwarev1.VSphereCluster{}, controllerOpts); err != nil {
+	opts.AddToManager = func(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+		if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, &vmwarev1.VSphereCluster{}, controllerOpts); err != nil {
 			return err
 		}
 
 		return controllers.AddMachineControllerToManager(controllerCtx, mgr, &vmwarev1.VSphereMachine{}, controllerOpts)
 	}
 
-	mgr, err := manager.New(opts)
+	mgr, err := manager.New(ctx, opts)
 	Expect(err).NotTo(HaveOccurred())
 	return mgr
 }

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -57,7 +57,7 @@ import (
 
 // AddClusterControllerToManager adds the cluster controller to the provided
 // manager.
-func AddClusterControllerToManager(controllerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterControlledType client.Object, options controller.Options) error {
+func AddClusterControllerToManager(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterControlledType client.Object, options controller.Options) error {
 	supervisorBased, err := util.IsSupervisorType(clusterControlledType)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func AddClusterControllerToManager(controllerCtx *capvcontext.ControllerManagerC
 		ControllerContext:       controllerContext,
 		clusterModuleReconciler: NewReconciler(controllerContext),
 	}
-	clusterToInfraFn := clusterToInfrastructureMapFunc(controllerCtx)
+	clusterToInfraFn := clusterToInfrastructureMapFunc(ctx, controllerCtx)
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		// Watch the controlled, infrastructure resource.
 		For(clusterControlledType).
@@ -173,7 +173,7 @@ func AddClusterControllerToManager(controllerCtx *capvcontext.ControllerManagerC
 	return nil
 }
 
-func clusterToInfrastructureMapFunc(controllerCtx *capvcontext.ControllerManagerContext) handler.MapFunc {
+func clusterToInfrastructureMapFunc(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext) handler.MapFunc {
 	gvk := infrav1.GroupVersion.WithKind(reflect.TypeOf(&infrav1.VSphereCluster{}).Elem().Name())
-	return clusterutilv1.ClusterToInfrastructureMapFunc(controllerCtx, gvk, controllerCtx.Client, &infrav1.VSphereCluster{})
+	return clusterutilv1.ClusterToInfrastructureMapFunc(ctx, gvk, controllerCtx.Client, &infrav1.VSphereCluster{})
 }

--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -700,14 +700,14 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(tt.initObjs...))
-				ctx := fake.NewClusterContext(controllerCtx)
-				ctx.VSphereCluster.Spec.Server = server
+				clusterCtx := fake.NewClusterContext(controllerCtx)
+				clusterCtx.VSphereCluster.Spec.Server = server
 
 				r := clusterReconciler{ControllerContext: controllerCtx}
-				reconciled, err := r.reconcileDeploymentZones(ctx)
+				reconciled, err := r.reconcileDeploymentZones(ctx, clusterCtx)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(reconciled).To(Equal(tt.reconciled))
-				tt.assert(ctx.VSphereCluster)
+				tt.assert(clusterCtx.VSphereCluster)
 			})
 		}
 	})
@@ -769,15 +769,15 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(tt.initObjs...))
-				ctx := fake.NewClusterContext(controllerCtx)
-				ctx.VSphereCluster.Spec.Server = server
-				ctx.VSphereCluster.Spec.FailureDomainSelector = &metav1.LabelSelector{MatchLabels: map[string]string{}}
+				clusterCtx := fake.NewClusterContext(controllerCtx)
+				clusterCtx.VSphereCluster.Spec.Server = server
+				clusterCtx.VSphereCluster.Spec.FailureDomainSelector = &metav1.LabelSelector{MatchLabels: map[string]string{}}
 
 				r := clusterReconciler{ControllerContext: controllerCtx}
-				reconciled, err := r.reconcileDeploymentZones(ctx)
+				reconciled, err := r.reconcileDeploymentZones(ctx, clusterCtx)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(reconciled).To(Equal(tt.reconciled))
-				tt.assert(ctx.VSphereCluster)
+				tt.assert(clusterCtx.VSphereCluster)
 			})
 		}
 	})
@@ -802,14 +802,14 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 
 		assertNumberOfZones := func(selector *metav1.LabelSelector, selectedZones int) {
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(zoneOne, zoneTwo, zoneThree))
-			ctx := fake.NewClusterContext(controllerCtx)
-			ctx.VSphereCluster.Spec.Server = server
-			ctx.VSphereCluster.Spec.FailureDomainSelector = selector
+			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx.VSphereCluster.Spec.Server = server
+			clusterCtx.VSphereCluster.Spec.FailureDomainSelector = selector
 
 			r := clusterReconciler{ControllerContext: controllerCtx}
-			_, err := r.reconcileDeploymentZones(ctx)
+			_, err := r.reconcileDeploymentZones(ctx, clusterCtx)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(ctx.VSphereCluster.Status.FailureDomains).To(HaveLen(selectedZones))
+			g.Expect(clusterCtx.VSphereCluster.Status.FailureDomains).To(HaveLen(selectedZones))
 		}
 
 		t.Run("with no zones matching labels", func(_ *testing.T) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -51,7 +51,7 @@ type Manager interface {
 }
 
 // New returns a new CAPV controller manager.
-func New(opts Options) (Manager, error) {
+func New(ctx context.Context, opts Options) (Manager, error) {
 	// Ensure the default options are set.
 	opts.defaults()
 
@@ -101,7 +101,7 @@ func New(opts Options) (Manager, error) {
 	}
 
 	// Add the requested items to the manager.
-	if err := opts.AddToManager(controllerManagerContext, mgr); err != nil {
+	if err := opts.AddToManager(ctx, controllerManagerContext, mgr); err != nil {
 		return nil, errors.Wrap(err, "failed to add resources to the manager")
 	}
 
@@ -124,7 +124,7 @@ func UpdateCredentials(opts *Options) {
 	opts.readAndSetCredentials()
 }
 
-// InitializeWatch adds a filesystem watcher for the capv credentials file
+// InitializeWatch adds a filesystem watcher for the capv credentials file.
 // In case of any update to the credentials file, the new credentials are passed to the capv manager context.
 func InitializeWatch(controllerCtx *capvcontext.ControllerManagerContext, managerOpts *Options) (watch *fsnotify.Watcher, err error) {
 	capvCredentialsFile := managerOpts.CredentialsFile

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -30,20 +30,20 @@ const (
 
 // GetNetworkProvider will return a network provider instance based on the environment
 // the cfg is used to initialize a client that talks directly to api-server without using the cache.
-func GetNetworkProvider(ctx *context.ControllerManagerContext) (services.NetworkProvider, error) {
-	switch ctx.NetworkProvider {
+func GetNetworkProvider(controllerCtx *context.ControllerManagerContext) (services.NetworkProvider, error) {
+	switch controllerCtx.NetworkProvider {
 	case NSXNetworkProvider:
 		// TODO: disableFirewall not configurable
-		ctx.Logger.Info("Pick NSX-T network provider")
-		return network.NsxtNetworkProvider(ctx.Client, "false"), nil
+		controllerCtx.Logger.Info("Pick NSX-T network provider")
+		return network.NsxtNetworkProvider(controllerCtx.Client, "false"), nil
 	case VDSNetworkProvider:
-		ctx.Logger.Info("Pick NetOp (VDS) network provider")
-		return network.NetOpNetworkProvider(ctx.Client), nil
+		controllerCtx.Logger.Info("Pick NetOp (VDS) network provider")
+		return network.NetOpNetworkProvider(controllerCtx.Client), nil
 	case DummyLBNetworkProvider:
-		ctx.Logger.Info("Pick Dummy network provider")
+		controllerCtx.Logger.Info("Pick Dummy network provider")
 		return network.DummyLBNetworkProvider(), nil
 	default:
-		ctx.Logger.Info("NetworkProvider not set. Pick Dummy network provider")
+		controllerCtx.Logger.Info("NetworkProvider not set. Pick Dummy network provider")
 		return network.DummyNetworkProvider(), nil
 	}
 }

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"os"
 	"strings"
 	"time"
@@ -28,13 +29,13 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 // AddToManagerFunc is a function that can be optionally specified with
 // the manager's Options in order to explicitly decide what controllers and
 // webhooks to add to the manager.
-type AddToManagerFunc func(*context.ControllerManagerContext, ctrlmgr.Manager) error
+type AddToManagerFunc func(context.Context, *capvcontext.ControllerManagerContext, ctrlmgr.Manager) error
 
 // Options describes the options used to create a new CAPV manager.
 type Options struct {

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -112,7 +112,7 @@ type (
 )
 
 // NewTestEnvironment creates a new environment spinning up a local api-server.
-func NewTestEnvironment() *TestEnvironment {
+func NewTestEnvironment(ctx context.Context) *TestEnvironment {
 	// initialize webhook here to be able to test the envtest install via webhookOptions
 	initializeWebhookInEnvironment()
 
@@ -141,7 +141,7 @@ func NewTestEnvironment() *TestEnvironment {
 		Username:   simr.Username(),
 		Password:   simr.Password(),
 	}
-	managerOpts.AddToManager = func(controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	managerOpts.AddToManager = func(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 		if err := (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func NewTestEnvironment() *TestEnvironment {
 		return (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr)
 	}
 
-	mgr, err := manager.New(managerOpts)
+	mgr, err := manager.New(ctx, managerOpts)
 	if err != nil {
 		klog.Fatalf("failed to create the CAPV controller manager: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Set up golang context when initiating controller manager and also pass it down to VSphereCluster controller.
For other controllers, will update in separate PR.
This is part of #2295.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2295
