### PR TITLE
🌱 test: allow retries creating vcsim

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -212,7 +212,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Byf("Creating a vcsim server")
 		Eventually(func() error {
 			return vspherevcsim.Create(ctx, bootstrapClusterProxy.GetClient())
-		}, 30*time.Second, 3*time.Second).ShouldNot(HaveOccurred(), "Failed to create VCenterSimulator")
+		}, time.Minute, 3*time.Second).ShouldNot(HaveOccurred(), "Failed to create VCenterSimulator")
 	}
 
 	By("Getting AddressClaim labels")

--- a/test/framework/vcsim/server.go
+++ b/test/framework/vcsim/server.go
@@ -68,7 +68,7 @@ func Get(ctx context.Context, c client.Client) (*vcsimv1.VCenterSimulator, error
 
 	var retryError error
 	// Wait for the Server to report an address.
-	_ = wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(ctx context.Context) (done bool, err error) {
+	_ = wait.PollUntilContextTimeout(ctx, time.Second, time.Second*5, true, func(ctx context.Context) (done bool, err error) {
 		if err := c.Get(ctx, client.ObjectKeyFromObject(vcsim), vcsim); err != nil {
 			retryError = errors.Wrap(err, "getting VCenterSimulator")
 			return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The upper timeout was 30s and the inner retry also 30s leading to not actually doing a retry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
