### PR TITLE
🌱 controllers: fix ProviderServiceAccount tests to create objects on-demand

### DIFF
--- a/controllers/serviceaccount_controller_intg_test.go
+++ b/controllers/serviceaccount_controller_intg_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 
@@ -30,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +37,7 @@ import (
 	helpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 )
 
-var _ = Describe("ProviderServiceAccount controller integration tests", func() {
+var _ = Describe("ProviderServiceAccount controller integration tests", Label("FOO"), func() {
 	var intCtx *helpers.IntegrationTestContext
 
 	BeforeEach(func() {
@@ -61,6 +59,12 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 			targetNSObj *corev1.Namespace
 		)
 		BeforeEach(func() {
+			By("Creating the Cluster, vSphereCluster and KubeconfigSecret", func() {
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+			})
+
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
 			createTestResource(ctx, intCtx.Client, pSvcAccount)
 			assertEventuallyExistsInNamespace(ctx, intCtx.Client, intCtx.Namespace, pSvcAccount.GetName(), pSvcAccount)
@@ -127,15 +131,11 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		})
 	})
 
-	Context("With non-existent Cluster object", func() {
+	Context("With non-existent Cluster object", Label("FOO"), func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
-			By("Deleting the CAPI cluster object", func() {
-				clusterName, ok := intCtx.VSphereCluster.GetLabels()[clusterv1.ClusterNameLabel]
-				Expect(ok).To(BeTrue())
-				cluster := &clusterv1.Cluster{}
-				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: clusterName}
-				Expect(intCtx.Client.Get(ctx, key, cluster)).To(Succeed())
-				Expect(intCtx.Client.Delete(ctx, cluster)).To(Succeed())
+			By("Creating the vSphereCluster and KubeconfigSecret only", func() {
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -155,16 +155,9 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 
 	Context("With non-existent Cluster credentials secret", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
-			By("Deleting the CAPI kubeconfig secret object", func() {
-				clusterName, ok := intCtx.VSphereCluster.GetLabels()[clusterv1.ClusterNameLabel]
-				Expect(ok).To(BeTrue())
-				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: intCtx.Namespace,
-						Name:      fmt.Sprintf("%s-kubeconfig", clusterName),
-					},
-				}
-				Expect(intCtx.Client.Delete(ctx, secret)).To(Succeed())
+			By("Creating the Cluster and vSphereCluster only", func() {
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -187,6 +180,11 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		var role *rbacv1.Role
 		var roleBinding *rbacv1.RoleBinding
 		BeforeEach(func() {
+			By("Creating the Cluster, vSphereCluster and KubeconfigSecret", func() {
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+			})
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
 			pSvcAccount.Spec.TargetNamespace = "default"
 			// Pause the ProviderServiceAccount so we can create dependent but legacy resources

--- a/controllers/serviceaccount_controller_intg_test.go
+++ b/controllers/serviceaccount_controller_intg_test.go
@@ -37,7 +37,7 @@ import (
 	helpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 )
 
-var _ = Describe("ProviderServiceAccount controller integration tests", Label("FOO"), func() {
+var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	var intCtx *helpers.IntegrationTestContext
 
 	BeforeEach(func() {
@@ -131,7 +131,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", Label("F
 		})
 	})
 
-	Context("With non-existent Cluster object", Label("FOO"), func() {
+	Context("With non-existent Cluster object", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
 			By("Creating the vSphereCluster and KubeconfigSecret only", func() {
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)

--- a/controllers/servicediscovery_controller_intg_test.go
+++ b/controllers/servicediscovery_controller_intg_test.go
@@ -32,6 +32,11 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 	)
 	BeforeEach(func() {
 		intCtx = helpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
+		By("Creating the Cluster, vSphereCluster and KubeconfigSecret", func() {
+			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+		})
 	})
 	AfterEach(func() {
 		intCtx.AfterEach()

--- a/internal/test/helpers/vmware/intg_test_context.go
+++ b/internal/test/helpers/vmware/intg_test_context.go
@@ -101,7 +101,7 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 	})
 
 	vsphereClusterName := capiutil.RandomString(6)
-	testCtx.Cluster = createCluster(testCtx.Namespace, vsphereClusterName)
+	testCtx.Cluster = generateCluster(testCtx.Namespace, vsphereClusterName)
 
 	var config *rest.Config
 
@@ -127,8 +127,8 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 
 		testCtx.envTest = envTest
 	})
-	By("Create the kubeconfig secret for the cluster", func() {
-		buf, err := writeKubeConfig(config)
+	By("Generating the kubeconfig secret for the cluster", func() {
+		buf, err := generateKubeConfig(config)
 		Expect(err).ToNot(HaveOccurred())
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -151,8 +151,8 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 		testCtx.KubeconfigSecret = secret
 	})
 
-	By("Create a vsphere cluster and wait for it to exist", func() {
-		testCtx.VSphereCluster = createVSphereCluster(testCtx.Namespace, vsphereClusterName, testCtx.Cluster.GetName())
+	By("Generating a vsphere cluster", func() {
+		testCtx.VSphereCluster = generateVSphereCluster(testCtx.Namespace, vsphereClusterName, testCtx.Cluster.GetName())
 		testCtx.VSphereClusterKey = client.ObjectKeyFromObject(testCtx.VSphereCluster)
 	})
 
@@ -168,8 +168,8 @@ func CreateAndWait(ctx context.Context, integrationTestClient client.Client, obj
 	}).Should(Succeed())
 }
 
-func createCluster(namespace, name string) *clusterv1.Cluster {
-	By("Create the CAPI Cluster and wait for it to exist")
+func generateCluster(namespace, name string) *clusterv1.Cluster {
+	By("Generate the CAPI Cluster")
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -193,7 +193,7 @@ func createCluster(namespace, name string) *clusterv1.Cluster {
 	return cluster
 }
 
-func createVSphereCluster(namespace, name, capiClusterName string) *vmwarev1.VSphereCluster {
+func generateVSphereCluster(namespace, name, capiClusterName string) *vmwarev1.VSphereCluster {
 	vsphereCluster := &vmwarev1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -204,8 +204,8 @@ func createVSphereCluster(namespace, name, capiClusterName string) *vmwarev1.VSp
 	return vsphereCluster
 }
 
-// writeKubeConfig writes an existing *rest.Config out as the typical kubeconfig YAML data.
-func writeKubeConfig(config *rest.Config) ([]byte, error) {
+// generateKubeConfig writes an existing *rest.Config out as the typical kubeconfig YAML data.
+func generateKubeConfig(config *rest.Config) ([]byte, error) {
 	return clientcmd.Write(api.Config{
 		Clusters: map[string]*api.Cluster{
 			config.ServerName: {

--- a/internal/test/helpers/vmware/intg_test_context.go
+++ b/internal/test/helpers/vmware/intg_test_context.go
@@ -46,6 +46,7 @@ type IntegrationTestContext struct {
 	Namespace         string
 	VSphereCluster    *vmwarev1.VSphereCluster
 	Cluster           *clusterv1.Cluster
+	KubeconfigSecret  *corev1.Secret
 	VSphereClusterKey client.ObjectKey
 	envTest           *envtest.Environment
 }
@@ -100,7 +101,7 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 	})
 
 	vsphereClusterName := capiutil.RandomString(6)
-	testCtx.Cluster = createCluster(ctx, integrationTestClient, testCtx.Namespace, vsphereClusterName)
+	testCtx.Cluster = createCluster(testCtx.Namespace, vsphereClusterName)
 
 	var config *rest.Config
 
@@ -138,7 +139,8 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 						APIVersion: clusterv1.GroupVersion.String(),
 						Kind:       "Cluster",
 						Name:       testCtx.Cluster.Name,
-						UID:        testCtx.Cluster.UID,
+						// Using a random id in this case is okay because we don't rely on it to be the correct uid.
+						UID: "should-be-uid-of-cluster",
 					},
 				},
 			},
@@ -146,26 +148,32 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 				"value": buf,
 			},
 		}
-		Expect(integrationTestClient.Create(ctx, secret)).To(Succeed())
-		Eventually(func() error {
-			return integrationTestClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
-		}).Should(Succeed())
+		testCtx.KubeconfigSecret = secret
 	})
 
 	By("Create a vsphere cluster and wait for it to exist", func() {
-		testCtx.VSphereCluster = createVSphereCluster(ctx, integrationTestClient, testCtx.Namespace, vsphereClusterName, testCtx.Cluster.GetName())
+		testCtx.VSphereCluster = createVSphereCluster(testCtx.Namespace, vsphereClusterName, testCtx.Cluster.GetName())
 		testCtx.VSphereClusterKey = client.ObjectKeyFromObject(testCtx.VSphereCluster)
 	})
 
 	return testCtx
 }
 
-func createCluster(ctx context.Context, integrationTestClient client.Client, namespace, name string) *clusterv1.Cluster {
+// CreateAndWait creates and waits for an object to exist.
+func CreateAndWait(ctx context.Context, integrationTestClient client.Client, obj client.Object) {
+	GinkgoHelper()
+	Expect(integrationTestClient.Create(ctx, obj)).To(Succeed())
+	Eventually(func() error {
+		return integrationTestClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	}).Should(Succeed())
+}
+
+func createCluster(namespace, name string) *clusterv1.Cluster {
 	By("Create the CAPI Cluster and wait for it to exist")
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
-			GenerateName: name,
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s-%s", name, capiutil.RandomString(6)),
 		},
 		Spec: clusterv1.ClusterSpec{
 			ClusterNetwork: &clusterv1.ClusterNetwork{
@@ -182,14 +190,10 @@ func createCluster(ctx context.Context, integrationTestClient client.Client, nam
 			},
 		},
 	}
-	Expect(integrationTestClient.Create(ctx, cluster)).To(Succeed())
-	Eventually(func() error {
-		return integrationTestClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
-	}).Should(Succeed())
 	return cluster
 }
 
-func createVSphereCluster(ctx context.Context, integrationTestClient client.Client, namespace, name, capiClusterName string) *vmwarev1.VSphereCluster {
+func createVSphereCluster(namespace, name, capiClusterName string) *vmwarev1.VSphereCluster {
 	vsphereCluster := &vmwarev1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -197,31 +201,6 @@ func createVSphereCluster(ctx context.Context, integrationTestClient client.Clie
 			Labels:    map[string]string{clusterv1.ClusterNameLabel: capiClusterName},
 		},
 	}
-	Expect(integrationTestClient.Create(ctx, vsphereCluster)).To(Succeed())
-	Eventually(func() error {
-		return integrationTestClient.Get(ctx, client.ObjectKeyFromObject(vsphereCluster), vsphereCluster)
-	}).Should(Succeed())
-
-	// TODO: remove if not needed
-	By("Creating a extensions ca", func() {
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vsphereCluster.Name + "-extensions-ca",
-				Namespace: namespace,
-			},
-			Data: map[string][]byte{
-				"ca.crt":  []byte("test-ca"),
-				"tls.crt": []byte("test-tls.crt"),
-				"tls.key": []byte("test-tls.key"),
-			},
-			Type: corev1.SecretTypeTLS,
-		}
-		Expect(integrationTestClient.Create(ctx, secret)).To(Succeed())
-		secretKey := client.ObjectKey{Namespace: secret.Namespace, Name: secret.Name}
-		Eventually(func() error {
-			return integrationTestClient.Get(ctx, secretKey, secret)
-		}).Should(Succeed())
-	})
 	return vsphereCluster
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR changes the controllers tests for serviceaccount_controller and servicediscovery_controller to only create the objects which are required, instead of creating all and deleting the ones not required.

This solves a race condition for the serviceaccount_controller related test cases for the following cases:

* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/serviceaccount_controller_intg_test.go#L130
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/serviceaccount_controller_intg_test.go#L156

In case of this tests, the serviceaccount_controller could already have reconciled once successfully and added a successful `ProviderServiceAccountsReadyCondition` before the tests have deleted the relevant objects.

This gets reproducible by adding a `time.Sleep(time.Second)` before the deletion, e.g. at:

* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/serviceaccount_controller_intg_test.go#L133
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/controllers/serviceaccount_controller_intg_test.go#L159

This solves the flake we heavily see on release-1.7:

![image](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/assets/417870/a40a002f-c1ba-4615-898e-6ef849bcb88b)

E.g.:

* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-release-1-7/1788104398212173824
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-release-1-7/1788074199512780800

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/hold 

I want to do final verification locally
