### PR TITLE
🌱 hack/e2e.sh fix waiting for ipam

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -75,13 +75,14 @@ docker logs vpn
 function wait_for_ipam_reachable() {
   local n=0
   until [ $n -ge 30 ]; do
-    kubectl --kubeconfig="${E2E_IPAM_KUBECONFIG}" --request-timeout=2s  cluster-info && RET=$? || RET=$?
+    kubectl --kubeconfig="${E2E_IPAM_KUBECONFIG}" --request-timeout=2s  get inclusterippools.ipam.cluster.x-k8s.io && RET=$? || RET=$?
     if [[ "$RET" -eq 0 ]]; then
       break
     fi
     n=$((n + 1))
     sleep 1
   done
+  return "$RET"
 }
 wait_for_ipam_reachable
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes the failing wait for ipam.

The service account used is not allowed to do `kubectl cluster-info`.

Also at the end it did not fail when reaching the timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
