### PR TITLE
✨ refactor context for vsphereclusteridentity controller

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -102,7 +102,7 @@ func setup() {
 	if err := AddVMControllerToManager(testEnv.GetContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereVM controller: %v", err))
 	}
-	if err := AddVsphereClusterIdentityControllerToManager(testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddVsphereClusterIdentityControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
 	if err := AddVSphereDeploymentZoneControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +29,6 @@ import (
 )
 
 var _ = Describe("VSphereClusterIdentity Reconciler", func() {
-	ctx := context.Background()
 	controllerNamespace := testEnv.Manager.GetContext().Namespace
 
 	Context("Reconcile Normal", func() {

--- a/main.go
+++ b/main.go
@@ -363,7 +363,7 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 	if err := controllers.AddVMControllerToManager(controllerCtx, mgr, tracker, concurrency(vSphereVMConcurrency)); err != nil {
 		return err
 	}
-	if err := controllers.AddVsphereClusterIdentityControllerToManager(controllerCtx, mgr, concurrency(vSphereClusterIdentityConcurrency)); err != nil {
+	if err := controllers.AddVsphereClusterIdentityControllerToManager(ctx, controllerCtx, mgr, concurrency(vSphereClusterIdentityConcurrency)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor the context in `vsphereclusteridentity_controller.go` and correct any corresponding function calls. You can discover additional information in reference to #2295.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2295 