### PR TITLE
🌱 kubetest: add flake attempts configuration to match upstream tests

### DIFF
--- a/test/e2e/data/kubetest/upstream-e2e-alpha-features.yaml
+++ b/test/e2e/data/kubetest/upstream-e2e-alpha-features.yaml
@@ -3,5 +3,6 @@ disable-log-dump: true
 ginkgo.focus: \[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking 
 ginkgo.skip: \[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0
 minStartupPods: 8
+ginkgo.flake-attempts: 1
 
 ginkgo.trace: true

--- a/test/e2e/data/kubetest/upstream-e2e-serial.yaml
+++ b/test/e2e/data/kubetest/upstream-e2e-serial.yaml
@@ -3,5 +3,6 @@ disable-log-dump: true
 ginkgo.focus: \[Serial\]|\[Disruptive\]
 ginkgo.skip: \[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]
 minStartupPods: 8
+ginkgo.flake-attempts: 1
 
 ginkgo.trace: true

--- a/test/e2e/data/kubetest/upstream-e2e-slow.yaml
+++ b/test/e2e/data/kubetest/upstream-e2e-slow.yaml
@@ -3,5 +3,6 @@ disable-log-dump: true
 ginkgo.focus: \[Slow\] 
 ginkgo.skip: \[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 minStartupPods: 8
+ginkgo.flake-attempts: 1
 
 ginkgo.trace: true

--- a/test/e2e/data/kubetest/upstream-e2e.yaml
+++ b/test/e2e/data/kubetest/upstream-e2e.yaml
@@ -3,5 +3,6 @@ disable-log-dump: true
 # ginkgo.focus:
 ginkgo.skip: \[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 minStartupPods: 8
+ginkgo.flake-attempts: 1
 
 ginkgo.trace: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes the kubetest configuration for the upstream tests to match the upstream configuration.

Adds `ginkgo.flake-attempts: 1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
part of #2452
