### PR TITLE
🌱 templates: add a script to run prekubeadmcommands in order of files defined in /etc/pre-kubeadm-scripts

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -603,6 +603,9 @@ func defaultPreKubeadmCommands() []string {
 		"hostnamectl set-hostname \"{{ ds.meta_data.hostname }}\"",
 		"echo \"::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6\" >/etc/hosts",
 		"echo \"127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost localhost.localdomain localhost4 localhost4.localdomain4\" >>/etc/hosts",
+		// Ensure the directory exists so the find does not fail if no files got created.
+		"mkdir -p /etc/pre-kubeadm-commands",
+		"for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo \"Running script $script\"; \"$script\"; done",
 	}
 }
 
@@ -610,6 +613,9 @@ func flatcarPreKubeadmCommands() []string {
 	return []string{
 		"envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp",
 		"mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml",
+		// Ensure the directory exists so the find does not fail if no files got created.
+		"mkdir -p /etc/pre-kubeadm-commands",
+		"for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo \"Running script $script\"; \"$script\"; done",
 	}
 }
 

--- a/packaging/flavorgen/flavors/kubevip/files.go
+++ b/packaging/flavorgen/flavors/kubevip/files.go
@@ -53,10 +53,10 @@ func newKubeVIPFiles() []bootstrapv1.File {
 			Permissions: "0644",
 			Content:     "127.0.0.1 localhost kubernetes",
 		},
-		// This two files are part of the workaround for https://github.com/kube-vip/kube-vip/issues/684
+		// This file is part of the workaround for https://github.com/kube-vip/kube-vip/issues/684
 		{
 			Owner:       "root:root",
-			Path:        "/etc/kube-vip-prepare.sh",
+			Path:        "/etc/pre-kubeadm-commands/50-kube-vip-prepare.sh",
 			Permissions: "0700",
 			Content:     kubeVipPrepare,
 		},

--- a/packaging/flavorgen/flavors/kubevip/kubevip.go
+++ b/packaging/flavorgen/flavors/kubevip/kubevip.go
@@ -24,10 +24,4 @@ import (
 // PatchControlPlane adds kube-vip to a KubeadmControlPlane object.
 func PatchControlPlane(cp *controlplanev1.KubeadmControlPlane) {
 	cp.Spec.KubeadmConfigSpec.Files = append(cp.Spec.KubeadmConfigSpec.Files, newKubeVIPFiles()...)
-
-	// This commands is part of the workaround for https://github.com/kube-vip/kube-vip/issues/684
-	cp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(
-		cp.Spec.KubeadmConfigSpec.PreKubeadmCommands,
-		"/etc/kube-vip-prepare.sh",
-	)
 }

--- a/packaging/flavorgen/flavors/kubevip/topology.go
+++ b/packaging/flavorgen/flavors/kubevip/topology.go
@@ -77,15 +77,7 @@ func TopologyPatch() clusterv1.ClusterClassPatch {
 		patches = append(patches, p)
 	}
 
-	// This two patches are part of the workaround for https://github.com/kube-vip/kube-vip/issues/684
-	patches = append(patches,
-		clusterv1.JSONPatch{
-			Op:        "add",
-			Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-",
-			ValueFrom: &clusterv1.JSONPatchValue{Template: ptr.To("/etc/kube-vip-prepare.sh")},
-		},
-	)
-
+	// This two patches is part of the workaround for https://github.com/kube-vip/kube-vip/issues/684
 	return clusterv1.ClusterClassPatch{
 		Name: "kubeVipPodManifest",
 		Definitions: []clusterv1.PatchDefinition{

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -121,6 +121,9 @@ spec:
       >/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
       localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     users:
     - name: capv
       sshAuthorizedKeys:
@@ -154,6 +157,9 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -199,7 +199,7 @@ spec:
             /etc/kubernetes/manifests/kube-vip.yaml
         fi
       owner: root:root
-      path: /etc/kube-vip-prepare.sh
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
       permissions: "0700"
     format: ignition
     ignition:
@@ -277,7 +277,9 @@ spec:
     preKubeadmCommands:
     - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
     - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
-    - /etc/kube-vip-prepare.sh
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     users:
     - name: core
       sshAuthorizedKeys:
@@ -369,6 +371,9 @@ spec:
       preKubeadmCommands:
       - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
       - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
       users:
       - name: core
         sshAuthorizedKeys:

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -236,7 +236,7 @@ spec:
             /etc/kubernetes/manifests/kube-vip.yaml
         fi
       owner: root:root
-      path: /etc/kube-vip-prepare.sh
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
       permissions: "0700"
     initConfiguration:
       nodeRegistration:
@@ -256,7 +256,9 @@ spec:
       >/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
       localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
-    - /etc/kube-vip-prepare.sh
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     users:
     - name: capv
       sshAuthorizedKeys:
@@ -290,6 +292,9 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/templates/cluster-template-supervisor.yaml
+++ b/templates/cluster-template-supervisor.yaml
@@ -193,7 +193,7 @@ spec:
             /etc/kubernetes/manifests/kube-vip.yaml
         fi
       owner: root:root
-      path: /etc/kube-vip-prepare.sh
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
       permissions: "0700"
     initConfiguration:
       nodeRegistration:
@@ -214,7 +214,9 @@ spec:
       >/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
       localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
-    - /etc/kube-vip-prepare.sh
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     users:
     - name: capv
       sshAuthorizedKeys:
@@ -249,6 +251,9 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -226,7 +226,7 @@ spec:
             /etc/kubernetes/manifests/kube-vip.yaml
         fi
       owner: root:root
-      path: /etc/kube-vip-prepare.sh
+      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
       permissions: "0700"
     initConfiguration:
       nodeRegistration:
@@ -246,7 +246,9 @@ spec:
       >/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
       localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
-    - /etc/kube-vip-prepare.sh
+    - mkdir -p /etc/pre-kubeadm-commands
+    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+      do echo "Running script $script"; "$script"; done
     users:
     - name: capv
       sshAuthorizedKeys:
@@ -280,6 +282,9 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/templates/clusterclass-template-supervisor.yaml
+++ b/templates/clusterclass-template-supervisor.yaml
@@ -174,12 +174,8 @@ spec:
                   /etc/kubernetes/manifests/kube-vip.yaml
               fi
             owner: root:root
-            path: /etc/kube-vip-prepare.sh
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
             permissions: "0700"
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        valueFrom:
-          template: /etc/kube-vip-prepare.sh
       selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
         kind: KubeadmControlPlaneTemplate
@@ -294,6 +290,9 @@ spec:
           >/etc/hosts
         - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
           localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - mkdir -p /etc/pre-kubeadm-commands
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
         users:
         - name: capv
           sshAuthorizedKeys:
@@ -321,3 +320,6 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -188,12 +188,8 @@ spec:
                   /etc/kubernetes/manifests/kube-vip.yaml
               fi
             owner: root:root
-            path: /etc/kube-vip-prepare.sh
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
             permissions: "0700"
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        valueFrom:
-          template: /etc/kube-vip-prepare.sh
       selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
         kind: KubeadmControlPlaneTemplate
@@ -353,6 +349,9 @@ spec:
           >/etc/hosts
         - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
           localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - mkdir -p /etc/pre-kubeadm-commands
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
         users:
         - name: capv
           sshAuthorizedKeys:
@@ -379,3 +378,6 @@ spec:
         >/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/clusterclass/patch-prekubeadmscript.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/clusterclass/patch-prekubeadmscript.yaml
@@ -4,14 +4,11 @@
     definitions:
     - jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/0
-        value: "/opt/prekubeadmscript.sh"
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
             owner: root:root
-            path:  "/opt/prekubeadmscript.sh"
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
             permissions: "0755"
             content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.controlPlane.version)) }}
       selector:
@@ -21,14 +18,11 @@
           controlPlane: true
     - jsonPatches:
       - op: add
-        path: /spec/template/spec/preKubeadmCommands/0
-        value: "/opt/prekubeadmscript.sh"
-      - op: add
         path: /spec/template/spec/files/-
         valueFrom:
           template: |
             owner: root:root
-            path:  "/opt/prekubeadmscript.sh"
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
             permissions: "0755"
             content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.machineDeployment.version)) }}
       selector:

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/clusterclass/patch-prekubeadmscript.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/clusterclass/patch-prekubeadmscript.yaml
@@ -4,15 +4,11 @@
     definitions:
     - jsonPatches:
       - op: add
-        # Note: We are adding prekubeadmscript.sh (install on bootstrap) at the end of the preKubeadmCommands because getting an ip for the machine (dhclient eth0) must always be executed as a first command.
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: "/opt/prekubeadmscript.sh"
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
             owner: root:root
-            path:  "/opt/prekubeadmscript.sh"
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
             permissions: "0755"
             content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.controlPlane.version)) }}
       selector:
@@ -22,15 +18,11 @@
           controlPlane: true
     - jsonPatches:
       - op: add
-        # Note: We are adding prekubeadmscript.sh (install on bootstrap) at the end of the preKubeadmCommands because getting an ip for the machine (dhclient eth0) must always be executed as a first command.
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: "/opt/prekubeadmscript.sh"
-      - op: add
         path: /spec/template/spec/files/-
         valueFrom:
           template: |
             owner: root:root
-            path:  "/opt/prekubeadmscript.sh"
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
             permissions: "0755"
             content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.machineDeployment.version)) }}
       selector:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The k8s v1.28 to v1.29 upgrade tests are currently failing on main and release-1.10, because the `prekubeadmscript.sh` gets run **after** `kube-vip-prepare.sh`. Because of that kube-vip fails on v1.28 and the kube-apiserver's public IP does not get up so provisioning including kubeadm fails.

This PR refactors the way we add additional pre-kubeadm scripts.

It changes the pattern from
* adding a script
* adding a preKubeadmCommand entry which runs the script

to
* adding scripts to `/etc/pre-kubeadm-commands`
* having a static script which runs the scripts inside that directory in alphabetical order

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
