### PR TITLE
🐛 Run only one manager with webhooks for supervisor tests

### DIFF
--- a/controllers/vmware/test/controllers_suite_test.go
+++ b/controllers/vmware/test/controllers_suite_test.go
@@ -97,6 +97,9 @@ func getTestEnv() (*envtest.Environment, *rest.Config) {
 var _ = BeforeSuite(func() {
 	By("bootstrapping test environments")
 	testEnv, restConfig = getTestEnv()
+
+	By("starting manager to serve webhooks")
+	initManagerAndBuildClient("", true)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/test/helpers/webhook.go
+++ b/internal/test/helpers/webhook.go
@@ -103,19 +103,19 @@ func InitializeWebhookInEnvironment(e *envtest.Environment, configPath string) {
 func (t *TestEnvironment) WaitForWebhooks() {
 	port := env.WebhookInstallOptions.LocalServingPort
 
-	klog.V(2).Infof("Waiting for webhook port %d to be open prior to running tests", port)
+	klog.Infof("Waiting for webhook port %d to be open prior to running tests", port)
 	timeout := 1 * time.Second
 	for {
 		time.Sleep(1 * time.Second)
 		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), timeout)
 		if err != nil {
-			klog.V(2).Infof("Webhook port is not ready, will retry in %v: %s", timeout, err)
+			klog.Infof("Webhook port is not ready, will retry in %v: %s", timeout, err)
 			continue
 		}
 		if err := conn.Close(); err != nil {
-			klog.V(2).Info("Connection to webhook port could not be closed. Continuing with tests...")
+			klog.Info("Connection to webhook port could not be closed. Continuing with tests...")
 		}
-		klog.V(2).Info("Webhook port is now open. Continuing with tests...")
+		klog.Info("Webhook port is now open. Continuing with tests...")
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We are running multiple managers in supervisor tests. If all of them are trying to serve webhook son the same port the tests will fail, e.g.: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-main/1793553292249272320

This PR ensures that we only run one manager with webhooks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
