### PR TITLE
🐛 Ensure entries for ProviderServiceAccount created in the ConfigMap are cleaned up

### DIFF
--- a/apis/vmware/v1beta1/vspherecluster_types.go
+++ b/apis/vmware/v1beta1/vspherecluster_types.go
@@ -26,6 +26,10 @@ const (
 	// resources associated with VSphereCluster before removing it from the
 	// API server.
 	ClusterFinalizer = "vspherecluster.vmware.infrastructure.cluster.x-k8s.io"
+
+	// ProviderServiceAccountFinalizer allows ServiceAccountReconciler to clean up service accounts
+	// resources associated with VSphereCluster from the SERVICE_ACCOUNTS_CM (service accounts ConfigMap).
+	ProviderServiceAccountFinalizer = "providerserviceaccount.vmware.infrastructure.cluster.x-k8s.io"
 )
 
 // VSphereClusterSpec defines the desired state of VSphereCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure entries for ProviderServiceAccount created in the ConfigMap are cleaned up by adding a finalizer on the vSphereCluster

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2845
