### PR TITLE
🌱 Get rid of unstructured type in VSphereVM reconciler

### DIFF
--- a/pkg/services/vimmachine_test.go
+++ b/pkg/services/vimmachine_test.go
@@ -275,7 +275,7 @@ var _ = Describe("VimMachineService_createOrPatchVSphereVM", func() {
 		})
 		It("returns a renamed vspherevm object", func() {
 			vm, err := vimMachineService.createOrPatchVSphereVM(machineCtx, getVSphereVM(hostAddr, corev1.ConditionTrue))
-			vmName := vm.(*infrav1.VSphereVM).GetName()
+			vmName := vm.Name
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmName).To(Equal("fake-long-rname"))
 		})
@@ -287,7 +287,7 @@ var _ = Describe("VimMachineService_createOrPatchVSphereVM", func() {
 		})
 		It("returns the same vspherevm name", func() {
 			vm, err := vimMachineService.createOrPatchVSphereVM(machineCtx, getVSphereVM(hostAddr, corev1.ConditionTrue))
-			vmName := vm.(*infrav1.VSphereVM).GetName()
+			vmName := vm.Name
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmName).To(Equal(fakeLongClusterName))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

I'm assuming this is an intermediate state when to support supervisor mode, so it uses unstructured type in VSphereVM reconciler to support two modes. As we now have [vmoperator](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/tree/main/pkg/services/vmoperator) to reconcile VM in supervisor mode, I think we are good to get rid of unstructured type in VSphereVM reconciler, but better to have a review from folks who're more familiar with supervisor mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2056 
