### PR TITLE
🐛 controllers/test: use APIReader to not assert on cached information

### DIFF
--- a/controllers/serviceaccount_controller_suite_test.go
+++ b/controllers/serviceaccount_controller_suite_test.go
@@ -58,11 +58,11 @@ func createTargetSecretWithInvalidToken(ctx context.Context, guestClient client.
 	Expect(guestClient.Create(ctx, secret)).To(Succeed())
 }
 
-func assertEventuallyExistsInNamespace(ctx context.Context, c client.Client, namespace, name string, obj client.Object) {
+func assertEventuallyExistsInNamespace(ctx context.Context, c client.Reader, namespace, name string, obj client.Object) {
 	EventuallyWithOffset(2, func() error {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		return c.Get(ctx, key, obj)
-	}).Should(Succeed())
+	}, time.Second*3).Should(Succeed())
 }
 
 func assertNoEntities(ctx context.Context, ctrlClient client.Client, namespace string) {

--- a/controllers/servicediscovery_controller_intg_test.go
+++ b/controllers/servicediscovery_controller_intg_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			headlessSvc := &corev1.Service{}
-			assertEventuallyExistsInNamespace(ctx, intCtx.Client, "kube-system", "kube-apiserver-lb-svc", headlessSvc)
-			assertHeadlessSvcWithVIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertEventuallyExistsInNamespace(ctx, testEnv.Manager.GetAPIReader(), "kube-system", "kube-apiserver-lb-svc", headlessSvc)
+			assertHeadlessSvcWithVIPEndpoints(ctx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 
@@ -67,7 +67,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		})
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the FIP in the guest cluster")
-			assertHeadlessSvcWithFIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithFIPEndpoints(ctx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 	Context("When headless svc and endpoints already exists", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		})
 		It("Should reconcile headless svc", func() {
 			By("updating the service and endpoints using the VIP in the guest cluster")
-			assertHeadlessSvcWithUpdatedVIPEndpoints(ctx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithUpdatedVIPEndpoints(ctx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 })

--- a/controllers/servicediscovery_controller_suite_test.go
+++ b/controllers/servicediscovery_controller_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -73,10 +74,10 @@ func assertEventuallyDoesNotExistInNamespace(ctx context.Context, guestClient cl
 
 func assertHeadlessSvc(ctx context.Context, guestClient client.Client, namespace, name string) {
 	headlessSvc := &corev1.Service{}
-	EventuallyWithOffset(4, func() error {
+	Eventually(func() error {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		return guestClient.Get(ctx, key, headlessSvc)
-	}).Should(Succeed())
+	}, time.Second*3).Should(Succeed())
 	Expect(headlessSvc.Spec.Ports[0].Port).To(Equal(int32(supervisorHeadlessSvcPort)))
 	Expect(headlessSvc.Spec.Ports[0].TargetPort.IntVal).To(Equal(int32(supervisorAPIServerPort)))
 }
@@ -137,7 +138,7 @@ func assertHeadlessSvcWithUpdatedVIPEndpoints(ctx context.Context, guestClient c
 	assertHeadlessSvc(ctx, guestClient, namespace, name)
 	headlessEndpoints := &corev1.Endpoints{}
 	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, headlessEndpoints)
-	EventuallyWithOffset(2, func() string {
+	Eventually(func() string {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		Expect(guestClient.Get(ctx, key, headlessEndpoints)).Should(Succeed())
 		return headlessEndpoints.Subsets[0].Addresses[0].IP


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This should resolve the flaky tests for the service discovery controller we have on main and release-1.9 from https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/servicediscovery_controller_intg_test.go.

The tests did use a cached client and did assert on cached client data. Using an uncached api reader / client instead makes the test stable.
Also this improves some timeouts in eventually instead of only trying it once.

Heavily tested at #2749

Should solve:

* [service discovery controller tests](https://storage.googleapis.com/k8s-triage/index.html?date=2024-02-19&job=.*-cluster-api-provider-vsphere.*&test=.*Service%20Discovery%20controller%20integration%20tests.*)

/cherry-pick release-1.9

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
