### PR TITLE
🌱 hack: fix janitor to properly set kubeconfig and log an error

### DIFF
--- a/hack/clean-ci.sh
+++ b/hack/clean-ci.sh
@@ -58,5 +58,8 @@ function wait_for_ipam_reachable() {
 }
 wait_for_ipam_reachable
 
+# Set kubeconfig for IPAM cleanup
+export KUBECONFIG="${E2E_IPAM_KUBECONFIG}"
+
 # Run e2e tests
 make clean-ci

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -92,7 +92,10 @@ func run(ctx context.Context) error {
 	defer vSphereClients.logout(ctx)
 
 	// Create controller-runtime client for IPAM.
-	restConfig := ctrl.GetConfigOrDie()
+	restConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "unable to get kubeconfig")
+	}
 	ipamClient, err := client.New(restConfig, client.Options{Scheme: ipamScheme})
 	if err != nil {
 		return errors.Wrap(err, "creating IPAM client")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Properly sets the KUBECONFIG env var and return a proper error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
