### PR TITLE
🌱 api: deprecate PreferredAPIServerCIDR

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -275,6 +275,8 @@ type NetworkSpec struct {
 	// PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
 	// server endpoint on this machine
 	// +optional
+	//
+	// Deprecated: This field is going to be removed in a future release.
 	PreferredAPIServerCIDR string `json:"preferredAPIServerCidr,omitempty"`
 }
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -359,8 +359,9 @@ spec:
                       type: object
                     type: array
                   preferredAPIServerCidr:
-                    description: PreferredAPIServeCIDR is the preferred CIDR for the
-                      Kubernetes API server endpoint on this machine
+                    description: "PreferredAPIServeCIDR is the preferred CIDR for
+                      the Kubernetes API server endpoint on this machine \n Deprecated:
+                      This field is going to be removed in a future release."
                     type: string
                   routes:
                     description: Routes is a list of optional, static routes applied

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -389,8 +389,10 @@ spec:
                               type: object
                             type: array
                           preferredAPIServerCidr:
-                            description: PreferredAPIServeCIDR is the preferred CIDR
+                            description: "PreferredAPIServeCIDR is the preferred CIDR
                               for the Kubernetes API server endpoint on this machine
+                              \n Deprecated: This field is going to be removed in
+                              a future release."
                             type: string
                           routes:
                             description: Routes is a list of optional, static routes

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -375,8 +375,9 @@ spec:
                       type: object
                     type: array
                   preferredAPIServerCidr:
-                    description: PreferredAPIServeCIDR is the preferred CIDR for the
-                      Kubernetes API server endpoint on this machine
+                    description: "PreferredAPIServeCIDR is the preferred CIDR for
+                      the Kubernetes API server endpoint on this machine \n Deprecated:
+                      This field is going to be removed in a future release."
                     type: string
                   routes:
                     description: Routes is a list of optional, static routes applied


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds the deprecation information to the field `PreferredAPIServeCIDR`. It is not even able to get used anymore due to the following validation which already exists:

https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/internal/webhooks/vspherevm.go?rgh-link-date=2024-01-25T08%3A19%3A43Z#L75-L77

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2092
