### PR TITLE
:bug: Re-add return on vimmachine error

### DIFF
--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -136,6 +136,7 @@ func (v *VimMachineService) ReconcileNormal(ctx context.Context, machineCtx capv
 	vm, err := v.createOrPatchVSphereVM(ctx, vimMachineCtx, vsphereVM)
 	if err != nil {
 		log.Error(err, "error creating or patching VM")
+		return false, err
 	}
 
 	// Waits the VM's ready state.


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2395 removed a return from reconciliation.

When an error occurs, the caller cannot be able to verify there was an error, and moves forward, calling the pointer of object "vm", which is null

This PR re-adds https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/commit/a3f651f1606429b718a1d4583bfa827665167e0e#diff-2f616e5f5f40526609f3723e82cbcf01b16b9f240ea00fcdf3fc06b6aa6d164cL132 

