### PR TITLE
🌱 Rename e2e-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ test-integration: $(GINKGO) $(KUSTOMIZE) $(KIND)
 .PHONY: e2e-image
 e2e-image: ## Build the e2e manager image
 	docker buildx build --platform linux/$(ARCH) --output=type=docker \
-		--build-arg ldflags="$(LDFLAGS)" --tag="gcr.io/k8s-staging-cluster-api/capv-manager:e2e" .
+		--build-arg ldflags="$(LDFLAGS)" --tag="gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev" .
 
 .PHONY: e2e
 e2e: e2e-image generate-e2e-templates

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -90,11 +90,11 @@ make envsubst
 # Save the docker image locally
 make e2e-image
 mkdir -p /tmp/images
-docker save gcr.io/k8s-staging-cluster-api/capv-manager:e2e -o "$DOCKER_IMAGE_TAR"
+docker save gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev -o "$DOCKER_IMAGE_TAR"
 
 # Store the image on gcs
 login
-E2E_IMAGE_SHA=$(docker inspect --format='{{index .Id}}' gcr.io/k8s-staging-cluster-api/capv-manager:e2e)
+E2E_IMAGE_SHA=$(docker inspect --format='{{index .Id}}' gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev)
 export E2E_IMAGE_SHA
 gsutil cp ${DOCKER_IMAGE_TAR} gs://capv-ci/"$E2E_IMAGE_SHA"
 

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -14,7 +14,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
     loadBehavior: tryLoad
@@ -106,7 +106,7 @@ providers:
         contract: v1beta1
         replacements:
           - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
-            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+            new: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
         files:

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -17,7 +17,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
     loadBehavior: tryLoad
@@ -109,7 +109,7 @@ providers:
         contract: v1beta1
         replacements:
           - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
-            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+            new: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
         files:

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -17,7 +17,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
     loadBehavior: tryLoad
@@ -80,7 +80,7 @@ providers:
           - sourcePath: "../e2e/data/shared/main/v1beta1_provider/metadata.yaml"
         replacements:
           - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
-            new: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
+            new: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
 variables:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Just renaming the image we use in e2e tests to be ~ consistent how we do it in CAPI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
