### PR TITLE
🌱 Improve patch helper error handling

### DIFF
--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -165,7 +165,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req reconcile.
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(vsphereCluster, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	// Create the cluster context for this request.

--- a/controllers/servicediscovery_controller.go
+++ b/controllers/servicediscovery_controller.go
@@ -173,7 +173,7 @@ func (r *serviceDiscoveryReconciler) Reconcile(ctx context.Context, req reconcil
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(vsphereCluster, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	// Create the cluster context for this request.

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -102,7 +102,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	// Build the patch helper.
 	patchHelper, err := patch.NewHelper(vsphereCluster, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	// Build the cluster context.

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -91,7 +91,7 @@ func (r *clusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(vsphereCluster, r.Client)
 	if err != nil {
-		return reconcile.Result{}, pkgerrors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	// Create the cluster context for this request.
@@ -264,12 +264,8 @@ func (r *clusterReconciler) reconcileIdentitySecret(ctx context.Context, cluster
 	if !ctrlutil.ContainsFinalizer(secret, infrav1.SecretIdentitySetFinalizer) {
 		ctrlutil.AddFinalizer(secret, infrav1.SecretIdentitySetFinalizer)
 	}
-	err = helper.Patch(ctx, secret)
-	if err != nil {
-		return pkgerrors.Wrapf(err, "Failed to patch secret %s", klog.KObj(secret))
-	}
 
-	return nil
+	return helper.Patch(ctx, secret)
 }
 
 func (r *clusterReconciler) reconcileVCenterConnectivity(ctx context.Context, clusterCtx *capvcontext.ClusterContext) (*session.Session, error) {

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -90,7 +90,7 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(identity, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	defer func() {

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -105,7 +105,7 @@ func (r vsphereDeploymentZoneReconciler) Reconcile(ctx context.Context, request 
 
 	patchHelper, err := patch.NewHelper(vsphereDeploymentZone, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	vsphereDeploymentZoneContext := &capvcontext.VSphereDeploymentZoneContext{
@@ -287,17 +287,14 @@ func (r vsphereDeploymentZoneReconciler) reconcileDelete(ctx context.Context, de
 func updateOwnerReferences(ctx context.Context, obj client.Object, client client.Client, ownerRefFunc func() []metav1.OwnerReference) error {
 	patchHelper, err := patch.NewHelper(obj, client)
 	if err != nil {
-		return errors.Wrapf(err, "failed to init patch helper for %s %s",
-			obj.GetObjectKind(),
-			obj.GetName())
+		return err
 	}
 
 	obj.SetOwnerReferences(ownerRefFunc())
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return errors.Wrapf(err, "failed to patch object %s %s",
-			obj.GetObjectKind(),
-			obj.GetName())
+		return errors.Wrapf(err, "failed to update OwnerReferences")
 	}
+
 	return nil
 }
 

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -231,7 +231,7 @@ func (r *machineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(machineContext.GetVSphereMachine(), r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 	machineContext.SetBaseMachineContext(&capvcontext.BaseMachineContext{
 		Cluster:     cluster,

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -172,7 +172,7 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 	// Create the patch helper.
 	patchHelper, err := patch.NewHelper(vsphereVM, r.Client)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to initialize patch helper")
+		return reconcile.Result{}, err
 	}
 
 	authSession, err := r.retrieveVcenterSession(ctx, vsphereVM)

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -251,7 +251,7 @@ func (vms *VMService) DestroyVM(ctx context.Context, vmCtx *capvcontext.VMContex
 
 		virtualMachineCtx.VSphereVM.Status.TaskRef = task.Reference().Value
 		if err = virtualMachineCtx.Patch(ctx); err != nil {
-			return reconcile.Result{}, vm, errors.Wrapf(err, "failed to patch VSphereVM")
+			return reconcile.Result{}, vm, err
 		}
 
 		log.Info("Wait for VM to be powered off")
@@ -363,7 +363,7 @@ func (vms *VMService) reconcilePowerState(ctx context.Context, virtualMachineCtx
 		// Update the VSphereVM.Status.TaskRef to track the power-on task.
 		virtualMachineCtx.VSphereVM.Status.TaskRef = task.Reference().Value
 		if err = virtualMachineCtx.Patch(ctx); err != nil {
-			return false, errors.Wrapf(err, "failed to patch VSphereVM")
+			return false, err
 		}
 
 		// Once the VM is successfully powered on, a reconcile request should be


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Improve patch helper error handling, as the patch package has improved to contain related context [here](https://github.com/kubernetes-sigs/cluster-api/pull/9946).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #2549
