### PR TITLE
🌱 config: add metrics configuration for kube-state-metrics

### DIFF
--- a/config/metrics/crd-clusterrole.yaml
+++ b/config/metrics/crd-clusterrole.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics-custom-resource-capv
+  labels:
+    kube-state-metrics/aggregate-to-manager: "true"
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusters
+  - vsphereclusteridentities
+  - vspheredeploymentzones
+  - vspherefailuredomains
+  - vspheremachines
+  - vspherevms
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/metrics/crd-metrics-config.yaml
+++ b/config/metrics/crd-metrics-config.yaml
@@ -1,0 +1,676 @@
+---
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereCluster
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vspherecluster
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vspherecluster is paused and any of its resources will not
+        be processed by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            identity_reference_kind:
+            - spec
+            - identityRef
+            - kind
+            identity_reference_name:
+            - spec
+            - identityRef
+            - name
+            spec_server:
+            - spec
+            - server
+            status_vsphere_version:
+            - status
+            - vCenterVersion
+          path: null
+        type: Info
+      help: Information about a vspherecluster.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    - each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - "True"
+          - "False"
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+      help: The condition of a vspherecluster.
+      name: status_condition
+    - each:
+        gauge:
+          labelFromKey: ""
+          labelsFromPath:
+            status:
+            - status
+            type:
+            - type
+          nilIsZero: false
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - lastTransitionTime
+        type: Gauge
+      help: The condition last transition time of a vspherecluster.
+      name: status_condition_last_transition_time
+    resourcePlural: ""
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereClusterIdentity
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vsphereclusteridentity
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vsphereclusteridentity is paused and any of its resources
+        will not be processed by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+          path: null
+        type: Info
+      help: Information about a vsphereclusteridentity.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    - each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - "True"
+          - "False"
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+      help: The condition of a vsphereclusteridentity.
+      name: status_condition
+    - each:
+        gauge:
+          labelFromKey: ""
+          labelsFromPath:
+            status:
+            - status
+            type:
+            - type
+          nilIsZero: false
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - lastTransitionTime
+        type: Gauge
+      help: The condition last transition time of a vsphereclusteridentity.
+      name: status_condition_last_transition_time
+    resourcePlural: ""
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereDeploymentZone
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vspheredeploymentzone
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vspheredeploymentzone is paused and any of its resources will
+        not be processed by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+          path: null
+        type: Info
+      help: Information about a vspheredeploymentzone.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    - each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - "True"
+          - "False"
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+      help: The condition of a vspheredeploymentzone.
+      name: status_condition
+    - each:
+        gauge:
+          labelFromKey: ""
+          labelsFromPath:
+            status:
+            - status
+            type:
+            - type
+          nilIsZero: false
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - lastTransitionTime
+        type: Gauge
+      help: The condition last transition time of a vspheredeploymentzone.
+      name: status_condition_last_transition_time
+    resourcePlural: ""
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereFailureDomain
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vspherefailuredomain
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vspherefailuredomain is paused and any of its resources will
+        not be processed by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+          path: null
+        type: Info
+      help: Information about a vspherefailuredomain.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    resourcePlural: ""
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereMachine
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vspheremachine
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vspheremachine is paused and any of its resources will not
+        be processed by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            provider_id:
+            - spec
+            - providerID
+          path: null
+        type: Info
+      help: Information about a vspheremachine.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            address:
+            - address
+            type:
+            - type
+          path:
+          - status
+          - addresses
+        type: Info
+      help: Address information about a vspheremachine.
+      name: status_addresses
+    - each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - "True"
+          - "False"
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+      help: The condition of a vspheremachine.
+      name: status_condition
+    - each:
+        gauge:
+          labelFromKey: ""
+          labelsFromPath:
+            status:
+            - status
+            type:
+            - type
+          nilIsZero: false
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - lastTransitionTime
+        type: Gauge
+      help: The condition last transition time of a vspheremachine.
+      name: status_condition_last_transition_time
+    resourcePlural: ""
+  - errorLogV: 0
+    groupVersionKind:
+      group: infrastructure.cluster.x-k8s.io
+      kind: VSphereVM
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - labels
+      - cluster.x-k8s.io/cluster-name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_vspherevm
+    metrics:
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            paused_value: []
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+        type: Info
+      help: Whether the vspherevm is paused and any of its resources will not be processed
+        by the controllers.
+      name: annotation_paused
+    - each:
+        gauge:
+          labelFromKey: ""
+          nilIsZero: false
+          path:
+          - metadata
+          - creationTimestamp
+          valueFrom: null
+        type: Gauge
+      help: Unix creation timestamp.
+      name: created
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            bootstrap_reference_kind:
+            - spec
+            - bootstrapRef
+            - kind
+            bootstrap_reference_name:
+            - spec
+            - bootstrapRef
+            - name
+            status_clonemode:
+            - status
+            - cloneMode
+            status_vmref:
+            - status
+            - vmRef
+          path: null
+        type: Info
+      help: Information about a vspherevm.
+      name: info
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+      help: Owner references.
+      name: owner
+    - each:
+        info:
+          labelFromKey: ""
+          labelsFromPath:
+            address: []
+          path:
+          - status
+          - addresses
+        type: Info
+      help: Address information about a vspherevm.
+      name: status_addresses
+    - each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - "True"
+          - "False"
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+      help: The condition of a vspherevm.
+      name: status_condition
+    - each:
+        gauge:
+          labelFromKey: ""
+          labelsFromPath:
+            status:
+            - status
+            type:
+            - type
+          nilIsZero: false
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - lastTransitionTime
+        type: Gauge
+      help: The condition last transition time of a vspherevm.
+      name: status_condition_last_transition_time
+    resourcePlural: ""

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+  - ./crd-clusterrole.yaml
+
+namespace: observability
+
+configMapGenerator:
+- name: kube-state-metrics-crd-config-capv
+  files:
+  - capv.yaml=crd-metrics-config.yaml
+  options:
+    disableNameSuffixHash: true
+    labels:
+      kube-state-metrics/custom-resource: "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds a custom resource config for kube-state-metrics to scrape metrics via kube-state-metrics from the CAPV resources.

This could be used together with https://github.com/kubernetes-sigs/cluster-api/pull/9390 and the following configuration in `tilt-settings.yaml`:

```yaml
deploy_kustomizations:
  kube-state-metrics-custom-resource-capv: ../cluster-api-provider-vsphere/config/metrics
```

**Note:** depends on the path to be correct here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
