### PR TITLE
🌱 test: set logger in e2e suite

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -99,6 +100,8 @@ func TestE2E(t *testing.T) {
 	w, err := ginkgoextensions.EnableFileLogging(filepath.Join(artifactFolder, "ginkgo-log.txt"))
 	NewWithT(t).Expect(err).ToNot(HaveOccurred())
 	defer w.Close()
+
+	ctrl.SetLogger(klog.Background())
 
 	RunSpecs(t, "capv-e2e")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Discovered the following during test:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 59 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0006756c0, {0x2dac73c, 0x14})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/deleg.go:147 +0x4c
	>  github.com/go-logr/logr.Logger.WithName({{0x31f08f8, 0xc0006756c0}, 0x0}, {0x2dac73c?, 0x0?})
	>  	/home/prow/go/pkg/mod/github.com/go-logr/logr@v1.3.0/logr.go:349 +0x46
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x40cc4d?, {0x0, 0xc00016e000, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:122 +0xff
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0x2628ea0?, {0x0, 0xc00016e000, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:103 +0x85
	>  sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).GetClient.func1({0x525760?, 0xc000dc0790?})
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.6.1-0.20231212113133-a1fff03d13f3/framework/cluster_proxy.go:204 +0x85
	>  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1(0xc0008011e0?, {0x31ea[520](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/2561/pull-cluster-api-provider-vsphere-e2e-main/1737818322868637696#1:build-log.txt%3A520)?, 0xc000cdef30?})
	>  	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/loop.go:49 +0x5d
	>  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext({0x31ea520, 0xc000cdef30}, {0x31e7c30?, 0xc0008011e0}, 0x1, 0x0, 0x0?)
	>  	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/loop.go:50 +0xf0
	>  k8s.io/apimachinery/pkg/util/wait.PollUntilContextTimeout({0x31ea4e8?, 0xc000198008?}, 0xb2d05e00, 0xc00100f070?, 0xea?, 0xc0002b68f0?)
	>  	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.28.4/pkg/util/wait/poll.go:48 +0xa7
	>  sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).GetClient(0xc000dd0cc0)
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.6.1-0.20231212113133-a1fff03d13f3/framework/cluster_proxy.go:203 +0xca
	>  sigs.k8s.io/cluster-api/test/framework/clusterctl.InitManagementClusterAndWatchControllerLogs({0x31ea4b0?, _}, {{0x31fbb48, 0xc000dd0cc0}, {0xc0009c6000, 0x31}, {0x2d918f8, 0xb}, {0xc0002b68c0, 0x1, ...}, ...}, ...)
	>  	/home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.6.1-0.20231212113133-a1fff03d13f3/framework/clusterctl/clusterctl_helpers.go:73 +0x416
	>  sigs.k8s.io/cluster-api-provider-vsphere/test/framework.InitBootstrapCluster({0x31ea4b0, 0xc00070bd60}, {0x31fbb48?, 0xc000dd0cc0?}, 0xc000219130, {0xc0009c6000, 0x31}, {0xc00005e0ca, 0xf})
	>  	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-vsphere/test/framework/framework.go:91 +0x493
	>  sigs.k8s.io/cluster-api-provider-vsphere/test/e2e.glob..func7()
	>  	/home/prow/go/src/sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/e2e_suite_test.go:133 +0x50f
	>  reflect.Value.call({0x26[535](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/2561/pull-cluster-api-provider-vsphere-e2e-main/1737818322868637696#1:build-log.txt%3A535)20?, 0x2f03d60?, 0x13?}, {0x2d83b1d, 0x4}, {0xc000167f20, 0x0, 0x0?})
	>  	/usr/local/go/src/reflect/value.go:586 +0xb07
	>  reflect.Value.Call({0x2653520?, 0x2f03d60?, 0x0?}, {0xc00013df20?, 0x0?, 0x0?})
	>  	/usr/local/go/src/reflect/value.go:370 +0xbc
	>  github.com/onsi/ginkgo/v2/internal.extractSynchronizedBeforeSuiteProc1Body.func1({0x31efb78?, 0xc000136090?})
	>  	/home/prow/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.2/internal/node.go:486 +0x107
	>  github.com/onsi/ginkgo/v2/internal.(*Suite).runSuiteNode.func1({0x31efb78?, 0xc000136090?})
	>  	/home/prow/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.2/internal/suite.go:642 +0x34
	>  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
	>  	/home/prow/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.2/internal/suite.go:889 +0x98
	>  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode
	>  	/home/prow/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.13.2/internal/suite.go:876 +0xd65
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
