### PR TITLE
🌱 e2e: Claim ip addresses dynamically so tests can run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ endif
 #
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
+GINKGO_NODES ?= 1
 GINKGO_TIMEOUT ?= 3h
 E2E_CONF_FILE ?= $(abspath test/e2e/config/vsphere-dev.yaml)
 INTEGRATION_CONF_FILE ?= $(abspath test/integration/integration-dev.yaml)
@@ -84,6 +85,7 @@ E2E_TEMPLATE_DIR := $(abspath test/e2e/data/infrastructure-vsphere/)
 SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 GINKGO_NOCOLOR ?= false
+E2E_IPAM_KUBECONFIG ?=
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)
@@ -524,12 +526,13 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 	@echo Contents of $(TOOLS_BIN_DIR):
 	@ls $(TOOLS_BIN_DIR)
 	@echo
-	time $(GINKGO) -v --trace -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -timeout=$(GINKGO_TIMEOUT) \
+	time $(GINKGO) -v --trace -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) --nodes=$(GINKGO_NODES) -timeout=$(GINKGO_TIMEOUT) \
 		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" ./test/e2e -- \
 		--e2e.config="$(E2E_CONF_FILE)" \
 		--e2e.artifacts-folder="$(ARTIFACTS)" \
 		--e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
-		--e2e.use-existing-cluster="$(USE_EXISTING_CLUSTER)"
+		--e2e.use-existing-cluster="$(USE_EXISTING_CLUSTER)" \
+		--e2e.ipam-kubeconfig="$(E2E_IPAM_KUBECONFIG)"
 
 ## --------------------------------------
 ## Release

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,30 +20,31 @@ In order to run the e2e tests the following requirements must be met:
 
 The first step to running the e2e tests is setting up the required environment variables:
 
-| Environment variable         | Description                                                                         | Example                                                                          |
-|------------------------------|-------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `VSPHERE_SERVER`             | The IP address or FQDN of a vCenter 6.7u3 server                                    | `my.vcenter.com`                                                                 |
-| `VSPHERE_USERNAME`           | The username used to access the vSphere server                                      | `my-username`                                                                    |
-| `VSPHERE_PASSWORD`           | The password used to access the vSphere server                                      | `my-password`                                                                    |
-| `VSPHERE_DATACENTER`         | The unique name or inventory path of the datacenter in which VMs will be created    | `my-datacenter` or `/my-datacenter`                                              |
-| `VSPHERE_FOLDER`             | The unique name or inventory path of the folder in which VMs will be created        | `my-folder` or `/my-datacenter/vm/my-folder`                                     |
-| `VSPHERE_RESOURCE_POOL`      | The unique name or inventory path of the resource pool in which VMs will be created | `my-resource-pool` or `/my-datacenter/host/Cluster-1/Resources/my-resource-pool` |
-| `VSPHERE_DATASTORE`          | The unique name or inventory path of the datastore in which VMs will be created     | `my-datastore` or `/my-datacenter/datstore/my-datastore`                         |
-| `VSPHERE_NETWORK`            | The unique name or inventory path of the network to which VMs will be connected     | `my-network` or `/my-datacenter/network/my-network`                              |
-| `VSPHERE_SSH_PRIVATE_KEY`    | The file path of the private key used to ssh into the CAPV VMs                      | `/home/foo/bar-ssh.key`                                                          |
-| `VSPHERE_SSH_AUTHORIZED_KEY` | The public key that is added to the CAPV VMs                                        | `ssh-rsa ABCDEF...XYZ=`                                                          |
-| `VSPHERE_TLS_THUMBPRINT`     | The TLS thumbprint of the vSphere server's certificate which should be trusted      | `2A:3F:BC:CA:C0:96:35:D4:B7:A2:AA:3C:C1:33:D9:D7:BE:EC:31:55`                    |
-| `CONTROL_PLANE_ENDPOINT_IP`  | The IP that kube-vip should use as a control plane endpoint                         | `10.10.123.100`                                                                  |
-| `VSPHERE_STORAGE_POLICY`     | The name of an existing vSphere storage policy to be assigned to created VMs        | `my-test-sp`                                                                     |
+| Environment variable         | Description                                                                                                       | Example                                                                          |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `VSPHERE_SERVER`             | The IP address or FQDN of a vCenter 6.7u3 server                                                                  | `my.vcenter.com`                                                                 |
+| `VSPHERE_USERNAME`           | The username used to access the vSphere server                                                                    | `my-username`                                                                    |
+| `VSPHERE_PASSWORD`           | The password used to access the vSphere server                                                                    | `my-password`                                                                    |
+| `VSPHERE_DATACENTER`         | The unique name or inventory path of the datacenter in which VMs will be created                                  | `my-datacenter` or `/my-datacenter`                                              |
+| `VSPHERE_FOLDER`             | The unique name or inventory path of the folder in which VMs will be created                                      | `my-folder` or `/my-datacenter/vm/my-folder`                                     |
+| `VSPHERE_RESOURCE_POOL`      | The unique name or inventory path of the resource pool in which VMs will be created                               | `my-resource-pool` or `/my-datacenter/host/Cluster-1/Resources/my-resource-pool` |
+| `VSPHERE_DATASTORE`          | The unique name or inventory path of the datastore in which VMs will be created                                   | `my-datastore` or `/my-datacenter/datstore/my-datastore`                         |
+| `VSPHERE_NETWORK`            | The unique name or inventory path of the network to which VMs will be connected                                   | `my-network` or `/my-datacenter/network/my-network`                              |
+| `VSPHERE_SSH_PRIVATE_KEY`    | The file path of the private key used to ssh into the CAPV VMs                                                    | `/home/foo/bar-ssh.key`                                                          |
+| `VSPHERE_SSH_AUTHORIZED_KEY` | The public key that is added to the CAPV VMs                                                                      | `ssh-rsa ABCDEF...XYZ=`                                                          |
+| `VSPHERE_TLS_THUMBPRINT`     | The TLS thumbprint of the vSphere server's certificate which should be trusted                                    | `2A:3F:BC:CA:C0:96:35:D4:B7:A2:AA:3C:C1:33:D9:D7:BE:EC:31:55`                    |
+| `CONTROL_PLANE_ENDPOINT_IP`  | The IP that kube-vip should use as a control plane endpoint. It will not be used if `E2E_IPAM_KUBECONFIG` is set. | `10.10.123.100`                                                                  |
+| `VSPHERE_STORAGE_POLICY`     | The name of an existing vSphere storage policy to be assigned to created VMs                                      | `my-test-sp`                                                                     |
 
 ### Flags
 
-| Flag                    | Description                                                                                              | Default Value |
-|-------------------------|----------------------------------------------------------------------------------------------------------|---------------|
-| `SKIP_RESOURCE_CLEANUP` | This flags skips cleanup of the resources created during the tests as well as the kind/bootstrap cluster | `false`       |
-| `USE_EXISTING_CLUSTER`  | This flag enables the usage of an existing K8S cluster as the management cluster to run tests against.   | `false`       |
-| `GINKGO_TEST_TIMEOUT`   | This sets the timeout for the E2E test suite.                                                            | `2h`          |
-| `GINKGO_FOCUS`          | This populates the `-focus` flag of the `ginkgo` run command.                                            | `""`          |
+| Flag                    | Description                                                                                                                                                                                                    | Default Value |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `SKIP_RESOURCE_CLEANUP` | This flags skips cleanup of the resources created during the tests as well as the kind/bootstrap cluster                                                                                                       | `false`       |
+| `USE_EXISTING_CLUSTER`  | This flag enables the usage of an existing K8S cluster as the management cluster to run tests against.                                                                                                         | `false`       |
+| `GINKGO_TEST_TIMEOUT`   | This sets the timeout for the E2E test suite.                                                                                                                                                                  | `2h`          |
+| `GINKGO_FOCUS`          | This populates the `-focus` flag of the `ginkgo` run command.                                                                                                                                                  | `""`          |
+| `E2E_IPAM_KUBECONFIG`   | This flag points to a kubeconfig where the in-cluster IPAM provider is running to dynamically claim IP addresses for tests. If this is set, the environment variable `CONTROL_PLANE_ENDPOINT_IP` gets ignored. | `""`          |
 
 ### Running the e2e tests
 

--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -34,6 +34,8 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/clustermodules"
+	. "sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/helper"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 type AntiAffinitySpecInput struct {
@@ -45,6 +47,17 @@ type AntiAffinitySpecInput struct {
 
 var _ = Describe("Cluster creation with anti affined nodes", func() {
 	var namespace *corev1.Namespace
+
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
 
 	BeforeEach(func() {
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -66,7 +79,7 @@ var _ = Describe("Cluster creation with anti affined nodes", func() {
 			},
 			Global: GlobalInput{
 				BootstrapClusterProxy: bootstrapClusterProxy,
-				ClusterctlConfigPath:  clusterctlConfigPath,
+				ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 				E2EConfig:             e2eConfig,
 				ArtifactFolder:        artifactFolder,
 			},

--- a/test/e2e/capi_machine_deployment_rollout_test.go
+++ b/test/e2e/capi_machine_deployment_rollout_test.go
@@ -18,15 +18,29 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("ClusterAPI Machine Deployment Tests", func() {
 	Context("Running the MachineDeployment rollout spec", func() {
+		var (
+			testSpecificClusterctlConfigPath string
+			testSpecificIPAddressClaims      ipam.IPAddressClaims
+		)
+		BeforeEach(func() {
+			testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+		})
+		defer AfterEach(func() {
+			Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+		})
+
 		capi_e2e.MachineDeploymentRolloutSpec(ctx, func() capi_e2e.MachineDeploymentRolloutSpecInput {
 			return capi_e2e.MachineDeploymentRolloutSpecInput{
 				E2EConfig:             e2eConfig,
-				ClusterctlConfigPath:  clusterctlConfigPath,
+				ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 				BootstrapClusterProxy: bootstrapClusterProxy,
 				ArtifactFolder:        artifactFolder,
 				SkipCleanup:           skipCleanup,

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -18,15 +18,29 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When upgrading a workload cluster using ClusterClass [ClusterClass]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -18,14 +18,28 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capie2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capie2e.ClusterClassChangesSpec(ctx, func() capie2e.ClusterClassChangesSpecInput {
 		return capie2e.ClusterClassChangesSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -18,14 +18,28 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=>current, CAPI 1.6=>1.6) [ClusterClass]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath, "WORKLOAD_CONTROL_PLANE_ENDPOINT_IP")
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
 			E2EConfig:                         e2eConfig,
-			ClusterctlConfigPath:              clusterctlConfigPath,
+			ClusterctlConfigPath:              testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy:             bootstrapClusterProxy,
 			ArtifactFolder:                    artifactFolder,
 			SkipCleanup:                       skipCleanup,
@@ -46,10 +60,21 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 })
 
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.8=>current, CAPI 1.5=>1.6) [ClusterClass]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath, "WORKLOAD_CONTROL_PLANE_ENDPOINT_IP")
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
 			E2EConfig:                         e2eConfig,
-			ClusterctlConfigPath:              clusterctlConfigPath,
+			ClusterctlConfigPath:              testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy:             bootstrapClusterProxy,
 			ArtifactFolder:                    artifactFolder,
 			SkipCleanup:                       skipCleanup,

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -18,10 +18,8 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo/v2"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vapi/rest"
@@ -33,10 +31,6 @@ import (
 const (
 	KubernetesVersion = "KUBERNETES_VERSION"
 )
-
-func Byf(format string, a ...interface{}) {
-	By(fmt.Sprintf(format, a...))
-}
 
 type InfraClients struct {
 	Client     *govmomi.Client

--- a/test/e2e/govmomi_test.go
+++ b/test/e2e/govmomi_test.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,6 +32,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -91,4 +93,27 @@ func initVSphereSession() {
 
 func terminateVSphereSession() {
 	Expect(vsphereClient.Logout(ctx)).To(Succeed())
+}
+
+func getClusterctlConfigVariable(clusterctlConfigPath, configVariable string) (string, error) {
+	// Environment variable overwrite takes priority.
+	if val := os.Getenv(configVariable); val != "" {
+		return val, nil
+	}
+
+	data, err := os.ReadFile(filepath.Clean(clusterctlConfigPath))
+	if err != nil {
+		return "", err
+	}
+
+	type clusterctlConfig struct {
+		Variables map[string]string `json:"variables"`
+	}
+
+	config := clusterctlConfig{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return "", err
+	}
+
+	return config.Variables[configVariable], nil
 }

--- a/test/e2e/hardware_upgrade_test.go
+++ b/test/e2e/hardware_upgrade_test.go
@@ -30,6 +30,8 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
+	. "sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/helper"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 type HardwareUpgradeSpecInput struct {
@@ -44,6 +46,17 @@ var _ = Describe("Hardware version upgrade", func() {
 	var (
 		namespace *corev1.Namespace
 	)
+
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
 
 	BeforeEach(func() {
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -68,7 +81,7 @@ var _ = Describe("Hardware version upgrade", func() {
 			},
 			Global: GlobalInput{
 				BootstrapClusterProxy: bootstrapClusterProxy,
-				ClusterctlConfigPath:  clusterctlConfigPath,
+				ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 				E2EConfig:             e2eConfig,
 				ArtifactFolder:        artifactFolder,
 			},

--- a/test/e2e/helper/helper.go
+++ b/test/e2e/helper/helper.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package helper provides helper functions.
+package helper
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+// Byf is By but with fmt.Sprintf.
+func Byf(format string, a ...interface{}) {
+	ginkgo.By(fmt.Sprintf(format, a...))
+}

--- a/test/e2e/ipam/ipamhelper.go
+++ b/test/e2e/ipam/ipamhelper.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ipam is a helper to claim ip addresses from an IPAM provider cluster.
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/mo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	. "sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/helper"
+)
+
+var ipamScheme *runtime.Scheme
+
+const controlPlaneEndpointVariable = "CONTROL_PLANE_ENDPOINT_IP"
+
+func init() {
+	ipamScheme = runtime.NewScheme()
+	_ = ipamv1.AddToScheme(ipamScheme)
+}
+
+type IPAddressClaims []*ipamv1.IPAddressClaim
+
+type Helper interface {
+	// ClaimIPs claims IP addresses with the variable name `CONTROL_PLANE_ENDPOINT_IP` and whatever is passed as
+	// additionalIPVariableNames and creates a new clusterctl config file.
+	// It returns the path to the new clusterctl config file and a slice of IPAddressClaims.
+	ClaimIPs(ctx context.Context, clusterctlConfigPath string, additionalIPVariableNames ...string) (localClusterctlConfigFile string, claims IPAddressClaims)
+
+	// Cleanup deletes the given IPAddressClaims.
+	Cleanup(ctx context.Context, claims IPAddressClaims) error
+
+	// Teardown tries to cleanup orphaned IPAddressClaims by checking if the corresponding IPs are still in use in vSphere.
+	// It identifies IPAddressClaims via labels.
+	Teardown(ctx context.Context, folderName string, vSphereClient *govmomi.Client) error
+}
+
+// New returns an ipam.Helper. If e2eIPAMKubeconfig is an empty string or skipCleanup is true
+// it will return a noop helper which does nothing so we can fallback on setting environment variables.
+func New(e2eIPAMKubeconfig string, labels map[string]string, skipCleanup bool) (Helper, error) {
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("expecting labels to be set to prevent deletion of other IPAddressClaims")
+	}
+
+	if e2eIPAMKubeconfig == "" {
+		return &noopHelper{}, nil
+	}
+
+	ipamClient, err := getClient(e2eIPAMKubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &helper{
+		labels:      labels,
+		client:      ipamClient,
+		skipCleanup: skipCleanup,
+	}, nil
+}
+
+type helper struct {
+	client      client.Client
+	labels      map[string]string
+	skipCleanup bool
+}
+
+func (h *helper) ClaimIPs(ctx context.Context, clusterctlConfigPath string, additionalIPVariableNames ...string) (string, IPAddressClaims) {
+	variables := map[string]string{}
+
+	ipAddressClaims := []*ipamv1.IPAddressClaim{}
+
+	// Claim an IP per variable.
+	for _, variable := range append(additionalIPVariableNames, controlPlaneEndpointVariable) {
+		ip, ipAddressClaim, err := h.claimIPAddress(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		ipAddressClaims = append(ipAddressClaims, ipAddressClaim)
+		Byf("Setting clusterctl variable %s to %s", variable, ip)
+		variables[variable] = ip
+	}
+
+	// Create a new clusterctl config file based on the passed file and add the new variables for the IPs.
+	modifiedClusterctlConfigPath := fmt.Sprintf("%s-%s.yaml", strings.TrimSuffix(clusterctlConfigPath, ".yaml"), rand.String(16))
+	Byf("Writing a new clusterctl config to %s", modifiedClusterctlConfigPath)
+	copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
+		ClusterctlConfigPath: clusterctlConfigPath,
+		OutputPath:           modifiedClusterctlConfigPath,
+		Variables:            variables,
+	})
+
+	return modifiedClusterctlConfigPath, ipAddressClaims
+}
+
+// Cleanup deletes the IPAddressClaims passed.
+func (h *helper) Cleanup(ctx context.Context, ipAddressClaims IPAddressClaims) error {
+	if CurrentSpecReport().Failed() {
+		By("Skipping cleanup of IPAddressClaims because the tests failed and the IPs could still be in use")
+		return nil
+	}
+
+	if h.skipCleanup {
+		By("Skipping cleanup of IPAddressClaims because skipCleanup is set to true")
+		return nil
+	}
+
+	var errList []error
+
+	for _, ipAddressClaim := range ipAddressClaims {
+		ipAddressClaim := ipAddressClaim
+		Byf("Deleting IPAddressClaim %s", klog.KObj(ipAddressClaim))
+		if err := h.client.Delete(ctx, ipAddressClaim); err != nil {
+			errList = append(errList, err)
+		}
+	}
+
+	if len(errList) > 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}
+
+// GetIPAddressClaimLabels returns a labels map from the prow environment variables
+// BUILD_ID and JOB_NAME. If none of both is set it falls back to add a custom random
+// label.
+func GetIPAddressClaimLabels() map[string]string {
+	labels := map[string]string{}
+	if val := os.Getenv("BUILD_ID"); val != "" {
+		labels["prow.k8s.io/build-id"] = val
+	}
+	if val := os.Getenv("JOB_NAME"); val != "" {
+		labels["prow.k8s.io/job"] = val
+	}
+	if len(labels) == 0 {
+		// Adding a custom label so we don't accidentally cleanup other IPAddressClaims
+		labels["capv-testing/random-uid"] = rand.String(32)
+	}
+	return labels
+}
+
+// Teardown lists all IPAddressClaims matching the passed labels and deletes the IPAddressClaim
+// if there are no VirtualMachines in vCenter using the IP address.
+func (h *helper) Teardown(ctx context.Context, folderName string, vSphereClient *govmomi.Client) error {
+	if h.skipCleanup {
+		By("Skipping cleanup of IPAddressClaims because skipCleanup is set to true")
+		return nil
+	}
+
+	virtualMachineIPAddresses, err := getVirtualMachineIPAddresses(ctx, folderName, vSphereClient)
+	if err != nil {
+		return err
+	}
+	// List all IPAddressClaims created matching the labels.
+	ipAddressClaims := &ipamv1.IPAddressClaimList{}
+	if err := h.client.List(ctx, ipAddressClaims,
+		client.MatchingLabels(h.labels),
+		client.InNamespace(metav1.NamespaceDefault),
+	); err != nil {
+		return err
+	}
+
+	ipAddressClaimsToDelete := []*ipamv1.IPAddressClaim{}
+	// Collect errors and skip these ip address claims, but report at the end.
+	var errList []error
+
+	ip := &ipamv1.IPAddress{}
+	for _, ipAddressClaim := range ipAddressClaims.Items {
+		ipAddressClaim := ipAddressClaim
+		if ipAddressClaim.Status.AddressRef.Name == "" {
+			continue
+		}
+		if err := h.client.Get(ctx, client.ObjectKey{Namespace: ipAddressClaim.GetNamespace(), Name: ipAddressClaim.Status.AddressRef.Name}, ip); err != nil {
+			// If we are not able to get an IP Address we skip the deletion for it but collect and return the error.
+			errList = append(errList, errors.Wrapf(err, "getting IPAddress for IPAddressClaim %s", klog.KObj(&ipAddressClaim)))
+			continue
+		}
+
+		// Skip deletion if there is still a virtual machine which refers this IP address.
+		if virtualMachineIPAddresses[ip.Spec.Address] {
+			continue
+		}
+
+		ipAddressClaimsToDelete = append(ipAddressClaimsToDelete, &ipAddressClaim)
+	}
+
+	if err := h.Cleanup(ctx, ipAddressClaimsToDelete); err != nil {
+		// Group with possible previous errors.
+		errList = append(errList, err)
+	}
+
+	if len(errList) > 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}
+
+func getClient(e2eIPAMKubeconfig string) (client.Client, error) {
+	kubeConfig, err := os.ReadFile(filepath.Clean(e2eIPAMKubeconfig))
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{Scheme: ipamScheme})
+}
+
+// getVirtualMachineIPAddresses lists all VirtualMachines in the given folder and
+// returns a map which contains the IP addresses of all machines.
+// If the given folder is not found it will return an error.
+func getVirtualMachineIPAddresses(ctx context.Context, folderName string, vSphereClient *govmomi.Client) (map[string]bool, error) {
+	finder := find.NewFinder(vSphereClient.Client)
+
+	// Find the given folder.
+	folder, err := finder.FolderOrDefault(ctx, folderName)
+	if err != nil {
+		return nil, err
+	}
+
+	// List all VirtualMachines in the folder.
+	managedObjects, err := finder.ManagedObjectListChildren(ctx, folder.InventoryPath+"/...", "VirtualMachine")
+	if err != nil {
+		return nil, err
+	}
+
+	var vm mo.VirtualMachine
+	virtualMachineIPAddresses := map[string]bool{}
+
+	// Iterate over the VirtualMachines, get the `guest.net` property and extract the IP addresses.
+	for _, mobj := range managedObjects {
+		// Get guest.net properties for mobj.
+		if err := vSphereClient.RetrieveOne(ctx, mobj.Object.Reference(), []string{"guest.net"}, &vm); err != nil {
+			return nil, errors.Wrapf(err, "get properties of VM %s", mobj.Object.Reference())
+		}
+		// Iterate over all nics and add IP addresses to virtualMachineIPAddresses.
+		for _, nic := range vm.Guest.Net {
+			if nic.IpConfig == nil {
+				continue
+			}
+			for _, ip := range nic.IpConfig.IpAddress {
+				virtualMachineIPAddresses[ip.IpAddress] = true
+			}
+		}
+	}
+
+	return virtualMachineIPAddresses, nil
+}
+
+func (h *helper) claimIPAddress(ctx context.Context) (_ string, _ *ipamv1.IPAddressClaim, err error) {
+	claim := &ipamv1.IPAddressClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ipclaim-" + rand.String(32),
+			Namespace: metav1.NamespaceDefault,
+			Labels:    h.labels,
+		},
+		Spec: ipamv1.IPAddressClaimSpec{
+			PoolRef: corev1.TypedLocalObjectReference{
+				APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
+				Kind:     "InClusterIPPool",
+				Name:     "capv-e2e-ippool",
+			},
+		},
+	}
+
+	// Create an IPAddressClaim
+	Byf("Creating IPAddressClaim %s", klog.KObj(claim))
+	if err := h.client.Create(ctx, claim); err != nil {
+		return "", nil, err
+	}
+	// Store claim inside the service so the cleanup function knows what to delete.
+	ip := &ipamv1.IPAddress{}
+
+	var retryError error
+	// Wait for the IPAddressClaim to refer an IPAddress.
+	_ = wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(ctx context.Context) (done bool, err error) {
+		if err := h.client.Get(ctx, client.ObjectKeyFromObject(claim), claim); err != nil {
+			retryError = errors.Wrap(err, "getting IPAddressClaim")
+			return false, nil
+		}
+
+		if claim.Status.AddressRef.Name == "" {
+			retryError = errors.Wrap(err, "IPAddressClaim.Status.AddressRef.Name is not set")
+			return false, nil
+		}
+
+		if err := h.client.Get(ctx, client.ObjectKey{Namespace: claim.GetNamespace(), Name: claim.Status.AddressRef.Name}, ip); err != nil {
+			retryError = errors.Wrap(err, "getting IPAddress")
+			return false, nil
+		}
+		if ip.Spec.Address == "" {
+			retryError = errors.Wrap(err, "IPAddress.Spec.Address is not set")
+			return false, nil
+		}
+
+		retryError = nil
+		return true, nil
+	})
+	if retryError != nil {
+		return "", nil, retryError
+	}
+
+	return ip.Spec.Address, claim, nil
+}
+
+// Note: Copy-paste from CAPI below.
+
+// copyAndAmendClusterctlConfigInput is the input for copyAndAmendClusterctlConfig.
+type copyAndAmendClusterctlConfigInput struct {
+	ClusterctlConfigPath string
+	OutputPath           string
+	Variables            map[string]string
+}
+
+// copyAndAmendClusterctlConfig copies the clusterctl-config from ClusterctlConfigPath to
+// OutputPath and adds the given Variables.
+func copyAndAmendClusterctlConfig(_ context.Context, input copyAndAmendClusterctlConfigInput) {
+	// Read clusterctl config from ClusterctlConfigPath.
+	clusterctlConfigFile := &clusterctlConfig{
+		Path: input.ClusterctlConfigPath,
+	}
+	clusterctlConfigFile.read()
+
+	// Overwrite variables.
+	if clusterctlConfigFile.Values == nil {
+		clusterctlConfigFile.Values = map[string]interface{}{}
+	}
+	for key, value := range input.Variables {
+		clusterctlConfigFile.Values[key] = value
+	}
+
+	// Write clusterctl config to OutputPath.
+	clusterctlConfigFile.Path = input.OutputPath
+	clusterctlConfigFile.write()
+}
+
+type clusterctlConfig struct {
+	Path   string
+	Values map[string]interface{}
+}
+
+// write writes a clusterctl config file to disk.
+func (c *clusterctlConfig) write() {
+	data, err := yaml.Marshal(c.Values)
+	Expect(err).ToNot(HaveOccurred(), "Failed to marshal the clusterctl config file")
+
+	Expect(os.WriteFile(c.Path, data, 0600)).To(Succeed(), "Failed to write the clusterctl config file")
+}
+
+// read reads a clusterctl config file from disk.
+func (c *clusterctlConfig) read() {
+	data, err := os.ReadFile(c.Path)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = yaml.Unmarshal(data, &c.Values)
+	Expect(err).ToNot(HaveOccurred(), "Failed to unmarshal the clusterctl config file")
+}

--- a/test/e2e/ipam/noop.go
+++ b/test/e2e/ipam/noop.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ipam is a helper to claim ip addresses from an IPAM provider cluster.
+package ipam
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/vmware/govmomi"
+)
+
+type noopHelper struct{}
+
+func (h *noopHelper) ClaimIPs(_ context.Context, _ string, _ ...string) (string, IPAddressClaims) {
+	return "", nil
+}
+
+func (h *noopHelper) Cleanup(_ context.Context, _ IPAddressClaims) error {
+	By("Skipping cleanup of IPAddressClaims because of using ipam.noopHelper")
+	return nil
+}
+
+func (*noopHelper) Teardown(_ context.Context, _ string, _ *govmomi.Client) error {
+	By("Skipping teardown of IPAddressClaims because of using ipam.noopHelper")
+	return nil
+}

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -18,14 +18,28 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When testing K8S conformance [Conformance]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.K8SConformanceSpec(ctx, func() capi_e2e.K8SConformanceSpecInput {
 		return capi_e2e.K8SConformanceSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -18,14 +18,28 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When testing MachineDeployment scale out/in", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.MachineDeploymentScaleSpec(ctx, func() capi_e2e.MachineDeploymentScaleSpecInput {
 		return capi_e2e.MachineDeploymentScaleSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/multivc_test.go
+++ b/test/e2e/multivc_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	. "sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/helper"
 	vsphereframework "sigs.k8s.io/cluster-api-provider-vsphere/test/framework"
 )
 

--- a/test/e2e/node_drain_timeout_test.go
+++ b/test/e2e/node_drain_timeout_test.go
@@ -18,14 +18,28 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("When testing node drain timeout", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.NodeDrainTimeoutSpec(ctx, func() capi_e2e.NodeDrainTimeoutSpecInput {
 		return capi_e2e.NodeDrainTimeoutSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/node_labeling_test.go
+++ b/test/e2e/node_labeling_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
+	. "sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/helper"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 type NodeLabelingSpecInput struct {
@@ -39,6 +41,17 @@ var _ = Describe("Label nodes with ESXi host info", func() {
 	var (
 		namespace *corev1.Namespace
 	)
+
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
 
 	BeforeEach(func() {
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -59,7 +72,7 @@ var _ = Describe("Label nodes with ESXi host info", func() {
 			},
 			Global: GlobalInput{
 				BootstrapClusterProxy: bootstrapClusterProxy,
-				ClusterctlConfigPath:  clusterctlConfigPath,
+				ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 				E2EConfig:             e2eConfig,
 				ArtifactFolder:        artifactFolder,
 			},

--- a/test/e2e/ownerreference_test.go
+++ b/test/e2e/ownerreference_test.go
@@ -39,9 +39,21 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("OwnerReference checks with FailureDomains and ClusterIdentity", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	// Before running the test create the secret used by the VSphereClusterIdentity to connect to the vCenter.
 	BeforeEach(func() {
 		createVsphereIdentitySecret(ctx, bootstrapClusterProxy)
@@ -50,7 +62,7 @@ var _ = Describe("OwnerReference checks with FailureDomains and ClusterIdentity"
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -18,15 +18,29 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/e2e/ipam"
 )
 
 var _ = Describe("Cluster Creation using Cluster API quick-start test", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
@@ -35,10 +49,21 @@ var _ = Describe("Cluster Creation using Cluster API quick-start test", func() {
 })
 
 var _ = Describe("ClusterClass Creation using Cluster API quick-start test [PR-Blocking] [ClusterClass]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
@@ -48,10 +73,21 @@ var _ = Describe("ClusterClass Creation using Cluster API quick-start test [PR-B
 })
 
 var _ = Describe("Cluster creation with [Ignition] bootstrap [PR-Blocking]", func() {
+	var (
+		testSpecificClusterctlConfigPath string
+		testSpecificIPAddressClaims      ipam.IPAddressClaims
+	)
+	BeforeEach(func() {
+		testSpecificClusterctlConfigPath, testSpecificIPAddressClaims = ipamHelper.ClaimIPs(ctx, clusterctlConfigPath)
+	})
+	defer AfterEach(func() {
+		Expect(ipamHelper.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+	})
+
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
+			ClusterctlConfigPath:  testSpecificClusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,

--- a/test/go.mod
+++ b/test/go.mod
@@ -27,6 +27,7 @@ require (
 	sigs.k8s.io/cluster-api/test v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/kind v0.20.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -138,5 +139,4 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2342
