### PR TITLE
:seedling: Fix deprecated markers across codebase

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -55,6 +55,8 @@ import (
 
 // legacyIdentityFinalizer is deprecated and should be used only while upgrading the cluster
 // from v1alpha3(v.0.7).
+//
+// Deprecated: legacyIdentityFinalizer will be removed in a future release.
 const legacyIdentityFinalizer string = "identity/infrastructure.cluster.x-k8s.io"
 
 type clusterReconciler struct {

--- a/pkg/services/network/constants.go
+++ b/pkg/services/network/constants.go
@@ -32,7 +32,7 @@ const (
 	SystemNamespace = "kube-system"
 
 	// legacyDefaultNetworkLabel was the label used for default networks.
-	// This is deprecated and is introduced only for smoother transitions.
-	// This will be released in a future release.
+	//
+	// Deprecated: legacyDefaultNetworkLabel will be removed in a future release.
 	legacyDefaultNetworkLabel = "capw.vmware.com/is-default-network"
 )

--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -50,8 +50,14 @@ const (
 	// legacyClusterSelectorKey and legacyNodeSelectorKey are added for backward compatibility.
 	// These will be removed in the future release.
 	// Please refer to the issue above for deprecation process.
+	//
+	// Deprecated: legacyClusterSelectorKey will be removed in a future release.
 	legacyClusterSelectorKey = "capw.vmware.com/cluster.name"
-	legacyNodeSelectorKey    = "capw.vmware.com/cluster.role"
+
+	// Please refer to the issue above for deprecation process.
+	//
+	// Deprecated: legacyClusterSelectorKey will be removed in a future release.
+	legacyNodeSelectorKey = "capw.vmware.com/cluster.role"
 )
 
 // CPService represents the ability to reconcile a ControlPlaneEndpoint.


### PR DESCRIPTION
Cleanup to fix deprecated markers across the codebase so that they meet the go api deprecation standard.