### PR TITLE
🌱 Stop relying on GVK being set on regular typed objects

### DIFF
--- a/controllers/serviceaccount_controller_intg_test.go
+++ b/controllers/serviceaccount_controller_intg_test.go
@@ -263,8 +263,8 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 
 		It("should fully reconciles dependent resources", func() {
 			correctOwnership := metav1.OwnerReference{
-				APIVersion: pSvcAccount.APIVersion,
-				Kind:       pSvcAccount.Kind,
+				APIVersion: vmwarev1.GroupVersion.String(),
+				Kind:       "ProviderServiceAccount",
 				Name:       pSvcAccount.GetName(),
 				UID:        pSvcAccount.UID,
 				Controller: ptr.To(true),

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -135,8 +135,8 @@ func deployCluster(namespace string, k8sClient client.Client) (client.ObjectKey,
 	infraCluster := newInfraCluster(namespace, cluster)
 	infraCluster.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion: cluster.APIVersion,
-			Kind:       cluster.Kind,
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Cluster",
 			Name:       cluster.Name,
 			UID:        cluster.UID,
 		},
@@ -162,8 +162,8 @@ func deployCAPIMachine(namespace string, cluster *clusterv1.Cluster, k8sClient c
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: cluster.APIVersion,
-					Kind:       cluster.Kind,
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "Cluster",
 					Name:       cluster.Name,
 					UID:        cluster.UID,
 				},
@@ -184,8 +184,8 @@ func deployInfraMachine(namespace string, machine *clusterv1.Machine, finalizers
 	infraMachine := newInfraMachine(namespace, machine)
 	infraMachine.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion: machine.APIVersion,
-			Kind:       machine.Kind,
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Machine",
 			Name:       machine.Name,
 			UID:        machine.UID,
 		},

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -252,7 +252,7 @@ func (r *clusterReconciler) reconcileIdentitySecret(ctx context.Context, cluster
 	secret.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(secret.GetOwnerReferences(),
 		metav1.OwnerReference{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       vsphereCluster.Kind,
+			Kind:       "VSphereCluster",
 			Name:       vsphereCluster.Name,
 			UID:        vsphereCluster.UID,
 		},

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -134,7 +134,7 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 		clusterutilv1.EnsureOwnerRef(secret.GetOwnerReferences(),
 			metav1.OwnerReference{
 				APIVersion: infrav1.GroupVersion.String(),
-				Kind:       identity.Kind,
+				Kind:       "VSphereClusterIdentity",
 				Name:       identity.Name,
 				UID:        identity.UID,
 			}))

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -264,7 +264,7 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx context.Context, de
 	if err := updateOwnerReferences(ctx, failureDomain, r.Client, func() []metav1.OwnerReference {
 		return clusterutilv1.RemoveOwnerRef(failureDomain.OwnerReferences, metav1.OwnerReference{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       deploymentZoneCtx.VSphereDeploymentZone.Kind,
+			Kind:       "VSphereDeploymentZone",
 			Name:       deploymentZoneCtx.VSphereDeploymentZone.Name,
 		})
 	}); err != nil {

--- a/controllers/vspheredeploymentzone_controller_domain.go
+++ b/controllers/vspheredeploymentzone_controller_domain.go
@@ -64,7 +64,7 @@ func (r vsphereDeploymentZoneReconciler) reconcileFailureDomain(ctx context.Cont
 				vsphereFailureDomain.OwnerReferences,
 				metav1.OwnerReference{
 					APIVersion: infrav1.GroupVersion.String(),
-					Kind:       deploymentZoneCtx.VSphereDeploymentZone.Kind,
+					Kind:       "VSphereDeploymentZone",
 					Name:       deploymentZoneCtx.VSphereDeploymentZone.Name,
 					UID:        deploymentZoneCtx.VSphereDeploymentZone.UID,
 				})

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -736,7 +736,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 	t.Run("delete failure domain", func(t *testing.T) {
 		vsphereFailureDomain.OwnerReferences = []metav1.OwnerReference{{
 			APIVersion: infrav1.GroupVersion.String(),
-			Kind:       vsphereDeploymentZone.Kind,
+			Kind:       "VSphereDeploymentZone",
 			Name:       vsphereDeploymentZone.Name,
 		}}
 
@@ -756,7 +756,7 @@ func TestVSphereDeploymentZoneReconciler_ReconcileDelete(t *testing.T) {
 		t.Run("when used by other deployment zones", func(t *testing.T) {
 			vsphereFailureDomain.OwnerReferences = append(vsphereFailureDomain.OwnerReferences, metav1.OwnerReference{
 				APIVersion: infrav1.GroupVersion.String(),
-				Kind:       vsphereDeploymentZone.Kind,
+				Kind:       "VSphereDeploymentZone",
 				Name:       "another-deployment-zone",
 			})
 

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -181,7 +181,7 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 					Finalizers: []string{
 						infrav1.IPAddressClaimFinalizer,
 					},
-					OwnerReferences: []metav1.OwnerReference{{APIVersion: infrav1.GroupVersion.String(), Kind: vsphereVM.Kind, Name: "foo"}},
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: infrav1.GroupVersion.String(), Kind: "VSphereVM", Name: "foo"}},
 				},
 				Spec: ipamv1.IPAddressClaimSpec{
 					PoolRef: corev1.TypedLocalObjectReference{

--- a/controllers/vspherevm_ipaddress_reconciler.go
+++ b/controllers/vspherevm_ipaddress_reconciler.go
@@ -146,8 +146,8 @@ func createOrPatchIPAddressClaim(ctx context.Context, vmCtx *capvcontext.VMConte
 		claim.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(
 			claim.OwnerReferences,
 			metav1.OwnerReference{
-				APIVersion: vmCtx.VSphereVM.APIVersion,
-				Kind:       vmCtx.VSphereVM.Kind,
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       "VSphereVM",
 				Name:       vmCtx.VSphereVM.Name,
 				UID:        vmCtx.VSphereVM.UID,
 			}))

--- a/internal/test/helpers/vmware/intg_test_context.go
+++ b/internal/test/helpers/vmware/intg_test_context.go
@@ -132,8 +132,8 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 				Name:      fmt.Sprintf("%s-kubeconfig", testCtx.Cluster.Name),
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: testCtx.Cluster.APIVersion,
-						Kind:       testCtx.Cluster.Kind,
+						APIVersion: clusterv1.GroupVersion.String(),
+						Kind:       "Cluster",
 						Name:       testCtx.Cluster.Name,
 						UID:        testCtx.Cluster.UID,
 					},

--- a/pkg/context/fake/fake_cluster_context.go
+++ b/pkg/context/fake/fake_cluster_context.go
@@ -81,8 +81,8 @@ func newVSphereCluster(owner clusterv1.Cluster) infrav1.VSphereCluster {
 			Labels:    map[string]string{clusterv1.ClusterNameLabel: owner.Name},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         owner.APIVersion,
-					Kind:               owner.Kind,
+					APIVersion:         clusterv1.GroupVersion.String(),
+					Kind:               "Cluster",
 					Name:               owner.Name,
 					UID:                owner.UID,
 					BlockOwnerDeletion: &boolTrue,

--- a/pkg/context/fake/fake_machine_context.go
+++ b/pkg/context/fake/fake_machine_context.go
@@ -76,8 +76,8 @@ func newVSphereMachine(owner clusterv1.Machine) infrav1.VSphereMachine {
 			UID:       VSphereMachineUUID,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         owner.APIVersion,
-					Kind:               owner.Kind,
+					APIVersion:         clusterv1.GroupVersion.String(),
+					Kind:               "Machine",
 					Name:               owner.Name,
 					UID:                owner.UID,
 					BlockOwnerDeletion: &boolTrue,

--- a/pkg/context/fake/fake_util.go
+++ b/pkg/context/fake/fake_util.go
@@ -45,8 +45,8 @@ func newCluster(vSphereCluster *vmwarev1.VSphereCluster) *clusterv1.Cluster {
 			Namespace: vSphereCluster.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         vSphereCluster.APIVersion,
-					Kind:               vSphereCluster.Kind,
+					APIVersion:         vmwarev1.GroupVersion.String(),
+					Kind:               "VSphereCluster",
 					Name:               vSphereCluster.Name,
 					UID:                vSphereCluster.UID,
 					BlockOwnerDeletion: &boolTrue,

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -283,7 +283,7 @@ func reconcileVSphereVMOnFuncCompletion(ctx context.Context, vmCtx *capvcontext.
 	log := ctrl.LoggerFrom(ctx)
 
 	obj := vmCtx.VSphereVM.DeepCopy()
-	gvk := obj.GetObjectKind().GroupVersionKind()
+	gvk := infrav1.GroupVersion.WithKind("VSphereVM")
 
 	// Wait on the function to complete in a background goroutine.
 	go func() {

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -291,8 +291,8 @@ func (v *VimMachineService) createOrPatchVSphereVM(ctx context.Context, vimMachi
 		vm.SetOwnerReferences(clusterutilv1.EnsureOwnerRef(
 			vm.OwnerReferences,
 			metav1.OwnerReference{
-				APIVersion: vimMachineCtx.VSphereMachine.APIVersion,
-				Kind:       vimMachineCtx.VSphereMachine.Kind,
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       "VSphereMachine",
 				Name:       vimMachineCtx.VSphereMachine.Name,
 				UID:        vimMachineCtx.VSphereMachine.UID,
 			}))


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Same as: https://github.com/kubernetes-sigs/cluster-api/pull/9956

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
