### PR TITLE
:seedling: Add flag to reserve memory to the virtual machine memory size

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -172,6 +172,13 @@ type VirtualMachineCloneSpec struct {
 	// virtual machine is cloned.
 	// +optional
 	MemoryMiB int64 `json:"memoryMiB,omitempty"`
+	// MemoryReservationLockedToMax is a flag that indicates whether or not the
+	// memory resource reservation for this virtual machine will always be
+	// equal to the virtual machine's memory size.
+	// Defaults to the eponymous property value in the template from which the
+	// virtual machine is cloned.
+	// +optional
+	MemoryReservationLockedToMax *bool `json:"memoryReservationLockedToMax,omitempty"`
 	// DiskGiB is the size of a virtual machine's disk, in GiB.
 	// Defaults to the eponymous property value in the template from which the
 	// virtual machine is cloned.

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -1297,6 +1297,11 @@ func (in *VirtualMachine) DeepCopy() *VirtualMachine {
 func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 	*out = *in
 	in.Network.DeepCopyInto(&out.Network)
+	if in.MemoryReservationLockedToMax != nil {
+		in, out := &in.MemoryReservationLockedToMax, &out.MemoryReservationLockedToMax
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalDisksGiB != nil {
 		in, out := &in.AdditionalDisksGiB, &out.AdditionalDisksGiB
 		*out = make([]int32, len(*in))

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -125,6 +125,13 @@ spec:
                   from which the virtual machine is cloned.
                 format: int64
                 type: integer
+              memoryReservationLockedToMax:
+                description: MemoryReservationLockedToMax is a flag that indicates
+                  whether or not the memory resource reservation for this virtual
+                  machine will always be equal to the virtual machine's memory size.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                type: boolean
               network:
                 description: Network is the network configuration for this machine's
                   VM.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -137,6 +137,13 @@ spec:
                           in the template from which the virtual machine is cloned.
                         format: int64
                         type: integer
+                      memoryReservationLockedToMax:
+                        description: MemoryReservationLockedToMax is a flag that indicates
+                          whether or not the memory resource reservation for this
+                          virtual machine will always be equal to the virtual machine's
+                          memory size. Defaults to the eponymous property value in
+                          the template from which the virtual machine is cloned.
+                        type: boolean
                       network:
                         description: Network is the network configuration for this
                           machine's VM.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -141,6 +141,13 @@ spec:
                   from which the virtual machine is cloned.
                 format: int64
                 type: integer
+              memoryReservationLockedToMax:
+                description: MemoryReservationLockedToMax is a flag that indicates
+                  whether or not the memory resource reservation for this virtual
+                  machine will always be equal to the virtual machine's memory size.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                type: boolean
               network:
                 description: Network is the network configuration for this machine's
                   VM.

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -167,6 +167,12 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 		memMiB = 2048
 	}
 
+	var memLockedToMax *bool
+	if vmCtx.VSphereVM.Spec.MemoryReservationLockedToMax != nil {
+		memLockedToMax = new(bool)
+		*memLockedToMax = *vmCtx.VSphereVM.Spec.MemoryReservationLockedToMax
+	}
+
 	// Disable the vAppConfig during VM creation to ensure Cloud-Init inside of the guest does not
 	// activate and prefer the OVF datasource over the VMware datasource.
 	vappConfigRemoved := true
@@ -176,14 +182,15 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 			// Assign the clone's InstanceUUID the value of the Kubernetes Machine
 			// object's UID. This allows lookup of the cloned VM prior to knowing
 			// the VM's UUID.
-			InstanceUuid:      string(vmCtx.VSphereVM.UID),
-			Flags:             newVMFlagInfo(),
-			DeviceChange:      deviceSpecs,
-			ExtraConfig:       extraConfig,
-			NumCPUs:           numCPUs,
-			NumCoresPerSocket: numCoresPerSocket,
-			MemoryMB:          memMiB,
-			VAppConfigRemoved: &vappConfigRemoved,
+			InstanceUuid:                 string(vmCtx.VSphereVM.UID),
+			Flags:                        newVMFlagInfo(),
+			DeviceChange:                 deviceSpecs,
+			ExtraConfig:                  extraConfig,
+			NumCPUs:                      numCPUs,
+			NumCoresPerSocket:            numCoresPerSocket,
+			MemoryMB:                     memMiB,
+			MemoryReservationLockedToMax: memLockedToMax,
+			VAppConfigRemoved:            &vappConfigRemoved,
 		},
 		Location: types.VirtualMachineRelocateSpec{
 			DiskMoveType: string(diskMoveType),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Add flag to configure memory reservation at VSphereMachineTemplate level.
**Which issue(s) this PR fixes**:
Fixes #2468
