### PR TITLE
🌱 Only ensure Go minor version

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -19,7 +19,9 @@ set -o nounset
 set -o pipefail
 
 # MIN_GO_VERSION is the minimum, supported Go version.
-MIN_GO_VERSION="go${MIN_GO_VERSION:-1.20.8}"
+# Note: Enforce only the minor version as we can't guarantee that
+# the images we use in ProwJobs already use the latest patch version.
+MIN_GO_VERSION="go${MIN_GO_VERSION:-1.20}"
 
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Test coverage jobs are broken (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-vsphere#periodic-test-coverage-main) as kubekins image still contains 1.20.7. I think it's not super important to enforce the patch version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
