### PR TITLE
🌱 Remove lint ignore for staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -194,6 +194,9 @@ issues:
     - staticcheck
     text: "SA1019: .* is deprecated: This package will be removed in one of the next releases."
   - linters:
+    - staticcheck
+    text: "SA1019: .* is deprecated: This field is going to be removed in a future release."
+  - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
   - linters:

--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -85,7 +85,7 @@ func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(ctx context.Cont
 }
 
 func (r vsphereDeploymentZoneReconciler) reconcileInfraFailureDomain(ctx context.Context, deploymentZoneCtx *capvcontext.VSphereDeploymentZoneContext, vsphereFailureDomain *infrav1.VSphereFailureDomain, failureDomain infrav1.FailureDomain) error {
-	if *failureDomain.AutoConfigure { //nolint:staticcheck
+	if *failureDomain.AutoConfigure {
 		return r.createAndAttachMetadata(ctx, deploymentZoneCtx, vsphereFailureDomain, failureDomain)
 	}
 	return r.verifyFailureDomain(ctx, deploymentZoneCtx, vsphereFailureDomain, failureDomain)

--- a/internal/webhooks/vspherefailuredomain.go
+++ b/internal/webhooks/vspherefailuredomain.go
@@ -107,12 +107,12 @@ func (webhook *VSphereFailureDomainWebhook) Default(_ context.Context, obj runti
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereFailureDomain but got a %T", obj))
 	}
-	if typedObj.Spec.Zone.AutoConfigure == nil { //nolint:staticcheck
-		typedObj.Spec.Zone.AutoConfigure = pointer.Bool(false) //nolint:staticcheck
+	if typedObj.Spec.Zone.AutoConfigure == nil {
+		typedObj.Spec.Zone.AutoConfigure = pointer.Bool(false)
 	}
 
-	if typedObj.Spec.Region.AutoConfigure == nil { //nolint:staticcheck
-		typedObj.Spec.Region.AutoConfigure = pointer.Bool(false) //nolint:staticcheck
+	if typedObj.Spec.Region.AutoConfigure == nil {
+		typedObj.Spec.Region.AutoConfigure = pointer.Bool(false)
 	}
 
 	return nil

--- a/internal/webhooks/vspherefailuredomain_test.go
+++ b/internal/webhooks/vspherefailuredomain_test.go
@@ -34,8 +34,8 @@ func TestVsphereFailureDomain_Default(t *testing.T) {
 	webhook := &VSphereFailureDomainWebhook{}
 	g.Expect(webhook.Default(context.Background(), m)).ToNot(HaveOccurred())
 
-	g.Expect(*m.Spec.Zone.AutoConfigure).To(BeFalse())   //nolint:staticcheck
-	g.Expect(*m.Spec.Region.AutoConfigure).To(BeFalse()) //nolint:staticcheck
+	g.Expect(*m.Spec.Zone.AutoConfigure).To(BeFalse())
+	g.Expect(*m.Spec.Region.AutoConfigure).To(BeFalse())
 }
 
 func TestVSphereFailureDomain_ValidateCreate(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Remove usage of `//nolint:staticcheck`.
- Add a new rule to exclude static check for some fields will be deprecated in a future release.
- The only remaining `nolint:staticcheck` [here](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/vmware/vspherecluster_reconciler.go#L312) is needed because the `ctx` is not used, but we need it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of fixes #2384 
