### PR TITLE
:bug: Remove logout from keepalive handler

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -263,9 +263,6 @@ func newClient(ctx context.Context, sessionKey string, url *url.URL, thumbprint 
 			_, err := methods.GetCurrentTime(ctx, tripper)
 			if err != nil {
 				log.Error(err, "Failed to keep alive govmomi client, Clearing the session now")
-				if errLogout := c.Logout(ctx); errLogout != nil {
-					log.Error(err, "Failed to logout keepalive failed session")
-				}
 				sessionCache.Delete(sessionKey)
 			}
 			return err
@@ -296,9 +293,6 @@ func newManager(ctx context.Context, sessionKey string, client *vim25.Client, us
 			}
 
 			log.Info("REST client session expired, clearing session")
-			if errLogout := rc.Logout(ctx); errLogout != nil {
-				log.Error(err, "Failed to logout keepalive failed REST session")
-			}
 			sessionCache.Delete(sessionKey)
 			return errors.New("REST client session expired")
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Apparently calling Logout() from keepalive handler is prune to deadlocks. 

Instead, we should rely on calling logout from the session cache only, but ignore the other errors that may come from keepalive handler

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
