### PR TITLE
[release-1.6] 🐛 controllers: use apireader to not assert on cached information

### DIFF
--- a/controllers/serviceaccount_controller_suite_test.go
+++ b/controllers/serviceaccount_controller_suite_test.go
@@ -59,11 +59,11 @@ func createTargetSecretWithInvalidToken(ctx goctx.Context, guestClient client.Cl
 	Expect(guestClient.Create(ctx, secret)).To(Succeed())
 }
 
-func assertEventuallyExistsInNamespace(ctx goctx.Context, c client.Client, namespace, name string, obj client.Object) {
+func assertEventuallyExistsInNamespace(ctx goctx.Context, c client.Reader, namespace, name string, obj client.Object) {
 	EventuallyWithOffset(2, func() error {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		return c.Get(ctx, key, obj)
-	}).Should(Succeed())
+	}, time.Second*3).Should(Succeed())
 }
 
 func assertNoEntities(ctx goctx.Context, ctrlClient client.Client, namespace string) {

--- a/controllers/svcdiscovery_controller_intg_test.go
+++ b/controllers/svcdiscovery_controller_intg_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			headlessSvc := &corev1.Service{}
-			assertEventuallyExistsInNamespace(intCtx, intCtx.Client, "kube-system", "kube-apiserver-lb-svc", headlessSvc)
-			assertHeadlessSvcWithVIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertEventuallyExistsInNamespace(intCtx, testEnv.Manager.GetAPIReader(), "kube-system", "kube-apiserver-lb-svc", headlessSvc)
+			assertHeadlessSvcWithVIPEndpoints(intCtx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 
@@ -67,7 +67,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		})
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the FIP in the guest cluster")
-			assertHeadlessSvcWithFIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithFIPEndpoints(intCtx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 	Context("When headless svc and endpoints already exists", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		})
 		It("Should reconcile headless svc", func() {
 			By("updating the service and endpoints using the VIP in the guest cluster")
-			assertHeadlessSvcWithUpdatedVIPEndpoints(intCtx, intCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertHeadlessSvcWithUpdatedVIPEndpoints(intCtx, intCtx.GuestAPIReader, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
 		})
 	})
 })

--- a/controllers/svcdiscovery_controller_suite_test.go
+++ b/controllers/svcdiscovery_controller_suite_test.go
@@ -142,7 +142,7 @@ func assertHeadlessSvcWithUpdatedVIPEndpoints(ctx context.Context, guestClient c
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		Expect(guestClient.Get(ctx, key, headlessEndpoints)).Should(Succeed())
 		return headlessEndpoints.Subsets[0].Addresses[0].IP
-	}).Should(Equal(testSupervisorAPIServerVIP))
+	}, time.Second*3).Should(Equal(testSupervisorAPIServerVIP))
 	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(supervisorAPIServerPort)))
 }
 

--- a/controllers/svcdiscovery_controller_suite_test.go
+++ b/controllers/svcdiscovery_controller_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -73,10 +74,10 @@ func assertEventuallyDoesNotExistInNamespace(ctx context.Context, guestClient cl
 
 func assertHeadlessSvc(ctx context.Context, guestClient client.Client, namespace, name string) {
 	headlessSvc := &corev1.Service{}
-	EventuallyWithOffset(4, func() error {
+	Eventually(func() error {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		return guestClient.Get(ctx, key, headlessSvc)
-	}).Should(Succeed())
+	}, time.Second*3).Should(Succeed())
 	Expect(headlessSvc.Spec.Ports[0].Port).To(Equal(int32(supervisorHeadlessSvcPort)))
 	Expect(headlessSvc.Spec.Ports[0].TargetPort.IntVal).To(Equal(int32(supervisorAPIServerPort)))
 }
@@ -137,7 +138,7 @@ func assertHeadlessSvcWithUpdatedVIPEndpoints(ctx context.Context, guestClient c
 	assertHeadlessSvc(ctx, guestClient, namespace, name)
 	headlessEndpoints := &corev1.Endpoints{}
 	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, headlessEndpoints)
-	EventuallyWithOffset(2, func() string {
+	Eventually(func() string {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		Expect(guestClient.Get(ctx, key, headlessEndpoints)).Should(Succeed())
 		return headlessEndpoints.Subsets[0].Addresses[0].IP


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2752 and https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2769