### PR TITLE
:seedling: Bump kube-vip to 0.6.3 and enable service mode

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -571,7 +571,7 @@ func kubeVIPPodSpec() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:            "kube-vip",
-					Image:           "ghcr.io/kube-vip/kube-vip:v0.5.11",
+					Image:           "ghcr.io/kube-vip/kube-vip:v0.6.3",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args: []string{
 						"manager",
@@ -622,6 +622,16 @@ func kubeVIPPodSpec() *corev1.Pod {
 							// Number of times the leader will hold the lease for
 							Name:  "vip_retryperiod",
 							Value: "2",
+						},
+						{
+							// Enables kube-vip to watch Services of type LoadBalancer
+							Name:  "svc_enable",
+							Value: "true",
+						},
+						{
+							// Enables a leadership Election for each Service, allowing them to be distributed
+							Name:  "svc_election",
+							Value: "true",
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -107,7 +107,11 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.11
+            - name: svc_enable
+              value: "true"
+            - name: svc_election
+              value: "true"
+            image: ghcr.io/kube-vip/kube-vip:v0.6.3
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -144,7 +144,11 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.11
+            - name: svc_enable
+              value: "true"
+            - name: svc_election
+              value: "true"
+            image: ghcr.io/kube-vip/kube-vip:v0.6.3
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -48,7 +48,11 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.11
+            - name: svc_enable
+              value: "true"
+            - name: svc_election
+              value: "true"
+            image: ghcr.io/kube-vip/kube-vip:v0.6.3
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -134,7 +134,11 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.11
+            - name: svc_enable
+              value: "true"
+            - name: svc_election
+              value: "true"
+            image: ghcr.io/kube-vip/kube-vip:v0.6.3
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump the kube-vip to 0.6.3 in the flavor templates.
Also enable kube-vip to watch service for LB.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2507