### PR TITLE
[release-1.6] 🌱 Disable govulncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,9 +386,10 @@ verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
 
 .PHONY: verify-security
 verify-security: ## Verify code and images for vulnerabilities
+	## Note: govulncheck has been disabled on this branch, because there are CVEs in (out-of-support) Go 1.20.
 	$(MAKE) verify-container-images && R1=$$? || R1=$$?; \
-	$(MAKE) verify-govulncheck && R2=$$? || R2=$$?; \
-	if [ "$$R1" -ne "0" ] || [ "$$R2" -ne "0" ]; then \
+#	$(MAKE) verify-govulncheck && R2=$$? || R2=$$?; \
+	if [ "$$R1" -ne "0" ] ; then \
 	  echo "Check for vulnerabilities failed! There are vulnerabilities to be fixed"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Quote from Slack: https://kubernetes.slack.com/archives/CKFGK3SSD/p1710424265062089

Hey folks,
the weekly scan found a few CVEs across all supported CAPV versions. We've fixed those in main / 1.9 / 1.8 / 1.7 by bumping the Go 1.21.8 and to a newer protobuf version.

It was not possible to fix CAPV 1.6 because it is based on Go 1.20. Go 1.20 is out of support and thus there is no patch release to fix the CVE.

We would ignore these CVEs for now as CAPV v1.10 will be released soon (a bit after the next CAPI minor versions). At this point CAPV v1.6 will be out of support and there will be no further patch releases.
If you're affected by these CVE's please consider upgrading to a newer CAPV version. Alternatively, we would recommend assessing if CAPV is actually by the CVE. Here is the scan: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/actions/runs/8232381773/job/22658011913

We think the only potentially relevant finding is
> Error:       #3: pkg/services/govmomi/vcenter/clone.go:221:34: vcenter.Clone calls pbm.NewClient, which eventually calls cookiejar.Jar.Cookies
> Error:       #4: pkg/services/govmomi/vcenter/clone.go:221:34: vcenter.Clone calls pbm.NewClient, which eventually calls cookiejar.Jar.SetCookies

To make it easier to keep an overview over our security scans that we run across all branches we'll disable govulncheck on release-1.6 (we don't have a more fine-granular way to ignore a CVE right now). Trivy will continue to run on release-1.6.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
