### PR TITLE
🌱 Ensure vm-operator VM has CAPI cluster-name label

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -594,6 +594,10 @@ func getVMLabels(supervisorMachineCtx *vmware.SupervisorMachineContext, vmLabels
 		vmLabels[k] = v
 	}
 
+	// Ensure the VM has a label that can be used when searching for
+	// resources associated with the target cluster.
+	vmLabels[clusterv1.ClusterNameLabel] = supervisorMachineCtx.GetClusterContext().Cluster.Name
+
 	return vmLabels
 }
 

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -71,6 +71,7 @@ const (
 	vmIP                     = "127.0.0.1"
 	biosUUID                 = "test-biosUuid"
 	missingK8SVersionFailure = "missing kubernetes version"
+	clusterNameLabel         = clusterv1.ClusterNameLabel
 )
 
 var _ = Describe("VirtualMachine tests", func() {
@@ -148,6 +149,7 @@ var _ = Describe("VirtualMachine tests", func() {
 				Expect(vmopVM.ObjectMeta.Annotations[ClusterModuleNameAnnotationKey]).To(Equal(ControlPlaneVMClusterModuleGroupName))
 				Expect(vmopVM.ObjectMeta.Annotations[ProviderTagsAnnotationKey]).To(Equal(ControlPlaneVMVMAntiAffinityTagValue))
 
+				Expect(vmopVM.Labels[clusterNameLabel]).To(Equal(clusterName))
 				Expect(vmopVM.Labels[clusterSelectorKey]).To(Equal(clusterName))
 				Expect(vmopVM.Labels[nodeSelectorKey]).To(Equal(roleControlPlane))
 				// for backward compatibility, will be removed in the future


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This is to ensure CAPV created resources should have the CAPI cluster-name label. VSphereVM already has it like [here](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/pkg/services/vimmachine.go#L316), so just add it for vm-operator VM in this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2218
