### PR TITLE
🌱 remove //nolint:nestif directives

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:nestif
-
 // Package controllers contains controllers for CAPV objects.
 package controllers
 

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -75,7 +75,6 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 
 	// Before going further, we need the VM's managed object reference.
 	vmRef, err := findVM(ctx)
-	//nolint:nestif
 	if err != nil {
 		if !isNotFound(err) {
 			return vm, err

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -81,7 +81,7 @@ func Clone(ctx *context.VMContext, bootstrapData []byte, format bootstrapv1.Form
 	// If a linked clone is requested then a MoRef for a snapshot must be
 	// found with which to perform the linked clone.
 	var snapshotRef *types.ManagedObjectReference
-	//nolint:nestif
+
 	if ctx.VSphereVM.Spec.CloneMode == "" || ctx.VSphereVM.Spec.CloneMode == infrav1.LinkedClone {
 		ctx.Logger.Info("linked clone requested")
 		// If the name of a snapshot was not provided then find the template's
@@ -105,7 +105,7 @@ func Clone(ctx *context.VMContext, bootstrapData []byte, format bootstrapv1.Form
 		}
 	}
 
-	// The type of clone operation depends on whether or not there is a snapshot
+	// The type of clone operation depends on whether there is a snapshot
 	// from which to do a linked clone.
 	diskMoveType := fullCloneDiskMoveType
 	ctx.VSphereVM.Status.CloneMode = infrav1.FullClone
@@ -217,7 +217,6 @@ func Clone(ctx *context.VMContext, bootstrapData []byte, format bootstrapv1.Form
 	}
 
 	var storageProfileID string
-	//nolint:nestif
 	if ctx.VSphereVM.Spec.StoragePolicyName != "" {
 		pbmClient, err := pbm.NewClient(ctx, ctx.Session.Client.Client)
 		if err != nil {

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -227,7 +227,6 @@ func (v *VimMachineService) reconcileProviderID(vimMachineCtx *capvcontext.VIMMa
 	return true, nil
 }
 
-//nolint:nestif
 func (v *VimMachineService) reconcileNetwork(vimMachineCtx *capvcontext.VIMMachineContext, vm *infrav1.VSphereVM) (bool, error) {
 	var errs []error
 	networkStatusListOfIfaces := vm.Status.Network
@@ -411,8 +410,6 @@ func generateVMObjectName(vimMachineCtx *capvcontext.VIMMachineContext, machineN
 
 // generateOverrideFunc returns a function which can override the values in the VSphereVM Spec
 // with the values from the FailureDomain (if any) set on the owner CAPI machine.
-//
-//nolint:nestif
 func (v *VimMachineService) generateOverrideFunc(vimMachineCtx *capvcontext.VIMMachineContext) (func(vm *infrav1.VSphereVM), bool) {
 	failureDomainName := vimMachineCtx.Machine.Spec.FailureDomain
 	if failureDomainName == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR removes all unused `//nolint:nestif `directives. 
Note: This specific lint check was not enabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2384
