### PR TITLE
🌱 Bump github.com/vmware/govmomi from 0.34.2 to 0.35.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/vmware-tanzu/vm-operator/api v1.8.5
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd
-	github.com/vmware/govmomi v0.34.2
+	github.com/vmware/govmomi v0.35.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.15.0
 	golang.org/x/tools v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585ee
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd h1:BleW2NxLCPbLvFoTzhoX/DsjCJuKyEdcmvYiY04k18U=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd/go.mod h1:dfYrWS8DMRN+XZfhu8M4LVHmeGvYB29Ipd7j4uIq+mU=
-github.com/vmware/govmomi v0.34.2 h1:o6ydkTVITOkpQU6HAf6tP5GvHFCNJlNUNlMsvFK77X4=
-github.com/vmware/govmomi v0.34.2/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
+github.com/vmware/govmomi v0.35.0 h1:vN6m2J5ezSJomSTHyKbvpfoEZTn2mGXWg2FFpjRTRp0=
+github.com/vmware/govmomi v0.35.0/go.mod h1:VvIo6siOYFKdF9eU7qrY9+j/F99DV/LtSgsOpxFXJAY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -164,7 +164,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 
 func waitForTasksFinished(ctx context.Context, tasks []*object.Task, ignoreErrors bool) error {
 	for _, t := range tasks {
-		if err := t.Wait(ctx); !ignoreErrors && err != nil {
+		if err := t.WaitEx(ctx); !ignoreErrors && err != nil {
 			return err
 		}
 	}

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -63,7 +63,7 @@ func Test_VMGroup(t *testing.T) {
 
 	task, err := vmGrp.Add(ctx, vmRef)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(task.Wait(ctx)).To(Succeed())
+	g.Expect(task.WaitEx(ctx)).To(Succeed())
 	g.Expect(vmGrp.listVMs()).To(HaveLen(3))
 
 	hasVM, err = vmGrp.HasVM(vmRef)

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -78,7 +78,7 @@ func TestCreate(t *testing.T) {
 		t.Fatal("could not make vim25 client.")
 	}
 	task := object.NewTask(vimClient, taskRef)
-	err = task.Wait(ctx)
+	err = task.WaitEx(ctx)
 	if err != nil {
 		t.Fatal("error waiting for task:", err)
 	}

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -192,7 +192,7 @@ func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx
 		&virtualMachineCtx.VMContext,
 		func() (<-chan []interface{}, <-chan error, error) {
 			// Wait for the VM to be powered on.
-			powerOnTaskInfo, err := powerOnTask.WaitForResult(ctx)
+			powerOnTaskInfo, err := powerOnTask.WaitForResultEx(ctx)
 			if err != nil && powerOnTaskInfo == nil {
 				return nil, nil, errors.Wrapf(err, "failed to wait for power on op for vm %s", ctx)
 			}
@@ -255,7 +255,7 @@ func reconcileVSphereVMOnTaskCompletion(ctx context.Context, vmCtx *capvcontext.
 		"taskDescriptionID", task.Info.DescriptionId)
 
 	reconcileVSphereVMOnFuncCompletion(ctx, vmCtx, func() ([]interface{}, error) {
-		taskInfo, err := taskHelper.WaitForResult(ctx)
+		taskInfo, err := taskHelper.WaitForResultEx(ctx)
 
 		// An error is only returned if the process of waiting for the result
 		// failed, *not* if the task itself failed.

--- a/test/go.mod
+++ b/test/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/vmware-tanzu/vm-operator/api v1.8.5
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd
-	github.com/vmware/govmomi v0.34.2
+	github.com/vmware/govmomi v0.35.0
 	go.etcd.io/etcd/api/v3 v3.5.12
 	go.etcd.io/etcd/client/v3 v3.5.12
 	golang.org/x/crypto v0.18.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -608,8 +608,8 @@ github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585ee
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd/go.mod h1:5rqRJ9zGR+KnKbkGx373WgN8xJpvAj99kHnfoDYRO5I=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd h1:BleW2NxLCPbLvFoTzhoX/DsjCJuKyEdcmvYiY04k18U=
 github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd/go.mod h1:dfYrWS8DMRN+XZfhu8M4LVHmeGvYB29Ipd7j4uIq+mU=
-github.com/vmware/govmomi v0.34.2 h1:o6ydkTVITOkpQU6HAf6tP5GvHFCNJlNUNlMsvFK77X4=
-github.com/vmware/govmomi v0.34.2/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
+github.com/vmware/govmomi v0.35.0 h1:vN6m2J5ezSJomSTHyKbvpfoEZTn2mGXWg2FFpjRTRp0=
+github.com/vmware/govmomi v0.35.0/go.mod h1:VvIo6siOYFKdF9eU7qrY9+j/F99DV/LtSgsOpxFXJAY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/infrastructure/vcsim/controllers/vmip_controller.go
+++ b/test/infrastructure/vcsim/controllers/vmip_controller.go
@@ -79,7 +79,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOff vm")
 	}
-	if err = task.Wait(ctx); err != nil {
+	if err = task.WaitEx(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOff vm task to complete")
 	}
 
@@ -117,7 +117,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to Customize vm")
 	}
-	if err = task.Wait(ctx); err != nil {
+	if err = task.WaitEx(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to wait for Customize vm task to complete")
 	}
 
@@ -126,7 +126,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOn vm")
 	}
-	if err = task.Wait(ctx); err != nil {
+	if err = task.WaitEx(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOn vm task to complete")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Dependabot upgraded Govmomi to version 0.35.0 and some functions have been deprecated. This PR replaces the deprecated functions on top of dependabot's upgrade.
