### PR TITLE
✨ Update kustomization.yaml to support kustomize v5

### DIFF
--- a/config/default/crd/kustomization.yaml
+++ b/config/default/crd/kustomization.yaml
@@ -17,24 +17,24 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_vspheremachines.yaml
-- patches/webhook_in_vsphereclusters.yaml
-- patches/webhook_in_vspheremachinetemplates.yaml
-- patches/webhook_in_vspherevms.yaml
-- patches/webhook_in_vspherefailuredomains.yaml
-- patches/webhook_in_vspheredeploymentzones.yaml
-- patches/webhook_in_vsphereclustertemplates.yaml
+- path: patches/webhook_in_vspheremachines.yaml
+- path: patches/webhook_in_vsphereclusters.yaml
+- path: patches/webhook_in_vspheremachinetemplates.yaml
+- path: patches/webhook_in_vspherevms.yaml
+- path: patches/webhook_in_vspherefailuredomains.yaml
+- path: patches/webhook_in_vspheredeploymentzones.yaml
+- path: patches/webhook_in_vsphereclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_vspheremachines.yaml
-- patches/cainjection_in_vsphereclusters.yaml
-- patches/cainjection_in_vspheremachinetemplates.yaml
-- patches/cainjection_in_vspherevms.yaml
-- patches/cainjection_in_vspherefailuredomains.yaml
-- patches/cainjection_in_vspheredeploymentzones.yaml
-- patches/cainjection_in_vsphereclustertemplates.yaml
+- path: patches/cainjection_in_vspheremachines.yaml
+- path: patches/cainjection_in_vsphereclusters.yaml
+- path: patches/cainjection_in_vspheremachinetemplates.yaml
+- path: patches/cainjection_in_vspherevms.yaml
+- path: patches/cainjection_in_vspherefailuredomains.yaml
+- path: patches/cainjection_in_vspheredeploymentzones.yaml
+- path: patches/cainjection_in_vsphereclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.


### PR DESCRIPTION
When building the manifests kustomizations with kustomize v5 I'm getting the following error.

```
error: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch
```
This is because kustomize v5.0 has dropped support for legacy patches.

https://github.com/kubernetes-sigs/kustomize/pull/4911
https://github.com/kubernetes-sigs/kustomize/issues/1373

As such the suggestion is to add the newly supported patches' `- path:` syntax, which should be [compatible as back as kustomize 3.0.1](https://github.com/kubernetes-sigs/kustomize/issues/1373#issuecomment-618439078)