### PR TITLE
🐛 controllers/vmware fix test to not contain data race

### DIFF
--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -27,6 +27,7 @@ import (
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -208,9 +209,12 @@ func updateClusterInfraRef(cluster *clusterv1.Cluster, infraCluster client.Objec
 }
 
 func getManager(cfg *rest.Config, networkProvider string) manager.Manager {
+	localScheme := runtime.NewScheme()
+	Expect(scheme.AddToScheme(localScheme)).To(Succeed())
+
 	opts := manager.Options{
 		Options: ctrlmgr.Options{
-			Scheme: scheme.Scheme,
+			Scheme: localScheme,
 			NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 				syncPeriod := 1 * time.Second
 				opts.SyncPeriod = &syncPeriod


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the error `fatal error: concurrent map read and map write` by not re-using `scheme.Scheme` but using our own `runtime.Scheme` instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2325
