### PR TITLE
🌱 Refactor: Get VSphereMachine functions

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 )
 
@@ -86,6 +87,7 @@ func AddClusterControllerToManager(ctx context.Context, controllerManagerCtx *ca
 		ControllerManagerContext: controllerManagerCtx,
 		Client:                   controllerManagerCtx.Client,
 		clusterModuleReconciler:  NewReconciler(controllerManagerCtx),
+		vmService:                services.VimMachineService{Client: controllerManagerCtx.Client},
 	}
 	clusterToInfraFn := clusterToInfrastructureMapFunc(ctx, controllerManagerCtx)
 	c, err := ctrl.NewControllerManagedBy(mgr).

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	infrautilv1 "sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
@@ -53,6 +54,7 @@ type clusterReconciler struct {
 	ControllerManagerContext *capvcontext.ControllerManagerContext
 	Client                   client.Client
 
+	vmService               services.VimMachineService
 	clusterModuleReconciler Reconciler
 }
 
@@ -126,7 +128,7 @@ func (r *clusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 func (r *clusterReconciler) reconcileDelete(ctx context.Context, clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	vsphereMachines, err := infrautilv1.GetVSphereMachinesInCluster(ctx, r.Client, clusterCtx.Cluster.Namespace, clusterCtx.Cluster.Name)
+	vsphereMachines, err := r.vmService.GetMachinesInCluster(ctx, clusterCtx.Cluster.Namespace, clusterCtx.Cluster.Name)
 	if err != nil {
 		return reconcile.Result{}, pkgerrors.Wrapf(err,
 			"unable to list VSphereMachines part of VSphereCluster %s/%s", clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
@@ -32,6 +33,7 @@ import (
 
 // VSphereMachineService is used for vsphere VM lifecycle and syncing with VSphereMachine types.
 type VSphereMachineService interface {
+	GetMachinesInCluster(ctx context.Context, namespace, clusterName string) ([]client.Object, error)
 	FetchVSphereMachine(ctx context.Context, name types.NamespacedName) (capvcontext.MachineContext, error)
 	FetchVSphereCluster(ctx context.Context, cluster *clusterv1.Cluster, machineContext capvcontext.MachineContext) (capvcontext.MachineContext, error)
 	ReconcileDelete(ctx context.Context, machineCtx capvcontext.MachineContext) error

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -47,6 +47,28 @@ type VimMachineService struct {
 	Client client.Client
 }
 
+// GetMachinesInCluster returns a list of VSphereMachine objects belonging to the cluster.
+func (v *VimMachineService) GetMachinesInCluster(
+	ctx context.Context,
+	namespace, clusterName string) ([]client.Object, error) {
+	labels := map[string]string{clusterv1.ClusterNameLabel: clusterName}
+	machineList := &infrav1.VSphereMachineList{}
+
+	if err := v.Client.List(
+		ctx, machineList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	objects := []client.Object{}
+	for _, machine := range machineList.Items {
+		m := machine
+		objects = append(objects, &m)
+	}
+	return objects, nil
+}
+
 // FetchVSphereMachine returns a new MachineContext containing the vsphereMachine.
 func (v *VimMachineService) FetchVSphereMachine(ctx context.Context, name types.NamespacedName) (capvcontext.MachineContext, error) {
 	vsphereMachine := &infrav1.VSphereMachine{}

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -36,52 +36,6 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 )
 
-// GetVSphereMachinesInCluster gets a cluster's VSphereMachine resources.
-func GetVSphereMachinesInCluster(
-	ctx context.Context,
-	controllerClient client.Client,
-	namespace, clusterName string) ([]*infrav1.VSphereMachine, error) {
-	labels := map[string]string{clusterv1.ClusterNameLabel: clusterName}
-	machineList := &infrav1.VSphereMachineList{}
-
-	if err := controllerClient.List(
-		ctx, machineList,
-		client.InNamespace(namespace),
-		client.MatchingLabels(labels)); err != nil {
-		return nil, err
-	}
-
-	machines := make([]*infrav1.VSphereMachine, len(machineList.Items))
-	for i := range machineList.Items {
-		machines[i] = &machineList.Items[i]
-	}
-
-	return machines, nil
-}
-
-// GetVMwareMachinesInCluster gets a cluster's vmware VSphereMachine resources.
-func GetVMwareMachinesInCluster(
-	ctx context.Context,
-	controllerClient client.Client,
-	namespace, clusterName string) ([]*vmwarev1.VSphereMachine, error) {
-	labels := map[string]string{clusterv1.ClusterNameLabel: clusterName}
-	machineList := &vmwarev1.VSphereMachineList{}
-
-	if err := controllerClient.List(
-		ctx, machineList,
-		client.InNamespace(namespace),
-		client.MatchingLabels(labels)); err != nil {
-		return nil, err
-	}
-
-	machines := make([]*vmwarev1.VSphereMachine, len(machineList.Items))
-	for i := range machineList.Items {
-		machines[i] = &machineList.Items[i]
-	}
-
-	return machines, nil
-}
-
 // GetVSphereMachine gets a vmware.infrastructure.cluster.x-k8s.io.VSphereMachine resource for the given CAPI Machine.
 func GetVSphereMachine(
 	ctx context.Context,


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch refactors the VSphereMachine Service interface to expose a new method to get the VSphereVM objects associated with a Cluster object.
The idea is to reuse the VSphereMachine service without the need to repeat similar code blocks in two places.

**Which issue(s) this PR fixes**:
n/a

/hold
Waiting for #2566 to be merged
