### PR TITLE
[release-1.10] 🐛 Remove logouts in keep alive handlers

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -263,9 +263,6 @@ func newClient(ctx context.Context, sessionKey string, url *url.URL, thumbprint 
 			_, err := methods.GetCurrentTime(ctx, tripper)
 			if err != nil {
 				log.Error(err, "Failed to keep alive govmomi client, Clearing the session now")
-				if errLogout := c.Logout(ctx); errLogout != nil {
-					log.Error(err, "Failed to logout keepalive failed session")
-				}
 				sessionCache.Delete(sessionKey)
 			}
 			return err
@@ -296,9 +293,6 @@ func newManager(ctx context.Context, sessionKey string, client *vim25.Client, us
 			}
 
 			log.Info("REST client session expired, clearing session")
-			if errLogout := rc.Logout(ctx); errLogout != nil {
-				log.Error(err, "Failed to logout keepalive failed REST session")
-			}
 			sessionCache.Delete(sessionKey)
 			return errors.New("REST client session expired")
 		})


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
PR #2530 introduced additional logouts to avoid session leaks. Unfortunately we realized later that this leads to more deadlocks.

Notes
* v1.11: keep alive handler has been removed
* v1.10 keep alive handler is disabled per default
* v1.9-v1.7: keep alive handler is enabled per default
*  in v1.10 and removed in v1.11

In general, the recomendation is to disable the keep alive handler in v1.10-v1.7. For folks that have it still enabled, this PR tries to remove the deadlock issue.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
