### PR TITLE
🌱 hack/janitor: fix printing task id

### DIFF
--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -128,7 +128,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 		if err != nil {
 			return err
 		}
-		log.Info("Created PowerOff task for VM", "vm", vm.managedObject.Config.Name, "task", task.Name())
+		log.Info("Created PowerOff task for VM", "vm", vm.managedObject.Config.Name, "task", task.Reference().Value)
 		poweroffTasks = append(poweroffTasks, task)
 	}
 	// Wait for all PowerOff tasks to be finished. We intentionally ignore errors here
@@ -151,7 +151,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 		if err != nil {
 			return err
 		}
-		log.Info("Created Destroy task for VM", "vm", vm.managedObject.Config.Name, "task", task.Name())
+		log.Info("Created Destroy task for VM", "vm", vm.managedObject.Config.Name, "task", task.Reference().Value)
 		destroyTasks = append(destroyTasks, task)
 	}
 	// Wait for all destroy tasks to succeed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

task.Name() returns empty strings 🤦 using `task.Reference().Value` now, as we do in our controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
