### PR TITLE
:seedling: Bump CAPI test components to v1.5.2

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -8,11 +8,11 @@
 # For creating local images, run ./hack/e2e.sh
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.2
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -28,9 +28,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -42,9 +42,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -56,9 +56,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -11,11 +11,11 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.2
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -31,9 +31,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -45,9 +45,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -59,9 +59,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -11,11 +11,11 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.2
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -30,9 +30,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -44,9 +44,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -58,9 +58,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.1
+      - name: v1.5.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:


### PR DESCRIPTION
Follow-up to #https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2401

Bump components in the e2e and integration test configurations.
