### PR TITLE
🌱 Use correct image from main per default when running e2e tests locally

### DIFF
--- a/config/base/manager_image_patch.yaml
+++ b/config/base/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+      - image: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         - --v=4
         - --enable-keep-alive
         - "--feature-gates=NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false}"
-        image: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+        image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -135,7 +135,7 @@ providers:
         value: ../../../../cluster-api-provider-vsphere/config/default
         contract: v1beta1
         replacements:
-          - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+          - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
             new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -138,7 +138,7 @@ providers:
         value: ../../../../cluster-api-provider-vsphere/config/default
         contract: v1beta1
         replacements:
-          - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+          - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
             new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -79,7 +79,7 @@ providers:
         files:
           - sourcePath: "../e2e/data/shared/main/v1beta1_provider/metadata.yaml"
         replacements:
-          - old: gcr.io/cluster-api-provider-vsphere/release/manager:latest
+          - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
             new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -2,7 +2,7 @@
   "name": "vsphere",
   "config": {
     "version": "v1.9.99",
-    "image": "gcr.io/cluster-api-provider-vsphere/release/manager",
+    "image": "gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller",
     "live_reload_deps": [
       "main.go",
       "go.mod",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
When the CAPV image hasn't been build locally we should default to using the latest image from main. Not some old image from the old registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
