### PR TITLE
🌱 lint: remove linter ignores from .golangci-lint for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -264,13 +264,6 @@ issues:
     path: ^apis\/.*\/.*conversion.*\.go$
 
   # FIXME: All below excludes should get removed over time.
-  - linters:
-    - staticcheck
-    text: "SA1019: failureDomain.AutoConfigure is deprecated"
-  - path: "test/e2e/*"
-    linters:
-      - gosec
-    text: "G106:"
 
   # missing comments
   - linters:
@@ -301,7 +294,3 @@ issues:
     - gosec
     text: "G104: Errors unhandled."
     path: ^(controllers/vspherecluster_reconciler|pkg/manager/options_test|test/helpers/webhook)\.go$
-  - linters:
-    - gosec
-    text: "(G204|G301|G304): "
-    path: ^test/

--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -85,7 +85,7 @@ func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(ctx context.Cont
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileInfraFailureDomain(ctx context.Context, deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext, failureDomain infrav1.FailureDomain) error {
-	if *failureDomain.AutoConfigure {
+	if *failureDomain.AutoConfigure { //nolint:staticcheck
 		return r.createAndAttachMetadata(ctx, deploymentZoneCtx, failureDomain)
 	}
 	return r.verifyFailureDomain(ctx, deploymentZoneCtx, failureDomain)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -106,7 +106,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
-	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gofumpt
+	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec // Non-production code
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -85,7 +85,7 @@ func createOutputFile(path string) (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		return nil, err
 	}
-	return os.Create(path)
+	return os.Create(filepath.Clean(path))
 }
 
 func executeRemoteCommand(f io.StringWriter, hostIPAddr, command string, args ...string) error {
@@ -137,7 +137,7 @@ func newSSHConfig() (*ssh.ClientConfig, error) {
 
 	config := &ssh.ClientConfig{
 		User:            DefaultUserName,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // Non-production code
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
@@ -152,5 +152,5 @@ func readPrivateKey() ([]byte, error) {
 		return nil, errors.Errorf("private key information missing. Please set %s environment variable", VSpherePrivateKeyFilePath)
 	}
 
-	return os.ReadFile(privateKeyFilePath)
+	return os.ReadFile(filepath.Clean(privateKeyFilePath))
 }

--- a/test/helpers/mod.go
+++ b/test/helpers/mod.go
@@ -18,6 +18,7 @@ package helpers
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"golang.org/x/mod/modfile"
@@ -30,7 +31,7 @@ type Mod struct {
 
 func NewMod(path string) (Mod, error) {
 	var mod Mod
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return mod, err
 	}

--- a/test/helpers/vcsim/builder.go
+++ b/test/helpers/vcsim/builder.go
@@ -78,7 +78,7 @@ func (b *Builder) Build() (*Simulator, error) {
 func govcCommand(govcURL, commandStr string, buffers ...*gbytes.Buffer) *exec.Cmd {
 	govcBinPath := os.Getenv("GOVC_BIN_PATH")
 	args := strings.Split(commandStr, " ")
-	cmd := exec.Command(govcBinPath, args...)
+	cmd := exec.Command(govcBinPath, args...) //nolint:gosec // Non-production code
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOVC_URL=%s", govcURL), "GOVC_INSECURE=true")
 

--- a/test/helpers/webhook.go
+++ b/test/helpers/webhook.go
@@ -83,7 +83,7 @@ func initializeWebhookInEnvironment() {
 		klog.Fatalf("Failed to get information for current file from runtime")
 	}
 	root := path.Join(path.Dir(filename), "..", "..")
-	configyamlFile, err := os.ReadFile(filepath.Join(root, "config", "webhook", "manifests.yaml"))
+	configyamlFile, err := os.ReadFile(filepath.Clean(filepath.Join(root, "config", "webhook", "manifests.yaml")))
 	if err != nil {
 		klog.Fatalf("Failed to read core webhook configuration file: %v ", err)
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -227,7 +227,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
-	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
+	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec // Non-production code
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Removes some exclusions from `.golangci.yaml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2058
