### PR TITLE
🌱 add make targets to build and push vm operator image for testing purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ test/e2e/data/infrastructure-vsphere/main/**/cluster-template*.yaml
 test/e2e/data/infrastructure-vsphere/*/cluster-template*.yaml
 test/e2e/data/infrastructure-vsphere/*/clusterclass-quick-start.yaml
 
+# vm-operator related
+test/infrastructure/vm-operator/vm-operator.yaml
+
 # env vars file used in getting-started.md and manifests generation
 envvars.txt
 

--- a/Makefile
+++ b/Makefile
@@ -765,6 +765,7 @@ set-manifest-image:
 ## vm-operator
 ## --------------------------------------
 
+##@ vm-operator:
 
 .PHONY: release-vm-operator
 release-vm-operator: docker-vm-operator-build-all vm-operator-manifest-build docker-vm-operator-push-all ## Build and push the vm-operator image and manifest for usage in CI
@@ -784,13 +785,13 @@ vm-operator-checkout:
 	fi
 
 .PHONY: vm-operator-manifest-build
-vm-operator-manifest-build: $(RELEASE_DIR) $(KUSTOMIZE) vm-operator-checkout
+vm-operator-manifest-build: $(RELEASE_DIR) $(KUSTOMIZE) vm-operator-checkout ## Build the vm-operator manifest yaml file
 	kustomize build --load-restrictor LoadRestrictionsNone "$(VM_OPERATOR_TMP_DIR)/config/local" > "$(VM_OPERATOR_DIR)/vm-operator.yaml"
 	sed -i'' -e 's@image: vmoperator.*@image: '"$(VM_OPERATOR_CONTROLLER_IMG):$(VM_OPERATOR_VERSION)"'@' "$(VM_OPERATOR_DIR)/vm-operator.yaml"
 	kustomize build "$(VM_OPERATOR_DIR)" > "$(RELEASE_DIR)/vm-operator-$(VM_OPERATOR_VERSION).yaml"
 
 .PHONY: vm-operator-manifest-push
-vm-operator-manifest-push:
+vm-operator-manifest-push: ## Push the vm-operator manifest yaml file to gcs
 	gsutil cp \
 		"$(RELEASE_DIR)/vm-operator-$(VM_OPERATOR_VERSION).yaml" \
 		"gs://artifacts.k8s-staging-capi-vsphere.appspot.com/vm-operator/$(VM_OPERATOR_VERSION).yaml"
@@ -802,7 +803,7 @@ docker-vm-operator-build-%:
 	$(MAKE) ARCH=$* docker-build-vm-operator
 
 .PHONY: docker-build-vm-operator
-docker-build-vm-operator: vm-operator-checkout ## Build the docker image for vmoperator
+docker-build-vm-operator: vm-operator-checkout
 	@if [ -z "${VM_OPERATOR_VERSION}" ]; then echo "VM_OPERATOR_VERSION is not set"; exit 1; fi
 	cd $(VM_OPERATOR_TMP_DIR) && \
 	$(MAKE) IMAGE=$(VM_OPERATOR_CONTROLLER_IMG)-$(ARCH) IMAGE_TAG=$(VM_OPERATOR_VERSION) GOARCH=$(ARCH) docker-build
@@ -815,12 +816,12 @@ docker-vm-operator-push-%:
 	$(MAKE) ARCH=$* docker-vm-operator-push
 
 .PHONY: docker-vm-operator-push
-docker-vm-operator-push: ## Push the docker images to be included in the release
+docker-vm-operator-push:
 	@if [ -z "${VM_OPERATOR_VERSION}" ]; then echo "VM_OPERATOR_VERSION is not set"; exit 1; fi
 	docker push $(VM_OPERATOR_CONTROLLER_IMG)-$(ARCH):$(VM_OPERATOR_VERSION)
 
 .PHONY: docker-vm-operator-push-manifest
-docker-vm-operator-push-manifest: ## Push the multiarch manifest for the vsphere docker images
+docker-vm-operator-push-manifest:
 	@if [ -z "${VM_OPERATOR_VERSION}" ]; then echo "VM_OPERATOR_VERSION is not set"; exit 1; fi
 	docker manifest create --amend $(VM_OPERATOR_CONTROLLER_IMG):$(VM_OPERATOR_VERSION) $(shell echo $(VM_OPERATOR_ALL_ARCH) | sed -e "s~[^ ]*~$(VM_OPERATOR_CONTROLLER_IMG)\-&:$(VM_OPERATOR_VERSION)~g")
 	@for arch in $(VM_OPERATOR_ALL_ARCH); do docker manifest annotate --arch $${arch} ${VM_OPERATOR_CONTROLLER_IMG}:${VM_OPERATOR_VERSION} ${VM_OPERATOR_CONTROLLER_IMG}-$${arch}:${VM_OPERATOR_VERSION}; done

--- a/test/infrastructure/vm-operator/kustomization.yaml
+++ b/test/infrastructure/vm-operator/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  # vm-operator is not a CAPI provider, but by adding this label
+  # we can get this installed by Cluster APIs Tiltfile.
+  cluster.x-k8s.io/provider: "infrastructure-vm-operator"
+
+resources:
+- vm-operator.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Usage:

```sh
make release-vm-operator
```

Or to build and push a specific version:

```sh
VM_OPERATOR_VERSION=v1.8.1 make release-vm-operator
```

Outputs:

Multiarch image (`linux/amd64`, `linux/arm64`) at: `https://gcr.io/k8s-staging-capi-vsphere/extra/vm-operator:v1.8.1`

Manifest at: `https://storage.googleapis.com/artifacts.k8s-staging-capi-vsphere.appspot.com/vm-operator/v1.8.1.yaml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
