### PR TITLE
🌱 [release-1.9] test: use rolloutStrategy to speed up K8s-Upgrade tests to not hit rollout timeout

### DIFF
--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -219,6 +219,7 @@ intervals:
   default/wait-worker-nodes: ["10m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-nodes-ready: ["10m", "10s"]
   default/wait-machine-remediation: ["15m", "10s"]
   mhc-remediation/mhc-remediation: ["30m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -243,6 +243,7 @@ intervals:
   default/wait-worker-nodes: ["10m", "10s"]
   default/wait-delete-cluster: ["5m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-nodes-ready: ["10m", "10s"]
   default/wait-machine-remediation: ["15m", "10s"]
   mhc-remediation/mhc-remediation: ["30m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]

--- a/test/e2e/data/infrastructure-vsphere/main/install-on-bootstrap/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere/main/install-on-bootstrap/kustomization.yaml
@@ -6,3 +6,6 @@ patches:
   - target:
       kind: Cluster
     path: ./inject-install-on-bootstrap.yaml
+  - target:
+      kind: Cluster
+    path: ./set-md-rollout-strategy.yaml

--- a/test/e2e/data/infrastructure-vsphere/main/install-on-bootstrap/set-md-rollout-strategy.yaml
+++ b/test/e2e/data/infrastructure-vsphere/main/install-on-bootstrap/set-md-rollout-strategy.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/topology/workers/machineDeployments/0/strategy
+  value:
+    rollingUpdate:
+      maxUnavailable: "100%"
+      maxSurge: "100%"
+    type: RollingUpdate


### PR DESCRIPTION
Manual cherry-pick of #3061