### PR TITLE
🌱 Remove context from capv customized controller context

### DIFF
--- a/controllers/clustermodule_reconciler_test.go
+++ b/controllers/clustermodule_reconciler_test.go
@@ -410,7 +410,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				tt.beforeFn(md)
 			}
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(kcp, md))
-			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 			clusterCtx.VSphereCluster.Spec.ClusterModules = tt.clusterModules
 			clusterCtx.VSphereCluster.Status = infrav1.VSphereClusterStatus{VCenterVersion: infrav1.NewVCenterVersion("7.0.0")}
 
@@ -486,7 +486,7 @@ func TestReconciler_fetchMachineOwnerObjects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(tt.initObjs...))
-			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 			r := Reconciler{Client: controllerCtx.Client}
 			objMap, err := r.fetchMachineOwnerObjects(ctx, clusterCtx)
 			if tt.hasError {
@@ -511,7 +511,7 @@ func TestReconciler_fetchMachineOwnerObjects(t *testing.T) {
 			machineDeployment("foo", metav1.NamespaceDefault, fake.Clusterv1a2Name),
 			mdToBeDeleted,
 		))
-		clusterCtx := fake.NewClusterContext(controllerCtx)
+		clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 		objMap, err := Reconciler{Client: controllerCtx.Client}.fetchMachineOwnerObjects(ctx, clusterCtx)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(objMap).To(gomega.HaveLen(2))

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -93,31 +93,31 @@ func setup() {
 		panic(fmt.Sprintf("unable to create ClusterCacheReconciler controller: %v", err))
 	}
 
-	if err := AddClusterControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, &infrav1.VSphereCluster{}, controllerOpts); err != nil {
+	if err := AddClusterControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, &infrav1.VSphereCluster{}, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereCluster controller: %v", err))
 	}
-	if err := AddMachineControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, &infrav1.VSphereMachine{}, controllerOpts); err != nil {
+	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, &infrav1.VSphereMachine{}, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereMachine controller: %v", err))
 	}
-	if err := AddVMControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+	if err := AddVMControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereVM controller: %v", err))
 	}
-	if err := AddVsphereClusterIdentityControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddVsphereClusterIdentityControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
 	}
-	if err := AddVSphereDeploymentZoneControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddVSphereDeploymentZoneControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
 	}
-	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ServiceAccount controller: %v", err))
 	}
-	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup SvcDiscovery controller: %v", err))
 	}
 
 	go func() {
 		fmt.Println("Starting the manager")
-		if err := testEnv.StartManager(testEnv.GetContext()); err != nil {
+		if err := testEnv.StartManager(ctx); err != nil {
 			panic(fmt.Sprintf("failed to start the envtest manager: %v", err))
 		}
 	}()
@@ -132,7 +132,7 @@ func setup() {
 			Name: manager.DefaultPodNamespace,
 		},
 	}
-	if err := testEnv.Create(testEnv.GetContext(), ns); err != nil {
+	if err := testEnv.Create(ctx, ns); err != nil {
 		panic("unable to create controller namespace")
 	}
 }

--- a/controllers/serviceaccount_controller_intg_test.go
+++ b/controllers/serviceaccount_controller_intg_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		intCtx = helpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 		testSystemSvcAcctCM := "test-system-svc-acct-cm"
 		cfgMap := getSystemServiceAccountsConfigMap(intCtx.VSphereCluster.Namespace, testSystemSvcAcctCM)
-		Expect(intCtx.Client.Create(intCtx, cfgMap)).To(Succeed())
+		Expect(intCtx.Client.Create(ctx, cfgMap)).To(Succeed())
 		_ = os.Setenv("SERVICE_ACCOUNTS_CM_NAMESPACE", intCtx.VSphereCluster.Namespace)
 		_ = os.Setenv("SERVICE_ACCOUNTS_CM_NAME", testSystemSvcAcctCM)
 	})
@@ -62,13 +62,13 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		)
 		BeforeEach(func() {
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
-			createTestResource(intCtx, intCtx.Client, pSvcAccount)
-			assertEventuallyExistsInNamespace(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
+			createTestResource(ctx, intCtx.Client, pSvcAccount)
+			assertEventuallyExistsInNamespace(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
 		})
 		AfterEach(func() {
 			// Deleting the provider service account is not strictly required as the context itself
 			// gets teared down but keeping it for clarity.
-			deleteTestResource(intCtx, intCtx.Client, pSvcAccount)
+			deleteTestResource(ctx, intCtx.Client, pSvcAccount)
 		})
 
 		Context("When serviceaccount secret is created", func() {
@@ -77,7 +77,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				// to create a secret containing the bearer token, cert etc for a service account. We need to
 				// simulate the job of the token controller by waiting for the service account creation and then updating it
 				// with a prototype secret.
-				assertServiceAccountAndUpdateSecret(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName())
+				assertServiceAccountAndUpdateSecret(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName())
 			})
 
 			It("should create the role and role binding", func() {
@@ -102,7 +102,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 
 			It("Should reconcile", func() {
 				By("Creating the target secret in the target namespace")
-				assertTargetSecret(intCtx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace, testTargetSecret)
+				assertTargetSecret(ctx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace, testTargetSecret)
 			})
 		})
 
@@ -113,16 +113,16 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 						Name: pSvcAccount.Spec.TargetNamespace,
 					},
 				}
-				Expect(intCtx.GuestClient.Create(intCtx, targetNSObj)).To(Succeed())
-				createTargetSecretWithInvalidToken(intCtx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace)
-				assertServiceAccountAndUpdateSecret(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName())
+				Expect(intCtx.GuestClient.Create(ctx, targetNSObj)).To(Succeed())
+				createTargetSecretWithInvalidToken(ctx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace)
+				assertServiceAccountAndUpdateSecret(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName())
 			})
 			AfterEach(func() {
-				deleteTestResource(intCtx, intCtx.GuestClient, targetNSObj)
+				deleteTestResource(ctx, intCtx.GuestClient, targetNSObj)
 			})
 			It("Should reconcile", func() {
 				By("Updating the target secret in the target namespace")
-				assertTargetSecret(intCtx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace, testTargetSecret)
+				assertTargetSecret(ctx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace, testTargetSecret)
 			})
 		})
 	})
@@ -134,20 +134,20 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				Expect(ok).To(BeTrue())
 				cluster := &clusterv1.Cluster{}
 				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: clusterName}
-				Expect(intCtx.Client.Get(intCtx, key, cluster)).To(Succeed())
-				Expect(intCtx.Client.Delete(intCtx, cluster)).To(Succeed())
+				Expect(intCtx.Client.Get(ctx, key, cluster)).To(Succeed())
+				Expect(intCtx.Client.Delete(ctx, cluster)).To(Succeed())
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
 				pSvcAccount := getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
-				createTestResource(intCtx, intCtx.Client, pSvcAccount)
-				assertEventuallyExistsInNamespace(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
+				createTestResource(ctx, intCtx.Client, pSvcAccount)
+				assertEventuallyExistsInNamespace(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
 			})
 
 			By("ProviderServiceAccountsReady Condition is not set", func() {
 				vsphereCluster := &vmwarev1.VSphereCluster{}
 				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: intCtx.VSphereCluster.GetName()}
-				Expect(intCtx.Client.Get(intCtx, key, vsphereCluster)).To(Succeed())
+				Expect(intCtx.Client.Get(ctx, key, vsphereCluster)).To(Succeed())
 				Expect(conditions.Has(vsphereCluster, vmwarev1.ProviderServiceAccountsReadyCondition)).To(BeFalse())
 			})
 		})
@@ -164,19 +164,19 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 						Name:      fmt.Sprintf("%s-kubeconfig", clusterName),
 					},
 				}
-				Expect(intCtx.Client.Delete(intCtx, secret)).To(Succeed())
+				Expect(intCtx.Client.Delete(ctx, secret)).To(Succeed())
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
 				pSvcAccount := getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
-				createTestResource(intCtx, intCtx.Client, pSvcAccount)
-				assertEventuallyExistsInNamespace(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
+				createTestResource(ctx, intCtx.Client, pSvcAccount)
+				assertEventuallyExistsInNamespace(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
 			})
 
 			By("ProviderServiceAccountsReady Condition is not set", func() {
 				vsphereCluster := &vmwarev1.VSphereCluster{}
 				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: intCtx.VSphereCluster.GetName()}
-				Expect(intCtx.Client.Get(intCtx, key, vsphereCluster)).To(Succeed())
+				Expect(intCtx.Client.Get(ctx, key, vsphereCluster)).To(Succeed())
 				Expect(conditions.Has(vsphereCluster, vmwarev1.ProviderServiceAccountsReadyCondition)).To(BeFalse())
 			})
 		})
@@ -193,7 +193,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 			pSvcAccount.ObjectMeta.Annotations = map[string]string{
 				"cluster.x-k8s.io/paused": "true",
 			}
-			createTestResource(intCtx, intCtx.Client, pSvcAccount)
+			createTestResource(ctx, intCtx.Client, pSvcAccount)
 			oldOwnerUID := uuid.New().String()
 
 			role = &rbacv1.Role{
@@ -246,9 +246,9 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				},
 			}
 
-			createTestResource(intCtx, intCtx.Client, role)
-			createTestResource(intCtx, intCtx.Client, roleBinding)
-			assertEventuallyExistsInNamespace(intCtx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
+			createTestResource(ctx, intCtx.Client, role)
+			createTestResource(ctx, intCtx.Client, roleBinding)
+			assertEventuallyExistsInNamespace(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
 			svcAccountPatcher, err := patch.NewHelper(pSvcAccount, intCtx.Client)
 			Expect(err).ToNot(HaveOccurred())
 			// Unpause the ProviderServiceAccount so we can reconcile
@@ -256,9 +256,9 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 			Expect(svcAccountPatcher.Patch(ctx, pSvcAccount)).To(Succeed())
 		})
 		AfterEach(func() {
-			deleteTestResource(intCtx, intCtx.Client, pSvcAccount)
-			deleteTestResource(intCtx, intCtx.Client, role)
-			deleteTestResource(intCtx, intCtx.Client, roleBinding)
+			deleteTestResource(ctx, intCtx.Client, pSvcAccount)
+			deleteTestResource(ctx, intCtx.Client, role)
+			deleteTestResource(ctx, intCtx.Client, roleBinding)
 		})
 
 		It("should fully reconciles dependent resources", func() {

--- a/controllers/serviceaccount_controller_suite_test.go
+++ b/controllers/serviceaccount_controller_suite_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	helpers "sigs.k8s.io/cluster-api-provider-vsphere/test/helpers/vmware"
 )
 
 const (
@@ -140,12 +139,12 @@ func assertRoleWithGetPVC(ctx context.Context, ctrlClient client.Client, namespa
 	}))
 }
 
-func assertRoleBinding(_ *helpers.UnitTestContextForController, ctrlClient client.Client, namespace, name string) {
+func assertRoleBinding(ctx context.Context, ctrlClient client.Client, namespace, name string) {
 	var roleBindingList rbacv1.RoleBindingList
 	opts := &client.ListOptions{
 		Namespace: namespace,
 	}
-	err := ctrlClient.List(context.TODO(), &roleBindingList, opts)
+	err := ctrlClient.List(ctx, &roleBindingList, opts)
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(roleBindingList.Items).To(HaveLen(1))
 	Expect(roleBindingList.Items[0].Name).To(Equal(name))

--- a/controllers/serviceaccount_controller_unit_test.go
+++ b/controllers/serviceaccount_controller_unit_test.go
@@ -44,7 +44,7 @@ func unitTestsReconcileNormal() {
 	)
 
 	JustBeforeEach(func() {
-		controllerCtx = helpers.NewUnitTestContextForController(namespace, vsphereCluster, false, initObjects, nil)
+		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, vsphereCluster, false, initObjects, nil)
 		// Note: The service account provider requires a reference to the vSphereCluster hence the need to create
 		// a fake vSphereCluster in the test and pass it to during context setup.
 		reconciler = ServiceAccountReconciler{
@@ -128,7 +128,7 @@ func unitTestsReconcileNormal() {
 				initObjects = append(initObjects, getTestRoleBindingWithInvalidRoleRef(namespace, vsphereCluster.GetName()))
 			})
 			It("Should update rolebinding", func() {
-				assertRoleBinding(controllerCtx, controllerCtx.ControllerContext.Client, namespace, vsphereCluster.GetName())
+				assertRoleBinding(ctx, controllerCtx.ControllerContext.Client, namespace, vsphereCluster.GetName())
 				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
 			})
 		})

--- a/controllers/servicediscovery_controller_intg_test.go
+++ b/controllers/servicediscovery_controller_intg_test.go
@@ -42,17 +42,17 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 			initObjects = []client.Object{
 				newTestSupervisorLBServiceWithIPStatus(),
 			}
-			createObjects(intCtx, intCtx.Client, initObjects)
+			createObjects(ctx, intCtx.Client, initObjects)
 			Expect(intCtx.Client.Status().Update(ctx, newTestSupervisorLBServiceWithIPStatus())).To(Succeed())
 		})
 		AfterEach(func() {
-			deleteObjects(intCtx, intCtx.Client, initObjects)
+			deleteObjects(ctx, intCtx.Client, initObjects)
 		})
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			headlessSvc := &corev1.Service{}
-			assertEventuallyExistsInNamespace(intCtx, intCtx.Client, "kube-system", "kube-apiserver-lb-svc", headlessSvc)
-			assertHeadlessSvcWithVIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertEventuallyExistsInNamespace(ctx, intCtx.Client, "kube-system", "kube-apiserver-lb-svc", headlessSvc)
+			assertHeadlessSvcWithVIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 
@@ -60,33 +60,33 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		BeforeEach(func() {
 			initObjects = []client.Object{
 				newTestConfigMapWithHost(testSupervisorAPIServerFIP)}
-			createObjects(intCtx, intCtx.Client, initObjects)
+			createObjects(ctx, intCtx.Client, initObjects)
 		})
 		AfterEach(func() {
-			deleteObjects(intCtx, intCtx.Client, initObjects)
+			deleteObjects(ctx, intCtx.Client, initObjects)
 		})
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the FIP in the guest cluster")
-			assertHeadlessSvcWithFIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithFIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 	Context("When headless svc and endpoints already exists", func() {
 		BeforeEach(func() {
 			// Create the svc & endpoint objects in guest cluster
-			createObjects(intCtx, intCtx.GuestClient, newTestHeadlessSvcEndpoints())
+			createObjects(ctx, intCtx.GuestClient, newTestHeadlessSvcEndpoints())
 			// Init objects in the supervisor cluster
 			initObjects = []client.Object{
 				newTestSupervisorLBServiceWithIPStatus()}
-			createObjects(intCtx, intCtx.Client, initObjects)
+			createObjects(ctx, intCtx.Client, initObjects)
 			Expect(intCtx.Client.Status().Update(ctx, newTestSupervisorLBServiceWithIPStatus())).To(Succeed())
 		})
 		AfterEach(func() {
-			deleteObjects(intCtx, intCtx.Client, initObjects)
+			deleteObjects(ctx, intCtx.Client, initObjects)
 			// Note: No need to delete guest cluster objects as a new guest cluster testenv endpoint is created for each test.
 		})
 		It("Should reconcile headless svc", func() {
 			By("updating the service and endpoints using the VIP in the guest cluster")
-			assertHeadlessSvcWithUpdatedVIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithUpdatedVIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 })

--- a/controllers/servicediscovery_controller_unit_test.go
+++ b/controllers/servicediscovery_controller_unit_test.go
@@ -42,7 +42,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 	namespace := capiutil.RandomString(6)
 	JustBeforeEach(func() {
 		vsphereCluster = fake.NewVSphereCluster(namespace)
-		controllerCtx = helpers.NewUnitTestContextForController(namespace, &vsphereCluster, false, initObjects, nil)
+		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
 		reconciler = serviceDiscoveryReconciler{
 			Client:   controllerCtx.ControllerContext.Client,
 			Recorder: controllerCtx.ControllerContext.Recorder,

--- a/controllers/vmware/vspherecluster_reconciler_test.go
+++ b/controllers/vmware/vspherecluster_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -85,13 +84,13 @@ var _ = Describe("Cluster Controller Tests", func() {
 	// Ensure that the mechanism for reconciling clusters when a control plane machine gets an IP works
 	Context("Test controlPlaneMachineToCluster", func() {
 		It("Returns nil if there is no IP address", func() {
-			request := reconciler.VSphereMachineToCluster(context.Background(), vsphereMachine)
+			request := reconciler.VSphereMachineToCluster(ctx, vsphereMachine)
 			Expect(request).Should(BeNil())
 		})
 
 		It("Returns valid request with IP address", func() {
 			vsphereMachine.Status.IPAddr = testIP
-			request := reconciler.VSphereMachineToCluster(context.Background(), vsphereMachine)
+			request := reconciler.VSphereMachineToCluster(ctx, vsphereMachine)
 			Expect(request).ShouldNot(BeNil())
 			Expect(request[0].Namespace).Should(Equal(cluster.Namespace))
 			Expect(request[0].Name).Should(Equal(cluster.Name))

--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -162,7 +162,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 
 		It("should error if secret is already owned by a different cluster", func() {
 			ctx := context.Background()
-
 			capiCluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test1-",
@@ -246,7 +245,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 	})
 	Context("Reconcile delete", func() {
 		var (
-			ctx             context.Context
 			secret          *corev1.Secret
 			capiCluster     *clusterv1.Cluster
 			instance        *infrav1.VSphereCluster
@@ -254,7 +252,7 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 			key             client.ObjectKey
 		)
 		It("should remove legacy finalizer if present during the cluster deletion", func() {
-			ctx = context.Background()
+			ctx := context.Background()
 			capiCluster = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test1-",
@@ -358,7 +356,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 
 	It("should remove vspherecluster finalizer if the secret does not exist", func() {
 		ctx := context.Background()
-
 		capiCluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test1-",
@@ -700,7 +697,7 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(tt.initObjs...))
-				clusterCtx := fake.NewClusterContext(controllerCtx)
+				clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 				clusterCtx.VSphereCluster.Spec.Server = server
 
 				r := clusterReconciler{
@@ -772,7 +769,7 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(tt.initObjs...))
-				clusterCtx := fake.NewClusterContext(controllerCtx)
+				clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 				clusterCtx.VSphereCluster.Spec.Server = server
 				clusterCtx.VSphereCluster.Spec.FailureDomainSelector = &metav1.LabelSelector{MatchLabels: map[string]string{}}
 
@@ -808,7 +805,7 @@ func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 
 		assertNumberOfZones := func(selector *metav1.LabelSelector, selectedZones int) {
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(zoneOne, zoneTwo, zoneThree))
-			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 			clusterCtx.VSphereCluster.Spec.Server = server
 			clusterCtx.VSphereCluster.Spec.FailureDomainSelector = selector
 

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("VSphereClusterIdentity Reconciler", func() {
-	controllerNamespace := testEnv.Manager.GetContext().Namespace
+	controllerNamespace := testEnv.Manager.GetControllerManagerContext().Namespace
 
 	Context("Reconcile Normal", func() {
 		It("should set the ownerRef on a secret and set Ready condition", func() {

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -129,7 +129,7 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 		PatchHelper:           patchHelper,
 	}
 	defer func() {
-		if err := vsphereDeploymentZoneContext.Patch(); err != nil {
+		if err := vsphereDeploymentZoneContext.Patch(ctx); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
@@ -233,7 +233,7 @@ func (r vsphereDeploymentZoneReconciler) getVCenterSession(ctx context.Context, 
 		}
 		logger.Info("using server credentials to create the authenticated session")
 		params = params.WithUserInfo(creds.Username, creds.Password)
-		return session.GetOrCreate(r.Context,
+		return session.GetOrCreate(ctx,
 			params)
 	}
 

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -62,7 +62,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_ComputeCl
 		WithServer(simr.ServerURL().Host).
 		WithUserInfo(simr.Username(), simr.Password()).
 		WithDatacenter("*")
-	authSession, err := session.GetOrCreate(controllerCtx, params)
+	authSession, err := session.GetOrCreate(ctx, params)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	vsphereFailureDomain := &infrav1.VSphereFailureDomain{

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -617,7 +616,7 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 			mgmtContext.Password = pass
 
 			controllerCtx := fake.NewControllerContext(mgmtContext)
-			Expect(controllerCtx.Client.Create(controllerCtx, &infrav1.VSphereFailureDomain{
+			Expect(controllerCtx.Client.Create(ctx, &infrav1.VSphereFailureDomain{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "blah",
 				},
@@ -792,7 +791,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			fetchedFailureDomain := &infrav1.VSphereFailureDomain{}
-			g.Expect(mgmtContext.Client.Get(context.Background(), client.ObjectKey{Name: vsphereFailureDomain.Name}, fetchedFailureDomain)).To(Succeed())
+			g.Expect(mgmtContext.Client.Get(ctx, client.ObjectKey{Name: vsphereFailureDomain.Name}, fetchedFailureDomain)).To(Succeed())
 			g.Expect(fetchedFailureDomain.OwnerReferences).To(HaveLen(1))
 		})
 	})

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -258,7 +258,7 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 		)
 
 		// Patch the VSphereVM resource.
-		if err := vmContext.Patch(); err != nil {
+		if err := vmContext.Patch(ctx); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -370,7 +370,7 @@ func TestVmReconciler_WaitingForStaticIPAllocation(t *testing.T) {
 	}
 
 	controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext())
-	vmContext := fake.NewVMContext(controllerCtx)
+	vmContext := fake.NewVMContext(context.Background(), controllerCtx)
 	r := vmReconciler{ControllerContext: controllerCtx}
 
 	for _, tt := range tests {

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -40,13 +40,14 @@ import (
 func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 	name, namespace := "test-vm", "my-namespace"
 	setup := func(vsphereVM *infrav1.VSphereVM, initObjects ...client.Object) *capvcontext.VMContext {
-		ctx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
+		controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
 		return &capvcontext.VMContext{
-			ControllerContext: ctx,
+			ControllerContext: controllerCtx,
 			VSphereVM:         vsphereVM,
 			Logger:            logr.Discard(),
 		}
 	}
+	ctx := context.Background()
 
 	t.Run("when VSphereVM Spec has address pool references", func(t *testing.T) {
 		vsphereVM := &infrav1.VSphereVM{
@@ -84,7 +85,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(ctx, ipAddrClaimList)).To(gomega.Succeed())
 			g.Expect(ipAddrClaimList.Items).To(gomega.HaveLen(3))
 
 			for idx := range ipAddrClaimList.Items {
@@ -133,7 +134,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(claimedCondition.Message).To(gomega.Equal("3/3 claims being processed"))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(ctx, ipAddrClaimList)).To(gomega.Succeed())
 
 			for idx := range ipAddrClaimList.Items {
 				claim := ipAddrClaimList.Items[idx]
@@ -167,7 +168,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionTrue))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
-			g.Expect(testCtx.Client.List(context.TODO(), ipAddrClaimList)).To(gomega.Succeed())
+			g.Expect(testCtx.Client.List(ctx, ipAddrClaimList)).To(gomega.Succeed())
 
 			for idx := range ipAddrClaimList.Items {
 				claim := ipAddrClaimList.Items[idx]

--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func main() {
 
 	// Create a function that adds all the controllers and webhooks to the manager.
 	addToManager := func(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-		tracker, err := setupRemoteClusterCacheTracker(controllerCtx, mgr)
+		tracker, err := setupRemoteClusterCacheTracker(ctx, mgr)
 		if err != nil {
 			return perrors.Wrapf(err, "unable to create remote cluster cache tracker")
 		}
@@ -319,7 +319,7 @@ func main() {
 	}
 
 	// initialize notifier for capv-manager-bootstrap-credentials
-	watch, err := manager.InitializeWatch(mgr.GetContext(), &managerOpts)
+	watch, err := manager.InitializeWatch(mgr.GetControllerManagerContext(), &managerOpts)
 	if err != nil {
 		setupLog.Error(err, "failed to initialize watch on CAPV credentials file")
 		os.Exit(1)
@@ -422,7 +422,7 @@ func concurrency(c int) controller.Options {
 	return controller.Options{MaxConcurrentReconciles: c}
 }
 
-func setupRemoteClusterCacheTracker(controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) (*remote.ClusterCacheTracker, error) {
+func setupRemoteClusterCacheTracker(ctx context.Context, mgr ctrlmgr.Manager) (*remote.ClusterCacheTracker, error) {
 	secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
 		HTTPClient: mgr.GetHTTPClient(),
 		Cache: &client.CacheOptions{
@@ -452,7 +452,7 @@ func setupRemoteClusterCacheTracker(controllerCtx *capvcontext.ControllerManager
 		Client:           mgr.GetClient(),
 		Tracker:          tracker,
 		WatchFilterValue: managerOpts.WatchFilterValue,
-	}).SetupWithManager(controllerCtx, mgr, concurrency(clusterCacheTrackerConcurrency)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(clusterCacheTrackerConcurrency)); err != nil {
 		return nil, perrors.Wrapf(err, "unable to create ClusterCacheReconciler controller")
 	}
 

--- a/pkg/clustermodule/service_test.go
+++ b/pkg/clustermodule/service_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestService_Create(t *testing.T) {
 	t.Run("creation is skipped", func(t *testing.T) {
+		ctx := context.Background()
 		t.Run("when wrapper points to template != VSphereMachineTemplate", func(t *testing.T) {
 			md := machineDeployment("md", fake.Namespace, fake.Clusterv1a2Name)
 			md.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
@@ -42,10 +43,10 @@ func TestService_Create(t *testing.T) {
 
 			g := gomega.NewWithT(t)
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(md))
-			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 			svc := NewService(controllerCtx.ControllerManagerContext, controllerCtx.Client)
 
-			moduleUUID, err := svc.Create(context.Background(), clusterCtx, mdWrapper{md})
+			moduleUUID, err := svc.Create(ctx, clusterCtx, mdWrapper{md})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(moduleUUID).To(gomega.BeEmpty())
 		})
@@ -73,10 +74,10 @@ func TestService_Create(t *testing.T) {
 
 			g := gomega.NewWithT(t)
 			controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(md, machineTemplate))
-			clusterCtx := fake.NewClusterContext(controllerCtx)
+			clusterCtx := fake.NewClusterContext(ctx, controllerCtx)
 			svc := NewService(controllerCtx.ControllerManagerContext, controllerCtx.Client)
 
-			moduleUUID, err := svc.Create(context.Background(), clusterCtx, mdWrapper{md})
+			moduleUUID, err := svc.Create(ctx, clusterCtx, mdWrapper{md})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(moduleUUID).To(gomega.BeEmpty())
 		})

--- a/pkg/clustermodule/util.go
+++ b/pkg/clustermodule/util.go
@@ -22,7 +22,7 @@ import (
 	"github.com/blang/semver"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 // Compare returns whether both the cluster module slices are the same.
@@ -50,8 +50,8 @@ func Compare(oldMods, newMods []infrav1.ClusterModule) bool {
 }
 
 // IsClusterCompatible checks if the VCenterVersion is compatibly with CAPV. Only version 7 and over are supported.
-func IsClusterCompatible(ctx *context.ClusterContext) bool {
-	version := ctx.VSphereCluster.Status.VCenterVersion
+func IsClusterCompatible(clusterCtx *capvcontext.ClusterContext) bool {
+	version := clusterCtx.VSphereCluster.Status.VCenterVersion
 	if version == "" {
 		return false
 	}

--- a/pkg/clustermodule/util_test.go
+++ b/pkg/clustermodule/util_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 func Test_IsCompatible(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_IsCompatible(t *testing.T) {
 			}
 
 			g := gomega.NewWithT(t)
-			isCompatible := IsClusterCompatible(&context.ClusterContext{
+			isCompatible := IsClusterCompatible(&capvcontext.ClusterContext{
 				VSphereCluster: cluster,
 			})
 			g.Expect(isCompatible).To(gomega.Equal(tt.isCompatible))

--- a/pkg/context/controller_manager_context.go
+++ b/pkg/context/controller_manager_context.go
@@ -17,7 +17,6 @@ limitations under the License.
 package context
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -33,8 +32,6 @@ import (
 // ControllerManagerContext is the context of the controller that owns the
 // controllers.
 type ControllerManagerContext struct {
-	context.Context //nolint:containedctx
-
 	// Namespace is the namespace in which the resource is located responsible
 	// for running the controller manager.
 	Namespace string

--- a/pkg/context/fake/fake_cluster_context.go
+++ b/pkg/context/fake/fake_cluster_context.go
@@ -17,29 +17,31 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 // NewClusterContext returns a fake ClusterContext for unit testing
 // reconcilers with a fake client.
-func NewClusterContext(ctx *context.ControllerContext) *context.ClusterContext {
+func NewClusterContext(ctx context.Context, controllerCtx *capvcontext.ControllerContext) *capvcontext.ClusterContext {
 	// Create the cluster resources.
 	cluster := newClusterV1()
 	vsphereCluster := newVSphereCluster(cluster)
 
 	// Add the cluster resources to the fake cluster client.
-	if err := ctx.Client.Create(ctx, &cluster); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &cluster); err != nil {
 		panic(err)
 	}
-	if err := ctx.Client.Create(ctx, &vsphereCluster); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &vsphereCluster); err != nil {
 		panic(err)
 	}
 
-	return &context.ClusterContext{
+	return &capvcontext.ClusterContext{
 		Cluster:        &cluster,
 		VSphereCluster: &vsphereCluster,
 	}

--- a/pkg/context/fake/fake_controller_context.go
+++ b/pkg/context/fake/fake_controller_context.go
@@ -19,17 +19,17 @@ package fake
 import (
 	clientrecord "k8s.io/client-go/tools/record"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/record"
 )
 
 // NewControllerContext returns a fake ControllerContext for unit testing
 // reconcilers with a fake client.
-func NewControllerContext(ctx *context.ControllerManagerContext) *context.ControllerContext {
-	return &context.ControllerContext{
-		ControllerManagerContext: ctx,
+func NewControllerContext(controllerManagerCtx *capvcontext.ControllerManagerContext) *capvcontext.ControllerContext {
+	return &capvcontext.ControllerContext{
+		ControllerManagerContext: controllerManagerCtx,
 		Name:                     ControllerName,
-		Logger:                   ctx.Logger.WithName(ControllerName),
+		Logger:                   controllerManagerCtx.Logger.WithName(ControllerName),
 		Recorder:                 record.New(clientrecord.NewFakeRecorder(1024)),
 	}
 }

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -17,8 +17,6 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -56,7 +54,6 @@ func NewControllerManagerContext(initObjects ...client.Object) *capvcontext.Cont
 	).WithObjects(initObjects...).Build()
 
 	return &capvcontext.ControllerManagerContext{
-		Context:                 context.Background(),
 		Client:                  clientWithObjects,
 		Logger:                  ctrllog.Log.WithName(ControllerManagerName),
 		Scheme:                  scheme,

--- a/pkg/context/fake/fake_machine_context.go
+++ b/pkg/context/fake/fake_machine_context.go
@@ -28,16 +28,16 @@ import (
 
 // NewMachineContext returns a fake VIMMachineContext for unit testing
 // reconcilers with a fake client.
-func NewMachineContext(clusterCtx *capvcontext.ClusterContext, controllerCtx *capvcontext.ControllerContext) *capvcontext.VIMMachineContext {
+func NewMachineContext(ctx context.Context, clusterCtx *capvcontext.ClusterContext, controllerCtx *capvcontext.ControllerContext) *capvcontext.VIMMachineContext {
 	// Create the machine resources.
 	machine := newMachineV1a4()
 	vsphereMachine := newVSphereMachine(machine)
 
 	// Add the cluster resources to the fake cluster client.
-	if err := controllerCtx.Client.Create(context.TODO(), &machine); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &machine); err != nil {
 		panic(err)
 	}
-	if err := controllerCtx.Client.Create(context.TODO(), &vsphereMachine); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &vsphereMachine); err != nil {
 		panic(err)
 	}
 

--- a/pkg/context/fake/fake_vm_context.go
+++ b/pkg/context/fake/fake_vm_context.go
@@ -17,33 +17,35 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 // NewVMContext returns a fake VMContext for unit testing
 // reconcilers with a fake client.
-func NewVMContext(ctx *context.ControllerContext) *context.VMContext {
+func NewVMContext(ctx context.Context, controllerCtx *capvcontext.ControllerContext) *capvcontext.VMContext {
 	// Create the resources.
 	vsphereVM := newVSphereVM()
 
 	// Add the resources to the fake client.
-	if err := ctx.Client.Create(ctx, &vsphereVM); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &vsphereVM); err != nil {
 		panic(err)
 	}
 
-	helper, err := patch.NewHelper(&vsphereVM, ctx.Client)
+	helper, err := patch.NewHelper(&vsphereVM, controllerCtx.Client)
 	if err != nil {
 		panic(err)
 	}
 
-	return &context.VMContext{
-		ControllerContext: ctx,
+	return &capvcontext.VMContext{
+		ControllerContext: controllerCtx,
 		VSphereVM:         &vsphereVM,
-		Logger:            ctx.Logger.WithName(vsphereVM.Name),
+		Logger:            controllerCtx.Logger.WithName(vsphereVM.Name),
 		PatchHelper:       helper,
 	}
 }

--- a/pkg/context/fake/fake_vmware_cluster_context.go
+++ b/pkg/context/fake/fake_vmware_cluster_context.go
@@ -26,7 +26,7 @@ import (
 
 // NewVmwareClusterContext returns a fake ClusterContext for unit testing
 // reconcilers with a fake client.
-func NewVmwareClusterContext(controllerCtx *capvcontext.ControllerContext, namespace string, vsphereCluster *vmwarev1.VSphereCluster) *vmware.ClusterContext {
+func NewVmwareClusterContext(ctx context.Context, controllerCtx *capvcontext.ControllerContext, namespace string, vsphereCluster *vmwarev1.VSphereCluster) *vmware.ClusterContext {
 	// Create the cluster resources.
 	cluster := newClusterV1()
 	if vsphereCluster == nil {
@@ -35,10 +35,10 @@ func NewVmwareClusterContext(controllerCtx *capvcontext.ControllerContext, names
 	}
 
 	// Add the cluster resources to the fake cluster client.
-	if err := controllerCtx.Client.Create(context.TODO(), &cluster); err != nil {
+	if err := controllerCtx.Client.Create(ctx, &cluster); err != nil {
 		panic(err)
 	}
-	if err := controllerCtx.Client.Create(context.TODO(), vsphereCluster); err != nil {
+	if err := controllerCtx.Client.Create(ctx, vsphereCluster); err != nil {
 		panic(err)
 	}
 

--- a/pkg/context/vm_context.go
+++ b/pkg/context/vm_context.go
@@ -18,6 +18,7 @@ limitations under the License.
 package context
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -44,8 +45,8 @@ func (c *VMContext) String() string {
 }
 
 // Patch updates the object and its status on the API server.
-func (c *VMContext) Patch() error {
-	return c.PatchHelper.Patch(c, c.VSphereVM)
+func (c *VMContext) Patch(ctx context.Context) error {
+	return c.PatchHelper.Patch(ctx, c.VSphereVM)
 }
 
 // GetLogger returns this context's logger.

--- a/pkg/context/vspheredeploymentzone_context.go
+++ b/pkg/context/vspheredeploymentzone_context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package context
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -37,7 +38,7 @@ type VSphereDeploymentZoneContext struct {
 }
 
 // Patch patches the VSphereDeploymentZone.
-func (c *VSphereDeploymentZoneContext) Patch() error {
+func (c *VSphereDeploymentZoneContext) Patch(ctx context.Context) error {
 	conditions.SetSummary(c.VSphereDeploymentZone,
 		conditions.WithConditions(
 			infrav1.VCenterAvailableCondition,
@@ -45,7 +46,7 @@ func (c *VSphereDeploymentZoneContext) Patch() error {
 			infrav1.PlacementConstraintMetCondition,
 		),
 	)
-	return c.PatchHelper.Patch(c, c.VSphereDeploymentZone)
+	return c.PatchHelper.Patch(ctx, c.VSphereDeploymentZone)
 }
 
 // String returns a string with the GroupVersionKind and name of the VSphereDeploymentZone.

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -44,8 +44,8 @@ import (
 type Manager interface {
 	ctrl.Manager
 
-	// GetContext returns the controller manager's context.
-	GetContext() *capvcontext.ControllerManagerContext
+	// GetControllerManagerContext returns the controller manager's context.
+	GetControllerManagerContext() *capvcontext.ControllerManagerContext
 }
 
 // New returns a new CAPV controller manager.
@@ -78,7 +78,6 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 
 	// Build the controller manager context.
 	controllerManagerContext := &capvcontext.ControllerManagerContext{
-		Context:                 context.Background(),
 		WatchNamespaces:         opts.Cache.Namespaces,
 		Namespace:               opts.PodNamespace,
 		Name:                    opts.PodName,
@@ -102,18 +101,18 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 	}
 
 	return &manager{
-		Manager:       mgr,
-		controllerCtx: controllerManagerContext,
+		Manager:              mgr,
+		controllerManagerCtx: controllerManagerContext,
 	}, nil
 }
 
 type manager struct {
 	ctrl.Manager
-	controllerCtx *capvcontext.ControllerManagerContext
+	controllerManagerCtx *capvcontext.ControllerManagerContext
 }
 
-func (m *manager) GetContext() *capvcontext.ControllerManagerContext {
-	return m.controllerCtx
+func (m *manager) GetControllerManagerContext() *capvcontext.ControllerManagerContext {
+	return m.controllerManagerCtx
 }
 
 // UpdateCredentials reads and updates credentials from the credentials file.

--- a/pkg/services/govmomi/cluster/cluster_suite_test.go
+++ b/pkg/services/govmomi/cluster/cluster_suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,8 +32,7 @@ func TestCluster(t *testing.T) {
 }
 
 type testComputeClusterCtx struct {
-	context.Context //nolint:containedctx
-	finder          *find.Finder
+	finder *find.Finder
 }
 
 func (t testComputeClusterCtx) GetSession() *session.Session {

--- a/pkg/services/govmomi/cluster/rule_test.go
+++ b/pkg/services/govmomi/cluster/rule_test.go
@@ -47,8 +47,7 @@ func TestVerifyAffinityRule(t *testing.T) {
 	finder.SetDatacenter(dc)
 
 	computeClusterCtx := testComputeClusterCtx{
-		Context: context.Background(),
-		finder:  finder,
+		finder: finder,
 	}
 
 	rule, err := VerifyAffinityRule(ctx, computeClusterCtx, "DC0_C0", "blah-host-group", "blah-vm-group")

--- a/pkg/services/govmomi/cluster/service.go
+++ b/pkg/services/govmomi/cluster/service.go
@@ -27,9 +27,6 @@ import (
 )
 
 type computeClusterContext interface {
-	// TODO(zhanggbj): remove context.Context in this interface after refactoring context for all controllers.
-	context.Context
-
 	GetSession() *session.Session
 }
 

--- a/pkg/services/govmomi/cluster/service_test.go
+++ b/pkg/services/govmomi/cluster/service_test.go
@@ -38,24 +38,25 @@ func TestListHostsFromGroup(t *testing.T) {
 	}
 	defer sim.Destroy()
 
-	client, _ := govmomi.NewClient(context.Background(), sim.ServerURL(), true)
+	ctx := context.Background()
+	client, _ := govmomi.NewClient(ctx, sim.ServerURL(), true)
 	finder := find.NewFinder(client.Client, false)
 
-	dc, _ := finder.DatacenterOrDefault(context.Background(), "DC0")
+	dc, _ := finder.DatacenterOrDefault(ctx, "DC0")
 	finder.SetDatacenter(dc)
 
-	ccr, err := finder.ClusterComputeResource(context.Background(), "DC0_C0")
+	ccr, err := finder.ClusterComputeResource(ctx, "DC0_C0")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	refs, err := ListHostsFromGroup(context.Background(), ccr, "test_grp_1")
+	refs, err := ListHostsFromGroup(ctx, ccr, "test_grp_1")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(refs).To(HaveLen(2))
 
-	refs, err = ListHostsFromGroup(context.Background(), ccr, "test_grp_2")
+	refs, err = ListHostsFromGroup(ctx, ccr, "test_grp_2")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(refs).To(HaveLen(1))
 
-	refs, err = ListHostsFromGroup(context.Background(), ccr, "blah")
+	refs, err = ListHostsFromGroup(ctx, ccr, "blah")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(refs).To(BeEmpty())
 }

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -43,8 +43,7 @@ func Test_VMGroup(t *testing.T) {
 	finder.SetDatacenter(dc)
 
 	computeClusterCtx := testComputeClusterCtx{
-		Context: context.Background(),
-		finder:  finder,
+		finder: finder,
 	}
 
 	computeClusterName := "DC0_C0"
@@ -62,7 +61,7 @@ func Test_VMGroup(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasVM).To(BeFalse())
 
-	task, err := vmGrp.Add(computeClusterCtx, vmRef)
+	task, err := vmGrp.Add(ctx, vmRef)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(task.Wait(ctx)).To(Succeed())
 	g.Expect(vmGrp.listVMs()).To(HaveLen(3))

--- a/pkg/services/govmomi/context.go
+++ b/pkg/services/govmomi/context.go
@@ -21,11 +21,11 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 )
 
 type virtualMachineContext struct {
-	context.VMContext
+	capvcontext.VMContext
 	Ref       types.ManagedObjectReference
 	Obj       *object.VirtualMachine
 	State     *infrav1.VirtualMachine

--- a/pkg/services/govmomi/ipam/status_test.go
+++ b/pkg/services/govmomi/ipam/status_test.go
@@ -49,8 +49,8 @@ func Test_buildIPAMDeviceConfigs(t *testing.T) {
 	)
 
 	before := func() {
-		vmCtx = *fake.NewVMContext(fake.NewControllerContext(fake.NewControllerManagerContext()))
 		ctx = context.Background()
+		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},
 		}
@@ -251,7 +251,7 @@ func Test_BuildState(t *testing.T) {
 
 	before := func() {
 		ctx = context.Background()
-		vmCtx = *fake.NewVMContext(fake.NewControllerContext(fake.NewControllerManagerContext()))
+		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},
 		}

--- a/pkg/services/govmomi/metadata/metadata_suite_test.go
+++ b/pkg/services/govmomi/metadata/metadata_suite_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	Expect(configureSimulatorAndContext()).To(Succeed())
+	Expect(configureSimulatorAndContext(ctx)).To(Succeed())
 	Expect(createTagsAndCategories()).To(Succeed())
 })
 
@@ -135,13 +135,13 @@ var _ = Describe("Metadata_CreateTag", func() {
 	})
 })
 
-func configureSimulatorAndContext() (err error) {
+func configureSimulatorAndContext(ctx context.Context) (err error) {
 	sim, err = vcsim.NewBuilder().Build()
 	if err != nil {
 		return
 	}
 
-	vmCtx = fake.NewVMContext(fake.NewControllerContext(fake.NewControllerManagerContext()))
+	vmCtx = fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
 	vmCtx.VSphereVM.Spec.Server = sim.ServerURL().Host
 
 	authSession, err := session.GetOrCreate(

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -245,7 +245,7 @@ func (vms *VMService) DestroyVM(ctx context.Context, vmCtx *capvcontext.VMContex
 		}
 
 		virtualMachineCtx.VSphereVM.Status.TaskRef = task.Reference().Value
-		if err = virtualMachineCtx.Patch(); err != nil {
+		if err = virtualMachineCtx.Patch(ctx); err != nil {
 			vmCtx.Logger.Error(err, "patch failed", "vm", virtualMachineCtx.String())
 			return reconcile.Result{}, vm, err
 		}
@@ -351,7 +351,7 @@ func (vms *VMService) reconcilePowerState(ctx context.Context, virtualMachineCtx
 
 		// Update the VSphereVM.Status.TaskRef to track the power-on task.
 		virtualMachineCtx.VSphereVM.Status.TaskRef = task.Reference().Value
-		if err = virtualMachineCtx.Patch(); err != nil {
+		if err = virtualMachineCtx.Patch(ctx); err != nil {
 			virtualMachineCtx.Logger.Error(err, "patch failed", "vm", virtualMachineCtx.String())
 			return false, err
 		}

--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -39,9 +39,7 @@ func emptyVirtualMachineContext() *virtualMachineContext {
 		VMContext: capvcontext.VMContext{
 			Logger: logr.Discard(),
 			ControllerContext: &capvcontext.ControllerContext{
-				ControllerManagerContext: &capvcontext.ControllerManagerContext{
-					Context: context.TODO(),
-				},
+				ControllerManagerContext: &capvcontext.ControllerManagerContext{},
 			},
 		},
 	}

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -180,7 +180,6 @@ func checkAndRetryTask(vmCtx *capvcontext.VMContext, task *mo.Task) (bool, error
 
 func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx *virtualMachineContext, powerOnTask *object.Task) {
 	reconcileVSphereVMOnChannel(
-		ctx,
 		&virtualMachineCtx.VMContext,
 		func() (<-chan []interface{}, <-chan error, error) {
 			// Wait for the VM to be powered on.
@@ -296,7 +295,7 @@ func reconcileVSphereVMOnFuncCompletion(_ context.Context, vmCtx *capvcontext.VM
 	}()
 }
 
-func reconcileVSphereVMOnChannel(_ context.Context, vmCtx *capvcontext.VMContext, waitFn func() (<-chan []interface{}, <-chan error, error)) {
+func reconcileVSphereVMOnChannel(vmCtx *capvcontext.VMContext, waitFn func() (<-chan []interface{}, <-chan error, error)) {
 	obj := vmCtx.VSphereVM.DeepCopy()
 	gvk := obj.GetObjectKind().GroupVersionKind()
 
@@ -328,8 +327,6 @@ func reconcileVSphereVMOnChannel(_ context.Context, vmCtx *capvcontext.VMContext
 				if err != nil {
 					vmCtx.Logger.Error(err, "error occurred while waiting to trigger a generic event")
 				}
-				return
-			case <-vmCtx.Done():
 				return
 			}
 		}

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -302,7 +302,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	// patch the vsphereVM early to ensure that the task is
 	// reflected in the status right away, this avoid situations
 	// of concurrent clones
-	if err := vmCtx.Patch(); err != nil {
+	if err := vmCtx.Patch(ctx); err != nil {
 		vmCtx.Logger.Error(err, "patch failed", "vspherevm", vmCtx.VSphereVM)
 	}
 	return nil

--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
@@ -120,7 +120,7 @@ func TestGetDiskSpec(t *testing.T) {
 					VirtualMachineCloneSpec: cloneSpec,
 				},
 			}
-			vmContext := &context.VMContext{VSphereVM: vsphereVM}
+			vmContext := &capvcontext.VMContext{VSphereVM: vsphereVM}
 			devices, err := getDiskSpec(vmContext, tc.disks)
 			if (tc.err != "" && err == nil) || (tc.err == "" && err != nil) || (err != nil && tc.err != err.Error()) {
 				t.Fatalf("Expected to get '%v' error from getDiskSpec, got: '%v'", tc.err, err)

--- a/pkg/services/vimmachine_test.go
+++ b/pkg/services/vimmachine_test.go
@@ -27,7 +27,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 )
 
@@ -60,14 +60,14 @@ var _ = Describe("VimMachineService_GenerateOverrideFunc", func() {
 		}
 	}
 	var (
-		controllerCtx     *context.ControllerContext
-		machineCtx        *context.VIMMachineContext
+		controllerCtx     *capvcontext.ControllerContext
+		machineCtx        *capvcontext.VIMMachineContext
 		vimMachineService *VimMachineService
 	)
 
 	BeforeEach(func() {
 		controllerCtx = fake.NewControllerContext(fake.NewControllerManagerContext(deplZone("one"), deplZone("two"), failureDomain("one"), failureDomain("two")))
-		machineCtx = fake.NewMachineContext(fake.NewClusterContext(controllerCtx), controllerCtx)
+		machineCtx = fake.NewMachineContext(ctx, fake.NewClusterContext(ctx, controllerCtx), controllerCtx)
 		vimMachineService = &VimMachineService{controllerCtx.Client}
 	})
 
@@ -188,8 +188,8 @@ var _ = Describe("VimMachineService_GenerateOverrideFunc", func() {
 
 var _ = Describe("VimMachineService_GetHostInfo", func() {
 	var (
-		controllerCtx     *context.ControllerContext
-		machineCtx        *context.VIMMachineContext
+		controllerCtx     *capvcontext.ControllerContext
+		machineCtx        *capvcontext.VIMMachineContext
 		vimMachineService = &VimMachineService{}
 		hostAddr          = "1.2.3.4"
 	)
@@ -215,7 +215,7 @@ var _ = Describe("VimMachineService_GetHostInfo", func() {
 	Context("When VMProvisioned Condition is set", func() {
 		BeforeEach(func() {
 			controllerCtx = fake.NewControllerContext(fake.NewControllerManagerContext(getVSphereVM(hostAddr, corev1.ConditionTrue)))
-			machineCtx = fake.NewMachineContext(fake.NewClusterContext(controllerCtx), controllerCtx)
+			machineCtx = fake.NewMachineContext(ctx, fake.NewClusterContext(ctx, controllerCtx), controllerCtx)
 			vimMachineService = &VimMachineService{controllerCtx.Client}
 		})
 		It("Fetches host address from the VSphereVM object", func() {
@@ -228,7 +228,7 @@ var _ = Describe("VimMachineService_GetHostInfo", func() {
 	Context("When VMProvisioned Condition is unset", func() {
 		BeforeEach(func() {
 			controllerCtx = fake.NewControllerContext(fake.NewControllerManagerContext(getVSphereVM(hostAddr, corev1.ConditionFalse)))
-			machineCtx = fake.NewMachineContext(fake.NewClusterContext(controllerCtx), controllerCtx)
+			machineCtx = fake.NewMachineContext(ctx, fake.NewClusterContext(ctx, controllerCtx), controllerCtx)
 			vimMachineService = &VimMachineService{controllerCtx.Client}
 		})
 		It("returns empty string", func() {
@@ -242,8 +242,8 @@ var _ = Describe("VimMachineService_GetHostInfo", func() {
 
 var _ = Describe("VimMachineService_createOrPatchVSphereVM", func() {
 	var (
-		controllerCtx       *context.ControllerContext
-		machineCtx          *context.VIMMachineContext
+		controllerCtx       *capvcontext.ControllerContext
+		machineCtx          *capvcontext.VIMMachineContext
 		vimMachineService   *VimMachineService
 		hostAddr            = "1.2.3.4"
 		fakeLongClusterName = "fake-long-clustername"
@@ -268,7 +268,7 @@ var _ = Describe("VimMachineService_createOrPatchVSphereVM", func() {
 	}
 
 	controllerCtx = fake.NewControllerContext(fake.NewControllerManagerContext(getVSphereVM(hostAddr, corev1.ConditionTrue)))
-	machineCtx = fake.NewMachineContext(fake.NewClusterContext(controllerCtx), controllerCtx)
+	machineCtx = fake.NewMachineContext(ctx, fake.NewClusterContext(ctx, controllerCtx), controllerCtx)
 	machineCtx.Machine.SetName(fakeLongClusterName)
 	vimMachineService = &VimMachineService{controllerCtx.Client}
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -53,30 +53,31 @@ func TestGetSession(t *testing.T) {
 		WithUserInfo(simr.Username(), simr.Password()).WithDatacenter("*")
 
 	// Get first session
-	s, err := GetOrCreate(context.Background(), params)
+	ctx := context.Background()
+	s, err := GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())
 	assertSessionCountEqualTo(g, simr, 1)
 
 	// Get session key
-	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	sessionInfo, err := s.SessionManager.UserSession(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(sessionInfo).ToNot(BeNil())
 	firstSession := sessionInfo.Key
 
 	// remove session expect no session
-	g.Expect(s.TagManager.Logout(context.Background())).To(Succeed())
+	g.Expect(s.TagManager.Logout(ctx)).To(Succeed())
 	g.Expect(simr.Run(fmt.Sprintf("session.rm %s", firstSession))).To(Succeed())
 	assertSessionCountEqualTo(g, simr, 0)
 
-	// request sesion again should be a new and different session
-	s, err = GetOrCreate(context.Background(), params)
+	// request session again should be a new and different session
+	s, err = GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())
 
 	// Get session info, session key should be different from
 	// last session
-	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	sessionInfo, err = s.SessionManager.UserSession(ctx)
 	g.Expect(sessionInfo).ToNot(BeNil())
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(firstSession))
@@ -132,13 +133,14 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 		WithDatacenter("*")
 
 	// Get first Session
-	s, err := GetOrCreate(context.Background(), params)
+	ctx := context.Background()
+	s, err := GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())
 	assertSessionCountEqualTo(g, simr, 1)
 
 	// Get session key
-	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	sessionInfo, err := s.SessionManager.UserSession(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(sessionInfo).ToNot(BeNil())
 	firstSession := sessionInfo.Key
@@ -146,25 +148,25 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	// Get the session again
 	// as keep alive is enabled and session is
 	// not expired we must get the same cached session
-	s, err = GetOrCreate(context.Background(), params)
+	s, err = GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())
-	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	sessionInfo, err = s.SessionManager.UserSession(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(sessionInfo).ToNot(BeNil())
 	g.Expect(sessionInfo.Key).To(BeEquivalentTo(firstSession))
 	assertSessionCountEqualTo(g, simr, 1)
 
 	// Try to remove vim session
-	g.Expect(s.Logout(context.Background())).To(Succeed())
+	g.Expect(s.Logout(ctx)).To(Succeed())
 
 	// after logging out old session must be deleted,
 	// we must get a new different session
 	// total session count must remain 1
-	s, err = GetOrCreate(context.Background(), params)
+	s, err = GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())
-	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	sessionInfo, err = s.SessionManager.UserSession(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(sessionInfo).ToNot(BeNil())
 	g.Expect(sessionInfo.Key).ToNot(BeEquivalentTo(firstSession))

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -17,8 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"context"
-
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
@@ -152,9 +150,8 @@ func createScheme() *runtime.Scheme {
 func CreateClusterContext(cluster *clusterv1.Cluster, vsphereCluster *vmwarev1.VSphereCluster) (*vmware.ClusterContext, *capvcontext.ControllerContext) {
 	scheme := createScheme()
 	controllerManagerContext := &capvcontext.ControllerManagerContext{
-		Context: context.Background(),
-		Logger:  klog.Background().WithName("controller-manager-logger"),
-		Scheme:  scheme,
+		Logger: klog.Background().WithName("controller-manager-logger"),
+		Scheme: scheme,
 		Client: testclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
 			&vmoprv1.VirtualMachineService{},
 			&vmoprv1.VirtualMachine{},

--- a/test/helpers/vmware/intg_test_context.go
+++ b/test/helpers/vmware/intg_test_context.go
@@ -40,7 +40,6 @@ import (
 // IntegrationTestContext is used for integration testing
 // Supervisor controllers.
 type IntegrationTestContext struct {
-	context.Context   //nolint:containedctx
 	Client            client.Client
 	GuestClient       client.Client
 	Namespace         string
@@ -63,7 +62,7 @@ func (ctx *IntegrationTestContext) AfterEach() {
 		},
 	}
 	By("Destroying integration test namespace")
-	Expect(ctx.Client.Delete(ctx, namespace)).To(Succeed())
+	Expect(ctx.Client.Delete(context.Background(), namespace)).To(Succeed())
 
 	if ctx.envTest != nil {
 		By("Shutting down guest cluster control plane")
@@ -84,8 +83,7 @@ func (ctx *IntegrationTestContext) AfterEach() {
 // with the IntegrationTestContext returned by this function.
 func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestClient client.Client) *IntegrationTestContext {
 	testCtx := &IntegrationTestContext{
-		Context: ctx,
-		Client:  integrationTestClient,
+		Client: integrationTestClient,
 	}
 
 	By("Creating a temporary namespace", func() {

--- a/test/helpers/vmware/unit_test_context.go
+++ b/test/helpers/vmware/unit_test_context.go
@@ -49,20 +49,20 @@ type UnitTestContextForController struct {
 // NewUnitTestContextForController returns a new UnitTestContextForController
 // with an optional prototype cluster for unit testing controllers that do not
 // invoke the VSphereCluster spec controller.
-func NewUnitTestContextForController( /*newReconcilerFn NewReconcilerFunc, */ namespace string, vSphereCluster *vmwarev1.VSphereCluster,
+func NewUnitTestContextForController(ctx context.Context, namespace string, vSphereCluster *vmwarev1.VSphereCluster,
 	prototypeCluster bool, initObjects, gcInitObjects []client.Object) *UnitTestContextForController {
 	controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
 
-	ctx := &UnitTestContextForController{
-		GuestClusterContext: fake.NewGuestClusterContext(context.TODO(), fake.NewVmwareClusterContext(controllerCtx, namespace, vSphereCluster),
+	unitTestCtx := &UnitTestContextForController{
+		GuestClusterContext: fake.NewGuestClusterContext(ctx, fake.NewVmwareClusterContext(ctx, controllerCtx, namespace, vSphereCluster),
 			controllerCtx, prototypeCluster, gcInitObjects...),
 		ControllerContext: controllerCtx,
 	}
-	ctx.Key = client.ObjectKey{Namespace: ctx.VSphereCluster.Namespace, Name: ctx.VSphereCluster.Name}
+	unitTestCtx.Key = client.ObjectKey{Namespace: unitTestCtx.VSphereCluster.Namespace, Name: unitTestCtx.VSphereCluster.Name}
 
-	CreatePrototypePrereqs(context.TODO(), controllerCtx.Client)
+	CreatePrototypePrereqs(ctx, controllerCtx.Client)
 
-	return ctx
+	return unitTestCtx
 }
 
 func CreatePrototypePrereqs(ctx context.Context, c client.Client) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Remove context from capv customized controller context, also get rid of containedctx exceptions.
This is part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2295.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of 
#2295
#2384 

