### PR TITLE
🌱 hack/e2e don't add binary files to artifacts and also censor base64 encoded values

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -49,11 +49,26 @@ on_exit() {
 
   # Cleanup VSPHERE_PASSWORD from temporary artifacts directory.
   if [[ "${ORIGINAL_ARTIFACTS}" != "" ]]; then
-    if [ -z "$VSPHERE_PASSWORD" ]; then
-      grep -r -l -e "${VSPHERE_PASSWORD}" "${ARTIFACTS}" | while IFS= read -r file
+    # Delete non-text files from artifacts directory to not leak files accidentially
+    find "${ARTIFACTS}" -type f -exec file --mime-type {} \; | grep -v -E -e "text/plain|text/xml|application/json|inode/x-empty" | while IFS= read -r line
+    do
+      file="$(echo "${line}" | cut -d ':' -f1)"
+      mimetype="$(echo "${line}" | cut -d ':' -f2)"
+      echo "Deleting file ${file} of type ${mimetype}"
+      rm "${file}"
+    done || true
+    # Replace secret and base64 secret in all files.
+    if [ -n "$VSPHERE_PASSWORD" ]; then
+      grep -I -r -l -e "${VSPHERE_PASSWORD}" "${ARTIFACTS}" | while IFS= read -r file
       do
         echo "Cleaning up VSPHERE_PASSWORD from file ${file}"
         sed -i "s/${VSPHERE_PASSWORD}/REDACTED/g" "${file}"
+      done || true
+      VSPHERE_PASSWORD_B64=$(echo -n "${VSPHERE_PASSWORD}" | base64 --wrap=0)
+      grep -I -r -l -e "${VSPHERE_PASSWORD_B64}" "${ARTIFACTS}" | while IFS= read -r file
+      do
+        echo "Cleaning up VSPHERE_PASSWORD_B64 from file ${file}"
+        sed -i "s/${VSPHERE_PASSWORD_B64}/REDACTED/g" "${file}"
       done || true
     fi
     # Move all artifacts to the original artifacts location.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Improves our censoring in e2e.sh to:

* not add binary files (e.g. gzipped files) to the output artifacts because we can't control their data
* also censor the base64 version of our secret

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
