### PR TITLE
🌱 test: ignore VMs on errors retrieving the properties

### DIFF
--- a/test/framework/ip/incluster.go
+++ b/test/framework/ip/incluster.go
@@ -253,7 +253,9 @@ func getVirtualMachineIPAddresses(ctx context.Context, folderName string, vSpher
 	for _, mobj := range managedObjects {
 		// Get guest.net properties for mobj.
 		if err := vSphereClient.RetrieveOne(ctx, mobj.Object.Reference(), []string{"guest.net"}, &vm); err != nil {
-			return nil, errors.Wrapf(err, "get properties of VM %s", mobj.Object.Reference())
+			// We cannot get the properties e.g. when the machine already got deleted or is getting deleted.
+			Byf("Ignoring VirtualMachine %s during ipam Teardown due to error retrieving properties: %v", mobj.Path, err)
+			continue
 		}
 		// Iterate over all nics and add IP addresses to virtualMachineIPAddresses.
 		for _, nic := range vm.Guest.Net {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixing flakes like: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/2655/pull-cluster-api-provider-vsphere-e2e-full-main/1750560965209886720

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
