### PR TITLE
🌱 Makefile: drop OVERRIDES_DIR and dependent make targets

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -80,10 +80,12 @@ make docker-push-all ALL_ARCH=$(go env GOARCH)
 
 Overrides need to be placed in `~/.cluster-api/overrides/infrastructure-vsphere/{version}`
 
-Running the following generates these overrides for you:
+Running the following re-generates the manifests for you and copies them over:
 
 ``` shell
-make dev-manifests
+mkdir -p "~/.cluster-api/overrides/infrastructure-vsphere/$(cat clusterctl-settings.json | jq .config.nextVersion -r)"
+make manifest-modification REGISTRY=$(REGISTRY) RELEASE_TAG=$(TAG) PULL_POLICY=Always
+make release-manifests STAGE=dev MANIFEST_DIR="~/.cluster-api/overrides/infrastructure-vsphere/$(cat clusterctl-settings.json | jq .config.nextVersion -r)"
 ```
 
 For development purposes, if you are using a `major.minor.x` version (see env variable VERSION) which is not present in the `metadata.yml`, include this version entry along with the API contract in the file.
@@ -95,8 +97,8 @@ After publishing your test image and generating the manifests, you can use
 
 #### Using custom cluster-templates  
 
-In order to generate a custom `custom-template.yaml`, run `make dev-flavors`.  
-This command will generate a `cluster-template.yaml` at and the logs will mention the path where this file is generated. On mac it will look something like this - `/Users/<user>/.cluster-api/overrides/infrastructure-vsphere/v0.x.0/cluster-template.yaml`.  
+In order to generate a custom `custom-template.yaml`, run `make generate-flavors`.  
+This command will generate all flavors in the `templates` directory.
 To create this custom cluster, use `clusterctl generate cluster --from="<cluster_template_path>" <cluster_name>`  
 
 ## Testing e2e


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Some cleanup to our Makefile to drop:

* Variable `VERSION` (only used for `OVERRIDES_DIR`)
* Variable `OVERRIDES_DIR`
* Make targets which did use `OVERRIDES_DIR`:
  * `dev-manifests`: generated manifests and copied them to `$HOME/.cluster-api/overrides/infrastructure-vsphere/...`
  * `dev-flavors`: generated flavors and copied them to `$HOME/.cluster-api/overrides/infrastructure-vsphere/...`

Folks should use tilt instead which also allows to add the templates directory to tilt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
