### PR TITLE
🐛 Fix potential panics when retrieving VSphereCluster from Cluster.spec.infrastructureRef

### DIFF
--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -526,7 +526,7 @@ func (r *clusterReconciler) controlPlaneMachineToCluster(ctx context.Context, o 
 		log.Error(err, "VSphereMachine is missing cluster label or cluster does not exist")
 		return nil
 	}
-	log = log.WithValues("Cluster", klog.KObj(cluster), "VSphereCluster", klog.KRef(cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+	log = log.WithValues("Cluster", klog.KObj(cluster))
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	if conditions.IsTrue(cluster, clusterv1.ControlPlaneInitializedCondition) {
@@ -536,6 +536,14 @@ func (r *clusterReconciler) controlPlaneMachineToCluster(ctx context.Context, o 
 	if !cluster.Spec.ControlPlaneEndpoint.IsZero() {
 		return nil
 	}
+
+	if cluster.Spec.InfrastructureRef == nil {
+		log.Info("Failed to get VSphereCluster: Cluster.spec.infrastructureRef is not yet set")
+		return nil
+	}
+
+	log = log.WithValues("VSphereCluster", klog.KRef(cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the VSphereCluster
 	vsphereCluster := &infrav1.VSphereCluster{}

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -568,7 +568,7 @@ func (r vmReconciler) retrieveVcenterSession(ctx context.Context, vsphereVM *inf
 	}
 
 	if cluster.Spec.InfrastructureRef == nil {
-		return nil, errors.Errorf("cannot retrieve vCenter session for cluster %s: .spec.infrastructureRef is nil", klog.KObj(cluster))
+		return nil, errors.Errorf("cannot retrieve vCenter session for cluster %s: Cluster.spec.infrastructureRef is nil", klog.KObj(cluster))
 	}
 	key := ctrlclient.ObjectKey{
 		Namespace: cluster.Namespace,

--- a/pkg/util/cluster.go
+++ b/pkg/util/cluster.go
@@ -45,6 +45,11 @@ func GetVSphereClusterFromVMwareMachine(ctx context.Context, c client.Client, ma
 		return nil, err
 	}
 
+	if cluster.Spec.InfrastructureRef == nil {
+		return nil, errors.Errorf("error getting VSphereCluster name from VSphereMachine %s/%s: Cluster.spec.infrastructureRef not yet set",
+			machine.Namespace, machine.Name)
+	}
+
 	vsphereClusterKey := apitypes.NamespacedName{
 		Namespace: machine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
@@ -70,6 +75,10 @@ func GetVSphereClusterFromVSphereMachine(ctx context.Context, c client.Client, m
 		return nil, err
 	}
 
+	if cluster.Spec.InfrastructureRef == nil {
+		return nil, errors.Errorf("error getting VSphereCluster name from VSphereMachine %s/%s: Cluster.spec.infrastructureRef not yet set",
+			machine.Namespace, machine.Name)
+	}
 	vsphereClusterKey := apitypes.NamespacedName{
 		Namespace: machine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
To be honest. Not sure how Machines can exist before Cluster.spec.infrastructureRef is set, but given someone hit this case with CAPD (https://github.com/kubernetes-sigs/cluster-api/pull/9673), I think there is no reason not to play it safe in CAPV as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
