### PR TITLE
🌱 Revert "Replace deprecated wait functions"

### DIFF
--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -164,7 +164,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 
 func waitForTasksFinished(ctx context.Context, tasks []*object.Task, ignoreErrors bool) error {
 	for _, t := range tasks {
-		if err := t.WaitEx(ctx); !ignoreErrors && err != nil {
+		if err := t.Wait(ctx); !ignoreErrors && err != nil {
 			return err
 		}
 	}

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -63,7 +63,7 @@ func Test_VMGroup(t *testing.T) {
 
 	task, err := vmGrp.Add(ctx, vmRef)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(task.WaitEx(ctx)).To(Succeed())
+	g.Expect(task.Wait(ctx)).To(Succeed())
 	g.Expect(vmGrp.listVMs()).To(HaveLen(3))
 
 	hasVM, err = vmGrp.HasVM(vmRef)

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -78,7 +78,7 @@ func TestCreate(t *testing.T) {
 		t.Fatal("could not make vim25 client.")
 	}
 	task := object.NewTask(vimClient, taskRef)
-	err = task.WaitEx(ctx)
+	err = task.Wait(ctx)
 	if err != nil {
 		t.Fatal("error waiting for task:", err)
 	}

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -192,7 +192,7 @@ func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx
 		&virtualMachineCtx.VMContext,
 		func() (<-chan []interface{}, <-chan error, error) {
 			// Wait for the VM to be powered on.
-			powerOnTaskInfo, err := powerOnTask.WaitForResultEx(ctx)
+			powerOnTaskInfo, err := powerOnTask.WaitForResult(ctx)
 			if err != nil && powerOnTaskInfo == nil {
 				return nil, nil, errors.Wrapf(err, "failed to wait for power on op for vm %s", ctx)
 			}
@@ -255,7 +255,7 @@ func reconcileVSphereVMOnTaskCompletion(ctx context.Context, vmCtx *capvcontext.
 		"taskDescriptionID", task.Info.DescriptionId)
 
 	reconcileVSphereVMOnFuncCompletion(ctx, vmCtx, func() ([]interface{}, error) {
-		taskInfo, err := taskHelper.WaitForResultEx(ctx)
+		taskInfo, err := taskHelper.WaitForResult(ctx)
 
 		// An error is only returned if the process of waiting for the result
 		// failed, *not* if the task itself failed.

--- a/test/infrastructure/vcsim/controllers/vmip_controller.go
+++ b/test/infrastructure/vcsim/controllers/vmip_controller.go
@@ -79,7 +79,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOff vm")
 	}
-	if err = task.WaitEx(ctx); err != nil {
+	if err = task.Wait(ctx); err != nil { // deprecation on Wait is going to be removed, see https://github.com/vmware/govmomi/issues/3394
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOff vm task to complete")
 	}
 
@@ -117,7 +117,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to Customize vm")
 	}
-	if err = task.WaitEx(ctx); err != nil {
+	if err = task.Wait(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to wait for Customize vm task to complete")
 	}
 
@@ -126,7 +126,7 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOn vm")
 	}
-	if err = task.WaitEx(ctx); err != nil {
+	if err = task.Wait(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to PowerOn vm task to complete")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As per comments in https://github.com/vmware/govmomi/issues/3394, we are going back to use thread-safe functions `task.Wait` and `task.WaitForResult`.
Deprecation notice is going to be removed in a future version of govmomi