### PR TITLE
🌱 Improve logging for `vspherevm_controller` & `vspherevm_ipaddress_reconciler`

### DIFF
--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -40,11 +40,10 @@ import (
 func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 	name, namespace := "test-vm", "my-namespace"
 	setup := func(vsphereVM *infrav1.VSphereVM, initObjects ...client.Object) *capvcontext.VMContext {
-		controllerCtx := fake.NewControllerContext(fake.NewControllerManagerContext(initObjects...))
 		return &capvcontext.VMContext{
-			ControllerContext: controllerCtx,
-			VSphereVM:         vsphereVM,
-			Logger:            logr.Discard(),
+			ControllerManagerContext: fake.NewControllerManagerContext(initObjects...),
+			VSphereVM:                vsphereVM,
+			Logger:                   logr.Discard(),
 		}
 	}
 	ctx := context.Background()

--- a/pkg/context/fake/fake_vm_context.go
+++ b/pkg/context/fake/fake_vm_context.go
@@ -28,25 +28,24 @@ import (
 
 // NewVMContext returns a fake VMContext for unit testing
 // reconcilers with a fake client.
-func NewVMContext(ctx context.Context, controllerCtx *capvcontext.ControllerContext) *capvcontext.VMContext {
+func NewVMContext(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext) *capvcontext.VMContext {
 	// Create the resources.
 	vsphereVM := newVSphereVM()
 
 	// Add the resources to the fake client.
-	if err := controllerCtx.Client.Create(ctx, &vsphereVM); err != nil {
+	if err := controllerManagerCtx.Client.Create(ctx, &vsphereVM); err != nil {
 		panic(err)
 	}
 
-	helper, err := patch.NewHelper(&vsphereVM, controllerCtx.Client)
+	helper, err := patch.NewHelper(&vsphereVM, controllerManagerCtx.Client)
 	if err != nil {
 		panic(err)
 	}
 
 	return &capvcontext.VMContext{
-		ControllerContext: controllerCtx,
-		VSphereVM:         &vsphereVM,
-		Logger:            controllerCtx.Logger.WithName(vsphereVM.Name),
-		PatchHelper:       helper,
+		ControllerManagerContext: controllerManagerCtx,
+		VSphereVM:                &vsphereVM,
+		PatchHelper:              helper,
 	}
 }
 

--- a/pkg/context/vm_context.go
+++ b/pkg/context/vm_context.go
@@ -30,7 +30,7 @@ import (
 
 // VMContext is a Go context used with a VSphereVM.
 type VMContext struct {
-	*ControllerContext
+	*ControllerManagerContext
 	ClusterModuleInfo    *string
 	VSphereVM            *infrav1.VSphereVM
 	PatchHelper          *patch.Helper

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 	defer simr.Destroy()
 
 	ctx := context.Background()
-	vmContext := fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
+	vmContext := fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 	vmContext.VSphereVM.Spec.Server = simr.ServerURL().Host
 
 	authSession, err := session.GetOrCreate(

--- a/pkg/services/govmomi/ipam/status_test.go
+++ b/pkg/services/govmomi/ipam/status_test.go
@@ -50,7 +50,7 @@ func Test_buildIPAMDeviceConfigs(t *testing.T) {
 
 	before := func() {
 		ctx = context.Background()
-		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
+		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},
 		}
@@ -251,7 +251,7 @@ func Test_BuildState(t *testing.T) {
 
 	before := func() {
 		ctx = context.Background()
-		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
+		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},
 		}

--- a/pkg/services/govmomi/metadata/metadata_suite_test.go
+++ b/pkg/services/govmomi/metadata/metadata_suite_test.go
@@ -141,7 +141,7 @@ func configureSimulatorAndContext(ctx context.Context) (err error) {
 		return
 	}
 
-	vmCtx = fake.NewVMContext(ctx, fake.NewControllerContext(fake.NewControllerManagerContext()))
+	vmCtx = fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 	vmCtx.VSphereVM.Spec.Server = sim.ServerURL().Host
 
 	authSession, err := session.GetOrCreate(

--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -45,10 +45,8 @@ const (
 func emptyVirtualMachineContext() *virtualMachineContext {
 	return &virtualMachineContext{
 		VMContext: capvcontext.VMContext{
-			Logger: logr.Discard(),
-			ControllerContext: &capvcontext.ControllerContext{
-				ControllerManagerContext: &capvcontext.ControllerManagerContext{},
-			},
+			Logger:                   logr.Discard(),
+			ControllerManagerContext: &capvcontext.ControllerManagerContext{},
 		},
 	}
 }

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -48,11 +48,11 @@ const (
 // in VMContext.VSphereVM.Status.TaskRef.
 func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []byte, format bootstrapv1.Format) error {
 	vmCtx = &capvcontext.VMContext{
-		ControllerContext: vmCtx.ControllerContext,
-		VSphereVM:         vmCtx.VSphereVM,
-		Session:           vmCtx.Session,
-		Logger:            vmCtx.Logger.WithName("vcenter"),
-		PatchHelper:       vmCtx.PatchHelper,
+		ControllerManagerContext: vmCtx.ControllerManagerContext,
+		VSphereVM:                vmCtx.VSphereVM,
+		Session:                  vmCtx.Session,
+		Logger:                   vmCtx.Logger.WithName("vcenter"),
+		PatchHelper:              vmCtx.PatchHelper,
 	}
 	vmCtx.Logger.Info("starting clone process")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: 
This improves logging in `vspherevm_controller `& `vspherevm_ipaddress_reconciler` by using the logger from passed context and removing `ControllerContext` types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2076
