### PR TITLE
:seedling: Clarify OWNER_ALIASES file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,9 @@ aliases:
     - randomvariable
     - srm09
     - yastij
+    - fabriziopandini
+    - killianmuldoon
+    - sbueringer
     - gab-satchi
     - chrischdi
   cluster-api-vsphere-reviewers:


### PR DESCRIPTION
Update the owners file to clarify which members of the `  cluster-api-maintainers` list are active maintainers of CAPV.

This adds a bit of duplication to the file, but it's clearer.