### PR TITLE
🌱 e2e: only upload images to gcs if we run tests which need it

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -91,16 +91,19 @@ wait_for_ipam_reachable
 
 make envsubst
 
-# Save the docker image locally
-make e2e-image
-mkdir -p /tmp/images
-docker save gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev -o "$DOCKER_IMAGE_TAR"
+# Only build and upload the image if we run tests which require it to save some $.
+if [[ -z "${GINKGO_FOCUS+x}" ]]; then
+  # Save the docker image locally
+  make e2e-image
+  mkdir -p /tmp/images
+  docker save gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev -o "$DOCKER_IMAGE_TAR"
 
-# Store the image on gcs
-login
-E2E_IMAGE_SHA=$(docker inspect --format='{{index .Id}}' gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev)
-export E2E_IMAGE_SHA
-gsutil cp ${DOCKER_IMAGE_TAR} gs://capv-ci/"$E2E_IMAGE_SHA"
+  # Store the image on gcs
+  login
+  E2E_IMAGE_SHA=$(docker inspect --format='{{index .Id}}' gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev)
+  export E2E_IMAGE_SHA
+  gsutil cp ${DOCKER_IMAGE_TAR} gs://capv-ci/"$E2E_IMAGE_SHA"
+fi
 
 # Run e2e tests
 make e2e


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Only uploads the docker image to gcs when we don't set `GINKGO_FOCUS`.

We set `GINKGO_FOCUS` at all e2e periodics + presubmits except for the `{periodic,pull}-cluster-api-provider-vsphere-e2e` which are the only ones where we require to upload the images because of running the clusterctl upgrade tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
