### PR TITLE
🌱 Use number of esxi hosts as worker node count for anti-affinity e2e test

### DIFF
--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -38,10 +38,9 @@ import (
 
 type AntiAffinitySpecInput struct {
 	InfraClients
-	Global          GlobalInput
-	Namespace       *corev1.Namespace
-	WorkerNodeCount int64
-	SkipCleanup     bool
+	Global      GlobalInput
+	Namespace   *corev1.Namespace
+	SkipCleanup bool
 }
 
 var _ = Describe("Cluster creation with anti affined nodes", func() {
@@ -61,8 +60,7 @@ var _ = Describe("Cluster creation with anti affined nodes", func() {
 	It("should create a cluster with anti-affined nodes", func() {
 		// Since the upstream CI has four nodes, worker node count is set to 4.
 		VerifyAntiAffinity(ctx, AntiAffinitySpecInput{
-			WorkerNodeCount: 4,
-			Namespace:       namespace,
+			Namespace: namespace,
 			InfraClients: InfraClients{
 				Client:     vsphereClient,
 				RestClient: restClient,
@@ -91,10 +89,16 @@ func VerifyAntiAffinity(ctx context.Context, input AntiAffinitySpecInput) {
 	By("checking if the target system has enough hosts")
 	hostSystems, err := input.Finder.HostSystemList(ctx, "*")
 	Expect(err).ToNot(HaveOccurred())
-	Expect(len(hostSystems)).To(BeNumerically(">=", int(input.WorkerNodeCount)), "This test requires more or equal number of hosts compared to the WorkerNodeCount. Expected at least %d but only got %d hosts.", input.WorkerNodeCount, len(hostSystems))
+	// Setting the number of worker nodes to the number of hosts.
+	// Later in the test we check that all worker nodes are located on different hosts.
+	workerNodeCount := len(hostSystems)
+	// Limit size to not create too much VMs when running in a big environment.
+	if workerNodeCount > 10 {
+		workerNodeCount = 10
+	}
 
 	Byf("creating a workload cluster %s", clusterName)
-	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, input.WorkerNodeCount,
+	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, int64(workerNodeCount),
 		input.Global)
 
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -123,30 +127,30 @@ func VerifyAntiAffinity(ctx context.Context, input AntiAffinitySpecInput) {
 
 	By("verifying node anti-affinity for worker nodes")
 	workerVMs := FetchWorkerVMsForCluster(ctx, input.Global.BootstrapClusterProxy, clusterName, namespace.Name)
-	Expect(workerVMs).To(HaveLen(int(input.WorkerNodeCount)))
+	Expect(workerVMs).To(HaveLen(workerNodeCount))
 	Expect(verifyAntiAffinityForVMs(ctx, input.Finder, workerVMs)).To(Succeed())
 
-	Byf("Scaling the MachineDeployment out to > %d nodes", input.WorkerNodeCount)
+	Byf("Scaling the MachineDeployment out to > %d nodes", workerNodeCount)
 	framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
 		ClusterProxy:              input.Global.BootstrapClusterProxy,
 		Cluster:                   clusterResources.Cluster,
 		MachineDeployment:         clusterResources.MachineDeployments[0],
-		Replicas:                  int32(input.WorkerNodeCount + 2),
+		Replicas:                  int32(workerNodeCount + 2),
 		WaitForMachineDeployments: input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
 	})
 
-	Byf("Scaling the MachineDeployment down to %d nodes", input.WorkerNodeCount)
+	Byf("Scaling the MachineDeployment down to %d nodes", workerNodeCount)
 	framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
 		ClusterProxy:              input.Global.BootstrapClusterProxy,
 		Cluster:                   clusterResources.Cluster,
 		MachineDeployment:         clusterResources.MachineDeployments[0],
-		Replicas:                  int32(input.WorkerNodeCount),
+		Replicas:                  int32(workerNodeCount),
 		WaitForMachineDeployments: input.Global.E2EConfig.GetIntervals("", "wait-worker-nodes"),
 	})
 
 	// Refetch the updated list of worker VMs
 	workerVMs = FetchWorkerVMsForCluster(ctx, input.Global.BootstrapClusterProxy, clusterName, namespace.Name)
-	Expect(workerVMs).To(HaveLen(int(input.WorkerNodeCount)))
+	Expect(workerVMs).To(HaveLen(workerNodeCount))
 
 	By("worker nodes should be anti-affined again since enough hosts are available")
 	Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR removes the requirement to have at least 4 esxi hosts for the anti-affinity test. Instead it uses the number of available esxi hosts with a maximum of 10.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2368
