### PR TITLE
🌱 hack/tools/janitor also cleanup child resource pools and folders for capv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -865,8 +865,10 @@ clean-ci: ## Cleanup orphaned objects in CI
 		--max-age=12h \
 		--ipam-namespace=default \
 		--folder=/SDDC-Datacenter/vm/Workloads/cluster-api-provider-vsphere \
-		--folder=/SDDC-Datacenter/vm/Workloads/cloud-provider-vsphere \
-		--folder=/SDDC-Datacenter/vm/Workloads/image-builder
+		--resource-pool=/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool/cluster-api-provider-vsphere \
+		--vm-folder=/SDDC-Datacenter/vm/Workloads/cluster-api-provider-vsphere \
+		--vm-folder=/SDDC-Datacenter/vm/Workloads/cloud-provider-vsphere \
+		--vm-folder=/SDDC-Datacenter/vm/Workloads/image-builder
 
 .PHONY: clean-temporary
 clean-temporary: ## Remove all temporary files and folders

--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -252,7 +252,7 @@ func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string
 	// Get key for the deletion marker.
 	deletionMarkerKey, err := s.vSphereClients.FieldsManager.FindKey(ctx, vSphereDeletionMarkerName)
 	if err != nil && err != object.ErrKeyNameNotFound {
-		return err
+		return errors.Wrapf(err, "finding custom field %q", vSphereDeletionMarkerName)
 	}
 
 	// Only create the deletion marker if we are not on dryRun.
@@ -262,12 +262,12 @@ func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string
 		if !s.dryRun {
 			_, err := s.vSphereClients.FieldsManager.Add(ctx, vSphereDeletionMarkerName, "ManagedEntity", nil, nil)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "creating custom field %q", vSphereDeletionMarkerName)
 			}
 
 			deletionMarkerKey, err = s.vSphereClients.FieldsManager.FindKey(ctx, vSphereDeletionMarkerName)
 			if err != nil && err != object.ErrKeyNameNotFound {
-				return err
+				return errors.Wrapf(err, "finding custom field %q", vSphereDeletionMarkerName)
 			}
 		}
 	}
@@ -316,7 +316,7 @@ func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string
 		}
 
 		if err := s.vSphereClients.FieldsManager.Set(ctx, managedElement.entity.Reference(), deletionMarkerKey, time.Now().Format(time.RFC3339)); err != nil {
-			return err
+			return errors.Wrapf(err, "setting field %s on object %s", vSphereDeletionMarkerName, managedElement.element.Path)
 		}
 	}
 

--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -19,10 +19,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	govmomicluster "github.com/vmware/govmomi/vapi/cluster"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -57,6 +59,47 @@ type virtualMachine struct {
 	object        *object.VirtualMachine
 }
 
+func (s *janitor) CleanupVSphere(ctx context.Context, folders, resourcePools, vmFolders []string) error {
+	errList := []error{}
+
+	// Delete vms to cleanup folders and resource pools.
+	for _, folder := range vmFolders {
+		if err := s.deleteVSphereVMs(ctx, folder); err != nil {
+			errList = append(errList, errors.Wrapf(err, "cleaning up vSphereVMs for folder %q", folder))
+		}
+	}
+	if err := kerrors.NewAggregate(errList); err != nil {
+		return errors.Wrap(err, "cleaning up vSphereVMs")
+	}
+
+	// Delete empty resource pools.
+	for _, resourcePool := range resourcePools {
+		if err := s.deleteObjectChildren(ctx, resourcePool, "ResourcePool"); err != nil {
+			errList = append(errList, errors.Wrapf(err, "cleaning up empty resource pool children for resource pool %q", resourcePool))
+		}
+	}
+	if err := kerrors.NewAggregate(errList); err != nil {
+		return errors.Wrap(err, "cleaning up resource pools")
+	}
+
+	// Delete empty folders.
+	for _, folder := range folders {
+		if err := s.deleteObjectChildren(ctx, folder, "Folder"); err != nil {
+			errList = append(errList, errors.Wrapf(err, "cleaning up empty folder children for folder %q", folder))
+		}
+	}
+	if err := kerrors.NewAggregate(errList); err != nil {
+		return errors.Wrap(err, "cleaning up folders")
+	}
+
+	// Delete empty cluster modules.
+	if err := s.deleteVSphereClusterModules(ctx); err != nil {
+		return errors.Wrap(err, "cleaning up vSphere cluster modules")
+	}
+
+	return nil
+}
+
 // deleteVSphereVMs deletes all VSphereVMs in a given folder in vSphere if their creation
 // timestamp is before the janitor's configured maxCreationDate.
 func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
@@ -70,8 +113,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 	log.Info("Deleting vSphere VMs in folder")
 
 	// List all virtual machines inside the folder.
-	finder := find.NewFinder(s.vSphereClients.Vim, false)
-	managedObjects, err := finder.ManagedObjectListChildren(ctx, folder+"/...", "VirtualMachine")
+	managedObjects, err := s.vSphereClients.Finder.ManagedObjectListChildren(ctx, folder+"/...", "VirtualMachine")
 	if err != nil {
 		return err
 	}
@@ -143,7 +185,7 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 	destroyTasks := []*object.Task{}
 	for _, vm := range append(vmsToDeleteAndPoweroff, vmsToDelete...) {
 		log.Info("Destroying vm in vSphere", "vm", vm.managedObject.Config.Name)
-		if dryRun {
+		if s.dryRun {
 			// Skipping actual destroy on dryRun.
 			continue
 		}
@@ -162,12 +204,149 @@ func (s *janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 	return nil
 }
 
-func waitForTasksFinished(ctx context.Context, tasks []*object.Task, ignoreErrors bool) error {
-	for _, t := range tasks {
-		if err := t.Wait(ctx); !ignoreErrors && err != nil {
+// deleteObjectChildren deletes all child objects in a given object in vSphere if they don't
+// contain any virtual machine.
+// An object only gets deleted if:
+// * it does not have any children of a different type
+// * the timestamp field's value is before s.maxCreationDate
+// If an object does not yet have a field, the janitor will add the field to it with the current timestamp as value.
+func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string, objectType string) error {
+	if !slices.Contains([]string{"ResourcePool", "Folder"}, objectType) {
+		return fmt.Errorf("deleteObjectChildren is not implemented for objectType %s", objectType)
+	}
+
+	if inventoryPath == "" {
+		return fmt.Errorf("cannot use empty string to delete children of type %s", objectType)
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithName(fmt.Sprintf("%sChildren", objectType)).WithValues(objectType, inventoryPath)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	log.Info("Deleting empty children")
+
+	// Recursively list all objects of the given objectType below the inventoryPath.
+	managedEntities, err := recursiveList(ctx, inventoryPath, s.vSphereClients.Govmomi, s.vSphereClients.Finder, s.vSphereClients.ViewManager, objectType)
+	if err != nil {
+		return err
+	}
+
+	// Build a map which notes if an object has children of a different type.
+	// Later on we will use that information to not delete objects which have children.
+	hasChildren := map[string]bool{}
+	for _, e := range managedEntities {
+		// Check if the object has children, because we only want to delete objects which have children of a different type.
+		children, err := recursiveList(ctx, e.element.Path, s.vSphereClients.Govmomi, s.vSphereClients.Finder, s.vSphereClients.ViewManager)
+		if err != nil {
+			return err
+		}
+		// Mark e to have children, if there are children which are of a different type.
+		for _, child := range children {
+			if child.entity.Reference().Type == objectType {
+				continue
+			}
+			hasChildren[e.element.Path] = true
+			break
+		}
+	}
+
+	// Get key for the deletion marker.
+	deletionMarkerKey, err := s.vSphereClients.FieldsManager.FindKey(ctx, vSphereDeletionMarkerName)
+	if err != nil && err != object.ErrKeyNameNotFound {
+		return err
+	}
+
+	// Only create the deletion marker if we are not on dryRun.
+	if deletionMarkerKey == -1 {
+		log.Info("Creating the deletion field")
+
+		if !s.dryRun {
+			_, err := s.vSphereClients.FieldsManager.Add(ctx, vSphereDeletionMarkerName, "ManagedEntity", nil, nil)
+			if err != nil {
+				return err
+			}
+
+			deletionMarkerKey, err = s.vSphereClients.FieldsManager.FindKey(ctx, vSphereDeletionMarkerName)
+			if err != nil && err != object.ErrKeyNameNotFound {
+				return err
+			}
+		}
+	}
+
+	objectsToMark := []*managedElement{}
+	objectsToDelete := []*managedElement{}
+
+	// Filter elements and collect two groups:
+	// * objects to add the timestamp field
+	// * objects to destroy
+	for i := range managedEntities {
+		managedEntity := managedEntities[i]
+
+		// We mark any object we find with a timestamp to determine the first time we did see this item.
+		// This is used as replacement for the non-existing CreationTimestamp on objects.
+		timestamp, err := getDeletionMarkerTimestamp(deletionMarkerKey, managedEntity.entity.Value)
+		if err != nil {
+			return err
+		}
+		// If no timestamp was found: queue it to get marked.
+		if timestamp == nil {
+			objectsToMark = append(objectsToMark, managedEntity)
+			continue
+		}
+
+		// Filter out objects we don't have to cleanup depending on s.maxCreationDate.
+		if timestamp.After(s.maxCreationDate) {
+			continue
+		}
+
+		// Filter out objects which have children.
+		if hasChildren[managedEntity.element.Path] {
+			continue
+		}
+
+		objectsToDelete = append(objectsToDelete, managedEntity)
+	}
+
+	for i := range objectsToMark {
+		managedElement := objectsToMark[i]
+		log.Info("Marking resource object for deletion in vSphere", objectType, managedElement.element.Path)
+
+		if s.dryRun {
+			// Skipping actual mark on dryRun.
+			continue
+		}
+
+		if err := s.vSphereClients.FieldsManager.Set(ctx, managedElement.entity.Reference(), deletionMarkerKey, time.Now().Format(time.RFC3339)); err != nil {
 			return err
 		}
 	}
+
+	sort.Slice(objectsToDelete, func(i, j int) bool {
+		a := objectsToDelete[i]
+		b := objectsToDelete[j]
+
+		return strings.Count(a.element.Path, "/") > strings.Count(b.element.Path, "/")
+	})
+
+	destroyTasks := []*object.Task{}
+	for _, managedEntity := range objectsToDelete {
+		log.Info("Destroying object in vSphere", objectType, managedEntity.element.Path)
+		if s.dryRun {
+			// Skipping actual destroy on dryRun.
+			continue
+		}
+
+		task, err := object.NewCommon(s.vSphereClients.Vim, managedEntity.entity.Reference()).Destroy(ctx)
+		if err != nil {
+			return err
+		}
+		log.Info("Created Destroy task for object", objectType, managedEntity.element.Path, "task", task.Reference().Value)
+		destroyTasks = append(destroyTasks, task)
+	}
+	// Wait for all destroy tasks to succeed.
+	if err := waitForTasksFinished(ctx, destroyTasks, false); err != nil {
+		return errors.Wrap(err, "failed to wait for object destroy task to finish")
+	}
+
 	return nil
 }
 

--- a/hack/tools/janitor/janitor.go
+++ b/hack/tools/janitor/janitor.go
@@ -295,11 +295,13 @@ func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string
 
 		// Filter out objects we don't have to cleanup depending on s.maxCreationDate.
 		if timestamp.After(s.maxCreationDate) {
+			log.Info("Skipping deletion of object: marked timestamp does not exceed maxCreationDate", "timestamp", timestamp, "inventoryPath", managedEntity.element.Path)
 			continue
 		}
 
 		// Filter out objects which have children.
 		if hasChildren[managedEntity.element.Path] {
+			log.Info("Skipping deletion of object: object has child objects of a different type", "inventoryPath", managedEntity.element.Path)
 			continue
 		}
 
@@ -320,6 +322,7 @@ func (s *janitor) deleteObjectChildren(ctx context.Context, inventoryPath string
 		}
 	}
 
+	// sort objects to delete so children are deleted before parents
 	sort.Slice(objectsToDelete, func(i, j int) bool {
 		a := objectsToDelete[i]
 		b := objectsToDelete[j]

--- a/hack/tools/janitor/janitor_test.go
+++ b/hack/tools/janitor/janitor_test.go
@@ -1,0 +1,566 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/simulator/vpx"
+	"github.com/vmware/govmomi/view"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vcsim"
+)
+
+func setup(ctx context.Context, t *testing.T) (*vSphereClients, *vcsim.Simulator) {
+	t.Helper()
+	model := &simulator.Model{
+		ServiceContent: vpx.ServiceContent,
+		RootFolder:     vpx.RootFolder,
+		Autostart:      true,
+		Datacenter:     1,
+		Portgroup:      1,
+		Host:           1,
+		Cluster:        1,
+		ClusterHost:    3,
+		DelayConfig:    simulator.DelayConfig{},
+	}
+
+	vcsim, err := vcsim.NewBuilder().WithModel(model).Build()
+	if err != nil {
+		panic(fmt.Sprintf("unable to create simulator %s", err))
+	}
+
+	fmt.Printf(" export GOVC_URL=%s\n", vcsim.ServerURL())
+	fmt.Printf(" export GOVC_USERNAME=%s\n", vcsim.Username())
+	fmt.Printf(" export GOVC_PASSWORD=%s\n", vcsim.Password())
+	fmt.Printf(" export GOVC_INSECURE=true\n")
+
+	clients, err := newVSphereClients(ctx, getVSphereClientInput{
+		Username:  vcsim.Username(),
+		Password:  vcsim.Password(),
+		Server:    vcsim.ServerURL().String(),
+		UserAgent: "capv-janitor-test",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	t.Cleanup(vcsim.Destroy)
+
+	return clients, vcsim
+}
+
+func setupTestCase(g *gomega.WithT, sim *vcsim.Simulator, objects []*simCreator) (string, map[string]bool) {
+	g.THelper()
+
+	relativePath := rand.String(10)
+
+	baseRP := vcsimResourcePool("")
+	baseFolder := vcsimFolder("")
+	baseDatastore := vcsimDatastore("", os.TempDir())
+	// Create base objects for the test case
+	g.Expect(baseRP.Create(sim, relativePath)).To(gomega.Succeed())
+	g.Expect(baseFolder.Create(sim, relativePath)).To(gomega.Succeed())
+	g.Expect(baseDatastore.Create(sim, relativePath)).To(gomega.Succeed())
+
+	createdObjects := map[string]bool{}
+
+	// Create objects
+	for _, object := range objects {
+		splitted := strings.Split(object.Path(relativePath), relativePath+"/")
+		if len(splitted) == 2 {
+			createdObjects[path.Join(object.t, splitted[1])] = true
+		}
+		g.Expect(object.Create(sim, relativePath)).To(gomega.Succeed())
+	}
+
+	return relativePath, createdObjects
+}
+
+const (
+	folderBase       = "/DC0/vm"
+	resourcePoolBase = "/DC0/host/DC0_C0/Resources"
+)
+
+func Test_janitor_deleteVSphereVMs(t *testing.T) {
+	ctx := context.Background()
+	ctx = ctrl.LoggerInto(ctx, klog.Background())
+
+	// Initialize and start vcsim
+	clients, sim := setup(ctx, t)
+
+	deleteAll := time.Now().Add(time.Hour * 1)
+	deleteNone := time.Now()
+
+	tests := []struct {
+		name            string
+		objects         []*simCreator
+		maxCreationDate time.Time
+		wantErr         bool
+		want            map[string]bool
+	}{
+		{
+			name: "delete all VMs",
+			objects: []*simCreator{
+				vcsimVirtualMachine("foo"),
+			},
+			maxCreationDate: deleteAll,
+			wantErr:         false,
+			want:            nil,
+		},
+		{
+			name: "delete no VMs",
+			objects: []*simCreator{
+				vcsimVirtualMachine("foo"),
+			},
+			maxCreationDate: deleteNone,
+			wantErr:         false,
+			want: map[string]bool{
+				"VirtualMachine/foo": true,
+			},
+		},
+		{
+			name: "recursive vm deletion",
+			objects: []*simCreator{
+				vcsimResourcePool("a"),
+				vcsimFolder("a"),
+				vcsimResourcePool("a/b"),
+				vcsimFolder("a/b"),
+				vcsimResourcePool("a/b/c"),
+				vcsimFolder("a/b/c"),
+				vcsimVirtualMachine("foo"),
+				vcsimVirtualMachine("a/bar"),
+				vcsimVirtualMachine("a/b/c/foobar"),
+			},
+			maxCreationDate: deleteAll,
+			wantErr:         false,
+			want: map[string]bool{
+				"ResourcePool/a":     true,
+				"ResourcePool/a/b":   true,
+				"ResourcePool/a/b/c": true,
+				"Folder/a":           true,
+				"Folder/a/b":         true,
+				"Folder/a/b/c":       true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			relativePath, _ := setupTestCase(g, sim, tt.objects)
+
+			s := &janitor{
+				dryRun:          false,
+				maxCreationDate: tt.maxCreationDate,
+				vSphereClients:  clients,
+			}
+
+			// use folder created for this test case as inventoryPath
+			inventoryPath := vcsimFolder("").Path(relativePath)
+
+			err := s.deleteVSphereVMs(ctx, inventoryPath)
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+
+			// Ensure the expected objects still exists
+			existingObjects, err := recursiveListFoldersAndResourcePools(ctx, relativePath, clients.Govmomi, clients.Finder, clients.ViewManager)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			if tt.want != nil {
+				g.Expect(existingObjects).To(gomega.BeEquivalentTo(tt.want))
+			} else {
+				g.Expect(existingObjects).To(gomega.BeEmpty())
+			}
+		})
+	}
+}
+
+func Test_janitor_deleteObjectChildren(t *testing.T) {
+	ctx := context.Background()
+	ctx = ctrl.LoggerInto(ctx, klog.Background())
+
+	// Initialize and start vcsim
+	clients, sim := setup(ctx, t)
+
+	tests := []struct {
+		name       string
+		basePath   string
+		objectType string
+		objects    []*simCreator
+		wantErr    bool
+		want       map[string]bool
+	}{
+		{
+			name:       "should preserve resource pool if it contains a vm and deleting resource pools",
+			basePath:   resourcePoolBase,
+			objectType: "ResourcePool",
+			objects: []*simCreator{
+				vcsimResourcePool("a"),
+				vcsimResourcePool("b"),
+				vcsimFolder("a"),
+				vcsimVirtualMachine("a/foo"),
+			},
+			want: map[string]bool{
+				"Folder/a":             true,
+				"ResourcePool/a":       true,
+				"VirtualMachine/a/foo": true,
+			},
+		},
+		{
+			name:       "should preserve folder if it contains a vm and deleting folders",
+			basePath:   folderBase,
+			objectType: "Folder",
+			objects: []*simCreator{
+				vcsimResourcePool("a"),
+				vcsimFolder("a"),
+				vcsimFolder("b"),
+				vcsimVirtualMachine("a/foo"),
+			},
+			want: map[string]bool{
+				"Folder/a":             true,
+				"ResourcePool/a":       true,
+				"VirtualMachine/a/foo": true,
+			},
+		},
+		{
+			name:       "no-op",
+			basePath:   resourcePoolBase,
+			objectType: "ResourcePool",
+			objects:    []*simCreator{},
+		},
+		{
+			name:       "single resource pool",
+			basePath:   resourcePoolBase,
+			objectType: "ResourcePool",
+			objects: []*simCreator{
+				vcsimResourcePool("a"),
+			},
+		},
+		{
+			name:       "multiple nested resource pools",
+			basePath:   resourcePoolBase,
+			objectType: "ResourcePool",
+			objects: []*simCreator{
+				vcsimResourcePool("a"),
+				vcsimResourcePool("a/b"),
+				vcsimResourcePool("a/b/c"),
+				vcsimResourcePool("d"),
+				vcsimResourcePool("d/e"),
+				vcsimResourcePool("f"),
+			},
+		},
+		{
+			name:       "no-op",
+			basePath:   folderBase,
+			objectType: "Folder",
+			objects:    []*simCreator{},
+		},
+		{
+			name:       "single folder",
+			basePath:   folderBase,
+			objectType: "Folder",
+			objects: []*simCreator{
+				vcsimFolder("a"),
+			},
+		},
+		{
+			name:       "multiple nested folders",
+			basePath:   folderBase,
+			objectType: "Folder",
+			objects: []*simCreator{
+				vcsimFolder("a"),
+				vcsimFolder("a/b"),
+				vcsimFolder("a/b/c"),
+				vcsimFolder("d"),
+				vcsimFolder("d/e"),
+				vcsimFolder("f"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			relativePath, wantMarkedObjects := setupTestCase(g, sim, tt.objects)
+
+			inventoryPath := path.Join(tt.basePath, relativePath)
+
+			s := &janitor{
+				dryRun:          false,
+				maxCreationDate: time.Now().Add(time.Hour * 1),
+				vSphereClients:  clients,
+			}
+
+			// Run first iteration which should only tag the resource pools with a timestamp.
+			g.Expect(s.deleteObjectChildren(ctx, inventoryPath, tt.objectType)).To(gomega.Succeed())
+			existingObjects, err := recursiveListFoldersAndResourcePools(ctx, relativePath, clients.Govmomi, clients.Finder, clients.ViewManager)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(existingObjects).To(gomega.BeEquivalentTo(wantMarkedObjects))
+
+			// Run second iteration which should destroy the resource pools with a timestamp.
+			g.Expect(s.deleteObjectChildren(ctx, inventoryPath, tt.objectType)).To(gomega.Succeed())
+			existingObjects, err = recursiveListFoldersAndResourcePools(ctx, relativePath, clients.Govmomi, clients.Finder, clients.ViewManager)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			if tt.want != nil {
+				g.Expect(existingObjects).To(gomega.BeEquivalentTo(tt.want))
+			} else {
+				g.Expect(existingObjects).To(gomega.BeEmpty())
+			}
+
+			// Ensure the parent object still exists
+			assertObjectExists(ctx, g, clients.Finder, inventoryPath)
+		})
+	}
+}
+
+func Test_janitor_CleanupVSphere(t *testing.T) {
+	ctx := context.Background()
+	ctx = ctrl.LoggerInto(ctx, klog.Background())
+
+	// Initialize and start vcsim
+	clients, sim := setup(ctx, t)
+
+	deleteAll := time.Now().Add(time.Hour * 1)
+
+	tests := []struct {
+		name               string
+		dryRun             bool
+		maxCreationDate    time.Time
+		objects            []*simCreator
+		wantAfterFirstRun  map[string]bool
+		wantAfterSecondRun map[string]bool
+	}{
+		{
+			name:               "no-op",
+			dryRun:             false,
+			maxCreationDate:    deleteAll,
+			objects:            nil,
+			wantAfterFirstRun:  map[string]bool{},
+			wantAfterSecondRun: map[string]bool{},
+		},
+		{
+			name:               "no-op dryRun",
+			dryRun:             true,
+			maxCreationDate:    deleteAll,
+			objects:            nil,
+			wantAfterFirstRun:  map[string]bool{},
+			wantAfterSecondRun: map[string]bool{},
+		},
+		{
+			name:            "delete everything",
+			dryRun:          false,
+			maxCreationDate: deleteAll,
+			objects: []*simCreator{
+				vcsimFolder("a"),
+				vcsimResourcePool("a"),
+				vcsimVirtualMachine("a/b"),
+				vcsimFolder("c"),
+				vcsimResourcePool("c"),
+			},
+			wantAfterFirstRun: map[string]bool{
+				"Folder/a":       true,
+				"Folder/c":       true,
+				"ResourcePool/a": true,
+				"ResourcePool/c": true,
+			},
+			wantAfterSecondRun: map[string]bool{},
+		},
+		{
+			name:            "delete everything dryrun",
+			dryRun:          true,
+			maxCreationDate: deleteAll,
+			objects: []*simCreator{
+				vcsimFolder("a"),
+				vcsimResourcePool("a"),
+				vcsimVirtualMachine("a/b"),
+				vcsimFolder("c"),
+				vcsimResourcePool("c"),
+			},
+			wantAfterFirstRun: map[string]bool{
+				"Folder/a":           true,
+				"Folder/c":           true,
+				"ResourcePool/a":     true,
+				"ResourcePool/c":     true,
+				"VirtualMachine/a/b": true,
+			},
+			wantAfterSecondRun: map[string]bool{
+				"Folder/a":           true,
+				"Folder/c":           true,
+				"ResourcePool/a":     true,
+				"ResourcePool/c":     true,
+				"VirtualMachine/a/b": true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			relativePath, _ := setupTestCase(g, sim, tt.objects)
+
+			s := &janitor{
+				dryRun:          tt.dryRun,
+				maxCreationDate: tt.maxCreationDate,
+				vSphereClients:  clients,
+			}
+
+			folder := vcsimFolder("").Path(relativePath)
+			resourcePool := vcsimResourcePool("").Path(relativePath)
+
+			folders := []string{folder}
+			resourcePools := []string{resourcePool}
+
+			g.Expect(s.CleanupVSphere(ctx, folders, resourcePools, folders)).To(gomega.Succeed())
+			existingObjects, err := recursiveListFoldersAndResourcePools(ctx, relativePath, clients.Govmomi, clients.Finder, clients.ViewManager)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(existingObjects).To(gomega.BeEquivalentTo(tt.wantAfterFirstRun))
+
+			g.Expect(s.CleanupVSphere(ctx, folders, resourcePools, folders)).To(gomega.Succeed())
+			existingObjects, err = recursiveListFoldersAndResourcePools(ctx, relativePath, clients.Govmomi, clients.Finder, clients.ViewManager)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(existingObjects).To(gomega.BeEquivalentTo(tt.wantAfterSecondRun))
+
+			// Ensure the parent object still exists
+			assertObjectExists(ctx, g, clients.Finder, folder)
+			assertObjectExists(ctx, g, clients.Finder, resourcePool)
+		})
+	}
+}
+
+func assertObjectExists(ctx context.Context, g *gomega.WithT, finder *find.Finder, inventoryPath string) {
+	g.THelper()
+
+	e, err := finder.ManagedObjectList(ctx, inventoryPath)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(e).To(gomega.HaveLen(1))
+}
+
+func recursiveListFoldersAndResourcePools(ctx context.Context, testPrefix string, govmomiClient *govmomi.Client, finder *find.Finder, viewManager *view.Manager) (map[string]bool, error) {
+	resourcePoolElements, err := recursiveList(ctx, path.Join(resourcePoolBase, testPrefix), govmomiClient, finder, viewManager)
+	if err != nil {
+		return nil, err
+	}
+
+	folderElements, err := recursiveList(ctx, path.Join(folderBase, testPrefix), govmomiClient, finder, viewManager)
+	if err != nil {
+		return nil, err
+	}
+
+	objects := map[string]bool{}
+
+	for _, e := range append(resourcePoolElements, folderElements...) {
+		splitted := strings.Split(e.element.Path, testPrefix+"/")
+		if len(splitted) == 2 {
+			objects[path.Join(e.element.Object.Reference().Type, splitted[1])] = true
+		}
+	}
+
+	return objects, nil
+}
+
+type simCreator struct {
+	p                string
+	t                string
+	datastoreTempDir string
+}
+
+func (c simCreator) Path(testPrefix string) string {
+	var base string
+
+	switch c.t {
+	case "ResourcePool":
+		base = resourcePoolBase
+	case "Folder":
+		base = folderBase
+	case "VirtualMachine":
+		// VMs exist at the folders.
+		base = folderBase
+	case "Datastore":
+		base = "/DC0/datastore"
+	default:
+		panic("unimplemented")
+	}
+
+	return path.Join(base, testPrefix, c.p)
+}
+
+func (c simCreator) Create(sim *vcsim.Simulator, testPrefix string) error {
+	var cmd string
+	switch c.t {
+	case "ResourcePool":
+		cmd = fmt.Sprintf("pool.create %s", c.Path(testPrefix))
+	case "Folder":
+		cmd = fmt.Sprintf("folder.create %s", c.Path(testPrefix))
+	case "Datastore":
+		tmpDir, err := os.MkdirTemp(c.datastoreTempDir, testPrefix)
+		if err != nil {
+			return err
+		}
+		cmd = fmt.Sprintf("datastore.create -type local -name %s -path %s /DC0/host/DC0_C0", testPrefix, tmpDir)
+	case "VirtualMachine":
+		fullPath := c.Path(testPrefix)
+		folderPath := path.Dir(fullPath)
+		rpPath := vcsimResourcePool(path.Dir(c.p)).Path(testPrefix)
+		name := path.Base(fullPath)
+		networkPath := "/DC0/network/DC0_DVPG0"
+		cmd = fmt.Sprintf("vm.create -on=true -pool %s -folder %s -net %s -ds /DC0/datastore/%s %s", rpPath, folderPath, networkPath, testPrefix, name)
+	default:
+		panic("unimplemented")
+	}
+
+	stdout, stderr := gbytes.NewBuffer(), gbytes.NewBuffer()
+	err := sim.Run(cmd, stdout, stderr)
+	if err != nil {
+		fmt.Printf("stdout:\n%s\n", stdout.Contents())
+		fmt.Printf("stderr:\n%s\n", stderr.Contents())
+		return err
+	}
+	return nil
+}
+
+func vcsimResourcePool(p string) *simCreator {
+	return &simCreator{p: p, t: "ResourcePool"}
+}
+
+func vcsimFolder(p string) *simCreator {
+	return &simCreator{p: p, t: "Folder"}
+}
+
+func vcsimDatastore(p, datastoreTempDir string) *simCreator {
+	return &simCreator{p: p, t: "Datastore", datastoreTempDir: datastoreTempDir}
+}
+
+func vcsimVirtualMachine(p string) *simCreator {
+	return &simCreator{p: p, t: "VirtualMachine"}
+}

--- a/hack/tools/janitor/janitor_test.go
+++ b/hack/tools/janitor/janitor_test.go
@@ -222,7 +222,7 @@ func Test_janitor_deleteObjectChildren(t *testing.T) {
 		want       map[string]bool
 	}{
 		{
-			name:       "should preserve resource pool if it contains a vm and deleting resource pools",
+			name:       "should preserve resource pool if it contains a vm and delete empty resource pools",
 			basePath:   resourcePoolBase,
 			objectType: "ResourcePool",
 			objects: []*simCreator{
@@ -238,7 +238,7 @@ func Test_janitor_deleteObjectChildren(t *testing.T) {
 			},
 		},
 		{
-			name:       "should preserve folder if it contains a vm and deleting folders",
+			name:       "should preserve folder if it contains a vm and delete empty folders",
 			basePath:   folderBase,
 			objectType: "Folder",
 			objects: []*simCreator{
@@ -370,7 +370,7 @@ func Test_janitor_CleanupVSphere(t *testing.T) {
 			wantAfterSecondRun: map[string]bool{},
 		},
 		{
-			name:               "no-op dryRun",
+			name:               "dryRun: no-op",
 			dryRun:             true,
 			maxCreationDate:    deleteAll,
 			objects:            nil,
@@ -397,7 +397,7 @@ func Test_janitor_CleanupVSphere(t *testing.T) {
 			wantAfterSecondRun: map[string]bool{},
 		},
 		{
-			name:            "delete everything dryrun",
+			name:            "dryRun: would delete everything",
 			dryRun:          true,
 			maxCreationDate: deleteAll,
 			objects: []*simCreator{

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -108,6 +108,8 @@ func run(ctx context.Context) error {
 
 	janitor := newJanitor(vSphereClients, ipamClient, maxAge, ipamNamespace, dryRun)
 
+	log.Info("Configured settings", "janitor.maxCreationDate", janitor.maxCreationDate)
+
 	// First cleanup old vms and other vSphere resources to free up IPAddressClaims or cluster modules which are still in-use.
 	if err := janitor.CleanupVSphere(ctx, vsphereFolders, vsphereResourcePools, vsphereVMFolders); err != nil {
 		return errors.Wrap(err, "cleaning up vSphere")

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,14 +40,18 @@ func init() {
 }
 
 var (
-	dryRun         bool
-	ipamNamespace  string
-	maxAge         time.Duration
-	vsphereFolders []string
+	dryRun               bool
+	ipamNamespace        string
+	maxAge               time.Duration
+	vsphereVMFolders     []string
+	vsphereFolders       []string
+	vsphereResourcePools []string
 )
 
 func initFlags(fs *pflag.FlagSet) {
-	fs.StringArrayVar(&vsphereFolders, "folder", []string{}, "Path to folders in vCenter to cleanup virtual machines.")
+	fs.StringArrayVar(&vsphereVMFolders, "vm-folder", []string{}, "Path to folders in vCenter to cleanup virtual machines.")
+	fs.StringArrayVar(&vsphereFolders, "folder", []string{}, "Path to a folder in vCenter to recursively cleanup empty subfolders.")
+	fs.StringArrayVar(&vsphereResourcePools, "resource-pool", []string{}, "Path to a resource pool in vCenter to recursively cleanup empty child resource pools.")
 	fs.StringVar(&ipamNamespace, "ipam-namespace", "", "Namespace for IPAddressClaim cleanup.")
 	fs.DurationVar(&maxAge, "max-age", time.Hour*12, "Maximum age of an object before it is getting deleted.")
 	fs.BoolVar(&dryRun, "dry-run", false, "dry-run results in not deleting anything but printing the actions.")
@@ -74,7 +77,8 @@ func run(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Configured settings", "dry-run", dryRun)
-	log.Info("Configured settings", "folders", vsphereFolders)
+	log.Info("Configured settings", "folders", vsphereVMFolders)
+	log.Info("Configured settings", "resource-pools", vsphereResourcePools)
 	log.Info("Configured settings", "ipam-namespace", ipamNamespace)
 	log.Info("Configured settings", "max-age", maxAge)
 
@@ -103,25 +107,14 @@ func run(ctx context.Context) error {
 
 	janitor := newJanitor(vSphereClients, ipamClient, maxAge, ipamNamespace, dryRun)
 
-	// First cleanup old vms to free up IPAddressClaims or cluster modules which are still in-use.
-	errList := []error{}
-	for _, folder := range vsphereFolders {
-		if err := janitor.deleteVSphereVMs(ctx, folder); err != nil {
-			errList = append(errList, errors.Wrapf(err, "cleaning up vSphereVMs for folder %q", folder))
-		}
-	}
-	if err := kerrors.NewAggregate(errList); err != nil {
-		return errors.Wrap(err, "cleaning up vSphereVMs")
+	// First cleanup old vms and other vSphere resources to free up IPAddressClaims or cluster modules which are still in-use.
+	if err := janitor.CleanupVSphere(ctx, vsphereFolders, vsphereResourcePools, vsphereVMFolders); err != nil {
+		return errors.Wrap(err, "cleaning up vSphere")
 	}
 
 	// Second cleanup IPAddressClaims.
 	if err := janitor.deleteIPAddressClaims(ctx); err != nil {
 		return errors.Wrap(err, "cleaning up IPAddressClaims")
-	}
-
-	// Third cleanup cluster modules.
-	if err := janitor.deleteVSphereClusterModules(ctx); err != nil {
-		return errors.Wrap(err, "cleaning up vSphere cluster modules")
 	}
 
 	return nil

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -77,9 +77,9 @@ func run(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Configured settings", "dry-run", dryRun)
-	log.Info("Configured settings", "folder", vsphereFolders)
-	log.Info("Configured settings", "vm-folder", vsphereVMFolders)
-	log.Info("Configured settings", "resource-pool", vsphereResourcePools)
+	log.Info("Configured settings", "folders", vsphereFolders)
+	log.Info("Configured settings", "vm-folders", vsphereVMFolders)
+	log.Info("Configured settings", "resource-pools", vsphereResourcePools)
 	log.Info("Configured settings", "ipam-namespace", ipamNamespace)
 	log.Info("Configured settings", "max-age", maxAge)
 
@@ -111,7 +111,7 @@ func run(ctx context.Context) error {
 	log.Info("Configured settings", "janitor.maxCreationDate", janitor.maxCreationDate)
 
 	// First cleanup old vms and other vSphere resources to free up IPAddressClaims or cluster modules which are still in-use.
-	if err := janitor.CleanupVSphere(ctx, vsphereFolders, vsphereResourcePools, vsphereVMFolders); err != nil {
+	if err := janitor.cleanupVSphere(ctx, vsphereFolders, vsphereResourcePools, vsphereVMFolders); err != nil {
 		return errors.Wrap(err, "cleaning up vSphere")
 	}
 

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -77,8 +77,9 @@ func run(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Configured settings", "dry-run", dryRun)
-	log.Info("Configured settings", "folders", vsphereVMFolders)
-	log.Info("Configured settings", "resource-pools", vsphereResourcePools)
+	log.Info("Configured settings", "folder", vsphereFolders)
+	log.Info("Configured settings", "vm-folder", vsphereVMFolders)
+	log.Info("Configured settings", "resource-pool", vsphereResourcePools)
 	log.Info("Configured settings", "ipam-namespace", ipamNamespace)
 	log.Info("Configured settings", "max-age", maxAge)
 

--- a/hack/tools/janitor/vsphere.go
+++ b/hack/tools/janitor/vsphere.go
@@ -138,7 +138,6 @@ func getDeletionMarkerTimestamp(key int32, values []types.BaseCustomFieldValue) 
 	// Find the value for the key
 	var b *types.BaseCustomFieldValue
 	for i := range values {
-		// Find the
 		if values[i].GetCustomFieldValue().Key != key {
 			continue
 		}

--- a/hack/tools/janitor/vsphere.go
+++ b/hack/tools/janitor/vsphere.go
@@ -171,7 +171,7 @@ func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *gov
 		return nil, err
 	}
 	if len(objList) != 1 {
-		return nil, errors.Errorf("expected to find object at managed object at path: %s", inventoryPath)
+		return nil, errors.Errorf("expected to find exactly 1 object at managed object at path: %s", inventoryPath)
 	}
 
 	root := objList[0].Object.Reference()
@@ -182,6 +182,7 @@ func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *gov
 	}
 	defer func() { _ = v.Destroy(ctx) }()
 
+	// Recursively find all objects.
 	managedObjects, err := v.Find(ctx, nil, property.Match{"name": "*"})
 	if err != nil {
 		return nil, err
@@ -193,6 +194,8 @@ func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *gov
 		return managedElements, nil
 	}
 
+	// Retrieve the availableField and value attributes of the found object so we
+	// later can check for the deletion marker.
 	var objs []mo.ManagedEntity
 	if err := govmomiClient.Retrieve(ctx, managedObjects, []string{"availableField", "value"}, &objs); err != nil {
 		return nil, err

--- a/hack/tools/janitor/vsphere.go
+++ b/hack/tools/janitor/vsphere.go
@@ -18,13 +18,23 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/url"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -38,9 +48,12 @@ type getVSphereClientInput struct {
 
 // vSphereClients is a collection of different clients for vSphere.
 type vSphereClients struct {
-	Vim     *vim25.Client
-	Govmomi *govmomi.Client
-	Rest    *rest.Client
+	Vim           *vim25.Client
+	Govmomi       *govmomi.Client
+	Rest          *rest.Client
+	FieldsManager *object.CustomFieldsManager
+	Finder        *find.Finder
+	ViewManager   *view.Manager
 }
 
 // logout logs out all clients. It logs errors if the context contains a logger.
@@ -92,9 +105,107 @@ func newVSphereClients(ctx context.Context, input getVSphereClientInput) (*vSphe
 		return nil, err
 	}
 
+	fieldsManager, err := object.GetCustomFieldsManager(vimClient)
+	if err != nil {
+		return nil, err
+	}
+
+	viewManager := view.NewManager(vimClient)
+	finder := find.NewFinder(vimClient, false)
+
 	return &vSphereClients{
-		Vim:     vimClient,
-		Govmomi: govmomiClient,
-		Rest:    restClient,
+		Vim:           vimClient,
+		Govmomi:       govmomiClient,
+		Rest:          restClient,
+		FieldsManager: fieldsManager,
+		Finder:        finder,
+		ViewManager:   viewManager,
 	}, nil
+}
+
+const vSphereDeletionMarkerName = "capv-janitor-deletion-marker"
+
+func waitForTasksFinished(ctx context.Context, tasks []*object.Task, ignoreErrors bool) error {
+	for _, t := range tasks {
+		if err := t.Wait(ctx); !ignoreErrors && err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getDeletionMarkerTimestamp(key int32, values []types.BaseCustomFieldValue) (*time.Time, error) {
+	// Find the value for the key
+	var b *types.BaseCustomFieldValue
+	for i := range values {
+		// Find the
+		if values[i].GetCustomFieldValue().Key != key {
+			continue
+		}
+		b = &values[i]
+		break
+	}
+
+	// Key does not exist
+	if b == nil {
+		return nil, nil
+	}
+
+	value, ok := (*b).(*types.CustomFieldStringValue)
+	if !ok {
+		return nil, fmt.Errorf("cannot typecast %t to *types.CustomFieldStringValue", *b)
+	}
+
+	t, err := time.Parse(time.RFC3339, value.Value)
+	return &t, err
+}
+
+type managedElement struct {
+	entity  mo.ManagedEntity
+	element *list.Element
+}
+
+func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *govmomi.Client, finder *find.Finder, viewManager *view.Manager, objectTypes ...string) ([]*managedElement, error) {
+	// Get the object at inventoryPath
+	objs, err := finder.ManagedObjectList(ctx, inventoryPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) != 1 {
+		return nil, errors.Errorf("expected to find object at managed object at path: %s", inventoryPath)
+	}
+
+	root := objs[0].Object.Reference()
+
+	v, err := viewManager.CreateContainerView(ctx, root, objectTypes, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = v.Destroy(ctx) }()
+
+	managedObjects, err := v.Find(ctx, nil, property.Match{"name": "*"})
+	if err != nil {
+		return nil, err
+	}
+
+	managedElements := []*managedElement{}
+
+	if len(managedObjects) == 0 {
+		return managedElements, nil
+	}
+
+	var objStuff []mo.ManagedEntity
+	if err := govmomiClient.Retrieve(ctx, managedObjects, []string{"availableField", "value"}, &objStuff); err != nil {
+		return nil, err
+	}
+
+	for _, entity := range objStuff {
+		element, err := finder.Element(ctx, entity.Reference())
+		if err != nil {
+			return nil, err
+		}
+		managedElements = append(managedElements, &managedElement{entity: entity, element: element})
+	}
+
+	return managedElements, nil
 }

--- a/hack/tools/janitor/vsphere.go
+++ b/hack/tools/janitor/vsphere.go
@@ -166,15 +166,15 @@ type managedElement struct {
 
 func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *govmomi.Client, finder *find.Finder, viewManager *view.Manager, objectTypes ...string) ([]*managedElement, error) {
 	// Get the object at inventoryPath
-	objs, err := finder.ManagedObjectList(ctx, inventoryPath)
+	objList, err := finder.ManagedObjectList(ctx, inventoryPath)
 	if err != nil {
 		return nil, err
 	}
-	if len(objs) != 1 {
+	if len(objList) != 1 {
 		return nil, errors.Errorf("expected to find object at managed object at path: %s", inventoryPath)
 	}
 
-	root := objs[0].Object.Reference()
+	root := objList[0].Object.Reference()
 
 	v, err := viewManager.CreateContainerView(ctx, root, objectTypes, true)
 	if err != nil {
@@ -193,12 +193,12 @@ func recursiveList(ctx context.Context, inventoryPath string, govmomiClient *gov
 		return managedElements, nil
 	}
 
-	var objStuff []mo.ManagedEntity
-	if err := govmomiClient.Retrieve(ctx, managedObjects, []string{"availableField", "value"}, &objStuff); err != nil {
+	var objs []mo.ManagedEntity
+	if err := govmomiClient.Retrieve(ctx, managedObjects, []string{"availableField", "value"}, &objs); err != nil {
 		return nil, err
 	}
 
-	for _, entity := range objStuff {
+	for _, entity := range objs {
 		element, err := finder.Element(ctx, entity.Reference())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds functionality to hack/tools/janitor:

* Delete created child folders (get created during supervisor tests)
* Delete created child resource pools (get created during supervisor tests)
* Unit test coverage for janitor

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
