### PR TITLE
🌱 Setup separate context for test files to avoid flaky errors

### DIFF
--- a/controllers/clustermodule_reconciler_test.go
+++ b/controllers/clustermodule_reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 )
 
 func TestReconciler_Reconcile(t *testing.T) {
+	ctx := context.Background()
 	kcpUUID, mdUUID := uuid.New().String(), uuid.New().String()
 	kcp := controlPlane("kcp", metav1.NamespaceDefault, fake.Clusterv1a2Name)
 	md := machineDeployment("md", metav1.NamespaceDefault, fake.Clusterv1a2Name)
@@ -437,6 +439,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 }
 
 func TestReconciler_fetchMachineOwnerObjects(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		name         string
 		numOfMDs     int

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -44,10 +44,7 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
-var (
-	testEnv *helpers.TestEnvironment
-	ctx     = ctrl.SetupSignalHandler()
-)
+var testEnv *helpers.TestEnvironment
 
 func TestMain(m *testing.M) {
 	setup()
@@ -61,6 +58,7 @@ func setup() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
 
+	ctx := ctrl.SetupSignalHandler()
 	testEnv = helpers.NewTestEnvironment(ctx)
 
 	secretCachingClient, err := client.New(testEnv.Manager.GetConfig(), client.Options{

--- a/controllers/serviceaccount_controller_intg_test.go
+++ b/controllers/serviceaccount_controller_intg_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -40,9 +41,13 @@ import (
 )
 
 var _ = Describe("ProviderServiceAccount controller integration tests", func() {
-	var intCtx *helpers.IntegrationTestContext
+	var (
+		ctx    context.Context
+		intCtx *helpers.IntegrationTestContext
+	)
 
 	BeforeEach(func() {
+		ctx = context.Background()
 		intCtx = helpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 		testSystemSvcAcctCM := "test-system-svc-acct-cm"
 		cfgMap := getSystemServiceAccountsConfigMap(intCtx.VSphereCluster.Namespace, testSystemSvcAcctCM)

--- a/controllers/serviceaccount_controller_unit_test.go
+++ b/controllers/serviceaccount_controller_unit_test.go
@@ -36,6 +36,7 @@ var _ = Describe("ServiceAccountReconciler ReconcileNormal", unitTestsReconcileN
 
 func unitTestsReconcileNormal() {
 	var (
+		ctx            context.Context
 		controllerCtx  *helpers.UnitTestContextForController
 		vsphereCluster *vmwarev1.VSphereCluster
 		initObjects    []client.Object
@@ -44,7 +45,9 @@ func unitTestsReconcileNormal() {
 	)
 
 	JustBeforeEach(func() {
+		ctx = context.Background()
 		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, vsphereCluster, false, initObjects, nil)
+
 		// Note: The service account provider requires a reference to the vSphereCluster hence the need to create
 		// a fake vSphereCluster in the test and pass it to during context setup.
 		reconciler = ServiceAccountReconciler{

--- a/controllers/servicediscovery_controller_intg_test.go
+++ b/controllers/servicediscovery_controller_intg_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -27,10 +29,12 @@ import (
 
 var _ = Describe("Service Discovery controller integration tests", func() {
 	var (
+		ctx         context.Context
 		intCtx      *helpers.IntegrationTestContext
 		initObjects []client.Object
 	)
 	BeforeEach(func() {
+		ctx = context.Background()
 		intCtx = helpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 	})
 	AfterEach(func() {

--- a/controllers/servicediscovery_controller_unit_test.go
+++ b/controllers/servicediscovery_controller_unit_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +36,7 @@ var _ = Describe("ServiceDiscoveryReconciler ReconcileNormal", serviceDiscoveryU
 
 func serviceDiscoveryUnitTestsReconcileNormal() {
 	var (
+		ctx            context.Context
 		controllerCtx  *helpers.UnitTestContextForController
 		vsphereCluster vmwarev1.VSphereCluster
 		initObjects    []client.Object
@@ -41,6 +44,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 	)
 	namespace := capiutil.RandomString(6)
 	JustBeforeEach(func() {
+		ctx = context.Background()
 		vsphereCluster = fake.NewVSphereCluster(namespace)
 		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
 		reconciler = serviceDiscoveryReconciler{

--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -47,7 +47,11 @@ const (
 )
 
 var _ = Describe("VIM based VSphere ClusterReconciler", func() {
-	BeforeEach(func() {})
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
 	AfterEach(func() {})
 
 	Context("Reconcile an VSphereCluster", func() {
@@ -161,7 +165,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 		})
 
 		It("should error if secret is already owned by a different cluster", func() {
-			ctx := context.Background()
 			capiCluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "test1-",
@@ -245,7 +248,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 	})
 
 	It("should remove vspherecluster finalizer if the secret does not exist", func() {
-		ctx := context.Background()
 		capiCluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test1-",
@@ -552,6 +554,7 @@ func createVsphereMachine(ctx context.Context, env *helpers.TestEnvironment, nam
 
 func TestClusterReconciler_ReconcileDeploymentZones(t *testing.T) {
 	server := "vcenter123.foo.com"
+	ctx := context.Background()
 
 	t.Run("with nil selectors", func(t *testing.T) {
 		g := NewWithT(t)

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +31,12 @@ import (
 )
 
 var _ = Describe("VSphereClusterIdentity Reconciler", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	controllerNamespace := testEnv.Manager.GetControllerManagerContext().Namespace
 
 	Context("Reconcile Normal", func() {

--- a/controllers/vspheredeploymentzone_controller_domain_test.go
+++ b/controllers/vspheredeploymentzone_controller_domain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -33,6 +34,7 @@ import (
 )
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_ComputeClusterZone(t *testing.T) {
+	ctx := context.Background()
 	g := NewWithT(t)
 
 	model := simulator.VPX()
@@ -114,6 +116,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_ComputeCl
 }
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_HostGroupZone(t *testing.T) {
+	ctx := context.Background()
 	g := NewWithT(t)
 
 	model := simulator.VPX()
@@ -195,6 +198,7 @@ func TestVsphereDeploymentZoneReconciler_Reconcile_VerifyFailureDomain_HostGroup
 }
 
 func TestVsphereDeploymentZoneReconciler_Reconcile_CreateAndAttachMetadata(t *testing.T) {
+	ctx := context.Background()
 	simr, err := vcsim.NewBuilder().
 		WithOperations("cluster.group.create -cluster DC0_C0 -name group-one -host DC0_C0_H0 DC0_C0_H1",
 			"cluster.group.create -cluster DC0_C0 -name group-two -host DC0_C0_H2").

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -41,6 +42,7 @@ import (
 
 var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 	var (
+		ctx  context.Context
 		simr *vcsim.Simulator
 
 		failureDomainKey, deploymentZoneKey client.ObjectKey
@@ -75,6 +77,7 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 	})
 
 	BeforeEach(func() {
+		ctx = context.Background()
 		vsphereFailureDomain = &infrav1.VSphereFailureDomain{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "blah-fd-",
@@ -301,6 +304,7 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 })
 
 func TestVSphereDeploymentZone_Reconcile(t *testing.T) {
+	ctx := context.Background()
 	g := NewWithT(t)
 	model := simulator.VPX()
 	model.Pool = 1
@@ -592,6 +596,8 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		// Looks odd, but need to reinitialize test variable
 		tt := tt
@@ -647,6 +653,7 @@ func TestVsphereDeploymentZone_Failed_ReconcilePlacementConstraint(t *testing.T)
 }
 
 func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
+	ctx := context.Background()
 	vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VSphereDeploymentZone",

--- a/controllers/vspheremachine_controller_test.go
+++ b/controllers/vspheremachine_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +34,7 @@ import (
 
 var _ = Describe("VsphereMachineReconciler", func() {
 	var (
+		ctx         context.Context
 		capiCluster *clusterv1.Cluster
 		capiMachine *clusterv1.Machine
 
@@ -54,6 +57,7 @@ var _ = Describe("VsphereMachineReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
+		ctx = context.Background()
 		testNs, err = testEnv.CreateNamespace(ctx, "vsphere-machine-reconciler")
 		Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -53,6 +53,7 @@ import (
 
 func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 	var (
+		ctx     context.Context
 		machine *clusterv1.Machine
 		cluster *clusterv1.Cluster
 
@@ -64,6 +65,7 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		ipAddressClaim *ipamv1.IPAddressClaim
 	)
 
+	ctx = context.Background()
 	poolAPIGroup := "some.ipam.api.group"
 
 	// initializing a fake server to replace the vSphere endpoint
@@ -534,6 +536,7 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 }
 
 func Test_reconcile(t *testing.T) {
+	ctx := context.Background()
 	ns := "test"
 	vsphereCluster := &infrav1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
+	ctx := context.Background()
 	name, namespace := "test-vm", "my-namespace"
 	setup := func(vsphereVM *infrav1.VSphereVM, initObjects ...client.Object) *capvcontext.VMContext {
 		controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
@@ -47,7 +48,6 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			Logger:            logr.Discard(),
 		}
 	}
-	ctx := context.Background()
 
 	t.Run("when VSphereVM Spec has address pool references", func(t *testing.T) {
 		vsphereVM := &infrav1.VSphereVM{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Setup separate context for test files under /controllers instead of using the test-package context, this is to avoid flaky errors we found in CI.

Please find more details in #2295


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2295
