### PR TITLE
📖 docs: document tagging the test go module

### DIFF
--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -116,12 +116,15 @@ From this point forward changes which should land in the release have to be cher
       # Export the tag of the release to be cut, e.g.:
       export RELEASE_TAG=v1.8.0-beta.0
       # Create tags locally
-      # Warning: The test tag MUST NOT be an annotated tag.
       git tag -s -a ${RELEASE_TAG} -m ${RELEASE_TAG}
+      # Warning: The test tag MUST NOT be an annotated tag.
+      # Warning: only for >= release-1.9
+      git tag -s test/${RELEASE_TAG}
 
       # Push tags
       # Note: `upstream` must be the remote pointing to `github.com/kubernetes-sigs/cluster-api-provider-vsphere`.
       git push upstream ${RELEASE_TAG}
+      git push upstream test/${RELEASE_TAG}
    ```
 
    This will automatically trigger:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

We added a go module in `test` since v1.9. We also should add tags for the test module.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
