### PR TITLE
:sparkles:Add NSX-VPC Network Provider Support

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -335,6 +335,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nsx.vmware.com
+  resources:
+  - subnetsets
+  - subnetsets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -62,6 +62,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclustertemplates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nsx.vmware.com,resources=subnetsets;subnetsets/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmware.com,resources=virtualnetworks;virtualnetworks/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachinesetresourcepolicies;virtualmachinesetresourcepolicies/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineservices;virtualmachineservices/status,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -90,12 +90,12 @@ func AddMachineControllerToManager(ctx context.Context, controllerManagerContext
 	}
 
 	if supervisorBased {
-		r.VMService = &vmoperator.VmopMachineService{Client: controllerManagerContext.Client}
 		networkProvider, err := inframanager.GetNetworkProvider(ctx, controllerManagerContext.Client, controllerManagerContext.NetworkProvider)
 		if err != nil {
 			return errors.Wrap(err, "failed to create a network provider")
 		}
 		r.networkProvider = networkProvider
+		r.VMService = &vmoperator.VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: r.networkProvider.SupportsVMReadinessProbe()}
 
 		return ctrl.NewControllerManagedBy(mgr).
 			// Watch the controlled, infrastructure resource.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware-tanzu/net-operator-api v0.0.0-20231019160108-42131d6e8360
+	github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0
 	github.com/vmware-tanzu/vm-operator/api v1.8.5
 	github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd
 	github.com/vmware-tanzu/vm-operator/external/tanzu-topology v0.0.0-20231214185006-5477585eebfd

--- a/go.sum
+++ b/go.sum
@@ -550,6 +550,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20231019160108-42131d6e8360 h1:yG158jviUd3wRqCTJcSDzp+prUZWtSA9dhfm/Rf8m9M=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20231019160108-42131d6e8360/go.mod h1:dtVG693FvGuOSxJvTaKRVGU0EJR8yvLG3E2VaDDHILM=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0 h1:HdnQb/X9vJ8a5WQ03g/0nDr9igIIK1fF6wO5wOtkJT4=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware-tanzu/vm-operator/api v1.8.5 h1:E8rpRdV8+cNp/eNZ/QUHvlrbpPh8uk6bKqwEEmGWe64=
 github.com/vmware-tanzu/vm-operator/api v1.8.5/go.mod h1:SXaSFtnw2502Tzy0bfQVHrvbFDijR96r1ihUYQWPOK8=
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd h1:qdfVf7KFW+XX7+D4xC/mlBpRA9+B+opdDPxGdqjxO+4=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
+	nsxopv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
@@ -64,6 +65,7 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 	_ = vmoprv1.AddToScheme(opts.Scheme)
 	_ = ncpv1.AddToScheme(opts.Scheme)
 	_ = netopv1.AddToScheme(opts.Scheme)
+	_ = nsxopv1.AddToScheme(opts.Scheme)
 	_ = topologyv1.AddToScheme(opts.Scheme)
 	_ = ipamv1.AddToScheme(opts.Scheme)
 

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	// NSXVPCNetworkProvider identifies the nsx-vpc network provider.
+	NSXVPCNetworkProvider = "NSX-VPC"
 	// NSXNetworkProvider identifies the NSX network provider.
 	NSXNetworkProvider = "NSX"
 	// VDSNetworkProvider identifies the VDS network provider.
@@ -41,6 +43,9 @@ func GetNetworkProvider(ctx context.Context, client client.Client, networkProvid
 	log := ctrl.LoggerFrom(ctx)
 
 	switch networkProvider {
+	case NSXVPCNetworkProvider:
+		log.Info("Pick NSX-VPC network provider")
+		return network.NSXTVpcNetworkProvider(client), nil
 	case NSXNetworkProvider:
 		// TODO: disableFirewall not configurable
 		log.Info("Pick NSX-T network provider")

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -71,6 +71,9 @@ type NetworkProvider interface {
 	// HasLoadBalancer indicates whether this provider has a load balancer for Services.
 	HasLoadBalancer() bool
 
+	// SupportsVMReadinessProbe indicates whether this provider support vm readiness probe.
+	SupportsVMReadinessProbe() bool
+
 	// ProvisionClusterNetwork creates network resource for a given cluster
 	// This operation should be idempotent
 	ProvisionClusterNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext) error

--- a/pkg/services/network/constants.go
+++ b/pkg/services/network/constants.go
@@ -22,6 +22,9 @@ const (
 	NSXTTypeNetwork = "nsx-t"
 	// NSXTVNetSelectorKey is also defined in VM Operator.
 	NSXTVNetSelectorKey = "ncp.vmware.com/virtual-network-name"
+	// NSXTVPCSubnetSetNetworkType is the name of the NSX VPC network type. Please refer to:
+	// https://github.com/vmware-tanzu/vm-operator/blob/main/api/v1alpha1/virtualmachine_types.go#L149.
+	NSXTVPCSubnetSetNetworkType = "nsx-t-subnetset"
 
 	// CAPVDefaultNetworkLabel is a label used to identify the default network.
 	CAPVDefaultNetworkLabel = "capv.vmware.com/is-default-network"

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -38,6 +38,10 @@ func (np *dummyNetworkProvider) HasLoadBalancer() bool {
 	return false
 }
 
+func (np *dummyNetworkProvider) SupportsVMReadinessProbe() bool {
+	return true
+}
+
 func (np *dummyNetworkProvider) ProvisionClusterNetwork(_ context.Context, _ *vmware.ClusterContext) error {
 	return nil
 }

--- a/pkg/services/network/netop_provider.go
+++ b/pkg/services/network/netop_provider.go
@@ -48,6 +48,10 @@ func (np *netopNetworkProvider) HasLoadBalancer() bool {
 	return true
 }
 
+func (np *netopNetworkProvider) SupportsVMReadinessProbe() bool {
+	return true
+}
+
 // ProvisionClusterNetwork marks the ClusterNetworkReadyCondition true.
 func (np *netopNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
 	conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)

--- a/pkg/services/network/nsxt_provider.go
+++ b/pkg/services/network/nsxt_provider.go
@@ -56,6 +56,10 @@ func (np *nsxtNetworkProvider) HasLoadBalancer() bool {
 	return true
 }
 
+func (np *nsxtNetworkProvider) SupportsVMReadinessProbe() bool {
+	return true
+}
+
 // GetNSXTVirtualNetworkName returns the name of the NSX-T vnet object.
 func GetNSXTVirtualNetworkName(clusterName string) string {
 	return fmt.Sprintf("%s-vnet", clusterName)

--- a/pkg/services/network/nsxt_vpc_provider.go
+++ b/pkg/services/network/nsxt_vpc_provider.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	nsxopv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+)
+
+// nsxtVPCNetworkProvider provisions nsx-vpc type cluster network.
+type nsxtVPCNetworkProvider struct {
+	client client.Client
+}
+
+// NSXTVpcNetworkProvider returns an instance of nsx-vpc type network provider.
+func NSXTVpcNetworkProvider(client client.Client) services.NetworkProvider {
+	return &nsxtVPCNetworkProvider{
+		client: client,
+	}
+}
+
+func (vp *nsxtVPCNetworkProvider) HasLoadBalancer() bool {
+	return true
+}
+
+func (vp *nsxtVPCNetworkProvider) SupportsVMReadinessProbe() bool {
+	// Note: The control plane VM network is private with nsx-vpc and
+	// readiness probe would fail. Therefore, nsxvpcNetworkProvider
+	// doesn't support VM readiness probe.
+	return false
+}
+
+// verifyNsxtVpcSubnetSetStatus checks the status conditions of a given SubnetSet within a cluster context.
+// If the subnet isn't ready, it is marked as false, and the function returns an error.
+// If the subnet is ready, the function updates the VSphereCluster with a "true" status and returns nil.
+func (vp *nsxtVPCNetworkProvider) verifyNsxtVpcSubnetSetStatus(vspherecluster *vmwarev1.VSphereCluster, subnetset *nsxopv1.SubnetSet) error {
+	clusterName := vspherecluster.Name
+	namespace := vspherecluster.Namespace
+	hasReadyCondition := false
+
+	for _, condition := range subnetset.Status.Conditions {
+		if condition.Type != nsxopv1.Ready {
+			continue
+		}
+		hasReadyCondition = true
+		if condition.Status != corev1.ConditionTrue {
+			conditions.MarkFalse(vspherecluster, vmwarev1.ClusterNetworkReadyCondition, vmwarev1.ClusterNetworkProvisionFailedReason, clusterv1.ConditionSeverityWarning, condition.Message)
+			return errors.Errorf("subnetset ready status is: '%s' in cluster %s. reason: %s, message: %s",
+				condition.Status, types.NamespacedName{Namespace: namespace, Name: clusterName}, condition.Reason, condition.Message)
+		}
+	}
+
+	if !hasReadyCondition {
+		conditions.MarkFalse(vspherecluster, vmwarev1.ClusterNetworkReadyCondition, vmwarev1.ClusterNetworkProvisionFailedReason, clusterv1.ConditionSeverityWarning, "No Ready status for SubnetSet")
+		return errors.Errorf("subnetset ready status in cluster %s has not been set", types.NamespacedName{Namespace: namespace, Name: clusterName})
+	}
+
+	conditions.MarkTrue(vspherecluster, vmwarev1.ClusterNetworkReadyCondition)
+	return nil
+}
+
+// VerifyNetworkStatus checks if the given runtime object is of type SubnetSet.
+// If it is, then it calls verifyNsxVpcSubnetSetStatus with the SubnetSet to verify its status.
+// If it's not, it returns an error.
+func (vp *nsxtVPCNetworkProvider) VerifyNetworkStatus(_ context.Context, clusterCtx *vmware.ClusterContext, obj runtime.Object) error {
+	subnetset, ok := obj.(*nsxopv1.SubnetSet)
+	if !ok {
+		return fmt.Errorf("expected NSX VPC SubnetSet but got %T", obj)
+	}
+
+	return vp.verifyNsxtVpcSubnetSetStatus(clusterCtx.VSphereCluster, subnetset)
+}
+
+// ProvisionClusterNetwork provisions a new network in the context of a given cluster.
+// It constructs a new SubnetSet and attempts to create or patch it on the cluster.
+// If it fails to do so, it marks the status of the VSphereCluster as false and returns an error.
+// If it succeeds, it calls verifyNsxVpcSubnetSetStatus to verify the status of the newly created/patched SubnetSet.
+func (vp *nsxtVPCNetworkProvider) ProvisionClusterNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	cluster := clusterCtx.VSphereCluster
+	networkNamespace := cluster.Namespace
+	networkName := cluster.Name
+	log = log.WithValues("SubnetSet", klog.KRef(networkNamespace, networkName))
+
+	log.Info("Provisioning ")
+	defer log.Info("Finished provisioning")
+
+	subnetset := &nsxopv1.SubnetSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: networkNamespace,
+			Name:      networkName,
+		},
+		Spec: nsxopv1.SubnetSetSpec{
+			AdvancedConfig: nsxopv1.AdvancedConfig{
+				StaticIPAllocation: nsxopv1.StaticIPAllocation{
+					Enable: true,
+				},
+			},
+		},
+	}
+
+	_, err := ctrlutil.CreateOrPatch(ctx, vp.client, subnetset, func() error {
+		if err := ctrlutil.SetOwnerReference(
+			clusterCtx.VSphereCluster,
+			subnetset,
+			vp.client.Scheme(),
+		); err != nil {
+			return errors.Wrapf(err, "error setting %s as owner of %s", klog.KObj(clusterCtx.VSphereCluster), klog.KObj(subnetset))
+		}
+
+		return nil
+	})
+	if err != nil {
+		conditions.MarkFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition, vmwarev1.ClusterNetworkProvisionFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+		return errors.Wrap(err, "Failed to provision network")
+	}
+
+	return vp.verifyNsxtVpcSubnetSetStatus(clusterCtx.VSphereCluster, subnetset)
+}
+
+// GetClusterNetworkName returns the name of a valid cluster network if one exists.
+func (vp *nsxtVPCNetworkProvider) GetClusterNetworkName(ctx context.Context, clusterCtx *vmware.ClusterContext) (string, error) {
+	subnetset := &nsxopv1.SubnetSet{}
+	cluster := clusterCtx.VSphereCluster
+	namespacedName := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name,
+	}
+	if err := vp.client.Get(ctx, namespacedName, subnetset); err != nil {
+		return "", err
+	}
+	return namespacedName.Name, nil
+}
+
+// The GetVMServiceAnnotations method always returns an empty map representing annotations.
+func (vp *nsxtVPCNetworkProvider) GetVMServiceAnnotations(_ context.Context, _ *vmware.ClusterContext) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// ConfigureVirtualMachine configures a VirtualMachine object based on the networking configuration.
+func (vp *nsxtVPCNetworkProvider) ConfigureVirtualMachine(_ context.Context, clusterCtx *vmware.ClusterContext, vm *vmoprv1.VirtualMachine) error {
+	networkName := clusterCtx.VSphereCluster.Name
+	for _, vnif := range vm.Spec.NetworkInterfaces {
+		if vnif.NetworkType == NSXTVPCSubnetSetNetworkType && vnif.NetworkName == networkName {
+			// expected network interface is already found
+			return nil
+		}
+	}
+	vm.Spec.NetworkInterfaces = append(vm.Spec.NetworkInterfaces, vmoprv1.VirtualMachineNetworkInterface{
+		NetworkName: networkName,
+		NetworkType: NSXTVPCSubnetSetNetworkType,
+	})
+	return nil
+}

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -43,7 +43,8 @@ import (
 
 // VmopMachineService reconciles VM Operator VM.
 type VmopMachineService struct {
-	Client client.Client
+	Client                                client.Client
+	ConfigureControlPlaneVMReadinessProbe bool
 }
 
 // GetMachinesInCluster returns a list of VSphereMachine objects belonging to the cluster.
@@ -345,7 +346,10 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 		// Once the initial control plane node is ready, we can re-add the probe so
 		// that subsequent machines do not attempt to speak to a kube-apiserver
 		// that is not yet ready.
-		if infrautilv1.IsControlPlaneMachine(supervisorMachineCtx.Machine) && supervisorMachineCtx.Cluster.Status.ControlPlaneReady {
+		// Not all network providers (for example, NSX-VPC) provide support for VM
+		// readiness probes. The flag PerformsVMReadinessProbe is used to determine
+		// whether a VM readiness probe should be conducted.
+		if v.ConfigureControlPlaneVMReadinessProbe && infrautilv1.IsControlPlaneMachine(supervisorMachineCtx.Machine) && supervisorMachineCtx.Cluster.Status.ControlPlaneReady {
 			vmOperatorVM.Spec.ReadinessProbe = &vmoprv1.Probe{
 				TCPSocket: &vmoprv1.TCPSocketAction{
 					Port: intstr.FromInt(defaultAPIBindPort),

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -37,6 +37,7 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
+	network "sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/network"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
@@ -118,7 +119,7 @@ var _ = Describe("VirtualMachine tests", func() {
 		clusterContext, controllerManagerContext := util.CreateClusterContext(cluster, vsphereCluster)
 		supervisorMachineContext = util.CreateMachineContext(clusterContext, machine, vsphereMachine)
 		supervisorMachineContext.ControllerManagerContext = controllerManagerContext
-		vmService = VmopMachineService{Client: controllerManagerContext.Client}
+		vmService = VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: network.DummyLBNetworkProvider().SupportsVMReadinessProbe()}
 	})
 
 	Context("Reconcile VirtualMachine", func() {
@@ -614,7 +615,7 @@ var _ = Describe("GetMachinesInCluster", func() {
 	}
 
 	controllerManagerContext := fake.NewControllerManagerContext(initObjs...)
-	vmService := VmopMachineService{Client: controllerManagerContext.Client}
+	vmService := VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: network.DummyLBNetworkProvider().SupportsVMReadinessProbe()}
 
 	It("returns a list of VMs belonging to the cluster", func() {
 		objs, err := vmService.GetMachinesInCluster(context.TODO(),

--- a/test/go.sum
+++ b/test/go.sum
@@ -629,6 +629,8 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20231019160108-42131d6e8360 h1:yG158jviUd3wRqCTJcSDzp+prUZWtSA9dhfm/Rf8m9M=
 github.com/vmware-tanzu/net-operator-api v0.0.0-20231019160108-42131d6e8360/go.mod h1:dtVG693FvGuOSxJvTaKRVGU0EJR8yvLG3E2VaDDHILM=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0 h1:HdnQb/X9vJ8a5WQ03g/0nDr9igIIK1fF6wO5wOtkJT4=
+github.com/vmware-tanzu/nsx-operator/pkg/apis v0.1.0/go.mod h1:Q4JzNkNMvjo7pXtlB5/R3oME4Nhah7fAObWgghVmtxk=
 github.com/vmware-tanzu/vm-operator/api v1.8.5 h1:E8rpRdV8+cNp/eNZ/QUHvlrbpPh8uk6bKqwEEmGWe64=
 github.com/vmware-tanzu/vm-operator/api v1.8.5/go.mod h1:SXaSFtnw2502Tzy0bfQVHrvbFDijR96r1ihUYQWPOK8=
 github.com/vmware-tanzu/vm-operator/external/ncp v0.0.0-20231214185006-5477585eebfd h1:qdfVf7KFW+XX7+D4xC/mlBpRA9+B+opdDPxGdqjxO+4=


### PR DESCRIPTION
This commit introduces NSX-T Virtual Private Cloud (nsx-vpc) as a new network provider for the vSphere Supervisor Cluster in anticipation of the upcoming vSphere 9 release. Key Changes:
    nsx-vpc implemented as a new NetworkProvider using nsx-operator libs.
    Skipped VM Readiness check as nsx-vpc offers private network access.
    Added unit tests for nsx-vpc network provider.

**What this PR does / why we need it**:
The vSphere Supervisor Cluster currently accommodates two network types: vSphere Distributed Switch (VDS) and NSX-T network. With the impending release of vSphere 9, a third network type will be introduced: NSX-T Virtual Private Cloud (nsx-vpc). 
To adapt this change,  CAPV need to add support for nsx-vpc  as a new network provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2847
