### PR TITLE
🌱 Implement consistent pause behavior

### DIFF
--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -89,6 +90,14 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	if cluster != nil {
 		log = log.WithValues("Cluster", klog.KObj(cluster))
 		ctx = ctrl.LoggerInto(ctx, log)
+
+		if annotations.IsPaused(cluster, vsphereCluster) {
+			log.Info("Reconciliation is paused for this object")
+			return ctrl.Result{}, nil
+		}
+	} else if annotations.HasPaused(vsphereCluster) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
 	}
 
 	// Build the patch helper.

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -96,6 +97,11 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 
 	log = log.WithValues("VSphereFailureDomain", klog.KRef("", vsphereDeploymentZone.Spec.FailureDomain))
 	ctx = ctrl.LoggerInto(ctx, log)
+
+	if annotations.HasPaused(vsphereDeploymentZone) {
+		log.Info("Reconciliation is paused for this object")
+		return reconcile.Result{}, nil
+	}
 
 	patchHelper, err := patch.NewHelper(vsphereDeploymentZone, r.Client)
 	if err != nil {

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -221,9 +221,11 @@ func (r *machineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 
 		if annotations.IsPaused(cluster, machineContext.GetVSphereMachine()) {
 			log.Info("Reconciliation is paused for this object")
-			// Cluster is set to nil to continue for the delete case and return in the regular case.
-			cluster = nil
+			return reconcile.Result{}, nil
 		}
+	} else if annotations.HasPaused(machineContext.GetVSphereMachine()) {
+		log.Info("Reconciliation is paused for this object")
+		return reconcile.Result{}, nil
 	}
 
 	// Create the patch helper.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The goal of this PR is to implement consistent pause behavior, which is:
* if cluster.spec.paused is true => do nothing (if the cluster object is available)
* if reconciled object has paused annotation => do nothing

I mostly tried to keep the previous behavior regarding what should happen if we can't retrieve the cluster object. This is handled very differently across various providers. Maybe the reconciles still have to work even if the Cluster object is already gone, I have no idea.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2510 
