### PR TITLE
[release-1.9] ✨ Bump to Go 1.22.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  go: "1.21"
+  go: "1.22"
   skip-files:
     - "zz_generated.*\\.go$"
     - "_conversion\\.go$"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.21.11
+GO_VERSION ?= 1.22.4
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -18,14 +18,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# MIN_GO_VERSION is the minimum, supported Go version.
-# Note: Enforce only the minor version as we can't guarantee that
-# the images we use in ProwJobs already use the latest patch version.
-MIN_GO_VERSION="go${MIN_GO_VERSION:-1.21}"
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+# shellcheck source=./hack/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {
-  if ! command -v go >/dev/null 2>&1; then
+  if [[ -z "$(command -v go)" ]]; then
     cat <<EOF
 Can't find 'go' in PATH, please fix and retry.
 See http://golang.org/doc/install for installation instructions.
@@ -34,19 +36,22 @@ EOF
   fi
 
   local go_version
-  IFS=" " read -ra go_version <<<"$(go version)"
-  if [ "${go_version[2]}" != 'devel' ] && \
-     [ "${MIN_GO_VERSION}" != "$(printf "%s\n%s" "${MIN_GO_VERSION}" "${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1)" ]; then
+  IFS=" " read -ra go_version <<< "$(go version)"
+  local minimum_go_version
+  minimum_go_version=go1.22
+  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.
-Kubernetes requires ${MIN_GO_VERSION} or greater.
-Please install ${MIN_GO_VERSION} or later.
+Kubernetes requires ${minimum_go_version} or greater.
+Please install ${minimum_go_version} or later.
 EOF
     return 2
   fi
 }
 
-verify_go_version
 
-# Explicitly opt into go modules.
+verify_go_version
+verify_gopath_bin
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,3 +17,18 @@
 get_root_path() {
     git rev-parse --show-toplevel
 }
+
+# ensure GOPATH/bin is in PATH as we may install binaries to that directory in
+# other ensure-* scripts, and expect them to be found in PATH later on
+verify_gopath_bin() {
+    local gopath_bin
+
+    gopath_bin="$(go env GOPATH)/bin"
+    if ! printenv PATH | grep -q "${gopath_bin}"; then
+        cat <<EOF
+error: \$GOPATH/bin=${gopath_bin} is not in your PATH.
+See https://go.dev/doc/gopath_code for more instructions.
+EOF
+        return 2
+    fi
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Bumps to Go 1.22 to stay on a supported Go version



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
