### PR TITLE
:bug: flatcar: Run kubeadm after containerd

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -90,6 +90,8 @@ systemd:
         # kubeadm must run after coreos-metadata populated /run/metadata directory.
         Requires=coreos-metadata.service
         After=coreos-metadata.service
+        # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+        After=containerd.service
         [Service]
         # Make metadata environment variables available for pre-kubeadm commands.
         EnvironmentFile=/run/metadata/*`

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -189,6 +189,8 @@ spec:
                   # kubeadm must run after coreos-metadata populated /run/metadata directory.
                   Requires=coreos-metadata.service
                   After=coreos-metadata.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
                   [Service]
                   # Make metadata environment variables available for pre-kubeadm commands.
                   EnvironmentFile=/run/metadata/*
@@ -284,6 +286,8 @@ spec:
                     # kubeadm must run after coreos-metadata populated /run/metadata directory.
                     Requires=coreos-metadata.service
                     After=coreos-metadata.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
                     [Service]
                     # Make metadata environment variables available for pre-kubeadm commands.
                     EnvironmentFile=/run/metadata/*

--- a/test/e2e/data/infrastructure-vsphere/main/ignition/ignition.yaml
+++ b/test/e2e/data/infrastructure-vsphere/main/ignition/ignition.yaml
@@ -122,6 +122,8 @@ spec:
                   # kubeadm must run after coreos-metadata populated /run/metadata directory.
                   Requires=coreos-metadata.service
                   After=coreos-metadata.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
                   [Service]
                   # Make metadata environment variables available for pre-kubeadm commands.
                   EnvironmentFile=/run/metadata/*
@@ -211,6 +213,8 @@ spec:
                     # kubeadm must run after coreos-metadata populated /run/metadata directory.
                     Requires=coreos-metadata.service
                     After=coreos-metadata.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
                     [Service]
                     # Make metadata environment variables available for pre-kubeadm commands.
                     EnvironmentFile=/run/metadata/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Ensure kubeadm runs after containerd to avoid a race condition between the two.

We intentionally add an `After=` directive and not a `Requires=` directive to avoid breaking things for distros which use Ignition and don't use containerd.

See https://github.com/kubernetes-sigs/image-builder/issues/939.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None