### PR TITLE
✨ refactor context for vspheredeploymentzone controller

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -105,7 +105,7 @@ func setup() {
 	if err := AddVsphereClusterIdentityControllerToManager(testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
-	if err := AddVSphereDeploymentZoneControllerToManager(testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddVSphereDeploymentZoneControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
 	}
 	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, tracker, controllerOpts); err != nil {

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -95,23 +95,23 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_ComputeCl
 
 	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
 
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Region)).To(Succeed())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Region)).To(Succeed())
 	stdout := gbytes.NewBuffer()
 	g.Expect(simr.Run("tags.attached.ls k8s-region-west", stdout)).To(Succeed())
 	g.Expect(stdout).Should(gbytes.Say("Datacenter"))
 
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(Succeed())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(Succeed())
 	stdout = gbytes.NewBuffer()
 	g.Expect(simr.Run("tags.attached.ls k8s-region-west-2", stdout)).To(Succeed())
 	g.Expect(stdout).Should(gbytes.Say("ClusterComputeResource"))
 
 	vsphereFailureDomain.Spec.Topology.ComputeCluster = pointer.String("DC0_C1")
 	// Since association is verified, the method errors since the tag is not associated to the object.
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
 
 	// Since the tag does not belong to the category
 	vsphereFailureDomain.Spec.Zone.TagCategory = "diff-k8s-region"
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
 }
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_HostGroupZone(t *testing.T) {
@@ -143,7 +143,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_HostGroup
 		WithServer(simr.ServerURL().Host).
 		WithUserInfo(simr.Username(), simr.Password()).
 		WithDatacenter("*")
-	authSession, err := session.GetOrCreate(controllerCtx, params)
+	authSession, err := session.GetOrCreate(ctx, params)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	vsphereFailureDomain := &infrav1.VSphereFailureDomain{
@@ -180,20 +180,20 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_HostGroup
 	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
 
 	// Fails since no hosts are tagged
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
 	stdout := gbytes.NewBuffer()
 
 	g.Expect(simr.Run("tags.attach k8s-region-west-2 /DC0/host/DC0_C0/DC0_C0_H0", stdout)).To(Succeed())
 	// Fails as not all hosts are tagged
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
 
 	g.Expect(simr.Run("tags.attach k8s-region-west-2 /DC0/host/DC0_C0/DC0_C0_H1", stdout)).To(Succeed())
 	// Succeeds as all hosts are tagged
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(Succeed())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(Succeed())
 
 	// Since the tag does not belong to the category
 	vsphereFailureDomain.Spec.Zone.TagCategory = "diff-k8s-region"
-	g.Expect(reconciler.verifyFailureDomain(deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
+	g.Expect(reconciler.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain.Spec.Zone)).To(HaveOccurred())
 }
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *testing.T) {
@@ -215,7 +215,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 		WithServer(simr.ServerURL().Host).
 		WithUserInfo(simr.Username(), simr.Password()).
 		WithDatacenter("*")
-	authSession, err := session.GetOrCreate(controllerCtx, params)
+	authSession, err := session.GetOrCreate(ctx, params)
 	NewWithT(t).Expect(err).NotTo(HaveOccurred())
 
 	reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
@@ -288,7 +288,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			AuthSession:          authSession,
 		}
 
-		g.Expect(reconciler.createAndAttachMetadata(deploymentZoneCtx, tests[0].vsphereFailureDomainSpec.Region)).NotTo(HaveOccurred())
+		g.Expect(reconciler.createAndAttachMetadata(ctx, deploymentZoneCtx, tests[0].vsphereFailureDomainSpec.Region)).NotTo(HaveOccurred())
 		stdout := gbytes.NewBuffer()
 		g.Expect(simr.Run("tags.category.info k8s-region", stdout)).To(Succeed())
 		g.Expect(stdout).To(gbytes.Say("k8s-region"))
@@ -309,7 +309,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			AuthSession:          authSession,
 		}
 
-		g.Expect(reconciler.createAndAttachMetadata(deploymentZoneCtx, tests[1].vsphereFailureDomainSpec.Zone)).NotTo(HaveOccurred())
+		g.Expect(reconciler.createAndAttachMetadata(ctx, deploymentZoneCtx, tests[1].vsphereFailureDomainSpec.Zone)).NotTo(HaveOccurred())
 		stdout := gbytes.NewBuffer()
 		g.Expect(simr.Run("tags.category.info k8s-zone", stdout)).To(Succeed())
 		g.Expect(stdout).To(gbytes.Say("k8s-zone"))
@@ -330,7 +330,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *te
 			AuthSession:          authSession,
 		}
 
-		g.Expect(reconciler.createAndAttachMetadata(deploymentZoneCtx, tests[2].vsphereFailureDomainSpec.Zone)).NotTo(HaveOccurred())
+		g.Expect(reconciler.createAndAttachMetadata(ctx, deploymentZoneCtx, tests[2].vsphereFailureDomainSpec.Zone)).NotTo(HaveOccurred())
 		stdout := gbytes.NewBuffer()
 		g.Expect(simr.Run("tags.category.info foo", stdout)).To(Succeed())
 		g.Expect(stdout).To(gbytes.Say("foo"))

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -43,7 +43,6 @@ import (
 var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 	var (
 		simr *vcsim.Simulator
-		ctx  context.Context
 
 		failureDomainKey, deploymentZoneKey client.ObjectKey
 
@@ -74,7 +73,6 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 			Expect(simr.Run(op, gbytes.NewBuffer(), gbytes.NewBuffer())).To(Succeed())
 		}
 
-		ctx = context.Background()
 	})
 
 	BeforeEach(func() {
@@ -578,7 +576,7 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 			}
 
 			reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-			err = reconciler.reconcileNormal(deploymentZoneCtx)
+			err = reconciler.reconcileNormal(ctx, deploymentZoneCtx)
 			g.Expect(err).To(HaveOccurred())
 		})
 	}
@@ -624,7 +622,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			g := NewWithT(t)
 			reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-			err := reconciler.reconcileDelete(deploymentZoneCtx)
+			err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(err.Error()).To(MatchRegexp(".*[is currently in use]{1}.*"))
 			g.Expect(vsphereDeploymentZone.Finalizers).To(HaveLen(1))
@@ -646,7 +644,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			g := NewWithT(t)
 			reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-			err := reconciler.reconcileDelete(deploymentZoneCtx)
+			err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(vsphereDeploymentZone.Finalizers).To(BeEmpty())
 		})
@@ -665,7 +663,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 		g := NewWithT(t)
 		reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-		err := reconciler.reconcileDelete(deploymentZoneCtx)
+		err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(vsphereDeploymentZone.Finalizers).To(BeEmpty())
 	})
@@ -682,7 +680,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 		g := NewWithT(t)
 		reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-		err := reconciler.reconcileDelete(deploymentZoneCtx)
+		err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(vsphereDeploymentZone.Finalizers).To(BeEmpty())
 	})
@@ -706,7 +704,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			g := NewWithT(t)
 			reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-			err := reconciler.reconcileDelete(deploymentZoneCtx)
+			err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 			g.Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -728,7 +726,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 
 			g := NewWithT(t)
 			reconciler := vsphereDeploymentZoneReconciler{controllerCtx}
-			err := reconciler.reconcileDelete(deploymentZoneCtx)
+			err := reconciler.reconcileDelete(ctx, deploymentZoneCtx)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			fetchedFailureDomain := &infrav1.VSphereFailureDomain{}

--- a/main.go
+++ b/main.go
@@ -367,7 +367,7 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 		return err
 	}
 
-	return controllers.AddVSphereDeploymentZoneControllerToManager(controllerCtx, mgr, concurrency(vSphereDeploymentZoneConcurrency))
+	return controllers.AddVSphereDeploymentZoneControllerToManager(ctx, controllerCtx, mgr, concurrency(vSphereDeploymentZoneConcurrency))
 }
 
 func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, tracker *remote.ClusterCacheTracker) error {

--- a/pkg/services/govmomi/cluster/rule.go
+++ b/pkg/services/govmomi/cluster/rule.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/vim25/types"
 	"k8s.io/utils/pointer"
@@ -47,8 +49,8 @@ func negate(input bool) bool {
 	return !input
 }
 
-func VerifyAffinityRule(ctx computeClusterContext, clusterName, hostGroupName, vmGroupName string) (Rule, error) {
-	rules, err := listRules(ctx, clusterName)
+func VerifyAffinityRule(ctx context.Context, computeClusterCtx computeClusterContext, clusterName, hostGroupName, vmGroupName string) (Rule, error) {
+	rules, err := listRules(ctx, computeClusterCtx, clusterName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to list rules for compute cluster %s", clusterName)
 	}
@@ -64,8 +66,8 @@ func VerifyAffinityRule(ctx computeClusterContext, clusterName, hostGroupName, v
 	return nil, errors.New("no matching affinity rule found/exists")
 }
 
-func listRules(ctx computeClusterContext, clusterName string) ([]types.BaseClusterRuleInfo, error) {
-	ccr, err := ctx.GetSession().Finder.ClusterComputeResource(ctx, clusterName)
+func listRules(ctx context.Context, computeClusterCtx computeClusterContext, clusterName string) ([]types.BaseClusterRuleInfo, error) {
+	ccr, err := computeClusterCtx.GetSession().Finder.ClusterComputeResource(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/govmomi/cluster/rule_test.go
+++ b/pkg/services/govmomi/cluster/rule_test.go
@@ -51,7 +51,7 @@ func TestVerifyAffinityRule(t *testing.T) {
 		finder:  finder,
 	}
 
-	rule, err := VerifyAffinityRule(computeClusterCtx, "DC0_C0", "blah-host-group", "blah-vm-group")
+	rule, err := VerifyAffinityRule(ctx, computeClusterCtx, "DC0_C0", "blah-host-group", "blah-vm-group")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(rule.IsMandatory()).To(BeTrue())
 	g.Expect(rule.Disabled()).To(BeFalse())

--- a/pkg/services/govmomi/cluster/service.go
+++ b/pkg/services/govmomi/cluster/service.go
@@ -26,6 +26,7 @@ import (
 )
 
 type computeClusterContext interface {
+	// TODO(zhanggbj): remove context.Context in this interface after refactoring context for all controllers.
 	context.Context
 
 	GetSession() *session.Session

--- a/pkg/services/govmomi/cluster/vmgroup.go
+++ b/pkg/services/govmomi/cluster/vmgroup.go
@@ -24,13 +24,14 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func FindVMGroup(ctx computeClusterContext, clusterName, vmGroupName string) (*VMGroup, error) {
-	ccr, err := ctx.GetSession().Finder.ClusterComputeResource(ctx, clusterName)
+// TODO(zhanggbj): add (ctx context.Context) in function signature after refactoring context for pkg/services/govmomi/service.go.
+func FindVMGroup(computeClusterCtx computeClusterContext, clusterName, vmGroupName string) (*VMGroup, error) {
+	ccr, err := computeClusterCtx.GetSession().Finder.ClusterComputeResource(computeClusterCtx, clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterConfigInfoEx, err := ccr.Configuration(ctx)
+	clusterConfigInfoEx, err := ccr.Configuration(computeClusterCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/govmomi/metadata/metadata.go
+++ b/pkg/services/govmomi/metadata/metadata.go
@@ -27,8 +27,6 @@ import (
 )
 
 type metadataContext interface {
-	context.Context
-
 	GetSession() *session.Session
 }
 
@@ -46,9 +44,9 @@ func getCategoryAssociableType(domainType infrav1.FailureDomainType) string {
 }
 
 // CreateCategory either creates a new vSphere category or updates the associable type for an existing category.
-func CreateCategory(ctx metadataContext, name string, failureDomainType infrav1.FailureDomainType) (string, error) {
+func CreateCategory(ctx context.Context, metadataCtx metadataContext, name string, failureDomainType infrav1.FailureDomainType) (string, error) {
 	logger := ctrl.LoggerFrom(ctx, "category", name)
-	manager := ctx.GetSession().TagManager
+	manager := metadataCtx.GetSession().TagManager
 	category, err := manager.GetCategory(ctx, name)
 	if err != nil {
 		logger.V(4).Info("failed to find existing category, creating a new category")
@@ -75,9 +73,9 @@ func getCategoryObject(name string, failureDomainType infrav1.FailureDomainType)
 	}
 }
 
-func CreateTag(ctx metadataContext, name, categoryID string) error {
+func CreateTag(ctx context.Context, metadataCtx metadataContext, name, categoryID string) error {
 	logger := ctrl.LoggerFrom(ctx, "tag", name, "category", categoryID)
-	manager := ctx.GetSession().TagManager
+	manager := metadataCtx.GetSession().TagManager
 	_, err := manager.GetTag(ctx, name)
 	if err != nil {
 		logger.V(4).Info("failed to find existing tag, creating a new tag")

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -35,20 +35,20 @@ import (
 type VSphereMachineService interface {
 	FetchVSphereMachine(client client.Client, name types.NamespacedName) (capvcontext.MachineContext, error)
 	FetchVSphereCluster(client client.Client, cluster *clusterv1.Cluster, machineContext capvcontext.MachineContext) (capvcontext.MachineContext, error)
-	ReconcileDelete(ctx capvcontext.MachineContext) error
-	SyncFailureReason(ctx capvcontext.MachineContext) (bool, error)
-	ReconcileNormal(ctx capvcontext.MachineContext) (bool, error)
-	GetHostInfo(ctx capvcontext.MachineContext) (string, error)
+	ReconcileDelete(machineCtx capvcontext.MachineContext) error
+	SyncFailureReason(machineCtx capvcontext.MachineContext) (bool, error)
+	ReconcileNormal(machineCtx capvcontext.MachineContext) (bool, error)
+	GetHostInfo(machineCtx capvcontext.MachineContext) (string, error)
 }
 
 // VirtualMachineService is a service for creating/updating/deleting virtual
 // machines on vSphere.
 type VirtualMachineService interface {
 	// ReconcileVM reconciles a VM with the intended state.
-	ReconcileVM(ctx *capvcontext.VMContext) (infrav1.VirtualMachine, error)
+	ReconcileVM(vmCtx *capvcontext.VMContext) (infrav1.VirtualMachine, error)
 
 	// DestroyVM powers off and removes a VM from the inventory.
-	DestroyVM(ctx *capvcontext.VMContext) (reconcile.Result, infrav1.VirtualMachine, error)
+	DestroyVM(vmCtx *capvcontext.VMContext) (reconcile.Result, infrav1.VirtualMachine, error)
 }
 
 // ControlPlaneEndpointService is a service for reconciling load balanced control plane endpoints.

--- a/pkg/taggable/get.go
+++ b/pkg/taggable/get.go
@@ -27,13 +27,12 @@ import (
 )
 
 type taggableContext interface {
-	context.Context
 	GetSession() *session.Session
 	GetVsphereFailureDomain() infrav1.VSphereFailureDomain
 }
 
-func GetObjects(ctx taggableContext, fdType infrav1.FailureDomainType) (Objects, error) {
-	finderFunc := find.ObjectFunc(fdType, ctx.GetVsphereFailureDomain().Spec.Topology, ctx.GetSession().Finder)
+func GetObjects(ctx context.Context, taggableCtx taggableContext, fdType infrav1.FailureDomainType) (Objects, error) {
+	finderFunc := find.ObjectFunc(fdType, taggableCtx.GetVsphereFailureDomain().Spec.Topology, taggableCtx.GetSession().Finder)
 	objRefs, err := finderFunc(ctx)
 	if err != nil {
 		return nil, err
@@ -45,7 +44,7 @@ func GetObjects(ctx taggableContext, fdType infrav1.FailureDomainType) (Objects,
 	objects := make(Objects, len(objRefs))
 	for i, ref := range objRefs {
 		objects[i] = managedObject{
-			tagManager: ctx.GetSession().TagManager,
+			tagManager: taggableCtx.GetSession().TagManager,
 			ref:        ref,
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Refactor context for vspheredeploymentzone_controller.go and vspheredeploymentzone_controller_domain.go, as they are related, also refactor some underlying functions. Please find more background in #2295 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2295 
