### PR TITLE
🐛 test: use GinkgoRecover in go subroutine of ownerreference test

### DIFF
--- a/test/e2e/ownerreference_test.go
+++ b/test/e2e/ownerreference_test.go
@@ -264,6 +264,7 @@ func forcePeriodicReconcile(ctx context.Context, c ctrlclient.Client, namespace 
 	ticker := time.NewTicker(20 * time.Second)
 	stopTimer := time.NewTimer(5 * time.Minute)
 	go func() {
+		defer GinkgoRecover()
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Properly uses `defer GinkgoRecover` in go routine.

Error occured in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/2550/pull-cluster-api-provider-vsphere-e2e-full-main/1734914800363769856

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
