### PR TITLE
:seedling:Update Kustomize deprecated syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ get_test_go_version = $(shell cat test/go.mod | grep $1 | awk '{print $$NF}')
 # Binaries.
 #
 # Note: Need to use abspath so we can invoke these from subdirectories
-KUSTOMIZE_VER := v4.5.2
+KUSTOMIZE_VER := v5.3.0
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
-KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4
+KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v5
 
 SETUP_ENVTEST_VER := 116a1b831fffe7ccc3c8145306c3e1a3b1b14ffa # Note: this matches the commit ID of the dependent controller-runtime module.
 SETUP_ENVTEST_BIN := setup-envtest

--- a/config/base/webhookcainjection_patch.yaml
+++ b/config/base/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -14,11 +14,11 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: capv-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -7,13 +7,3 @@ nameReference:
         group: cert-manager.io
         path: spec/issuerRef/name
 
-varReference:
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/commonName
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/dnsNames
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/secretName

--- a/config/default/crd/kustomizeconfig.yaml
+++ b/config/default/crd/kustomizeconfig.yaml
@@ -13,5 +13,3 @@ namespace:
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
-varReference:
-- path: metadata/annotations

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,8 +6,10 @@ namespace: capv-system
 
 namePrefix: capv-
 
-commonLabels:
-  cluster.x-k8s.io/provider: "infrastructure-vsphere"
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: infrastructure-vsphere  
 
 resources:
   - ../base

--- a/test/infrastructure/net-operator/config/certmanager/certificate.yaml
+++ b/test/infrastructure/net-operator/config/certmanager/certificate.yaml
@@ -14,11 +14,11 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME).SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: capv-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/test/infrastructure/net-operator/config/certmanager/kustomizeconfig.yaml
+++ b/test/infrastructure/net-operator/config/certmanager/kustomizeconfig.yaml
@@ -7,13 +7,3 @@ nameReference:
         group: cert-manager.io
         path: spec/issuerRef/name
 
-varReference:
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/commonName
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/dnsNames
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/secretName

--- a/test/infrastructure/net-operator/config/default/kustomization.yaml
+++ b/test/infrastructure/net-operator/config/default/kustomization.yaml
@@ -2,53 +2,122 @@ namespace: vmware-system-netop
 
 namePrefix: vmware-system-netop-
 
-commonLabels:
+labels:
   # capvsim is not a provider, but by adding this label
   # we can get this installed by Cluster APIs Tiltfile and by the clusterctl machinery we use in E2E tests.
-  cluster.x-k8s.io/provider: "runtime-extension-net-operator"
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: runtime-extension-net-operator
 
 resources:
-  - namespace.yaml
+- namespace.yaml
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
 
-bases:
-  - ../rbac
-  - ../manager
-  - ../webhook
-  - ../certmanager
 
-patchesStrategicMerge:
-  # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
-  - manager_webhook_patch.yaml
+patches:
+# Provide customizable hook for make targets.
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+# Enable webhook.
+- path: manager_webhook_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/test/infrastructure/net-operator/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/net-operator/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,5 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+          secretName: vmware-system-netop-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
 

--- a/test/infrastructure/net-operator/config/webhook/kustomizeconfig.yaml
+++ b/test/infrastructure/net-operator/config/webhook/kustomizeconfig.yaml
@@ -21,5 +21,3 @@ namespace:
   path: webhooks/clientConfig/service/namespace
   create: true
 
-varReference:
-- path: metadata/annotations

--- a/test/infrastructure/vcsim/config/certmanager/certificate.yaml
+++ b/test/infrastructure/vcsim/config/certmanager/certificate.yaml
@@ -14,11 +14,11 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: capv-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/test/infrastructure/vcsim/config/certmanager/kustomizeconfig.yaml
+++ b/test/infrastructure/vcsim/config/certmanager/kustomizeconfig.yaml
@@ -7,13 +7,3 @@ nameReference:
         group: cert-manager.io
         path: spec/issuerRef/name
 
-varReference:
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/commonName
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/dnsNames
-  - kind: Certificate
-    group: cert-manager.io
-    path: spec/secretName

--- a/test/infrastructure/vcsim/config/crd/kustomization.yaml
+++ b/test/infrastructure/vcsim/config/crd/kustomization.yaml
@@ -1,5 +1,7 @@
-commonLabels:
-  cluster.x-k8s.io/v1beta1: v1alpha1
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/v1beta1: v1alpha1
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
@@ -7,22 +9,22 @@ commonLabels:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - bases/vcsim.infrastructure.cluster.x-k8s.io_vcentersimulators.yaml
-  - bases/vcsim.infrastructure.cluster.x-k8s.io_controlplaneendpoints.yaml
-  - bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
-  - bases/vcsim.infrastructure.cluster.x-k8s.io_vmoperatordependencies.yaml
+- bases/vcsim.infrastructure.cluster.x-k8s.io_vcentersimulators.yaml
+- bases/vcsim.infrastructure.cluster.x-k8s.io_controlplaneendpoints.yaml
+- bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
+- bases/vcsim.infrastructure.cluster.x-k8s.io_vmoperatordependencies.yaml
 
-patchesStrategicMerge:
-  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-  # patches here are for enabling the conversion webhook for each CRD
+patches:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
 
-  # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
-  # patches here are for enabling the CA injection for each CRD
-  - patches/cainjection_in_vcentersimulators.yaml
-  - patches/cainjection_in_controlplaneendpoints.yaml
-  - patches/cainjection_in_envvars.yaml
-  - patches/cainjection_in_vmoperatordependencies.yaml
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+- path: patches/cainjection_in_vcentersimulators.yaml
+- path: patches/cainjection_in_controlplaneendpoints.yaml
+- path: patches/cainjection_in_envvars.yaml
+- path: patches/cainjection_in_vmoperatordependencies.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml

--- a/test/infrastructure/vcsim/config/crd/kustomizeconfig.yaml
+++ b/test/infrastructure/vcsim/config/crd/kustomizeconfig.yaml
@@ -13,5 +13,3 @@ namespace:
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
-varReference:
-- path: metadata/annotations

--- a/test/infrastructure/vcsim/config/crd/patches/cainjection_in_controlplaneendpoints.yaml
+++ b/test/infrastructure/vcsim/config/crd/patches/cainjection_in_controlplaneendpoints.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: controlplaneendpoints.vcsim.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/vcsim/config/crd/patches/cainjection_in_envvars.yaml
+++ b/test/infrastructure/vcsim/config/crd/patches/cainjection_in_envvars.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE)/CERTIFICATE_NAME
   name: envvars.vcsim.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/vcsim/config/crd/patches/cainjection_in_vcentersimulators.yaml
+++ b/test/infrastructure/vcsim/config/crd/patches/cainjection_in_vcentersimulators.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: vcentersimulators.vcsim.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/vcsim/config/crd/patches/cainjection_in_vmoperatordependencies.yaml
+++ b/test/infrastructure/vcsim/config/crd/patches/cainjection_in_vmoperatordependencies.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: vmoperatordependencies.vcsim.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/vcsim/config/default/kustomization.yaml
+++ b/test/infrastructure/vcsim/config/default/kustomization.yaml
@@ -2,54 +2,121 @@ namespace: vcsim-system
 
 namePrefix: vcsim-
 
-commonLabels:
-  # capvsim is not a provider, but by adding this label
-  # we can get this installed by Cluster APIs Tiltfile and by the clusterctl machinery we use in E2E tests.
-  cluster.x-k8s.io/provider: "runtime-extension-vcsim"
+labels:
+# capvsim is not a provider, but by adding this label
+# we can get this installed by Cluster APIs Tiltfile and by the clusterctl machinery we use in E2E tests.
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: runtime-extension-vcsim
 
 resources:
-  - namespace.yaml
+- namespace.yaml
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
 
-bases:
-  - ../crd
-  - ../rbac
-  - ../manager
-  - ../webhook
-  - ../certmanager
+patches:
+# Provide customizable hook for make targets.
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+- path: manager_webhook_patch.yaml
 
-patchesStrategicMerge:
-  # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
-  - manager_webhook_patch.yaml
-
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/test/infrastructure/vcsim/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/vcsim/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,5 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+          secretName: vcsim-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
 

--- a/test/infrastructure/vcsim/config/webhook/kustomizeconfig.yaml
+++ b/test/infrastructure/vcsim/config/webhook/kustomizeconfig.yaml
@@ -21,5 +21,3 @@ namespace:
   path: webhooks/clientConfig/service/namespace
   create: true
 
-varReference:
-- path: metadata/annotations


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump kustomize to v5 and Update Kustomize deprecated syntax.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2886 
