### PR TITLE
🐛 Handle missing VSphereFailureDomain on VSphereDeploymentZone deletion

### DIFF
--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -112,16 +112,6 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 		return reconcile.Result{}, err
 	}
 
-	failureDomain := &infrav1.VSphereFailureDomain{}
-	failureDomainKey := client.ObjectKey{Name: vsphereDeploymentZone.Spec.FailureDomain}
-	if err := r.Client.Get(ctx, failureDomainKey, failureDomain); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.V(4).Info("Failure Domain not found, won't reconcile", "key", failureDomainKey)
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, err
-	}
-
 	patchHelper, err := patch.NewHelper(vsphereDeploymentZone, r.Client)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(
@@ -135,7 +125,6 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 	vsphereDeploymentZoneContext := &capvcontext.VSphereDeploymentZoneContext{
 		ControllerContext:     r.ControllerContext,
 		VSphereDeploymentZone: vsphereDeploymentZone,
-		VSphereFailureDomain:  failureDomain,
 		Logger:                log,
 		PatchHelper:           patchHelper,
 	}
@@ -160,6 +149,13 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileNormal(ctx context.Context, deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext) error {
+	failureDomain := &infrav1.VSphereFailureDomain{}
+	failureDomainKey := client.ObjectKey{Name: deploymentZoneCtx.VSphereDeploymentZone.Spec.FailureDomain}
+	// Return an error if the FailureDomain can not be retrieved.
+	if err := r.Client.Get(ctx, failureDomainKey, failureDomain); err != nil {
+		return errors.Wrap(err, "VSphereFailureDomain could not be retrieved")
+	}
+	deploymentZoneCtx.VSphereFailureDomain = failureDomain
 	authSession, err := r.getVCenterSession(ctx, deploymentZoneCtx)
 	if err != nil {
 		deploymentZoneCtx.Logger.V(4).Error(err, "unable to create session")
@@ -252,7 +248,6 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx context.Context, de
 
 	machines := &clusterv1.MachineList{}
 	if err := r.Client.List(ctx, machines); err != nil {
-		r.Logger.Error(err, "unable to list machines")
 		return errors.Wrapf(err, "unable to list machines")
 	}
 
@@ -264,12 +259,26 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx context.Context, de
 	})
 	if len(machinesUsingDeploymentZone) > 0 {
 		machineNamesStr := util.MachinesAsString(machinesUsingDeploymentZone.SortedByCreationTimestamp())
-		err := errors.Errorf("%s is currently in use by machines: %s", deploymentZoneCtx.VSphereDeploymentZone.Name, machineNamesStr)
-		r.Logger.Error(err, "Error deleting VSphereDeploymentZone", "name", deploymentZoneCtx.VSphereDeploymentZone.Name)
+		err := errors.Errorf("error deleting VSphereDeploymentZone: %s is currently in use by machines: %s", deploymentZoneCtx.VSphereDeploymentZone.Name, machineNamesStr)
 		return err
 	}
 
-	if err := updateOwnerReferences(ctx, deploymentZoneCtx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
+	failureDomain := &infrav1.VSphereFailureDomain{}
+	failureDomainKey := client.ObjectKey{Name: deploymentZoneCtx.VSphereDeploymentZone.Spec.FailureDomain}
+	// Return an error if the FailureDomain can not be retrieved.
+	if err := r.Client.Get(ctx, failureDomainKey, failureDomain); err != nil {
+		// If the VSphereFailureDomain is not found return early and remove the finalizer.
+		// This prevents early deletion of the VSphereFailureDomain from blocking VSphereDeploymentZone deletion.
+		if apierrors.IsNotFound(err) {
+			ctrlutil.RemoveFinalizer(deploymentZoneCtx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
+			return nil
+		}
+		return err
+	}
+	deploymentZoneCtx.VSphereFailureDomain = failureDomain
+
+	// Reconcile the deletion of the VSphereFailureDomain by removing ownerReferences and deleting if necessary.
+	if err := updateOwnerReferences(deploymentZoneCtx, deploymentZoneCtx.VSphereFailureDomain, r.Client, func() []metav1.OwnerReference {
 		return clusterutilv1.RemoveOwnerRef(deploymentZoneCtx.VSphereFailureDomain.OwnerReferences, metav1.OwnerReference{
 			APIVersion: infrav1.GroupVersion.String(),
 			Kind:       deploymentZoneCtx.VSphereDeploymentZone.Kind,
@@ -280,14 +289,13 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx context.Context, de
 	}
 
 	if len(deploymentZoneCtx.VSphereFailureDomain.OwnerReferences) == 0 {
-		deploymentZoneCtx.Logger.Info("deleting vsphereFailureDomain", "name", deploymentZoneCtx.VSphereFailureDomain.Name)
+		deploymentZoneCtx.Logger.Info("deleting VSphereFailureDomain", "name", deploymentZoneCtx.VSphereFailureDomain.Name)
 		if err := r.Client.Delete(ctx, deploymentZoneCtx.VSphereFailureDomain); err != nil && !apierrors.IsNotFound(err) {
-			deploymentZoneCtx.Logger.Error(err, "failed to delete related %s %s", deploymentZoneCtx.VSphereFailureDomain.GroupVersionKind(), deploymentZoneCtx.VSphereFailureDomain.Name)
+			return errors.Wrapf(err, "failed to delete VSphereFailureDomain %s", deploymentZoneCtx.VSphereFailureDomain.Name)
 		}
 	}
 
 	ctrlutil.RemoveFinalizer(deploymentZoneCtx.VSphereDeploymentZone, infrav1.DeploymentZoneFinalizer)
-
 	return nil
 }
 

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -495,12 +495,11 @@ func TestVSphereDeploymentZone_Reconcile(t *testing.T) {
 
 		g.Consistently(func(g Gomega) bool {
 			g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(vsphereDeploymentZone), vsphereDeploymentZone)).To(Succeed())
-
 			return vsphereDeploymentZone.Status.Ready != nil && !*vsphereDeploymentZone.Status.Ready
 		}, timeout).Should(BeFalse())
 	})
 
-	t.Run("it should delete the VSphereDeploymentZone when the associated VSphereFailureDomain does not exist", func(t *testing.T) {
+	t.Run("Delete the VSphereDeploymentZone when the associated VSphereFailureDomain does not exist", func(t *testing.T) {
 		g := NewWithT(t)
 
 		vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{
@@ -618,6 +617,17 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 			mgmtContext.Password = pass
 
 			controllerCtx := fake.NewControllerContext(mgmtContext)
+			Expect(controllerCtx.Client.Create(controllerCtx, &infrav1.VSphereFailureDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "blah",
+				},
+				Spec: infrav1.VSphereFailureDomainSpec{
+					Topology: infrav1.Topology{
+						Datacenter:     "DC0",
+						ComputeCluster: pointer.String("DC0_C0"),
+					},
+				},
+			})).To(Succeed())
 
 			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext: controllerCtx,
@@ -627,17 +637,6 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 					ControlPlane:        pointer.Bool(true),
 					PlacementConstraint: tt.placementConstraint,
 				}},
-				VSphereFailureDomain: &infrav1.VSphereFailureDomain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "blah",
-					},
-					Spec: infrav1.VSphereFailureDomainSpec{
-						Topology: infrav1.Topology{
-							Datacenter:     "DC0",
-							ComputeCluster: pointer.String("DC0_C0"),
-						},
-					},
-				},
 				Logger: logr.Discard(),
 			}
 
@@ -685,7 +684,6 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
-				VSphereFailureDomain:  vsphereFailureDomain,
 				Logger:                logr.Discard(),
 			}
 
@@ -707,7 +705,6 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
-				VSphereFailureDomain:  vsphereFailureDomain,
 				Logger:                logr.Discard(),
 			}
 
@@ -726,7 +723,6 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:     controllerCtx,
 			VSphereDeploymentZone: vsphereDeploymentZone,
-			VSphereFailureDomain:  vsphereFailureDomain,
 			Logger:                logr.Discard(),
 		}
 
@@ -743,7 +739,6 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 			ControllerContext:     controllerCtx,
 			VSphereDeploymentZone: vsphereDeploymentZone,
-			VSphereFailureDomain:  vsphereFailureDomain,
 			Logger:                logr.Discard(),
 		}
 
@@ -767,7 +762,6 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 			deploymentZoneCtx := &capvcontext.VSphereDeploymentZoneContext{
 				ControllerContext:     controllerCtx,
 				VSphereDeploymentZone: vsphereDeploymentZone,
-				VSphereFailureDomain:  vsphereFailureDomain,
 				Logger:                logr.Discard(),
 			}
 

--- a/pkg/context/vspheredeploymentzone_context.go
+++ b/pkg/context/vspheredeploymentzone_context.go
@@ -31,7 +31,6 @@ import (
 type VSphereDeploymentZoneContext struct {
 	*ControllerContext
 	VSphereDeploymentZone *infrav1.VSphereDeploymentZone
-	VSphereFailureDomain  *infrav1.VSphereFailureDomain
 	Logger                logr.Logger
 	PatchHelper           *patch.Helper
 	AuthSession           *session.Session
@@ -57,9 +56,4 @@ func (c *VSphereDeploymentZoneContext) String() string {
 // GetSession returns the session for the VSphereDeploymentZoneContext.
 func (c *VSphereDeploymentZoneContext) GetSession() *session.Session {
 	return c.AuthSession
-}
-
-// GetVsphereFailureDomain returns the VSphereFailureDomain for the VSphereDeploymentZoneContext.
-func (c *VSphereDeploymentZoneContext) GetVsphereFailureDomain() infrav1.VSphereFailureDomain {
-	return *c.VSphereFailureDomain
 }

--- a/pkg/taggable/get.go
+++ b/pkg/taggable/get.go
@@ -29,12 +29,11 @@ import (
 
 type taggableContext interface {
 	GetSession() *session.Session
-	GetVsphereFailureDomain() infrav1.VSphereFailureDomain
 }
 
 // GetObjects returns the objects for a given failure domain.
-func GetObjects(ctx context.Context, taggableCtx taggableContext, fdType infrav1.FailureDomainType) (Objects, error) {
-	finderFunc := find.ObjectFunc(fdType, taggableCtx.GetVsphereFailureDomain().Spec.Topology, taggableCtx.GetSession().Finder)
+func GetObjects(ctx context.Context, taggableCtx taggableContext, failureDomain *infrav1.VSphereFailureDomain, fdType infrav1.FailureDomainType) (Objects, error) {
+	finderFunc := find.ObjectFunc(fdType, failureDomain.Spec.Topology, taggableCtx.GetSession().Finder)
 	objRefs, err := finderFunc(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reorder the reconcile function of the VSphereDeploymentZone in order to ensure deletion can proceed even if the failureDomain does not exist.
