### PR TITLE
🌱 test: use a daemonset and kubectl exec to provide images to remote clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,6 @@ generate-e2e-templates-main: $(KUSTOMIZE) ## Generate test templates for the mai
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/clusterclass" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/clusterclass-quick-start.yaml"
 	cp "$(RELEASE_DIR)/main/cluster-template-topology.yaml" "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/topology/cluster-template-topology.yaml"
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/topology" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/cluster-template-topology.yaml"
-	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/remote-management" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/cluster-template-remote-management.yaml"
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/install-on-bootstrap" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/cluster-template-install-on-bootstrap.yaml"
 	# for PCI passthrough template
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/pci" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/main/cluster-template-pci.yaml"

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -55,7 +55,6 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10
 				SkipCleanup:                       skipCleanup,
 				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("topology"),
 				PostNamespaceCreated:              testSpecificSettingsGetter().PostNamespaceCreatedFunc,
-				PreInit:                           vsphereframework.LoadImagesFunc(ctx),
 				PreUpgrade:                        vsphereframework.LoadImagesFunc(ctx),
 				InitWithBinary:                    fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 				InitWithCoreProvider:              fmt.Sprintf(providerCAPIPrefix, capiStableRelease),

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -93,7 +93,6 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 				SkipCleanup:                       skipCleanup,
 				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("topology"),
 				PostNamespaceCreated:              testSpecificSettingsGetter().PostNamespaceCreatedFunc,
-				PreInit:                           vsphereframework.LoadImagesFunc(ctx),
 				PreUpgrade:                        vsphereframework.LoadImagesFunc(ctx),
 				InitWithBinary:                    fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 				InitWithCoreProvider:              fmt.Sprintf(providerCAPIPrefix, capiStableRelease),

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	vsphereframework "sigs.k8s.io/cluster-api-provider-vsphere/test/framework"
 )
 
 var (
@@ -51,8 +53,10 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10
 				BootstrapClusterProxy:             bootstrapClusterProxy,
 				ArtifactFolder:                    artifactFolder,
 				SkipCleanup:                       skipCleanup,
-				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("remote-management"),
+				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("topology"),
 				PostNamespaceCreated:              testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+				PreInit:                           vsphereframework.LoadImagesFunc(ctx),
+				PreUpgrade:                        vsphereframework.LoadImagesFunc(ctx),
 				InitWithBinary:                    fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 				InitWithCoreProvider:              fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
 				InitWithBootstrapProviders:        []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
@@ -87,8 +91,10 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 				BootstrapClusterProxy:             bootstrapClusterProxy,
 				ArtifactFolder:                    artifactFolder,
 				SkipCleanup:                       skipCleanup,
-				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("remote-management"),
+				MgmtFlavor:                        testSpecificSettingsGetter().FlavorForMode("topology"),
 				PostNamespaceCreated:              testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+				PreInit:                           vsphereframework.LoadImagesFunc(ctx),
+				PreUpgrade:                        vsphereframework.LoadImagesFunc(ctx),
 				InitWithBinary:                    fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 				InitWithCoreProvider:              fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
 				InitWithBootstrapProviders:        []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -169,7 +169,6 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-node-drain.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-ownerrefs-finalizers.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-pci.yaml"
-          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-remote-management.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-storage-policy.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template-topology.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/main/cluster-template.yaml"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/remote-management/image-injection.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/remote-management/image-injection.yaml
@@ -1,8 +1,0 @@
-- op: add
-  path: /spec/topology/variables/-
-  value:
-    name: preKubeadmScript
-    value: |
-      mkdir -p /opt/cluster-api
-      curl "https://storage.googleapis.com/capv-ci/${E2E_IMAGE_SHA}" -o /opt/cluster-api/image.tar
-      ctr -n k8s.io images import /opt/cluster-api/image.tar

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/remote-management/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/remote-management/kustomization.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../topology
-patches:
-  - target:
-      kind: Cluster
-    path: ./image-injection.yaml

--- a/test/framework/daemonset_helpers.go
+++ b/test/framework/daemonset_helpers.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// waitForDaemonSetAvailableInput is the input for WaitForDeploymentsAvailable.
+type waitForDaemonSetAvailableInput struct {
+	Getter    framework.Getter
+	Daemonset *appsv1.DaemonSet
+}
+
+// waitForDaemonSetAvailable waits until the Deployment has status.Available = True, that signals that
+// all the desired replicas are in place.
+// This can be used to check if Cluster API controllers installed in the management cluster are working.
+// xref: https://github.com/kubernetes/kubernetes/blob/bfa4188/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status.go#L95
+func waitForDaemonSetAvailable(ctx context.Context, input waitForDaemonSetAvailableInput, intervals ...interface{}) {
+	Byf("Waiting for daemonset %s to be available", klog.KObj(input.Daemonset))
+	daemon := &appsv1.DaemonSet{}
+	Eventually(func() bool {
+		key := client.ObjectKey{
+			Namespace: input.Daemonset.GetNamespace(),
+			Name:      input.Daemonset.GetName(),
+		}
+		if err := input.Getter.Get(ctx, key, daemon); err != nil {
+			return false
+		}
+		if daemon.Generation <= daemon.Status.ObservedGeneration {
+			if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
+				return false
+			}
+			if daemon.Status.NumberAvailable < daemon.Status.DesiredNumberScheduled {
+				return false
+			}
+			return true
+		}
+		return false
+	}, intervals...).Should(BeTrue())
+}

--- a/test/framework/image_preloading.go
+++ b/test/framework/image_preloading.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/test/framework"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func LoadImagesFunc(ctx context.Context) func(clusterProxy framework.ClusterProxy) {
+	sourceFile := os.Getenv("DOCKER_IMAGE_TAR")
+	Expect(sourceFile).ToNot(BeEmpty(), "DOCKER_IMAGE_TAR must be set")
+
+	loader := imagePreloader{
+		sourceFile: sourceFile,
+	}
+
+	return func(clusterProxy framework.ClusterProxy) {
+		loader.ImagesToCluster(ctx, clusterProxy)
+	}
+}
+
+type imagePreloader struct {
+	sourceFile string
+}
+
+// ImagesToCluster deploys a privileged daemonset and uses it to stream-load container images.
+func (loader *imagePreloader) ImagesToCluster(ctx context.Context, clusterProxy framework.ClusterProxy) {
+	daemon, daemonMutateFn, daemonLabels := getPreloadDaemonset()
+	ctrlClient := clusterProxy.GetClient()
+
+	// Create Daemonset
+	_, err := controllerutil.CreateOrPatch(ctx, ctrlClient, daemon, daemonMutateFn)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Wait for DaemonSet to be available.
+	waitForDaemonSetAvailable(ctx, waitForDaemonSetAvailableInput{Getter: ctrlClient, Daemonset: daemon}, time.Minute*3, time.Second*10)
+
+	// List all pods and load images via each found pod.
+	pods := &corev1.PodList{}
+	Expect(ctrlClient.List(
+		ctx,
+		pods,
+		client.InNamespace(daemon.Namespace),
+		client.MatchingLabels(daemonLabels),
+	)).To(Succeed())
+
+	errs := []error{}
+	for j := range pods.Items {
+		pod := pods.Items[j]
+		Byf("Loading images to node %s via pod %s", pod.Spec.NodeName, klog.KObj(&pod))
+		if err := loader.imagesViaPod(ctx, clusterProxy, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	Expect(kerrors.NewAggregate(errs)).ToNot(HaveOccurred())
+}
+
+func (loader *imagePreloader) imagesViaPod(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, podName, containerName string) error {
+	// Open source tar file.
+	reader, writer := io.Pipe()
+	file, err := os.Open(loader.sourceFile)
+	if err != nil {
+		return err
+	}
+
+	// Use go routine to pipe source file content into then stdin.
+	go func(file *os.File, writer io.WriteCloser) {
+		defer writer.Close()
+		defer file.Close()
+		_, _ = io.Copy(writer, file)
+	}(file, writer)
+
+	// Load the container images using ctr and delete the file.
+	loadCommand := "ctr -n k8s.io images import -"
+	return loader.execPod(ctx, clusterProxy, namespace, podName, containerName, loadCommand, reader)
+}
+
+func (loader *imagePreloader) execPod(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, podName, containerName, cmd string, stdin io.Reader) error {
+	var hasStdin bool
+	if stdin != nil {
+		hasStdin = true
+	}
+
+	req := clusterProxy.GetClientSet().CoreV1().RESTClient().Post().
+		Namespace(namespace).
+		Resource("pods").
+		Name(podName).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: containerName,
+			Command:   []string{"/bin/sh", "-c", cmd},
+			Stdin:     hasStdin,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(clusterProxy.GetRESTConfig(), "POST", req.URL())
+	if err != nil {
+		return err
+	}
+	// WebSocketExecutor must be "GET" method as described in RFC 6455 Sec. 4.1 (page 17).
+	websocketExec, err := remotecommand.NewWebSocketExecutor(clusterProxy.GetRESTConfig(), "GET", req.URL().String())
+	if err != nil {
+		return err
+	}
+	exec, err = remotecommand.NewFallbackExecutor(websocketExec, exec, httpstream.IsUpgradeFailure)
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "running command %q stdout=%q, stderr=%q", cmd, stdout.String(), stderr.String())
+	}
+
+	return nil
+}
+
+func getPreloadDaemonset() (*appsv1.DaemonSet, controllerutil.MutateFn, map[string]string) {
+	labels := map[string]string{
+		"app": "image-preloader",
+	}
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceSystem,
+			Name:      "image-preloader",
+			Labels:    labels,
+		},
+	}
+	muatetFn := func() error {
+		ds.Labels = labels
+		ds.Spec = appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "pause",
+							Image:   "registry.k8s.io/pause:3.9",
+							Command: []string{"/usr/bin/tail", "-f", "/dev/null"},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "host",
+									MountPath: "/",
+								},
+							},
+						},
+					},
+					HostPID: true,
+					HostIPC: true,
+					Volumes: []corev1.Volume{
+						{
+							Name: "host",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+									Type: ptr.To(corev1.HostPathDirectory),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return nil
+	}
+	return ds, muatetFn, labels
+}

--- a/test/framework/image_preloading.go
+++ b/test/framework/image_preloading.go
@@ -19,11 +19,13 @@ package framework
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -99,7 +101,10 @@ func loadImagesViaPod(ctx context.Context, clusterProxy framework.ClusterProxy, 
 		defer file.Close()
 		// Ignoring the error here because the execPod command should fail in case of
 		// failure copying over the data.
-		_, _ = io.Copy(writer, file)
+		_, err := io.Copy(writer, file)
+		if err != nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to copy file data to io.Pipe: %v\n", err)
+		}
 	}(file, writer)
 
 	// Load the container images using ctr and delete the file.

--- a/test/framework/image_preloading.go
+++ b/test/framework/image_preloading.go
@@ -174,7 +174,7 @@ func getPreloadDaemonset() (*appsv1.DaemonSet, controllerutil.MutateFn, map[stri
 			Labels:    labels,
 		},
 	}
-	muatetFunc := func() error {
+	mutateFunc := func() error {
 		ds.Labels = labels
 		ds.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -225,5 +225,5 @@ func getPreloadDaemonset() (*appsv1.DaemonSet, controllerutil.MutateFn, map[stri
 		}
 		return nil
 	}
-	return ds, muatetFunc, labels
+	return ds, mutateFunc, labels
 }

--- a/test/go.mod
+++ b/test/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Removes pushing the images to gcloud and instead uses a daemonset and streams the image tarball via kubectl exec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
