### PR TITLE
🐛 Skip updating VMOp immutable fields

### DIFF
--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -282,6 +282,14 @@ var _ = Describe("VirtualMachine tests", func() {
 			}
 			requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
 			verifyOutput(supervisorMachineContext)
+
+			By("Updates to immutable VMOp fields are dropped", func() {
+				vsphereMachine.Spec.ImageName = "new-image"
+				vsphereMachine.Spec.ClassName = "new-class"
+
+				requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
+				verifyOutput(supervisorMachineContext)
+			})
 		})
 
 		Specify("Reconcile will add a probe once the cluster reports that the control plane is ready", func() {

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -50,7 +50,8 @@ func CreateCluster(clusterName string) *clusterv1.Cluster {
 			Kind:       clusterKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterName,
+			Name:      clusterName,
+			Namespace: corev1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
 			InfrastructureRef: &corev1.ObjectReference{
@@ -69,7 +70,8 @@ func CreateVSphereCluster(clusterName string) *vmwarev1.VSphereCluster {
 			Kind:       infraClusterKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterName,
+			Name:      clusterName,
+			Namespace: corev1.NamespaceDefault,
 		},
 	}
 }
@@ -81,7 +83,8 @@ func CreateMachine(machineName, clusterName, k8sVersion string, controlPlaneLabe
 			Kind:       machineKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: machineName,
+			Name:      machineName,
+			Namespace: corev1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterNameLabelName: clusterName,
 			},
@@ -116,7 +119,8 @@ func CreateVSphereMachine(machineName, clusterName, className, imageName, storag
 			Kind:       infraMachineKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: machineName,
+			Name:      machineName,
+			Namespace: corev1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: clusterName,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
VMOp mutation webhook updates the VMOp Spec.ImageName to a user-friendly name prefixed `vmi-` or `cvmi-`. This causes the reconciliation of the VSphereMachine to fail since the controllers copy the all spec fields to the VMOp `VirtualMachine` on every reconcile. Since imageName is an immutable field we see the below error:
```yaml
Name:         guestcluster1-control-plane-bz7k9-c9whq
Namespace:    gctest
Labels:       cluster.x-k8s.io/cluster-name=guestcluster1
              cluster.x-k8s.io/control-plane=
              cluster.x-k8s.io/control-plane-name=guestcluster1-control-plane
              topology.cluster.x-k8s.io/owned=
Annotations:  cluster.x-k8s.io/cloned-from-groupkind: VSphereMachineTemplate.vmware.infrastructure.cluster.x-k8s.io
              cluster.x-k8s.io/cloned-from-name: guestcluster1-control-plane-bz7k9
              run.tanzu.vmware.com/resolve-os-image: os-name=photon
API Version:  vmware.infrastructure.cluster.x-k8s.io/v1beta1
Kind:         VSphereMachine
Metadata:
  Creation Timestamp:  2023-12-14T20:01:42Z
  Finalizers:
    vspheremachine.infrastructure.cluster.x-k8s.io
  Generation:  2
  Owner References:
    API Version:           cluster.x-k8s.io/v1beta1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  Machine
    Name:                  guestcluster1-control-plane-wr5w2
    UID:                   fd9da4eb-8b09-4484-9e1a-90a284861f4c
  Resource Version:        415153
  UID:                     1ba496ef-ccc4-4a6a-9e29-4a8009ec7957
Spec:
  Class Name:      best-effort-xsmall
  Failure Domain:  vmware-system-legacy
  Image Name:      tkgs-ova-photon-3-v1.23.8---vmware.3-tkg.1
  Storage Class:   wcpglobalstorageprofile
Status:
  Conditions:
    Last Transition Time:  2023-12-14T20:01:46Z
    Message:               failed to create or update VirtualMachine: admission webhook "default.validating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: spec.imageName: Invalid value: "tkgs-ova-photon-3-v1.23.8---vmware.3-tkg.1": field is immutable
    Reason:                VMCreationFailed
    Severity:              Warning
    Status:                False
    Type:                  Ready
    Last Transition Time:  2023-12-14T20:01:46Z
    Message:               failed to create or update VirtualMachine: admission webhook "default.validating.virtualmachine.v1alpha1.vmoperator.vmware.com" denied the request: spec.imageName: Invalid value: "tkgs-ova-photon-3-v1.23.8---vmware.3-tkg.1": field is immutable
    Reason:                VMCreationFailed
    Severity:              Warning
    Status:                False
    Type:                  VMProvisioned
  Vmstatus:                pending
```
This patch ensures the immutable fields on the VMop VM Spec do not get set if these  fields on the existing VM object are not empty.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2430 
