### PR TITLE
🌱 use sha256 thumbprint in tests

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -115,7 +115,7 @@ VSPHERE_FOLDER: "vm"                                          # The VM folder fo
 VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.17.3"                  # The VM template to use for your management cluster.
 CONTROL_PLANE_ENDPOINT_IP: "192.168.9.230"                    # the IP that kube-vip is going to use as a control plane endpoint
 VIP_NETWORK_INTERFACE: "ens192"                               # The interface that kube-vip should apply the IP to. Omit to tell kube-vip to autodetect the interface.
-VSPHERE_TLS_THUMBPRINT: "..."                                 # sha1 thumbprint of the vcenter certificate: openssl x509 -sha1 -fingerprint -in ca.crt -noout
+VSPHERE_TLS_THUMBPRINT: "..."                                 # sha256 thumbprint of the vcenter certificate: openssl x509 -sha256 -fingerprint -in ca.crt -noout
 EXP_CLUSTER_RESOURCE_SET: "true"                              # This enables the ClusterResourceSet feature that we are using to deploy CSI
 VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."              # The public ssh authorized key on all machines in this cluster.
                                                               #  Set to "" if you don't want to enable SSH, or are using another solution.

--- a/test/infrastructure/vcsim/controllers/vcsim_controller.go
+++ b/test/infrastructure/vcsim/controllers/vcsim_controller.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha1" //nolint: gosec
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -206,7 +206,7 @@ func (r *VCenterSimulatorReconciler) reconcileNormal(ctx context.Context, vCente
 		defer conn.Close()
 
 		cert := conn.ConnectionState().PeerCertificates[0]
-		vCenterSimulator.Status.Thumbprint = ThumbprintSHA1(cert)
+		vCenterSimulator.Status.Thumbprint = ThumbprintSHA256(cert)
 	}
 
 	if r.SupervisorMode {
@@ -293,9 +293,9 @@ func (r *VCenterSimulatorReconciler) SetupWithManager(ctx context.Context, mgr c
 	return nil
 }
 
-// ThumbprintSHA1 returns the thumbprint of the given cert in the same format used by the SDK and Client.SetThumbprint.
-func ThumbprintSHA1(cert *x509.Certificate) string {
-	sum := sha1.Sum(cert.Raw) //nolint: gosec
+// ThumbprintSHA256 returns the thumbprint of the given cert in the same format used by the SDK and Client.SetThumbprint.
+func ThumbprintSHA256(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
 	hex := make([]string, len(sum))
 	for i, b := range sum {
 		hex[i] = fmt.Sprintf("%02X", b)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

sha1 support for certificates gets removed in Go 1.24 ([xref](https://github.com/golang/go/issues/62048)).

Due to its insecurity we should also use sha256 for thumbprints to ensure this works.

Note: govmomi directly verifies the thumbprint and does not use the library for it, so its not going to break with v1.24.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
