### PR TITLE
🌱 Remove infraServer and credsSecretName from supervisor ClusterClass

### DIFF
--- a/packaging/flavorgen/flavors/flavors.go
+++ b/packaging/flavorgen/flavors/flavors.go
@@ -82,7 +82,7 @@ func ClusterClassTemplateSupervisor() []runtime.Object {
 }
 
 func ClusterTopologyTemplateKubeVIP() ([]runtime.Object, error) {
-	cluster, err := newClusterTopologyCluster()
+	cluster, err := newClusterTopologyCluster(false)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func ClusterTopologyTemplateKubeVIP() ([]runtime.Object, error) {
 }
 
 func ClusterTopologyTemplateSupervisor() ([]runtime.Object, error) {
-	cluster, err := newClusterTopologyCluster()
+	cluster, err := newClusterTopologyCluster(true)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/cluster-template-topology-supervisor.yaml
+++ b/templates/cluster-template-topology-supervisor.yaml
@@ -14,10 +14,6 @@ spec:
     variables:
     - name: sshKey
       value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
-    - name: infraServer
-      value:
-        thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
-        url: '${VSPHERE_SERVER}'
     - name: kubeVipPodManifest
       value: |
         apiVersion: v1
@@ -93,8 +89,6 @@ spec:
       value: ${CONTROL_PLANE_ENDPOINT_IP}
     - name: controlPlanePort
       value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
-    - name: credsSecretName
-      value: '${CLUSTER_NAME}'
     version: '${KUBERNETES_VERSION}'
     workers:
       machineDeployments:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -14,10 +14,6 @@ spec:
     variables:
     - name: sshKey
       value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
-    - name: infraServer
-      value:
-        thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
-        url: '${VSPHERE_SERVER}'
     - name: kubeVipPodManifest
       value: |
         apiVersion: v1
@@ -93,6 +89,10 @@ spec:
       value: ${CONTROL_PLANE_ENDPOINT_IP}
     - name: controlPlanePort
       value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
+    - name: infraServer
+      value:
+        thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+        url: '${VSPHERE_SERVER}'
     - name: credsSecretName
       value: '${CLUSTER_NAME}'
     version: '${KUBERNETES_VERSION}'

--- a/templates/clusterclass-template-supervisor.yaml
+++ b/templates/clusterclass-template-supervisor.yaml
@@ -195,17 +195,6 @@ spec:
         description: Public key to SSH onto the cluster nodes.
         type: string
   - metadata: {}
-    name: infraServer
-    required: true
-    schema:
-      openAPIV3Schema:
-        properties:
-          thumbprint:
-            type: string
-          url:
-            type: string
-        type: object
-  - metadata: {}
     name: controlPlaneIpAddr
     required: true
     schema:
@@ -219,13 +208,6 @@ spec:
       openAPIV3Schema:
         description: Port for the control plane endpoint.
         type: integer
-  - metadata: {}
-    name: credsSecretName
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: Secret containing the credentials for the infra cluster.
-        type: string
   - metadata: {}
     name: kubeVipPodManifest
     required: true

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -209,17 +209,6 @@ spec:
         description: Public key to SSH onto the cluster nodes.
         type: string
   - metadata: {}
-    name: infraServer
-    required: true
-    schema:
-      openAPIV3Schema:
-        properties:
-          thumbprint:
-            type: string
-          url:
-            type: string
-        type: object
-  - metadata: {}
     name: controlPlaneIpAddr
     required: true
     schema:
@@ -234,18 +223,29 @@ spec:
         description: Port for the control plane endpoint.
         type: integer
   - metadata: {}
-    name: credsSecretName
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: Secret containing the credentials for the infra cluster.
-        type: string
-  - metadata: {}
     name: kubeVipPodManifest
     required: true
     schema:
       openAPIV3Schema:
         description: kube-vip manifest for the control plane.
+        type: string
+  - metadata: {}
+    name: infraServer
+    required: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          thumbprint:
+            type: string
+          url:
+            type: string
+        type: object
+  - metadata: {}
+    name: credsSecretName
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Secret containing the credentials for the infra cluster.
         type: string
   workers:
     machineDeployments:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Refine `make generate-flavors` to not generate unused variables for supervisor mode.
- infraServer
- credsSecretName


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2829
