### PR TITLE
🌱 Set provider label for vm-operator as runtime-extension

### DIFF
--- a/test/infrastructure/vm-operator/kustomization.yaml
+++ b/test/infrastructure/vm-operator/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 commonLabels:
   # vm-operator is not a CAPI provider, but by adding this label
   # we can get this installed by Cluster APIs Tiltfile.
-  cluster.x-k8s.io/provider: "infrastructure-vm-operator"
+  cluster.x-k8s.io/provider: "runtime-extension-vm-operator"
 
 resources:
 - vm-operator.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Changes vm-operator to be a runtime-extension instead of infrastructure provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
