### PR TITLE
🌱 test: fix log collector for cloud-init

### DIFF
--- a/test/framework/log/collector.go
+++ b/test/framework/log/collector.go
@@ -72,9 +72,9 @@ func (collector MachineLogCollector) CollectMachineLog(_ context.Context, _ clie
 		captureLogs("containerd.log",
 			"sudo journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service"),
 		captureLogs("cloud-init.log",
-			"cat", "/var/log/cloud-init.log"),
+			"sudo", "cat", "/var/log/cloud-init.log"),
 		captureLogs("cloud-init-output.log",
-			"cat", "/var/log/cloud-init-output.log"),
+			"sudo", "cat", "/var/log/cloud-init-output.log"),
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

`cat /var/log/cloud-init-output.log` resulted in:

```
cat: /var/log/cloud-init-output.log: Permission denied
```

This makes use of sudo which fixes that. Also adds stderr to the output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
