### PR TITLE
🌱 test: use rolloutStrategy to speed up K8s-Upgrade tests to not hit rollout timeout

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -291,6 +291,7 @@ intervals:
   default/wait-worker-nodes: ["10m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-nodes-ready: ["10m", "10s"]
   default/wait-machine-remediation: ["15m", "10s"]
   mhc-remediation/mhc-remediation: ["30m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/install-on-bootstrap/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/install-on-bootstrap/kustomization.yaml
@@ -6,3 +6,6 @@ patches:
   - target:
       kind: Cluster
     path: ./inject-install-on-bootstrap.yaml
+  - target:
+      kind: Cluster
+    path: ./set-md-rollout-strategy.yaml

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/install-on-bootstrap/set-md-rollout-strategy.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/install-on-bootstrap/set-md-rollout-strategy.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/topology/workers/machineDeployments/0/strategy
+  value:
+    rollingUpdate:
+      maxUnavailable: "100%"
+      maxSurge: "100%"
+    type: RollingUpdate

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/install-on-bootstrap/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/install-on-bootstrap/kustomization.yaml
@@ -6,3 +6,6 @@ patches:
   - target:
       kind: Cluster
     path: ./inject-install-on-bootstrap.yaml
+  - target:
+      kind: Cluster
+    path: ./set-md-rollout-strategy.yaml

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/install-on-bootstrap/set-md-rollout-strategy.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/install-on-bootstrap/set-md-rollout-strategy.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/topology/workers/machineDeployments/0/strategy
+  value:
+    rollingUpdate:
+      maxUnavailable: "100%"
+      maxSurge: "100%"
+    type: RollingUpdate


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This speeds up the K8s-Upgrade tests by changing the rolloutStrategy for MachineDeployments in the used `install-on-bootstrap` flavor.

This test uses 5 replicas for the machine deployment which makes the test currently flaky by reaching the 15mins timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
