### PR TITLE
🌱 cloudbuild: bump images to match capi

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:de53ba7cd20326776a00adb065430a8bb51beaf24876ffcbd4e8f71b74dbc22d' # v20240210-29014a6e3a
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:de53ba7cd20326776a00adb065430a8bb51beaf24876ffcbd4e8f71b74dbc22d' # v20240210-29014a6e3a
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

This should fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-provider-vsphere-push-images/1800527833475321856

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
