### PR TITLE
:seedling: Remove handling for orphaned VSphereMachines

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -121,10 +121,6 @@ func (r *clusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		}
 	}()
 
-	if err := r.setOwnerRefsOnVsphereMachines(ctx, clusterContext); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner refs on VSphereMachine objects")
-	}
-
 	// Handle deleted clusters
 	if !vsphereCluster.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, clusterContext)
@@ -151,37 +147,8 @@ func (r *clusterReconciler) reconcileDelete(ctx context.Context, clusterCtx *cap
 			"unable to list VSphereMachines part of VSphereCluster %s/%s", clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
 	}
 
-	machineDeletionCount := 0
-	var deletionErrors []error
-	for _, vsphereMachine := range vsphereMachines {
-		// Note: We have to use := here to not overwrite log & ctx outside the for loop.
-		log := log.WithValues("VSphereMachine", klog.KObj(vsphereMachine))
-		ctx := ctrl.LoggerInto(ctx, log)
-
-		// If the VSphereMachine is not owned by the CAPI Machine object because the machine object was deleted
-		// before setting the owner references, then proceed with the deletion of the VSphereMachine object.
-		// This is required until CAPI has a solution for https://github.com/kubernetes-sigs/cluster-api/issues/5483
-		if !clusterutilv1.IsOwnedByObject(vsphereMachine, clusterCtx.VSphereCluster) || len(vsphereMachine.OwnerReferences) != 1 {
-			continue
-		}
-		machineDeletionCount++
-		// Remove the finalizer since VM creation wouldn't proceed
-		log.Info("Removing finalizer from VSphereMachine")
-		ctrlutil.RemoveFinalizer(vsphereMachine, infrav1.MachineFinalizer)
-		if err := r.Client.Update(ctx, vsphereMachine); err != nil {
-			return reconcile.Result{}, err
-		}
-		if err := r.Client.Delete(ctx, vsphereMachine); err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to delete for VSphereMachine")
-			deletionErrors = append(deletionErrors, err)
-		}
-	}
-	if len(deletionErrors) > 0 {
-		return reconcile.Result{}, kerrors.NewAggregate(deletionErrors)
-	}
-
-	if len(vsphereMachines)-machineDeletionCount > 0 {
-		log.Info("Waiting for VSphereMachines to be deleted", "count", len(vsphereMachines)-machineDeletionCount)
+	if len(vsphereMachines) > 0 {
+		log.Info("Waiting for VSphereMachines to be deleted", "count", len(vsphereMachines))
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
@@ -526,37 +493,6 @@ func (r *clusterReconciler) isControlPlaneInitialized(ctx context.Context, clust
 		return true
 	}
 	return conditions.IsTrue(clusterCtx.Cluster, clusterv1.ControlPlaneInitializedCondition)
-}
-
-func (r *clusterReconciler) setOwnerRefsOnVsphereMachines(ctx context.Context, clusterCtx *capvcontext.ClusterContext) error {
-	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(ctx, r.Client, clusterCtx.Cluster.Namespace, clusterCtx.Cluster.Name)
-	if err != nil {
-		return errors.Wrapf(err,
-			"unable to list VSphereMachines part of VSphereCluster %s/%s", clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
-	}
-
-	var patchErrors []error
-	for _, vsphereMachine := range vsphereMachines {
-		patchHelper, err := patch.NewHelper(vsphereMachine, r.Client)
-		if err != nil {
-			patchErrors = append(patchErrors, err)
-			continue
-		}
-
-		vsphereMachine.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(
-			vsphereMachine.OwnerReferences,
-			metav1.OwnerReference{
-				APIVersion: clusterCtx.VSphereCluster.APIVersion,
-				Kind:       clusterCtx.VSphereCluster.Kind,
-				Name:       clusterCtx.VSphereCluster.Name,
-				UID:        clusterCtx.VSphereCluster.UID,
-			}))
-
-		if err := patchHelper.Patch(ctx, vsphereMachine); err != nil {
-			patchErrors = append(patchErrors, err)
-		}
-	}
-	return kerrors.NewAggregate(patchErrors)
 }
 
 func (r *clusterReconciler) reconcileClusterModules(ctx context.Context, clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {

--- a/test/e2e/ownerreference_test.go
+++ b/test/e2e/ownerreference_test.go
@@ -122,8 +122,7 @@ var (
 			return framework.HasExactOwners(owners, clusterClassOwner)
 		},
 		"VSphereMachine": func(owners []metav1.OwnerReference) error {
-			// The vSphereCluster takes ownership of all vSphereMachines in addition to the core Machine.
-			return framework.HasExactOwners(owners, vSphereClusterOwner, machineController)
+			return framework.HasExactOwners(owners, machineController)
 		},
 		"VSphereMachineTemplate": func(owners []metav1.OwnerReference) error {
 			// The vSphereMachineTemplate can be owned by the Cluster or the ClusterClass.


### PR DESCRIPTION
Remove special handling for orphaned VSphereMachines. VSphereMachines should no longer be orphaned by CAPI MachineSets on creation so this safeguard is no longer needed.


Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2054
