### PR TITLE
[release-1.8] 🐛 Ensure entries for ProviderServiceAccount created in the ConfigMap are cleaned up

### DIFF
--- a/apis/vmware/v1beta1/vspherecluster_types.go
+++ b/apis/vmware/v1beta1/vspherecluster_types.go
@@ -27,6 +27,10 @@ const (
 	// resources associated with VSphereCluster before removing it from the
 	// API server.
 	ClusterFinalizer = "vspherecluster.vmware.infrastructure.cluster.x-k8s.io"
+
+	// ProviderServiceAccountFinalizer allows ServiceAccountReconciler to clean up service accounts
+	// resources associated with VSphereCluster from the SERVICE_ACCOUNTS_CM (service accounts ConfigMap).
+	ProviderServiceAccountFinalizer = "providerserviceaccount.vmware.infrastructure.cluster.x-k8s.io"
 )
 
 // VSphereClusterSpec defines the desired state of VSphereCluster

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -100,6 +100,19 @@ func AddServiceAccountProviderControllerToManager(ctx *context.ControllerManager
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.secretToVSphereCluster),
 		).
+		Watches(
+			&vmwarev1.VSphereCluster{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx goctx.Context, o client.Object) []reconcile.Request {
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Namespace: o.GetNamespace(),
+							Name:      o.GetName(),
+						},
+					},
+				}
+			}),
+		).
 		// Watches clusters and reconciles the vSphereCluster
 		Watches(
 			&clusterv1.Cluster{},

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -198,6 +198,13 @@ func (r ServiceAccountReconciler) Reconcile(_ goctx.Context, req reconcile.Reque
 		return reconcile.Result{}, nil
 	}
 
+	// Add finalizer first if not set to avoid the race condition between init and delete.
+	// Note: Finalizers in general can only be added when the deletionTimestamp is not set.
+	if !controllerutil.ContainsFinalizer(clusterContext.VSphereCluster, vmwarev1.ProviderServiceAccountFinalizer) {
+		controllerutil.AddFinalizer(clusterContext.VSphereCluster, vmwarev1.ProviderServiceAccountFinalizer)
+		return ctrl.Result{}, nil
+	}
+
 	// We cannot proceed until we are able to access the target cluster. Until
 	// then just return a no-op and wait for the next sync. This will occur when
 	// the Cluster's status is updated with a reference to the secret that has
@@ -235,6 +242,7 @@ func (r ServiceAccountReconciler) ReconcileDelete(ctx *vmwarecontext.ClusterCont
 		}
 	}
 
+	controllerutil.RemoveFinalizer(ctx.VSphereCluster, vmwarev1.ProviderServiceAccountFinalizer)
 	return reconcile.Result{}, nil
 }
 
@@ -512,6 +520,9 @@ func (r ServiceAccountReconciler) ensureServiceAccountConfigMap(ctx *vmwareconte
 	configMapBuffer, configMap, err := r.getConfigMapAndBuffer(ctx)
 	if err != nil {
 		return err
+	}
+	if configMap.Data == nil {
+		configMap.Data = map[string]string{}
 	}
 	if valid, exist := configMap.Data[svcAccountName]; exist && valid == strconv.FormatBool(true) {
 		// Service account name is already in the config map


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Manual cherry-pick of:

- #2846

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
