### PR TITLE
🌱 Fix release instructions and release note generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,6 +612,8 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 ifneq (,$(findstring -,$(RELEASE_TAG)))
     PRE_RELEASE=true
+else
+    PRE_RELEASE=false
 endif
 # the previous release tag, e.g., v0.3.9, excluding pre-release tags
 PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
@@ -725,10 +727,7 @@ release-alias-tag: ## Add the release alias tag to the last build tag
 generate-release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 	# Reset the file
 	echo -n > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
-	if [ -n "${PRE_RELEASE}" ]; then \
-	echo -e ":rotating_light: This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/new/choose).\n" >> $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md; \
-	fi
-	"$(RELEASE_NOTES)" --release=$(RELEASE_TAG) --repository kubernetes-sigs/cluster-api-provider-vsphere >> $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
+	"$(RELEASE_NOTES)" --release=$(RELEASE_TAG) --repository kubernetes-sigs/cluster-api-provider-vsphere --prefix-area-label=false --deprecation=false --add-kubernetes-version-support=false --pre-release-version=$(PRE_RELEASE) >> $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 .PHONY: promote-images
 promote-images: $(KPROMO)

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -119,7 +119,7 @@ From this point forward changes which should land in the release have to be cher
       git tag -s -a ${RELEASE_TAG} -m ${RELEASE_TAG}
       # Warning: The test tag MUST NOT be an annotated tag.
       # Warning: only for >= release-1.9
-      git tag -s test/${RELEASE_TAG}
+      git tag test/${RELEASE_TAG}
 
       # Push tags
       # Note: `upstream` must be the remote pointing to `github.com/kubernetes-sigs/cluster-api-provider-vsphere`.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
