### PR TITLE
🌱 test: remove getClusterctlConfigVariable function and use capi framework functions instead

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -266,8 +266,7 @@ var _ = SynchronizedAfterSuite(func() {
 	// After all ParallelNodes.
 	if !skipCleanup {
 		By("Cleaning up orphaned IPAddressClaims")
-		vSphereFolderName, err := getClusterctlConfigVariable(clusterctlConfigPath, "VSPHERE_FOLDER")
-		Expect(err).ToNot(HaveOccurred())
+		vSphereFolderName := e2eConfig.GetVariable("VSPHERE_FOLDER")
 		Expect(ipAddressManager.Teardown(ctx, vSphereFolderName, vsphereClient)).To(Succeed())
 	}
 

--- a/test/e2e/govmomi_test.go
+++ b/test/e2e/govmomi_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"net/url"
 	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +31,6 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -93,27 +91,4 @@ func initVSphereSession() {
 
 func terminateVSphereSession() {
 	Expect(vsphereClient.Logout(ctx)).To(Succeed())
-}
-
-func getClusterctlConfigVariable(clusterctlConfigPath, configVariable string) (string, error) {
-	// Environment variable overwrite takes priority.
-	if val := os.Getenv(configVariable); val != "" {
-		return val, nil
-	}
-
-	data, err := os.ReadFile(filepath.Clean(clusterctlConfigPath))
-	if err != nil {
-		return "", err
-	}
-
-	type clusterctlConfig struct {
-		Variables map[string]string `json:"variables"`
-	}
-
-	config := clusterctlConfig{}
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return "", err
-	}
-
-	return config.Variables[configVariable], nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Cleanup of function which is already implemented in CAPI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
