### PR TITLE
[release-1.8] 🐛 Remove logouts in keep alive handlers 

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -250,9 +250,6 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 			if err != nil {
 				logger.Error(err, "failed to keep alive govmomi client")
 				logger.Info("clearing the session")
-				if errLogout := c.Logout(ctx); errLogout != nil {
-					logger.Error(err, "failed to logout keepalive failed session")
-				}
 				sessionCache.Delete(sessionKey)
 			}
 			return err
@@ -281,9 +278,6 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
 			}
 
 			logger.Info("rest client session expired, clearing session")
-			if errLogout := rc.Logout(ctx); errLogout != nil {
-				logger.Error(err, "failed to logout keepalive failed rest session")
-			}
 			sessionCache.Delete(sessionKey)
 			return errors.New("rest client session expired")
 		})


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2987

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
