### PR TITLE
🌱 vm-operator: remove web-validator and set replicas to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -775,7 +775,7 @@ set-manifest-image:
 ##@ vm-operator:
 
 .PHONY: release-vm-operator
-release-vm-operator: docker-vm-operator-build-all vm-operator-manifest-build docker-vm-operator-push-all ## Build and push the vm-operator image and manifest for usage in CI
+release-vm-operator: docker-vm-operator-build-all vm-operator-manifest-build docker-vm-operator-push-all vm-operator-manifest-push ## Build and push the vm-operator image and manifest for usage in CI
 
 .PHONY: vm-operator-checkout
 vm-operator-checkout:

--- a/test/infrastructure/vm-operator/kustomization.yaml
+++ b/test/infrastructure/vm-operator/kustomization.yaml
@@ -8,3 +8,15 @@ commonLabels:
 
 resources:
 - vm-operator.yaml
+
+patchesStrategicMerge:
+- vm-operator-replicas.yaml
+
+patches:
+- target:
+    labelSelector: app=web-console-validator
+  patch: |
+    $patch: delete
+    kind: Deployment
+    metadata:
+      name: web-console-validator

--- a/test/infrastructure/vm-operator/vm-operator-replicas.yaml
+++ b/test/infrastructure/vm-operator/vm-operator-replicas.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmware-system-vmop-controller-manager
+  namespace: vmware-system-vmop
+spec:
+  replicas: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Improves the vm-operator kustomization which gets used for testing CAPV in supervisor mode.

* Sets number of replicas to 1
* Removes the web-validator deployment which is not relevant for our use case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
