### PR TITLE
🐛 kube-vip: fix prepare script to work on pre k8s v1.29

### DIFF
--- a/packaging/flavorgen/flavors/kubevip/kube-vip-prepare.sh
+++ b/packaging/flavorgen/flavors/kubevip/kube-vip-prepare.sh
@@ -22,7 +22,7 @@ set -e
 # Nothing to do for kubernetes < v1.29
 KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
 if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-  return
+  exit 0
 fi
 
 IS_KUBEADM_INIT="false"

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -168,7 +168,7 @@ spec:
         # Nothing to do for kubernetes < v1.29
         KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
         if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-          return
+          exit 0
         fi
 
         IS_KUBEADM_INIT="false"

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -205,7 +205,7 @@ spec:
         # Nothing to do for kubernetes < v1.29
         KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
         if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-          return
+          exit 0
         fi
 
         IS_KUBEADM_INIT="false"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -195,7 +195,7 @@ spec:
         # Nothing to do for kubernetes < v1.29
         KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
         if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-          return
+          exit 0
         fi
 
         IS_KUBEADM_INIT="false"

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -168,7 +168,7 @@ spec:
               # Nothing to do for kubernetes < v1.29
               KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
               if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-                return
+                exit 0
               fi
 
               IS_KUBEADM_INIT="false"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes the kubve-vip-prepare.sh for kubernetes versions < v1.29

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2659
