### PR TITLE
🌱  test: implement check for all pods running

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -17,9 +17,17 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
@@ -45,13 +53,14 @@ var _ = Describe("ClusterClass Creation using Cluster API quick-start test [vcsi
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 			return capi_e2e.QuickStartSpecInput{
-				E2EConfig:             e2eConfig,
-				ClusterctlConfigPath:  testSpecificSettingsGetter().ClusterctlConfigPath,
-				BootstrapClusterProxy: bootstrapClusterProxy,
-				ArtifactFolder:        artifactFolder,
-				SkipCleanup:           skipCleanup,
-				Flavor:                ptr.To(testSpecificSettingsGetter().FlavorForMode("topology")),
-				PostNamespaceCreated:  testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+				E2EConfig:               e2eConfig,
+				ClusterctlConfigPath:    testSpecificSettingsGetter().ClusterctlConfigPath,
+				BootstrapClusterProxy:   bootstrapClusterProxy,
+				ArtifactFolder:          artifactFolder,
+				SkipCleanup:             skipCleanup,
+				Flavor:                  ptr.To(testSpecificSettingsGetter().FlavorForMode("topology")),
+				PostNamespaceCreated:    testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+				PostMachinesProvisioned: checkAllPodsReady,
 			}
 		})
 	})
@@ -73,3 +82,38 @@ var _ = Describe("Cluster creation with [Ignition] bootstrap [PR-Blocking]", fun
 		})
 	})
 })
+
+func checkAllPodsReady(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string) {
+	if testTarget == VCSimTestTarget {
+		return
+	}
+
+	wlProxy := managementClusterProxy.GetWorkloadCluster(ctx, workloadClusterNamespace, workloadClusterName)
+	wlClient := wlProxy.GetClient()
+
+	pods := &corev1.PodList{}
+	Eventually(func() error {
+		if err := wlClient.List(ctx, pods); err != nil {
+			return err
+		}
+
+		errs := []error{}
+
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				errs = append(errs, fmt.Errorf("pod %s not in phase running", klog.KObj(&pod)))
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type != corev1.PodReady {
+					continue
+				}
+				if cond.Status != corev1.ConditionTrue {
+					errs = append(errs, fmt.Errorf("pod %s not ready: reason=%q message=%q", klog.KObj(&pod), cond.Reason, cond.Message))
+				}
+				break
+			}
+		}
+
+		return kerrors.NewAggregate(errs)
+	}, time.Minute*5, time.Second).Should(Succeed())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds a check to the basic PR-Blocking test to check if all pods (e.g. CSI) are running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
