### PR TITLE
🌱 Drop pre-load of cert-manager images in E2E tests

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -8,12 +8,6 @@
 # For creating local images, run ./hack/e2e.sh
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.1
-    loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.1
-    loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.1
-    loadBehavior: tryLoad
   - name: registry.k8s.io/capi-ipam-ic/cluster-api-ipam-in-cluster-controller:v0.1.0
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller-{ARCH}:dev

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -24,12 +24,6 @@ images:
     loadBehavior: mustLoad
   - name: gcr.io/k8s-staging-capi-vsphere/extra/vm-operator:v1.8.6-0-gde75746a
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
-    loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v1.12.2
-    loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v1.12.2
-    loadBehavior: tryLoad
 
 providers:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3046
