### PR TITLE
✨ Set InternalDNS address for machines

### DIFF
--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -266,6 +266,10 @@ func (v *VimMachineService) reconcileNetwork(ctx context.Context, vimMachineCtx 
 			Address: addr,
 		})
 	}
+	machineAddresses = append(machineAddresses, clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalDNS,
+		Address: vm.GetName(),
+	})
 	vimMachineCtx.VSphereMachine.Status.Addresses = machineAddresses
 
 	if len(vimMachineCtx.VSphereMachine.Status.Addresses) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it:**
Currently, CAPV doesn't set an internal dns address for its machines as other providers do. We would ideally want to set this value to the virtual machine's name, so we know that this address can be resolvable.

**Which issue(s) this PR fixes** _(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2013