### PR TITLE
🌱 Fill up supervisor e2e test - clusterctl upgrades using ClusterClass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,10 +403,16 @@ generate-e2e-templates-v1.10: $(KUSTOMIZE)
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.10/clusterclass" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.10/clusterclass-quick-start.yaml"
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.10/workload" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.10/cluster-template-workload.yaml"
 
+	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.10/clusterclass" > "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.10/clusterclass-quick-start-supervisor.yaml"
+	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.10/workload" > "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.10/cluster-template-workload-supervisor.yaml"
+
 .PHONY: generate-e2e-templates-v1.9
 generate-e2e-templates-v1.9: $(KUSTOMIZE)
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.9/clusterclass" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.9/clusterclass-quick-start.yaml"
 	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.9/workload" > "$(E2E_GOVMOMI_TEMPLATE_DIR)/v1.9/cluster-template-workload.yaml"
+
+	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.9/clusterclass" > "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.9/clusterclass-quick-start-supervisor.yaml"
+	"$(KUSTOMIZE)" --load-restrictor LoadRestrictionsNone build "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.9/workload" > "$(E2E_SUPERVISOR_TEMPLATE_DIR)/v1.9/cluster-template-workload-supervisor.yaml"
 
 .PHONY: generate-test-infra-prowjobs
 generate-test-infra-prowjobs: $(PROWJOB_GEN) ## Generates the prowjob configurations in test-infra

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -166,6 +166,8 @@ providers:
           # Add a cluster template
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/v1.10/cluster-template-workload.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/v1.10/clusterclass-quick-start.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-supervisor/v1.10/cluster-template-workload-supervisor.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass-quick-start-supervisor.yaml"
           - sourcePath: "../data/shared/capv/v1.10/metadata.yaml"
       - name: "{go://sigs.k8s.io/cluster-api-provider-vsphere@v1.9}" # supported release in the v1beta1 series
         value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/{go://sigs.k8s.io/cluster-api-provider-vsphere@v1.9}/infrastructure-components.yaml"
@@ -175,6 +177,8 @@ providers:
           # Add a cluster template
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/v1.9/cluster-template-workload.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-govmomi/v1.9/clusterclass-quick-start.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-supervisor/v1.9/cluster-template-workload-supervisor.yaml"
+          - sourcePath: "../../../test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass-quick-start-supervisor.yaml"
           - sourcePath: "../data/shared/capv/v1.9/metadata.yaml"
 
   - name: vcsim
@@ -260,6 +264,9 @@ variables:
   EXP_NODE_ANTI_AFFINITY: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
+  # Required to be set to install capv-supervisor <= v1.10, but getting created.
+  SERVICE_ACCOUNTS_CM_NAMESPACE: "capv-system"
+  SERVICE_ACCOUNTS_CM_NAME: "service-accounts-cm"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/clusterclass-quick-start-supervisor.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/clusterclass-quick-start-supervisor.yaml
@@ -1,0 +1,324 @@
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterTemplate
+metadata:
+  name: '${CLUSTER_CLASS_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: '${CLUSTER_CLASS_NAME}'
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: ${CLUSTER_CLASS_NAME}-template
+        namespace: '${NAMESPACE}'
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: ${CLUSTER_CLASS_NAME}-controlplane
+      namespace: '${NAMESPACE}'
+  infrastructure:
+    ref:
+      apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereClusterTemplate
+      name: '${CLUSTER_CLASS_NAME}'
+      namespace: '${NAMESPACE}'
+  patches:
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    name: createEmptyArrays
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    enabledIf: '{{ if .sshKey }}true{{end}}'
+    name: enableSSHIntoNodes
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/controlPlaneEndpoint
+        valueFrom:
+          template: |
+            host: '{{ .controlPlaneIpAddr }}'
+            port: {{ .controlPlanePort }}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+    name: infraClusterSubstitutions
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |-
+            owner: "root:root"
+            path: "/etc/kubernetes/manifests/kube-vip.yaml"
+            content: {{ printf "%q" (regexReplaceAll "(name: address\n +value:).*" .kubeVipPodManifest (printf "$1 %s" .controlPlaneIpAddr)) }}
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: 127.0.0.1 localhost kubernetes
+            owner: root:root
+            path: /etc/kube-vip.hosts
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: |
+              #!/bin/bash
+
+              # Copyright 2020 The Kubernetes Authors.
+              #
+              # Licensed under the Apache License, Version 2.0 (the "License");
+              # you may not use this file except in compliance with the License.
+              # You may obtain a copy of the License at
+              #
+              #     http://www.apache.org/licenses/LICENSE-2.0
+              #
+              # Unless required by applicable law or agreed to in writing, software
+              # distributed under the License is distributed on an "AS IS" BASIS,
+              # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              # See the License for the specific language governing permissions and
+              # limitations under the License.
+
+              set -e
+
+              # Configure the workaround required for kubeadm init with kube-vip:
+              # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+              # Nothing to do for kubernetes < v1.29
+              KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+              if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+                exit 0
+              fi
+
+              IS_KUBEADM_INIT="false"
+
+              # cloud-init kubeadm init
+              if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              # ignition kubeadm init
+              if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+                sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+                  /etc/kubernetes/manifests/kube-vip.yaml
+              fi
+            owner: root:root
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+            permissions: "0700"
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    name: kubeVipPodManifest
+  variables:
+  - metadata: {}
+    name: sshKey
+    required: false
+    schema:
+      openAPIV3Schema:
+        description: Public key to SSH onto the cluster nodes.
+        type: string
+  - metadata: {}
+    name: controlPlaneIpAddr
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Floating VIP for the control plane.
+        type: string
+  - metadata: {}
+    name: controlPlanePort
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Port for the control plane endpoint.
+        type: integer
+  - metadata: {}
+    name: kubeVipPodManifest
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: kube-vip manifest for the control plane.
+        type: string
+  workers:
+    machineDeployments:
+    - class: ${CLUSTER_CLASS_NAME}-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
+            namespace: '${NAMESPACE}'
+        infrastructure:
+          ref:
+            apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereMachineTemplate
+            name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+            namespace: '${NAMESPACE}'
+        metadata: {}
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      className: ${VSPHERE_MACHINE_CLASS_NAME}
+      imageName: ${VSPHERE_IMAGE_NAME}
+      powerOffMode: ${VSPHERE_POWER_OFF_MODE:=trySoft}
+      storageClass: ${VSPHERE_STORAGE_CLASS}
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      className: ${VSPHERE_MACHINE_CLASS_NAME}
+      imageName: ${VSPHERE_IMAGE_NAME}
+      powerOffMode: ${VSPHERE_POWER_OFF_MODE:=trySoft}
+      storageClass: ${VSPHERE_STORAGE_CLASS}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-controlplane
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              cloud-provider: external
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        preKubeadmCommands:
+        - dhclient eth0
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+        - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+          >/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+          localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - mkdir -p /etc/pre-kubeadm-commands
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
+        users:
+        - name: capv
+          sshAuthorizedKeys:
+          - '${VSPHERE_SSH_AUTHORIZED_KEY}'
+          sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ local_hostname }}'
+      preKubeadmCommands:
+      - dhclient eth0
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+        >/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+        localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./clusterclass-quick-start-supervisor.yaml
+patches:
+  - target:
+      kind: ClusterClass
+    path: ./patch-vsphere-template.yaml
+  - target:
+      kind: ClusterClass
+    path: ./patch-prekubeadmscript.yaml
+  - target:
+      kind: ClusterClass
+    path: ./patch-namingstrategy.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-namingstrategy.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-namingstrategy.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/controlPlane/namingStrategy
+  value:
+    template: '{{ .cluster.name }}-cp-{{ .random }}'
+- op: add
+  path: /spec/workers/machineDeployments/0/namingStrategy
+  value:
+    template: '{{ .cluster.name }}-md-{{ .machineDeployment.topologyName }}-{{ .random }}'

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-prekubeadmscript.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-prekubeadmscript.yaml
@@ -1,0 +1,45 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            owner: root:root
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
+            permissions: "0755"
+            content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.controlPlane.version)) }}
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: |
+            owner: root:root
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
+            permissions: "0755"
+            content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.machineDeployment.version)) }}
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    enabledIf: '{{ if .preKubeadmScript }}true{{ end }}'
+    name: preKubeadmScript
+- op: add
+  path: /spec/variables/-
+  value:
+    name: preKubeadmScript
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        description: Script to run in preKubeadmCommands.

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-vsphere-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/clusterclass/patch-vsphere-template.yaml
@@ -1,0 +1,45 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    definitions:
+    - jsonPatches:
+      - op: replace
+        path: /spec/template/spec/imageName
+        valueFrom:
+          # We have to fall back to v1.30.0 for the conformance latest ci test which uses
+          # versions without corresponding templates like "v1.30.0-alpha.0.525+09a5049ca78502".
+          template: |-
+            {{- if eq .builtin.controlPlane.version "v1.28.0" -}}
+            ubuntu-2204-kube-v1.28.0
+            {{- else -}}{{- if eq .builtin.controlPlane.version "v1.29.0" -}}
+            ubuntu-2204-kube-v1.29.0
+            {{- else -}}
+            ubuntu-2204-kube-v1.30.0
+            {{- end -}}{{- end -}}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: replace
+        path: /spec/template/spec/imageName
+        valueFrom:
+          # We have to fall back to v1.30.0 for the conformance latest ci test which uses
+          # versions without corresponding templates like "v1.30.0-alpha.0.525+09a5049ca78502".
+          template: |-
+            {{- if eq .builtin.machineDeployment.version "v1.28.0" -}}
+            ubuntu-2204-kube-v1.28.0
+            {{- else -}}{{- if eq .builtin.machineDeployment.version "v1.29.0" -}}
+            ubuntu-2204-kube-v1.29.0
+            {{- else -}}
+            ubuntu-2204-kube-v1.30.0
+            {{- end -}}{{- end -}}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    name: vSphereTemplate

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-network-CIDR.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-network-CIDR.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.30.0/24

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set-csi-insecure.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set-csi-insecure.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vsphere-config-secret
+      namespace: vmware-system-csi
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        insecure-flag = "${VSPHERE_INSECURE_CSI}"
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/commons/cluster-resource-set.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/topology/cluster-template-topology-supervisor.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/topology/cluster-template-topology-supervisor.yaml
@@ -1,0 +1,1278 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  topology:
+    class: '${CLUSTER_CLASS_NAME}'
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: sshKey
+      value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
+    - name: kubeVipPodManifest
+      value: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_interface
+              value: ${VIP_NETWORK_INTERFACE:=""}
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: svc_enable
+              value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: svc_election
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: address
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
+            - name: prometheus_server
+              value: :2112
+            image: ghcr.io/kube-vip/kube-vip:v0.6.4
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+            - mountPath: /etc/hosts
+              name: etchosts
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+            name: kubeconfig
+          - hostPath:
+              path: /etc/kube-vip.hosts
+              type: File
+            name: etchosts
+        status: {}
+    - name: controlPlaneIpAddr
+      value: ${CONTROL_PLANE_ENDPOINT_IP}
+    - name: controlPlanePort
+      value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
+    version: '${KUBERNETES_VERSION}'
+    workers:
+      machineDeployments:
+      - class: ${CLUSTER_CLASS_NAME}-worker
+        metadata: {}
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+stringData:
+  password: "${VSPHERE_PASSWORD}"
+  username: "${VSPHERE_USERNAME}"
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: '${NAMESPACE}'
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  resources:
+  - kind: Secret
+    name: vsphere-config-secret
+  - kind: ConfigMap
+    name: csi-manifests
+  - kind: Secret
+    name: cloud-provider-vsphere-credentials
+  - kind: ConfigMap
+    name: cpi-manifests
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vsphere-config-secret
+      namespace: vmware-system-csi
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: vmware-system-csi
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: CSIDriver
+    metadata:
+      name: csi.vsphere.vmware.com
+    spec:
+      attachRequired: true
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-controller-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - storageclasses
+      - csinodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments
+      verbs:
+      - get
+      - list
+      - watch
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - triggercsifullsyncs
+      verbs:
+      - create
+      - get
+      - update
+      - watch
+      - list
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvspherevolumemigrations
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeinfoes
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments/status
+      verbs:
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeoperationrequests
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshots
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotclasses
+      verbs:
+      - watch
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents/status
+      verbs:
+      - update
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - get
+      - update
+      - watch
+      - list
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-controller-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-controller-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-node-cluster-role
+    rules:
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - create
+      - watch
+      - get
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-node-cluster-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-node-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: vsphere-csi-node-role
+      namespace: vmware-system-csi
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: vsphere-csi-node-binding
+      namespace: vmware-system-csi
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: vsphere-csi-node-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    data:
+      async-query-volume: "true"
+      block-volume-snapshot: "true"
+      cnsmgr-suspend-create-volume: "true"
+      csi-auth-check: "true"
+      csi-internal-generated-cluster-id: "true"
+      csi-migration: "true"
+      csi-windows-support: "true"
+      list-volumes: "true"
+      listview-tasks: "true"
+      max-pvscsi-targets-per-vm: "true"
+      multi-vcenter-csi-topology: "true"
+      online-volume-extend: "true"
+      pv-to-backingdiskobjectid-mapping: "false"
+      topology-preferential-datastores: "true"
+      trigger-csi-fullsync: "false"
+    kind: ConfigMap
+    metadata:
+      name: internal-feature-states.csi.vsphere.vmware.com
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      ports:
+      - name: ctlr
+        port: 2112
+        protocol: TCP
+        targetPort: 2112
+      - name: syncer
+        port: 2113
+        protocol: TCP
+        targetPort: 2113
+      selector:
+        app: vsphere-csi-controller
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vsphere-csi-controller
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-controller
+            role: vsphere-csi
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - vsphere-csi-controller
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+            name: csi-attacher
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+            name: csi-resizer
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              periodSeconds: 180
+              timeoutSeconds: 10
+            name: vsphere-csi-controller
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --leader-election
+            - --leader-election-lease-duration=30s
+            - --leader-election-renew-deadline=20s
+            - --leader-election-retry-period=10s
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: GODEBUG
+              value: x509sha1=1
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0
+            imagePullPolicy: Always
+            name: vsphere-syncer
+            ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --default-fstype=ext4
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+            name: csi-provisioner
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+            name: csi-snapshotter
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          dnsPolicy: Default
+          priorityClassName: system-cluster-critical
+          serviceAccountName: vsphere-csi-controller
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+          volumes:
+          - name: vsphere-config-volume
+            secret:
+              secretName: vsphere-config-secret
+          - emptyDir: {}
+            name: socket-dir
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node
+            role: vsphere-csi
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: GODEBUG
+              value: x509sha1=1
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+              privileged: true
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+              name: pods-mount-dir
+            - mountPath: /dev
+              name: device-dir
+            - mountPath: /sys/block
+              name: blocks-dir
+            - mountPath: /sys/devices
+              name: sys-devices-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /var/lib/kubelet/plugins_registry
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: /var/lib/kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: /dev
+            name: device-dir
+          - hostPath:
+              path: /sys/block
+              type: Directory
+            name: blocks-dir
+          - hostPath:
+              path: /sys/devices
+              type: Directory
+            name: sys-devices-dir
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node-windows
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node-windows
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node-windows
+            role: vsphere-csi-windows
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: unix://C:\\csi\\csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://C:\\csi\\csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: DEBUG
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            volumeMounts:
+            - mountPath: C:\csi
+              name: plugin-dir
+            - mountPath: C:\var\lib\kubelet
+              name: pods-mount-dir
+            - mountPath: \\.\pipe\csi-proxy-volume-v1
+              name: csi-proxy-volume-v1
+            - mountPath: \\.\pipe\csi-proxy-filesystem-v1
+              name: csi-proxy-filesystem-v1
+            - mountPath: \\.\pipe\csi-proxy-disk-v1
+              name: csi-proxy-disk-v1
+            - mountPath: \\.\pipe\csi-proxy-system-v1alpha1
+              name: csi-proxy-system-v1alpha1
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          nodeSelector:
+            kubernetes.io/os: windows
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins_registry\
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: \var\lib\kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: \\.\pipe\csi-proxy-disk-v1
+              type: ""
+            name: csi-proxy-disk-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-volume-v1
+              type: ""
+            name: csi-proxy-volume-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-filesystem-v1
+              type: ""
+            name: csi-proxy-filesystem-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-system-v1alpha1
+              type: ""
+            name: csi-proxy-system-v1alpha1
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: csi-manifests
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-vsphere-credentials
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        component: cloud-controller-manager
+        vsphere-cpi-infra: secret
+      name: cloud-provider-vsphere-credentials
+      namespace: kube-system
+    stringData:
+      ${VSPHERE_SERVER}.password: "${VSPHERE_PASSWORD}"
+      ${VSPHERE_SERVER}.username: "${VSPHERE_USERNAME}"
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |-
+    ---
+    # Source: vsphere-cpi/templates/service-account.yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: service-account
+        component: cloud-controller-manager
+      namespace: kube-system
+    ---
+    # Source: vsphere-cpi/templates/role.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: role
+        component: cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - services/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - "coordination.k8s.io"
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+    ---
+    # Source: vsphere-cpi/templates/daemonset.yaml
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-cpi
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: daemonset
+        component: cloud-controller-manager
+        tier: control-plane
+      namespace: kube-system
+      annotations:
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-cpi
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-cpi
+            component: cloud-controller-manager
+            tier: control-plane
+            release: release-name
+            vsphere-cpi-infra: daemonset
+        spec:
+          tolerations:
+          - key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+            operator: Exists
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+            operator: Exists
+          - key: node.kubernetes.io/not-ready
+            effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            effect: NoExecute
+            operator: Exists
+          securityContext:
+            fsGroup: 1001
+            runAsUser: 1001
+          serviceAccountName: cloud-controller-manager
+          hostNetwork: true
+          dnsPolicy: ClusterFirst
+          priorityClassName: system-node-critical
+          containers:
+          - name: vsphere-cpi
+            image: gcr.io/cloud-provider-vsphere/cpi/release/manager:${CPI_IMAGE_K8S_VERSION}
+            imagePullPolicy: IfNotPresent
+            args:
+              - --cloud-provider=vsphere
+              - --v=2
+              - --cloud-config=/etc/cloud/vsphere.conf
+            volumeMounts:
+              - mountPath: /etc/cloud
+                name: vsphere-config-volume
+                readOnly: true
+          volumes:
+            - name: vsphere-config-volume
+              configMap:
+                name: cloud-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: role-binding
+      name: servicecatalog.k8s.io:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - apiGroup: ""
+      kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - apiGroup: ""
+      kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: cluster-role-binding
+      name: cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    data:
+      vsphere.conf: |
+        global:
+          port: 443
+          secretName: cloud-provider-vsphere-credentials
+          secretNamespace: kube-system
+          thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+        vcenter:
+          ${VSPHERE_SERVER}:
+            datacenters:
+            - '${VSPHERE_DATACENTER}'
+            server: '${VSPHERE_SERVER}'
+    kind: ConfigMap
+    metadata:
+      name: cloud-config
+      namespace: kube-system
+kind: ConfigMap
+metadata:
+  name: cpi-manifests
+  namespace: '${NAMESPACE}'

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/topology/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-template-topology-supervisor.yaml
+  - ../commons/cluster-resource-set.yaml
+patchesStrategicMerge:
+  - ../commons/cluster-resource-set-label.yaml
+  - ../commons/cluster-network-CIDR.yaml
+  - ../commons/cluster-resource-set-csi-insecure.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/workload/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/workload/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../topology
+patches:
+  - target:
+      kind: Cluster
+    path: workload-control-plane-endpoint-ip.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/workload/workload-control-plane-endpoint-ip.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.10/workload/workload-control-plane-endpoint-ip.yaml
@@ -1,0 +1,5 @@
+- op: replace
+  path: /spec/topology/variables/2
+  value:
+    name: controlPlaneIpAddr
+    value: "${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/clusterclass-quick-start-supervisor.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/clusterclass-quick-start-supervisor.yaml
@@ -1,0 +1,324 @@
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterTemplate
+metadata:
+  name: '${CLUSTER_CLASS_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: '${CLUSTER_CLASS_NAME}'
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: ${CLUSTER_CLASS_NAME}-template
+        namespace: '${NAMESPACE}'
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: ${CLUSTER_CLASS_NAME}-controlplane
+      namespace: '${NAMESPACE}'
+  infrastructure:
+    ref:
+      apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereClusterTemplate
+      name: '${CLUSTER_CLASS_NAME}'
+      namespace: '${NAMESPACE}'
+  patches:
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    name: createEmptyArrays
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    enabledIf: '{{ if .sshKey }}true{{end}}'
+    name: enableSSHIntoNodes
+  - definitions:
+    - jsonPatches:
+      - op: replace
+        path: /spec/template/spec/controlPlaneEndpoint
+        valueFrom:
+          template: |
+            host: '{{ .controlPlaneIpAddr }}'
+            port: {{ .controlPlanePort }}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+    name: infraClusterSubstitutions
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |-
+            owner: "root:root"
+            path: "/etc/kubernetes/manifests/kube-vip.yaml"
+            content: {{ printf "%q" (regexReplaceAll "(name: address\n +value:).*" .kubeVipPodManifest (printf "$1 %s" .controlPlaneIpAddr)) }}
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: 127.0.0.1 localhost kubernetes
+            owner: root:root
+            path: /etc/kube-vip.hosts
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: |
+              #!/bin/bash
+
+              # Copyright 2020 The Kubernetes Authors.
+              #
+              # Licensed under the Apache License, Version 2.0 (the "License");
+              # you may not use this file except in compliance with the License.
+              # You may obtain a copy of the License at
+              #
+              #     http://www.apache.org/licenses/LICENSE-2.0
+              #
+              # Unless required by applicable law or agreed to in writing, software
+              # distributed under the License is distributed on an "AS IS" BASIS,
+              # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              # See the License for the specific language governing permissions and
+              # limitations under the License.
+
+              set -e
+
+              # Configure the workaround required for kubeadm init with kube-vip:
+              # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+              # Nothing to do for kubernetes < v1.29
+              KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+              if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+                exit 0
+              fi
+
+              IS_KUBEADM_INIT="false"
+
+              # cloud-init kubeadm init
+              if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              # ignition kubeadm init
+              if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+                sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+                  /etc/kubernetes/manifests/kube-vip.yaml
+              fi
+            owner: root:root
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+            permissions: "0700"
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    name: kubeVipPodManifest
+  variables:
+  - metadata: {}
+    name: sshKey
+    required: false
+    schema:
+      openAPIV3Schema:
+        description: Public key to SSH onto the cluster nodes.
+        type: string
+  - metadata: {}
+    name: controlPlaneIpAddr
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Floating VIP for the control plane.
+        type: string
+  - metadata: {}
+    name: controlPlanePort
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Port for the control plane endpoint.
+        type: integer
+  - metadata: {}
+    name: kubeVipPodManifest
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: kube-vip manifest for the control plane.
+        type: string
+  workers:
+    machineDeployments:
+    - class: ${CLUSTER_CLASS_NAME}-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
+            namespace: '${NAMESPACE}'
+        infrastructure:
+          ref:
+            apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereMachineTemplate
+            name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+            namespace: '${NAMESPACE}'
+        metadata: {}
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      className: ${VSPHERE_MACHINE_CLASS_NAME}
+      imageName: ${VSPHERE_IMAGE_NAME}
+      powerOffMode: ${VSPHERE_POWER_OFF_MODE:=trySoft}
+      storageClass: ${VSPHERE_STORAGE_CLASS}
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      className: ${VSPHERE_MACHINE_CLASS_NAME}
+      imageName: ${VSPHERE_IMAGE_NAME}
+      powerOffMode: ${VSPHERE_POWER_OFF_MODE:=trySoft}
+      storageClass: ${VSPHERE_STORAGE_CLASS}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-controlplane
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              cloud-provider: external
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        preKubeadmCommands:
+        - dhclient eth0
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+        - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+          >/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+          localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - mkdir -p /etc/pre-kubeadm-commands
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
+        users:
+        - name: capv
+          sshAuthorizedKeys:
+          - '${VSPHERE_SSH_AUTHORIZED_KEY}'
+          sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
+  namespace: '${NAMESPACE}'
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ local_hostname }}'
+      preKubeadmCommands:
+      - dhclient eth0
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+        >/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+        localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./clusterclass-quick-start-supervisor.yaml
+patches:
+  - target:
+      kind: ClusterClass
+    path: ./patch-vsphere-template.yaml
+  - target:
+      kind: ClusterClass
+    path: ./patch-prekubeadmscript.yaml
+  - target:
+      kind: ClusterClass
+    path: ./patch-namingstrategy.yaml
+  - target:
+      kind: VSphereClusterTemplate
+    path: ./patch-controlplaneendpoint.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-controlplaneendpoint.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-controlplaneendpoint.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/controlPlaneEndpoint
+  value:
+    host: ""
+    port: 0

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-namingstrategy.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-namingstrategy.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/controlPlane/namingStrategy
+  value:
+    template: '{{ .cluster.name }}-cp-{{ .random }}'
+- op: add
+  path: /spec/workers/machineDeployments/0/namingStrategy
+  value:
+    template: '{{ .cluster.name }}-md-{{ .machineDeployment.topologyName }}-{{ .random }}'

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-prekubeadmscript.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-prekubeadmscript.yaml
@@ -1,0 +1,45 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            owner: root:root
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
+            permissions: "0755"
+            content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.controlPlane.version)) }}
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: |
+            owner: root:root
+            path:  "/etc/pre-kubeadm-commands/10-prekubeadmscript.sh"
+            permissions: "0755"
+            content: {{ printf "%q" (regexReplaceAll "(KUBERNETES_VERSION=.*)" .preKubeadmScript (printf "KUBERNETES_VERSION=%s" .builtin.machineDeployment.version)) }}
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    enabledIf: '{{ if .preKubeadmScript }}true{{ end }}'
+    name: preKubeadmScript
+- op: add
+  path: /spec/variables/-
+  value:
+    name: preKubeadmScript
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        description: Script to run in preKubeadmCommands.

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-vsphere-template.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/clusterclass/patch-vsphere-template.yaml
@@ -1,0 +1,45 @@
+- op: add
+  path: /spec/patches/-
+  value:
+    definitions:
+    - jsonPatches:
+      - op: replace
+        path: /spec/template/spec/imageName
+        valueFrom:
+          # We have to fall back to v1.30.0 for the conformance latest ci test which uses
+          # versions without corresponding templates like "v1.30.0-alpha.0.525+09a5049ca78502".
+          template: |-
+            {{- if eq .builtin.controlPlane.version "v1.28.0" -}}
+            ubuntu-2204-kube-v1.28.0
+            {{- else -}}{{- if eq .builtin.controlPlane.version "v1.29.0" -}}
+            ubuntu-2204-kube-v1.29.0
+            {{- else -}}
+            ubuntu-2204-kube-v1.30.0
+            {{- end -}}{{- end -}}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: replace
+        path: /spec/template/spec/imageName
+        valueFrom:
+          # We have to fall back to v1.30.0 for the conformance latest ci test which uses
+          # versions without corresponding templates like "v1.30.0-alpha.0.525+09a5049ca78502".
+          template: |-
+            {{- if eq .builtin.machineDeployment.version "v1.28.0" -}}
+            ubuntu-2204-kube-v1.28.0
+            {{- else -}}{{- if eq .builtin.machineDeployment.version "v1.29.0" -}}
+            ubuntu-2204-kube-v1.29.0
+            {{- else -}}
+            ubuntu-2204-kube-v1.30.0
+            {{- end -}}{{- end -}}
+      selector:
+        apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - ${CLUSTER_CLASS_NAME}-worker
+    name: vSphereTemplate

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-network-CIDR.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-network-CIDR.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.30.0/24

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set-csi-insecure.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set-csi-insecure.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vsphere-config-secret
+      namespace: vmware-system-csi
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        insecure-flag = "${VSPHERE_INSECURE_CSI}"
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/commons/cluster-resource-set.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/topology/cluster-template-topology-supervisor.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/topology/cluster-template-topology-supervisor.yaml
@@ -1,0 +1,1278 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+spec:
+  topology:
+    class: '${CLUSTER_CLASS_NAME}'
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: sshKey
+      value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
+    - name: kubeVipPodManifest
+      value: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_interface
+              value: ${VIP_NETWORK_INTERFACE:=""}
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: svc_enable
+              value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: svc_election
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: address
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
+            - name: prometheus_server
+              value: :2112
+            image: ghcr.io/kube-vip/kube-vip:v0.6.4
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+            - mountPath: /etc/hosts
+              name: etchosts
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+            name: kubeconfig
+          - hostPath:
+              path: /etc/kube-vip.hosts
+              type: File
+            name: etchosts
+        status: {}
+    - name: controlPlaneIpAddr
+      value: ${CONTROL_PLANE_ENDPOINT_IP}
+    - name: controlPlanePort
+      value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
+    version: '${KUBERNETES_VERSION}'
+    workers:
+      machineDeployments:
+      - class: ${CLUSTER_CLASS_NAME}-worker
+        metadata: {}
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: '${NAMESPACE}'
+stringData:
+  password: "${VSPHERE_PASSWORD}"
+  username: "${VSPHERE_USERNAME}"
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: '${NAMESPACE}'
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  resources:
+  - kind: Secret
+    name: vsphere-config-secret
+  - kind: ConfigMap
+    name: csi-manifests
+  - kind: Secret
+    name: cloud-provider-vsphere-credentials
+  - kind: ConfigMap
+    name: cpi-manifests
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vsphere-config-secret
+      namespace: vmware-system-csi
+    stringData:
+      csi-vsphere.conf: |+
+        [Global]
+        thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
+
+        [VirtualCenter "${VSPHERE_SERVER}"]
+        user = "${VSPHERE_USERNAME}"
+        password = "${VSPHERE_PASSWORD}"
+        datacenters = "${VSPHERE_DATACENTER}"
+
+        [Network]
+        public-network = "${VSPHERE_NETWORK}"
+
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: vmware-system-csi
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: CSIDriver
+    metadata:
+      name: csi.vsphere.vmware.com
+    spec:
+      attachRequired: true
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-controller-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumeclaims/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - storageclasses
+      - csinodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments
+      verbs:
+      - get
+      - list
+      - watch
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - triggercsifullsyncs
+      verbs:
+      - create
+      - get
+      - update
+      - watch
+      - list
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvspherevolumemigrations
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeinfoes
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - storage.k8s.io
+      resources:
+      - volumeattachments/status
+      verbs:
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - cnsvolumeoperationrequests
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshots
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotclasses
+      verbs:
+      - watch
+      - get
+      - list
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+    - apiGroups:
+      - snapshot.storage.k8s.io
+      resources:
+      - volumesnapshotcontents/status
+      verbs:
+      - update
+      - patch
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - get
+      - update
+      - watch
+      - list
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-controller-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-controller-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: vsphere-csi-node-cluster-role
+    rules:
+    - apiGroups:
+      - cns.vmware.com
+      resources:
+      - csinodetopologies
+      verbs:
+      - create
+      - watch
+      - get
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: vsphere-csi-node-cluster-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: vsphere-csi-node-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: vsphere-csi-node-role
+      namespace: vmware-system-csi
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: vsphere-csi-node-binding
+      namespace: vmware-system-csi
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: vsphere-csi-node-role
+    subjects:
+    - kind: ServiceAccount
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    data:
+      async-query-volume: "true"
+      block-volume-snapshot: "true"
+      cnsmgr-suspend-create-volume: "true"
+      csi-auth-check: "true"
+      csi-internal-generated-cluster-id: "true"
+      csi-migration: "true"
+      csi-windows-support: "true"
+      list-volumes: "true"
+      listview-tasks: "true"
+      max-pvscsi-targets-per-vm: "true"
+      multi-vcenter-csi-topology: "true"
+      online-volume-extend: "true"
+      pv-to-backingdiskobjectid-mapping: "false"
+      topology-preferential-datastores: "true"
+      trigger-csi-fullsync: "false"
+    kind: ConfigMap
+    metadata:
+      name: internal-feature-states.csi.vsphere.vmware.com
+      namespace: vmware-system-csi
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      ports:
+      - name: ctlr
+        port: 2112
+        protocol: TCP
+        targetPort: 2112
+      - name: syncer
+        port: 2113
+        protocol: TCP
+        targetPort: 2113
+      selector:
+        app: vsphere-csi-controller
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vsphere-csi-controller
+      namespace: vmware-system-csi
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vsphere-csi-controller
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-controller
+            role: vsphere-csi
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - vsphere-csi-controller
+                topologyKey: kubernetes.io/hostname
+          containers:
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+            name: csi-attacher
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+            name: csi-resizer
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: controller
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              periodSeconds: 180
+              timeoutSeconds: 10
+            name: vsphere-csi-controller
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --leader-election
+            - --leader-election-lease-duration=30s
+            - --leader-election-renew-deadline=20s
+            - --leader-election-retry-period=10s
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: GODEBUG
+              value: x509sha1=1
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0
+            imagePullPolicy: Always
+            name: vsphere-syncer
+            ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+            securityContext:
+              runAsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          - args:
+            - --v=4
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            - --default-fstype=ext4
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+            name: csi-provisioner
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          - args:
+            - --v=4
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+            - --timeout=300s
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --leader-election-lease-duration=120s
+            - --leader-election-renew-deadline=60s
+            - --leader-election-retry-period=30s
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+            name: csi-snapshotter
+            volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          dnsPolicy: Default
+          priorityClassName: system-cluster-critical
+          serviceAccountName: vsphere-csi-controller
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+          volumes:
+          - name: vsphere-config-volume
+            secret:
+              secretName: vsphere-config-secret
+          - emptyDir: {}
+            name: socket-dir
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node
+            role: vsphere-csi
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: GODEBUG
+              value: x509sha1=1
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+              privileged: true
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+              name: pods-mount-dir
+            - mountPath: /dev
+              name: device-dir
+            - mountPath: /sys/block
+              name: blocks-dir
+            - mountPath: /sys/devices
+              name: sys-devices-dir
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: /var/lib/kubelet/plugins_registry
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: /var/lib/kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: /dev
+            name: device-dir
+          - hostPath:
+              path: /sys/block
+              type: Directory
+            name: blocks-dir
+          - hostPath:
+              path: /sys/devices
+              type: Directory
+            name: sys-devices-dir
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-csi-node-windows
+      namespace: vmware-system-csi
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-csi-node-windows
+      template:
+        metadata:
+          labels:
+            app: vsphere-csi-node-windows
+            role: vsphere-csi-windows
+        spec:
+          containers:
+          - args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            env:
+            - name: ADDRESS
+              value: unix://C:\\csi\\csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+            image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+            livenessProbe:
+              exec:
+                command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+                - --mode=kubelet-registration-probe
+              initialDelaySeconds: 3
+            name: node-driver-registrar
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+          - args:
+            - --fss-name=internal-feature-states.csi.vsphere.vmware.com
+            - --fss-namespace=$(CSI_NAMESPACE)
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://C:\\csi\\csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59"
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: DEBUG
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+            image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
+            imagePullPolicy: Always
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              timeoutSeconds: 5
+            name: vsphere-csi-node
+            ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+            volumeMounts:
+            - mountPath: C:\csi
+              name: plugin-dir
+            - mountPath: C:\var\lib\kubelet
+              name: pods-mount-dir
+            - mountPath: \\.\pipe\csi-proxy-volume-v1
+              name: csi-proxy-volume-v1
+            - mountPath: \\.\pipe\csi-proxy-filesystem-v1
+              name: csi-proxy-filesystem-v1
+            - mountPath: \\.\pipe\csi-proxy-disk-v1
+              name: csi-proxy-disk-v1
+            - mountPath: \\.\pipe\csi-proxy-system-v1alpha1
+              name: csi-proxy-system-v1alpha1
+          - args:
+            - --v=4
+            - --csi-address=/csi/csi.sock
+            image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+            name: liveness-probe
+            volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          nodeSelector:
+            kubernetes.io/os: windows
+          priorityClassName: system-node-critical
+          serviceAccountName: vsphere-csi-node
+          tolerations:
+          - effect: NoExecute
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          volumes:
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins_registry\
+              type: Directory
+            name: registration-dir
+          - hostPath:
+              path: C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\
+              type: DirectoryOrCreate
+            name: plugin-dir
+          - hostPath:
+              path: \var\lib\kubelet
+              type: Directory
+            name: pods-mount-dir
+          - hostPath:
+              path: \\.\pipe\csi-proxy-disk-v1
+              type: ""
+            name: csi-proxy-disk-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-volume-v1
+              type: ""
+            name: csi-proxy-volume-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-filesystem-v1
+              type: ""
+            name: csi-proxy-filesystem-v1
+          - hostPath:
+              path: \\.\pipe\csi-proxy-system-v1alpha1
+              type: ""
+            name: csi-proxy-system-v1alpha1
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: csi-manifests
+  namespace: '${NAMESPACE}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-vsphere-credentials
+  namespace: '${NAMESPACE}'
+stringData:
+  data: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        component: cloud-controller-manager
+        vsphere-cpi-infra: secret
+      name: cloud-provider-vsphere-credentials
+      namespace: kube-system
+    stringData:
+      ${VSPHERE_SERVER}.password: "${VSPHERE_PASSWORD}"
+      ${VSPHERE_SERVER}.username: "${VSPHERE_USERNAME}"
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |-
+    ---
+    # Source: vsphere-cpi/templates/service-account.yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: service-account
+        component: cloud-controller-manager
+      namespace: kube-system
+    ---
+    # Source: vsphere-cpi/templates/role.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: cloud-controller-manager
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: role
+        component: cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - services/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - "coordination.k8s.io"
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+    ---
+    # Source: vsphere-cpi/templates/daemonset.yaml
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: vsphere-cpi
+      labels:
+        app: vsphere-cpi
+        vsphere-cpi-infra: daemonset
+        component: cloud-controller-manager
+        tier: control-plane
+      namespace: kube-system
+      annotations:
+    spec:
+      selector:
+        matchLabels:
+          app: vsphere-cpi
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: vsphere-cpi
+            component: cloud-controller-manager
+            tier: control-plane
+            release: release-name
+            vsphere-cpi-infra: daemonset
+        spec:
+          tolerations:
+          - key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+            operator: Exists
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+            operator: Exists
+          - key: node.kubernetes.io/not-ready
+            effect: NoSchedule
+            operator: Exists
+          - key: CriticalAddonsOnly
+            effect: NoExecute
+            operator: Exists
+          securityContext:
+            fsGroup: 1001
+            runAsUser: 1001
+          serviceAccountName: cloud-controller-manager
+          hostNetwork: true
+          dnsPolicy: ClusterFirst
+          priorityClassName: system-node-critical
+          containers:
+          - name: vsphere-cpi
+            image: gcr.io/cloud-provider-vsphere/cpi/release/manager:${CPI_IMAGE_K8S_VERSION}
+            imagePullPolicy: IfNotPresent
+            args:
+              - --cloud-provider=vsphere
+              - --v=2
+              - --cloud-config=/etc/cloud/vsphere.conf
+            volumeMounts:
+              - mountPath: /etc/cloud
+                name: vsphere-config-volume
+                readOnly: true
+          volumes:
+            - name: vsphere-config-volume
+              configMap:
+                name: cloud-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: role-binding
+      name: servicecatalog.k8s.io:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - apiGroup: ""
+      kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - apiGroup: ""
+      kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: vsphere-cpi
+        component: cloud-controller-manager
+        vsphere-cpi-infra: cluster-role-binding
+      name: cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    data:
+      vsphere.conf: |
+        global:
+          port: 443
+          secretName: cloud-provider-vsphere-credentials
+          secretNamespace: kube-system
+          thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+        vcenter:
+          ${VSPHERE_SERVER}:
+            datacenters:
+            - '${VSPHERE_DATACENTER}'
+            server: '${VSPHERE_SERVER}'
+    kind: ConfigMap
+    metadata:
+      name: cloud-config
+      namespace: kube-system
+kind: ConfigMap
+metadata:
+  name: cpi-manifests
+  namespace: '${NAMESPACE}'

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/topology/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-template-topology-supervisor.yaml
+  - ../commons/cluster-resource-set.yaml
+patchesStrategicMerge:
+  - ../commons/cluster-resource-set-label.yaml
+  - ../commons/cluster-network-CIDR.yaml
+  - ../commons/cluster-resource-set-csi-insecure.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/workload/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/workload/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../topology
+patches:
+  - target:
+      kind: Cluster
+    path: workload-control-plane-endpoint-ip.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/workload/workload-control-plane-endpoint-ip.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.9/workload/workload-control-plane-endpoint-ip.yaml
@@ -1,0 +1,5 @@
+- op: replace
+  path: /spec/topology/variables/2
+  value:
+    name: controlPlaneIpAddr
+    value: "${WORKLOAD_CONTROL_PLANE_ENDPOINT_IP}"

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -74,10 +74,11 @@ func WithPrefix(variableName string) SetupOption {
 }
 
 type testSettings struct {
-	ClusterctlConfigPath     string
-	Variables                map[string]string
-	PostNamespaceCreatedFunc func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
-	FlavorForMode            func(flavor string) string
+	ClusterctlConfigPath      string
+	Variables                 map[string]string
+	PostNamespaceCreatedFunc  func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+	FlavorForMode             func(flavor string) string
+	RuntimeExtensionProviders []string
 }
 
 // Setup for the specific test.
@@ -92,6 +93,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 		testSpecificIPAddressClaims      vsphereip.AddressClaims
 		testSpecificVariables            map[string]string
 		postNamespaceCreatedFunc         func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+		runtimeExtensionProviders        []string
 	)
 	BeforeEach(func() {
 		Byf("Setting up test env for %s", specName)
@@ -182,6 +184,14 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			OutputPath:           testSpecificClusterctlConfigPath,
 			Variables:            testSpecificVariables,
 		})
+
+		if testMode == SupervisorTestMode {
+			runtimeExtensionProviders = append(runtimeExtensionProviders, "vm-operator", "net-operator")
+		}
+
+		if testTarget == VCSimTestTarget {
+			runtimeExtensionProviders = append(runtimeExtensionProviders, "vcsim")
+		}
 	})
 	defer AfterEach(func() {
 		Byf("Cleaning up test env for %s", specName)
@@ -214,6 +224,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 				}
 				return flavor
 			},
+			RuntimeExtensionProviders: runtimeExtensionProviders,
 		}
 	})
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -142,7 +142,15 @@ func LoadE2EConfig(ctx context.Context, configPath string, configOverridesPath, 
 		Byf("Overriding source folder for vsphere provider to /config/supervisor in the e2e config")
 		for i := range config.Providers {
 			if config.Providers[i].Name == "vsphere" {
+				// Replace relativ path for latest version.
 				config.Providers[i].Versions[0].Value = strings.ReplaceAll(config.Providers[i].Versions[0].Value, "/config/default", "/config/supervisor")
+				// Replace target file in github.
+				for j, version := range config.Providers[i].Versions {
+					if strings.HasSuffix(version.Value, "infrastructure-components.yaml") {
+						version.Value = fmt.Sprintf("%s-supervisor.yaml", strings.TrimSuffix(version.Value, ".yaml"))
+						config.Providers[i].Versions[j] = version
+					}
+				}
 				break
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

- Enable test "When testing clusterctl upgrades using ClusterClass"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of  #2995
