### PR TITLE
🌱 test: change way to get number of hosts to not rely on read hosts permissions

### DIFF
--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/mo"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -98,17 +99,20 @@ func VerifyAntiAffinity(ctx context.Context, input AntiAffinitySpecInput) {
 	Expect(namespace).NotTo(BeNil())
 
 	By("checking if the target system has enough hosts")
-	hostSystems, err := input.Finder.HostSystemList(ctx, "*")
+	computeResource, err := input.Finder.ComputeResourceOrDefault(ctx, "")
 	Expect(err).ToNot(HaveOccurred())
+	computeCluster := mo.ComputeResource{}
+	Expect(input.Client.RetrieveOne(ctx, computeResource.Reference(), []string{"summary"}, &computeCluster)).To(Succeed())
+
 	// Setting the number of worker nodes to the number of hosts.
 	// Later in the test we check that all worker nodes are located on different hosts.
-	workerNodeCount := len(hostSystems)
+	workerNodeCount := int(computeCluster.Summary.GetComputeResourceSummary().NumEffectiveHosts)
 	// Limit size to not create too much VMs when running in a big environment.
 	if workerNodeCount > 10 {
 		workerNodeCount = 10
 	}
 
-	Byf("creating a workload cluster %s", clusterName)
+	Byf("creating a workload cluster %s having %d worker nodes", clusterName, workerNodeCount)
 	configCluster := defaultConfigCluster(clusterName, namespace.Name, "", 1, int64(workerNodeCount),
 		input.Global)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Follow-up from release-1.6 flakyness.

Requires manual cherry-pick to release-1.6

/assign sbueringer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
