### PR TITLE
🌱 test: fix wording in vsphere.yaml comment, always use bootstrapClusterProxy to get vCenterSimulator

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -264,7 +264,7 @@ variables:
   EXP_NODE_ANTI_AFFINITY: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
-  # Required to be set to install capv-supervisor <= v1.10, but getting created.
+  # Required to be set to install capv-supervisor <= v1.10.
   SERVICE_ACCOUNTS_CM_NAMESPACE: "capv-system"
   SERVICE_ACCOUNTS_CM_NAME: "service-accounts-cm"
 

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -111,7 +111,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			testSpecificIPAddressClaims, testSpecificVariables = vcsimAddressManager.ClaimIPs(ctx, vsphereip.WithIP(options.additionalIPVariableNames...))
 
 			// variables derived from the vCenterSimulator
-			vCenterSimulator, err := vspherevcsim.Get(ctx, c)
+			vCenterSimulator, err := vspherevcsim.Get(ctx, bootstrapClusterProxy.GetClient())
 			Expect(err).ToNot(HaveOccurred(), "Failed to get VCenterSimulator")
 
 			Byf("Creating EnvVar %s", klog.KRef(metav1.NamespaceDefault, specName))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
