### PR TITLE
🌱 Remove lint ignore for `gocritic`

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -51,9 +51,9 @@ var (
 
 func TestMain(m *testing.M) {
 	setup()
-	defer teardown()
 	code := m.Run()
-	os.Exit(code) //nolint:gocritic
+	teardown()
+	os.Exit(code)
 }
 
 func setup() {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -291,18 +291,19 @@ func (r *machineReconciler) reconcileNormal(ctx context.Context, machineCtx capv
 		return reconcile.Result{}, nil
 	}
 
-	//nolint:gocritic
-	if r.supervisorBased {
-		err := r.setVMModifiers(ctx, machineCtx)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	} else {
+	// Cluster `.status.infrastructureReady == false is handled differently depending on if the machine is supervisor based.
+	// 1) If the Cluster is not supervisor-based mark the VMProvisionedCondition false and return nil.
+	// 2) If the Cluster is supervisor-based continue to reconcile as InfrastructureReady is not set to true until after the kube apiserver is available.
+	if !r.supervisorBased {
 		// vmwarev1.VSphereCluster doesn't set Cluster.Status.Ready until the API endpoint is available.
 		if !machineCtx.GetCluster().Status.InfrastructureReady {
 			log.Info("Cluster infrastructure is not ready yet")
 			conditions.MarkFalse(machineCtx.GetVSphereMachine(), infrav1.VMProvisionedCondition, infrav1.WaitingForClusterInfrastructureReason, clusterv1.ConditionSeverityInfo, "")
 			return reconcile.Result{}, nil
+		}
+	} else {
+		if err := r.setVMModifiers(ctx, machineCtx); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -529,17 +529,9 @@ func (vms *VMService) getMetadata(ctx *virtualMachineContext) (string, error) {
 
 	var metadataBase64 string
 	for _, ec := range obj.Config.ExtraConfig {
-		if optVal := ec.GetOptionValue(); optVal != nil {
-			// TODO(akutz) Using a switch instead of if in case we ever
-			//             want to check the metadata encoding as well.
-			//             Since the image stamped images always use
-			//             base64, it should be okay to not check.
-			//nolint:gocritic
-			switch optVal.Key {
-			case guestInfoKeyMetadata:
-				if v, ok := optVal.Value.(string); ok {
-					metadataBase64 = v
-				}
+		if optVal := ec.GetOptionValue(); optVal != nil && optVal.Key == guestInfoKeyMetadata {
+			if v, ok := optVal.Value.(string); ok {
+				metadataBase64 = v
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `//nolint:gocritic` linter and fix findings.
1. Remove `nolint:gocritic` for `/controllers/controllers_suite_test.go`
    1. To properly execute the `teardown`, I remove the `defer` keyword and place it before the `os.Exit(code)` statement.
2. Remove `nolint:gocritic` for `/controllers/vspheremachine_controller.go`
    1. To simplify the code, I merge the conditions `r.supervisorBased` and `machineCtx.GetCluster().Status.InfrastructureReady` using an `else if` statement as recommended by `gocritic`.
3. Remove `nolint:gocritic` for `pkg/services/govmomi/service.go`
    1. Reconstruct the `switch` logic, and use an if to replace it.
    2. I noticed a TODO comment from @akutz  that suggests using a switch instead of an if statement to check metadata encoding. However, I have not seen any follow-ups on this. As everything seems to be working well, I have refactored it to an if structure. If anyone has a better solution or suggestion, or, perhaps I made a mistake, please feel free to comment on this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2384 
