### PR TITLE
[release-1.6] 🐛 Ensure entries for ProviderServiceAccount created in the ConfigMap are cleaned up

### DIFF
--- a/apis/vmware/v1beta1/vspherecluster_types.go
+++ b/apis/vmware/v1beta1/vspherecluster_types.go
@@ -27,6 +27,10 @@ const (
 	// resources associated with VSphereCluster before removing it from the
 	// API server.
 	ClusterFinalizer = "vspherecluster.vmware.infrastructure.cluster.x-k8s.io"
+
+	// ProviderServiceAccountFinalizer allows ServiceAccountReconciler to clean up service accounts
+	// resources associated with VSphereCluster from the SERVICE_ACCOUNTS_CM (service accounts ConfigMap).
+	ProviderServiceAccountFinalizer = "providerserviceaccount.vmware.infrastructure.cluster.x-k8s.io"
 )
 
 // VSphereClusterSpec defines the desired state of VSphereCluster

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -33,6 +33,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -83,6 +84,8 @@ func AddServiceAccountProviderControllerToManager(ctx *context.ControllerManager
 		remoteClientGetter: remote.NewClusterClient,
 	}
 
+	clusterToInfraFn := clusterToSupervisorInfrastructureMapFunc(ctx)
+
 	return ctrl.NewControllerManagedBy(mgr).For(controlledType).
 		// Watch a ProviderServiceAccount
 		Watches(
@@ -94,7 +97,47 @@ func AddServiceAccountProviderControllerToManager(ctx *context.ControllerManager
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.secretToVSphereCluster),
 		).
+		Watches(
+			&source.Kind{Type: &vmwarev1.VSphereCluster{}},
+			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Namespace: o.GetNamespace(),
+							Name:      o.GetName(),
+						},
+					},
+				}
+			}),
+		).
+		// Watches clusters and reconciles the vSphereCluster
+		Watches(
+			&source.Kind{Type: &clusterv1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+				requests := clusterToInfraFn(o)
+				if requests == nil {
+					return nil
+				}
+
+				c := &vmwarev1.VSphereCluster{}
+				if err := r.Client.Get(ctx, requests[0].NamespacedName, c); err != nil {
+					r.Logger.V(4).Error(err, "Failed to get VSphereCluster")
+					return nil
+				}
+
+				if annotations.IsExternallyManaged(c) {
+					r.Logger.V(4).Info("VSphereCluster is externally managed, skipping mapping.")
+					return nil
+				}
+				return requests
+			}),
+		).
 		Complete(r)
+}
+
+func clusterToSupervisorInfrastructureMapFunc(managerContext *context.ControllerManagerContext) handler.MapFunc {
+	gvk := vmwarev1.GroupVersion.WithKind(reflect.TypeOf(&vmwarev1.VSphereCluster{}).Elem().Name())
+	return clusterutilv1.ClusterToInfrastructureMapFunc(managerContext, gvk, managerContext.Client, &vmwarev1.VSphereCluster{})
 }
 
 type ServiceAccountReconciler struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Manual cherry-pick of:

- #2846

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
