### PR TITLE
🌱 Align docker build to CAPI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,22 +1,34 @@
 .git
 .github
 .vscode
-
-.dockerignore
 .gitignore
 .golangci.yml
-*.out
 bin/
-hack/.bin/
-hack/tools/bin/
+**/*.yaml
+hack/
 out/
 docs/
-scripts/
+packaging/
+templates/
 **/*.md
-*.test
-cluster-api-provider-vsphere
-examples/provider-components/provider-components*.yaml
-test/
+**/.tiltbuild
+**/config/**/*.yaml
+**/config/**/*.yaml-e
+_artifacts
+Makefile
+**/Makefile
+
+# ignores changes to test-only code to avoid extra rebuilds
+test/e2e/**
+
+# We want to ignore any frequently modified files to avoid cache-busting the COPY ./ ./
+# Binaries for programs and plugins
+**/*.exe
+**/*.dll
+**/*.so
+**/*.dylib
+**/bin/**
+**/out/**
 
 # go.work files
 go.work

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -94,7 +94,7 @@ make envsubst
 # Only build and upload the image if we run tests which require it to save some $.
 if [[ -z "${GINKGO_FOCUS+x}" ]]; then
   # Save the docker image locally
-  make e2e-image
+  make e2e-images
   mkdir -p /tmp/images
   docker save gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev -o "$DOCKER_IMAGE_TAR"
 

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -14,7 +14,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
+  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller-{ARCH}:dev
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
     loadBehavior: tryLoad
@@ -104,11 +104,6 @@ providers:
         # Use manifest from source files
         value: ../../../../cluster-api-provider-vsphere/config/default
         contract: v1beta1
-        replacements:
-          - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
-            new: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
-          - old: "imagePullPolicy: Always"
-            new: "imagePullPolicy: IfNotPresent"
         files:
           # Add a cluster template
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/cluster-template-conformance.yaml"

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"sigs.k8s.io/cluster-api-provider-vsphere/packaging/flavorgen/flavors/util"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
@@ -342,7 +341,7 @@ func ReconcileDependencies(ctx context.Context, c client.Client, config Dependen
 		},
 		ClassRef: vmoprv1.ClassReference{
 			APIVersion: vmoprv1.SchemeGroupVersion.String(),
-			Kind:       util.TypeToKind(&vmoprv1.VirtualMachineClass{}),
+			Kind:       "VirtualMachineClass",
 			Name:       vmClass.Name,
 		},
 	}
@@ -430,7 +429,7 @@ func ReconcileDependencies(ctx context.Context, c client.Client, config Dependen
 		},
 		ContentSourceRef: vmoprv1.ContentSourceReference{
 			APIVersion: vmoprv1.SchemeGroupVersion.String(),
-			Kind:       util.TypeToKind(&vmoprv1.ContentSource{}),
+			Kind:       "ContentSource",
 			Name:       contentSource.Name,
 		},
 	}

--- a/test/infrastructure/vcsim/Dockerfile
+++ b/test/infrastructure/vcsim/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # This needs to build with the entire Cluster API context
 WORKDIR /workspace
-# Copy the sources (which includes the test/infrastructure/inmemory subdirectory)
+# Copy the sources (which includes the test/infrastructure/vcsim subdirectory)
 COPY ./ ./
 
 # Essentially, change directories into vcsim
@@ -61,6 +61,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build .
 
 # Build
+ARG package=.
 ARG ARCH
 ARG ldflags
 
@@ -69,12 +70,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -trimpath -ldflags "${ldflags} -extldflags '-static'" \
-    -o /workspace/manager .
+    -o manager ${package}
 
 
 FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/test/infrastructure/vcsim/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 USER 65532
 ENTRYPOINT ["/manager"]

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -17,7 +17,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
+  - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller-{ARCH}:dev
     loadBehavior: mustLoad
   - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
     loadBehavior: tryLoad
@@ -78,11 +78,7 @@ providers:
         contract: v1beta1
         files:
           - sourcePath: "../e2e/data/shared/main/v1beta1_provider/metadata.yaml"
-        replacements:
-          - old: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:main
-            new: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller:dev
-          - old: "imagePullPolicy: Always"
-            new: "imagePullPolicy: IfNotPresent"
+
 variables:
   VSPHERE_PASSWORD: "admin123"
   VSPHERE_USERNAME: "admin123"


### PR DESCRIPTION
**What this PR does / why we need it**:
Align docker-build (Dockerfiles, .dockerignore, make targets) to what we are doing in CAPI, use the same build targets for E2E