### PR TITLE
🐛 Fixes issue with NCP versioning while using the semver package

### DIFF
--- a/pkg/util/networkutil_test.go
+++ b/pkg/util/networkutil_test.go
@@ -63,6 +63,12 @@ func TestNCPSupportFW(t *testing.T) {
 			false,
 		},
 		{
+			"compatible version with more than 3 segments",
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(newNCPConfigMap("3.0.1.1.1")).Build(),
+			true,
+			false,
+		},
+		{
 			"incompatible version lower end",
 			fake.NewClientBuilder().WithScheme(scheme).WithObjects(newNCPConfigMap("3.0.0")).Build(),
 			false,
@@ -71,6 +77,12 @@ func TestNCPSupportFW(t *testing.T) {
 		{
 			"incompatible version upper end",
 			fake.NewClientBuilder().WithScheme(scheme).WithObjects(newNCPConfigMap(NCPVersionSupportFWEnded)).Build(),
+			false,
+			false,
+		},
+		{
+			"incompatible version with more than 3 segments",
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(newNCPConfigMap("3.1.0.1")).Build(),
 			false,
 			false,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
NSX releases can have more than 3 segments. They frequently have 4. This causes an issue when there's an attempt to parse it with the semver package. 

In this PR, if a version with 4 segments is found, it will trim the last segment before parsing it as a semver. The codepath is only there to check that the version is >= 3.0.1 and < 3.1.0 so precision isn't lost by trimming down to 3 segments.

