### PR TITLE
🌱 Remove nolint usages for errcheck, revive, prealloc, goconst, ineffassign

### DIFF
--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -285,7 +285,7 @@ func (r *ClusterReconciler) reconcileAPIEndpoints(ctx context.Context, clusterCt
 
 	// Define a variable to assign the API endpoints of control plane
 	// machines as they are discovered.
-	var apiEndpointList []clusterv1.APIEndpoint //nolint:prealloc
+	apiEndpointList := []clusterv1.APIEndpoint{}
 
 	// Iterate over the cluster's control plane CAPI machines.
 	for _, machine := range machines {

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
-//nolint:goconst
 var _ = Describe("GetCredentials", func() {
 	var (
 		ns      *corev1.Namespace
@@ -116,7 +115,7 @@ var _ = Describe("GetCredentials", func() {
 			if labels == nil {
 				labels = map[string]string{}
 			}
-			labels["identity-authorized"] = "true"
+			labels["identity-authorized"] = "true" //nolint: goconst
 			ns.Labels = labels
 			Expect(k8sclient.Update(ctx, ns)).To(Succeed())
 

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:revive
 package network
 
 import (
@@ -39,23 +38,23 @@ func (np *dummyNetworkProvider) HasLoadBalancer() bool {
 	return false
 }
 
-func (np *dummyNetworkProvider) ProvisionClusterNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+func (np *dummyNetworkProvider) ProvisionClusterNetwork(_ context.Context, _ *vmware.ClusterContext) error {
 	return nil
 }
 
-func (np *dummyNetworkProvider) GetClusterNetworkName(ctx context.Context, clusterCtx *vmware.ClusterContext) (string, error) {
+func (np *dummyNetworkProvider) GetClusterNetworkName(_ context.Context, _ *vmware.ClusterContext) (string, error) {
 	return "", nil
 }
 
-func (np *dummyNetworkProvider) ConfigureVirtualMachine(ctx context.Context, clusterCtx *vmware.ClusterContext, vm *vmoprv1.VirtualMachine) error {
+func (np *dummyNetworkProvider) ConfigureVirtualMachine(_ context.Context, _ *vmware.ClusterContext, _ *vmoprv1.VirtualMachine) error {
 	return nil
 }
 
-func (np *dummyNetworkProvider) GetVMServiceAnnotations(ctx context.Context, clusterCtx *vmware.ClusterContext) (map[string]string, error) {
+func (np *dummyNetworkProvider) GetVMServiceAnnotations(_ context.Context, _ *vmware.ClusterContext) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 
-func (np *dummyNetworkProvider) VerifyNetworkStatus(ctx context.Context, clusterCtx *vmware.ClusterContext, obj runtime.Object) error {
+func (np *dummyNetworkProvider) VerifyNetworkStatus(_ context.Context, _ *vmware.ClusterContext, _ runtime.Object) error {
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove usage of following:
`//nolint:revive`
`//nolint:prealloc`
`//nolint:goconst`

Didn't find any occurrence of `//nolint:errcheck` in codebase.
The comment for `//nolint:ineffassign` is alrady present in the occurrence.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2384 
