### PR TITLE
🌱 test: enable vcsim to run clusterctl upgrade e2e tests

### DIFF
--- a/test/e2e/anti_affinity_test.go
+++ b/test/e2e/anti_affinity_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Cluster creation with anti affined nodes", func() {
 
 		BeforeEach(func() {
 			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-			namespace = setupSpecNamespace("anti-affinity-e2e")
+			namespace = setupSpecNamespace("anti-affinity-e2e", testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 		})
 
 		AfterEach(func() {

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -25,6 +25,8 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/framework/vcsim"
 )
 
 var (
@@ -67,11 +69,11 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10
 				InitWithKubernetesVersion:                "v1.30.0",
 				WorkloadKubernetesVersion:                "v1.30.0",
 				WorkloadFlavor:                           testSpecificSettingsGetter().FlavorForMode("workload"),
-				UseKindForManagementCluster:              true,
+				UseKindForManagementCluster:              testSpecificSettingsGetter().UseKindForManagementCluster,
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithUseKindForManagementCluster())
+	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithAdditionalVCSimServer(true))
 })
 
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=>current, CAPI 1.6=>1.8) [vcsim] [supervisor] [ClusterClass]", func() {
@@ -105,11 +107,11 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 				InitWithKubernetesVersion:                "v1.29.0",
 				WorkloadKubernetesVersion:                "v1.29.0",
 				WorkloadFlavor:                           testSpecificSettingsGetter().FlavorForMode("workload"),
-				UseKindForManagementCluster:              true,
+				UseKindForManagementCluster:              testSpecificSettingsGetter().UseKindForManagementCluster,
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithUseKindForManagementCluster())
+	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithAdditionalVCSimServer(true))
 })
 
 // getStableReleaseOfMinor returns the latest stable version of minorRelease.
@@ -119,5 +121,8 @@ func getStableReleaseOfMinor(ctx context.Context, releaseMarkerPrefix, minorRele
 }
 
 func kindManagementClusterNewClusterProxyFunc(name string, kubeconfigPath string) framework.ClusterProxy {
+	if testTarget == VCSimTestTarget {
+		return vcsim.NewClusterProxy(name, kubeconfigPath, initScheme())
+	}
 	return framework.NewClusterProxy(name, kubeconfigPath, initScheme())
 }

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -36,7 +36,7 @@ var (
 	capvReleaseMarkerPrefix = "go://sigs.k8s.io/cluster-api-provider-vsphere@v%s"
 )
 
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10=>current, CAPI 1.7=>1.8) [supervisor] [ClusterClass]", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10=>current, CAPI 1.7=>1.8) [vcsim] [supervisor] [ClusterClass]", func() {
 	const specName = "clusterctl-upgrade-1.10-current" // prefix (clusterctl-upgrade) copied from CAPI
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
@@ -71,10 +71,10 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"))
+	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithUseKindForManagementCluster())
 })
 
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=>current, CAPI 1.6=>1.8) [supervisor] [ClusterClass]", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=>current, CAPI 1.6=>1.8) [vcsim] [supervisor] [ClusterClass]", func() {
 	const specName = "clusterctl-upgrade-1.9-current" // prefix (clusterctl-upgrade) copied from CAPI
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
@@ -109,7 +109,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"))
+	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithUseKindForManagementCluster())
 })
 
 // getStableReleaseOfMinor returns the latest stable version of minorRelease.

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -66,14 +66,20 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.10
 				// InitWithKubernetesVersion should be the highest kubernetes version supported by the init Cluster API version.
 				// This is to guarantee that both, the old and new CAPI version, support the defined version.
 				// Ensure all Kubernetes versions used here are covered in patch-vsphere-template.yaml
-				InitWithKubernetesVersion:                "v1.30.0",
-				WorkloadKubernetesVersion:                "v1.30.0",
-				WorkloadFlavor:                           testSpecificSettingsGetter().FlavorForMode("workload"),
-				UseKindForManagementCluster:              testSpecificSettingsGetter().UseKindForManagementCluster,
+				InitWithKubernetesVersion: "v1.30.0",
+				WorkloadKubernetesVersion: "v1.30.0",
+				WorkloadFlavor:            testSpecificSettingsGetter().FlavorForMode("workload"),
+				// We are using a separate management cluster. For running in VCSim we also have to pass WithAdditionalVCSimServer
+				// below otherwise there will be no VCSim instance created in the management cluster.
+				UseKindForManagementCluster:              true,
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithAdditionalVCSimServer(true))
+	},
+		WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"),
+		// This is required because we are using a separate management cluster with kind by passing `UseKindForManagementCluster` above.
+		WithAdditionalVCSimServer(true),
+	)
 })
 
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=>current, CAPI 1.6=>1.8) [vcsim] [supervisor] [ClusterClass]", func() {
@@ -104,14 +110,20 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.9=
 				// InitWithKubernetesVersion should be the highest kubernetes version supported by the init Cluster API version.
 				// This is to guarantee that both, the old and new CAPI version, support the defined version.
 				// Ensure all Kubernetes versions used here are covered in patch-vsphere-template.yaml
-				InitWithKubernetesVersion:                "v1.29.0",
-				WorkloadKubernetesVersion:                "v1.29.0",
-				WorkloadFlavor:                           testSpecificSettingsGetter().FlavorForMode("workload"),
-				UseKindForManagementCluster:              testSpecificSettingsGetter().UseKindForManagementCluster,
+				InitWithKubernetesVersion: "v1.29.0",
+				WorkloadKubernetesVersion: "v1.29.0",
+				WorkloadFlavor:            testSpecificSettingsGetter().FlavorForMode("workload"),
+				// We are using a separate management cluster. For running in VCSim we also have to pass WithAdditionalVCSimServer
+				// below otherwise there will be no VCSim instance created in the management cluster.
+				UseKindForManagementCluster:              true,
 				KindManagementClusterNewClusterProxyFunc: kindManagementClusterNewClusterProxyFunc,
 			}
 		})
-	}, WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"), WithAdditionalVCSimServer(true))
+	},
+		WithIP("WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"),
+		// This is required because we are using a separate management cluster with kind by passing `UseKindForManagementCluster` above.
+		WithAdditionalVCSimServer(true),
+	)
 })
 
 // getStableReleaseOfMinor returns the latest stable version of minorRelease.

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/clusterclass/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/clusterclass/clusterclass-quick-start.yaml
@@ -100,7 +100,7 @@ spec:
         valueFrom:
           template: |
             host: '{{ .controlPlaneIpAddr }}'
-            port: 6443
+            port: {{ .controlPlanePort }}
       - op: add
         path: /spec/template/spec/identityRef
         valueFrom:
@@ -223,6 +223,13 @@ spec:
       openAPIV3Schema:
         description: Floating VIP for the control plane.
         type: string
+  - metadata: {}
+    name: controlPlanePort
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Port for the control plane endpoint.
+        type: integer
   - name: credsSecretName
     required: true
     schema:

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/cluster-template-topology.yaml
@@ -78,6 +78,8 @@ spec:
             name: etchosts
     - name: controlPlaneIpAddr
       value: ${CONTROL_PLANE_ENDPOINT_IP}
+    - name: controlPlanePort
+      value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
     - name: credsSecretName
       value: '${CLUSTER_NAME}'
     version: '${KUBERNETES_VERSION}'

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/kustomization.yaml
@@ -7,3 +7,7 @@ patchesStrategicMerge:
   - ../commons/cluster-resource-set-label.yaml
   - ../commons/cluster-network-CIDR.yaml
   - ../commons/cluster-resource-set-csi-insecure.yaml
+patches:
+  - target:
+      kind: Cluster
+    path: workload-control-plane-port.yaml

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/kustomization.yaml
@@ -7,7 +7,3 @@ patchesStrategicMerge:
   - ../commons/cluster-resource-set-label.yaml
   - ../commons/cluster-network-CIDR.yaml
   - ../commons/cluster-resource-set-csi-insecure.yaml
-patches:
-  - target:
-      kind: Cluster
-    path: workload-control-plane-port.yaml

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/workload-control-plane-port.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/workload-control-plane-port.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/topology/variables/-
+  value:
+    name: controlPlanePort
+    value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/workload-control-plane-port.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.9/topology/workload-control-plane-port.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: /spec/topology/variables/-
-  value:
-    name: controlPlanePort
-    value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}

--- a/test/e2e/dhcp_overrides_test.go
+++ b/test/e2e/dhcp_overrides_test.go
@@ -57,7 +57,7 @@ var _ = Describe("DHCPOverrides configuration test", func() {
 			var namespace *corev1.Namespace
 
 			BeforeEach(func() {
-				namespace = setupSpecNamespace(specName)
+				namespace = setupSpecNamespace(specName, testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 			})
 
 			AfterEach(func() {

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -247,10 +247,12 @@ func allocateIPAddresses(managementClusterProxy framework.ClusterProxy, options 
 		}
 
 	case VCSimTestTarget:
+		testSpecificIPAddressManager = vcsimAddressManager
+
+		// Create a new address manager when using VCSim in a separate management cluster.
+		// Otherwise it allocates IPs in the wrong management cluster.
 		if options.additionalVCSimServer {
 			var err error
-			// Create a new address manager when using VCSim in a separate management cluster.
-			// Otherwise it allocates IPs in the wrong management cluster.
 			testSpecificIPAddressManager, err = vsphereip.VCSIMAddressManager(managementClusterProxy.GetClient(), map[string]string{}, skipCleanup)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -167,7 +167,6 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			}
 
 			// Re-write the clusterctl config file and add the new variables created above (ip addresses, VCSim variables).
-			testSpecificClusterctlConfigPath = fmt.Sprintf("%s-%s.yaml", strings.TrimSuffix(clusterctlConfigPath, ".yaml"), specName)
 			Byf("Writing a new clusterctl config to %s", testSpecificClusterctlConfigPath)
 			copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
 				ClusterctlConfigPath: testSpecificClusterctlConfigPath,

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -43,9 +43,10 @@ import (
 )
 
 type setupOptions struct {
-	additionalIPVariableNames []string
-	gatewayIPVariableName     string
-	prefixVariableName        string
+	additionalIPVariableNames   []string
+	gatewayIPVariableName       string
+	prefixVariableName          string
+	useKindForManagementCluster bool
 }
 
 // SetupOption is a configuration option supplied to Setup.
@@ -73,6 +74,13 @@ func WithPrefix(variableName string) SetupOption {
 	}
 }
 
+// WithUseKindForManagementCluster instructs Setup to run extra steps for the separate kind management cluster.
+func WithUseKindForManagementCluster() SetupOption {
+	return func(o *setupOptions) {
+		o.useKindForManagementCluster = true
+	}
+}
+
 type testSettings struct {
 	ClusterctlConfigPath      string
 	Variables                 map[string]string
@@ -91,92 +99,34 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 	var (
 		testSpecificClusterctlConfigPath string
 		testSpecificIPAddressClaims      vsphereip.AddressClaims
+		testSpecificIPAddressManager     vsphereip.AddressManager
 		testSpecificVariables            map[string]string
 		postNamespaceCreatedFunc         func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
 		runtimeExtensionProviders        []string
 	)
 	BeforeEach(func() {
 		Byf("Setting up test env for %s", specName)
-		switch testTarget {
-		case VCenterTestTarget:
-			Byf("Getting IP for %s", strings.Join(append([]string{vsphereip.ControlPlaneEndpointIPVariable}, options.additionalIPVariableNames...), ","))
-			// get IPs from the in cluster address manager
-			testSpecificIPAddressClaims, testSpecificVariables = inClusterAddressManager.ClaimIPs(ctx, vsphereip.WithGateway(options.gatewayIPVariableName), vsphereip.WithPrefix(options.prefixVariableName), vsphereip.WithIP(options.additionalIPVariableNames...))
-		case VCSimTestTarget:
-			c := bootstrapClusterProxy.GetClient()
-
-			// get IPs from the vcsim controller
-			// NOTE: ControlPlaneEndpointIP is the first claim in the returned list (this assumption is used below).
-			Byf("Getting IP for %s", strings.Join(append([]string{vsphereip.ControlPlaneEndpointIPVariable}, options.additionalIPVariableNames...), ","))
-			testSpecificIPAddressClaims, testSpecificVariables = vcsimAddressManager.ClaimIPs(ctx, vsphereip.WithIP(options.additionalIPVariableNames...))
-
-			// variables derived from the vCenterSimulator
-			vCenterSimulator, err := vspherevcsim.Get(ctx, bootstrapClusterProxy.GetClient())
-			Expect(err).ToNot(HaveOccurred(), "Failed to get VCenterSimulator")
-
-			Byf("Creating EnvVar %s", klog.KRef(metav1.NamespaceDefault, specName))
-			envVar := &vcsimv1.EnvVar{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      specName,
-					Namespace: metav1.NamespaceDefault,
-				},
-				Spec: vcsimv1.EnvVarSpec{
-					VCenterSimulator: &vcsimv1.NamespacedRef{
-						Namespace: vCenterSimulator.Namespace,
-						Name:      vCenterSimulator.Name,
-					},
-					ControlPlaneEndpoint: vcsimv1.NamespacedRef{
-						Namespace: testSpecificIPAddressClaims[0].Namespace,
-						Name:      testSpecificIPAddressClaims[0].Name,
-					},
-					// NOTE: we are omitting VMOperatorDependencies because it is not created yet (it will be created by the PostNamespaceCreated hook)
-					// But this is not a issue because a default dependenciesConfig that works for vcsim will be automatically used.
-				},
-			}
-
-			err = c.Create(ctx, envVar)
-			Expect(err).ToNot(HaveOccurred(), "Failed to create EnvVar")
-
-			Eventually(func() bool {
-				if err := c.Get(ctx, crclient.ObjectKeyFromObject(envVar), envVar); err != nil {
-					return false
-				}
-				return len(envVar.Status.Variables) > 0
-			}, 30*time.Second, 5*time.Second).Should(BeTrue(), "Failed to get EnvVar %s", klog.KObj(envVar))
-
-			Byf("Setting test variables for %s", specName)
-			for k, v := range envVar.Status.Variables {
-				// ignore variables that will be set later on by the test
-				if sets.New("NAMESPACE", "CLUSTER_NAME", "KUBERNETES_VERSION", "CONTROL_PLANE_MACHINE_COUNT", "WORKER_MACHINE_COUNT").Has(k) {
-					continue
-				}
-
-				// unset corresponding env variable (that in CI contains VMC data), so we are sure we use the value for vcsim
-				if strings.HasPrefix(k, "VSPHERE_") {
-					Expect(os.Unsetenv(k)).To(Succeed())
-				}
-
-				testSpecificVariables[k] = v
-			}
+		if testSpecificVariables == nil {
+			testSpecificVariables = map[string]string{}
 		}
 
+		// Update the CLUSTER_CLASS_NAME variable adding the supervisor suffix.
 		if testMode == SupervisorTestMode {
-			postNamespaceCreatedFunc = setupNamespaceWithVMOperatorDependenciesVCenter
-			if testTarget == VCSimTestTarget {
-				postNamespaceCreatedFunc = setupNamespaceWithVMOperatorDependenciesVCSim
-			}
-
-			if testSpecificVariables == nil {
-				testSpecificVariables = map[string]string{}
-			}
-
-			// Update the CLUSTER_CLASS_NAME variable adding the supervisor suffix.
 			if e2eConfig.HasVariable("CLUSTER_CLASS_NAME") {
 				testSpecificVariables["CLUSTER_CLASS_NAME"] = fmt.Sprintf("%s-supervisor", e2eConfig.GetVariable("CLUSTER_CLASS_NAME"))
 			}
 		}
 
-		// Create a new clusterctl config file based on the passed file and add the new variables for the IPs.
+		// Enable additional providers depending on testMode and testTarget.
+		if testMode == SupervisorTestMode {
+			runtimeExtensionProviders = append(runtimeExtensionProviders, "vm-operator", "net-operator")
+		}
+		if testTarget == VCSimTestTarget {
+			runtimeExtensionProviders = append(runtimeExtensionProviders, "vcsim")
+		}
+
+		// Create a new clusterctl config file based on the passed file. The postNamespaceCreatedFunc
+		// may re-write the file to add some variables, but it needs to exist already before that.
 		testSpecificClusterctlConfigPath = fmt.Sprintf("%s-%s.yaml", strings.TrimSuffix(clusterctlConfigPath, ".yaml"), specName)
 		Byf("Writing a new clusterctl config to %s", testSpecificClusterctlConfigPath)
 		copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
@@ -185,23 +135,126 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			Variables:            testSpecificVariables,
 		})
 
-		if testMode == SupervisorTestMode {
-			runtimeExtensionProviders = append(runtimeExtensionProviders, "vm-operator", "net-operator")
-		}
+		postNamespaceCreatedFunc = func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string) {
+			var ipVariables map[string]string
 
-		if testTarget == VCSimTestTarget {
-			runtimeExtensionProviders = append(runtimeExtensionProviders, "vcsim")
+			if testTarget == VCSimTestTarget && options.useKindForManagementCluster {
+				Byf("Creating a vcsim server")
+				Eventually(func() error {
+					return vspherevcsim.Create(ctx, managementClusterProxy.GetClient())
+				}, time.Minute, 3*time.Second).ShouldNot(HaveOccurred(), "Failed to create VCenterSimulator")
+			}
+
+			// IP Address Management
+			switch testTarget {
+			case VCenterTestTarget:
+				testSpecificIPAddressManager = inClusterAddressManager
+
+				Byf("Getting IP for %s", strings.Join(append([]string{vsphereip.ControlPlaneEndpointIPVariable}, options.additionalIPVariableNames...), ","))
+				// get IPs from the in cluster address manager
+				testSpecificIPAddressClaims, ipVariables = testSpecificIPAddressManager.ClaimIPs(ctx, vsphereip.WithGateway(options.gatewayIPVariableName), vsphereip.WithPrefix(options.prefixVariableName), vsphereip.WithIP(options.additionalIPVariableNames...))
+				for k, v := range ipVariables {
+					testSpecificVariables[k] = v
+				}
+
+			case VCSimTestTarget:
+				testSpecificIPAddressManager = vcsimAddressManager
+				// Use a new address manager when using VCSim in a separate kind management cluster.
+				if options.useKindForManagementCluster {
+					var err error
+					testSpecificIPAddressManager, err = vsphereip.VCSIMAddressManager(managementClusterProxy.GetClient(), map[string]string{}, skipCleanup)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				// get IPs from the vcsim controller
+				// NOTE: ControlPlaneEndpointIP is the first claim in the returned list (this assumption is used below).
+				Byf("Getting IP for %s", strings.Join(append([]string{vsphereip.ControlPlaneEndpointIPVariable}, options.additionalIPVariableNames...), ","))
+				testSpecificIPAddressClaims, ipVariables = testSpecificIPAddressManager.ClaimIPs(ctx, vsphereip.WithIP(options.additionalIPVariableNames...))
+				for k, v := range ipVariables {
+					testSpecificVariables[k] = v
+				}
+			}
+
+			// Additional initialization required when running on VCSim.
+			if testTarget == VCSimTestTarget {
+				// variables derived from the vCenterSimulator
+				vCenterSimulator, err := vspherevcsim.Get(ctx, managementClusterProxy.GetClient())
+				Expect(err).ToNot(HaveOccurred(), "Failed to get VCenterSimulator")
+
+				Byf("Creating EnvVar %s", klog.KRef(metav1.NamespaceDefault, specName))
+				envVar := &vcsimv1.EnvVar{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      specName,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: vcsimv1.EnvVarSpec{
+						VCenterSimulator: &vcsimv1.NamespacedRef{
+							Namespace: vCenterSimulator.Namespace,
+							Name:      vCenterSimulator.Name,
+						},
+						ControlPlaneEndpoint: vcsimv1.NamespacedRef{
+							Namespace: testSpecificIPAddressClaims[0].Namespace,
+							Name:      testSpecificIPAddressClaims[0].Name,
+						},
+						// NOTE: we are omitting VMOperatorDependencies because it is not created yet (it will be created by the PostNamespaceCreated hook)
+						// But this is not a issue because a default dependenciesConfig that works for vcsim will be automatically used.
+					},
+				}
+
+				err = managementClusterProxy.GetClient().Create(ctx, envVar)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create EnvVar")
+
+				Eventually(func() bool {
+					if err := managementClusterProxy.GetClient().Get(ctx, crclient.ObjectKeyFromObject(envVar), envVar); err != nil {
+						return false
+					}
+					return len(envVar.Status.Variables) > 0
+				}, 30*time.Second, 5*time.Second).Should(BeTrue(), "Failed to get EnvVar %s", klog.KObj(envVar))
+
+				Byf("Setting test variables for %s", specName)
+				for k, v := range envVar.Status.Variables {
+					// ignore variables that will be set later on by the test
+					if sets.New("NAMESPACE", "CLUSTER_NAME", "KUBERNETES_VERSION", "CONTROL_PLANE_MACHINE_COUNT", "WORKER_MACHINE_COUNT").Has(k) {
+						continue
+					}
+
+					// unset corresponding env variable (that in CI contains VMC data), so we are sure we use the value for vcsim
+					if strings.HasPrefix(k, "VSPHERE_") {
+						Expect(os.Unsetenv(k)).To(Succeed())
+					}
+
+					testSpecificVariables[k] = v
+				}
+			}
+
+			// Re-write the clusterctl config file and add the new variables.
+			testSpecificClusterctlConfigPath = fmt.Sprintf("%s-%s.yaml", strings.TrimSuffix(clusterctlConfigPath, ".yaml"), specName)
+			Byf("Writing a new clusterctl config to %s", testSpecificClusterctlConfigPath)
+			copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
+				ClusterctlConfigPath: testSpecificClusterctlConfigPath,
+				OutputPath:           testSpecificClusterctlConfigPath,
+				Variables:            testSpecificVariables,
+			})
+
+			// Run additional initialization required for supervisor.
+			if testMode == SupervisorTestMode {
+				switch testTarget {
+				case VCenterTestTarget:
+					setupNamespaceWithVMOperatorDependenciesVCenter(managementClusterProxy, workloadClusterNamespace)
+				case VCSimTestTarget:
+					setupNamespaceWithVMOperatorDependenciesVCSim(managementClusterProxy, workloadClusterNamespace)
+				}
+			}
 		}
 	})
 	defer AfterEach(func() {
-		Byf("Cleaning up test env for %s", specName)
-		switch testTarget {
-		case VCenterTestTarget:
-			// cleanup IPs/controlPlaneEndpoint created by the in cluster ipam provider.
-			Expect(inClusterAddressManager.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
-		case VCSimTestTarget:
-			// cleanup IPs/controlPlaneEndpoint created by the vcsim controller manager.
-			Expect(vcsimAddressManager.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+		if !skipCleanup {
+			Byf("Cleaning up test env for %s", specName)
+			// We can't cleanup when a kind management cluster is used, because it won't exist anymore.
+			if !options.useKindForManagementCluster {
+				// cleanup IPs/controlPlaneEndpoint created by the IPAddressManager.
+				Expect(testSpecificIPAddressManager.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
+			}
 		}
 	})
 
@@ -232,7 +285,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 func setupNamespaceWithVMOperatorDependenciesVCSim(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string) {
 	c := managementClusterProxy.GetClient()
 
-	vCenterSimulator, err := vspherevcsim.Get(ctx, bootstrapClusterProxy.GetClient())
+	vCenterSimulator, err := vspherevcsim.Get(ctx, c)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get VCenterSimulator")
 
 	Byf("Creating VMOperatorDependencies %s", klog.KRef(workloadClusterNamespace, "vcsim"))

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -125,6 +125,13 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			runtimeExtensionProviders = append(runtimeExtensionProviders, "vcsim")
 		}
 
+		if testTarget == VCSimTestTarget {
+			// We have to set empty username and password to install capv <= v1.9 because it is in the infrastructure-components,
+			// but it is okay to be empty.
+			testSpecificVariables["VSPHERE_USERNAME"] = ""
+			testSpecificVariables["VSPHERE_PASSWORD"] = ""
+		}
+
 		// Create a new clusterctl config file based on the passed file. The postNamespaceCreatedFunc
 		// may re-write the file to add some variables, but it needs to exist already before that.
 		testSpecificClusterctlConfigPath = fmt.Sprintf("%s-%s.yaml", strings.TrimSuffix(clusterctlConfigPath, ".yaml"), specName)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -361,7 +361,7 @@ func initScheme() *runtime.Scheme {
 	return sc
 }
 
-func setupSpecNamespace(specName string) *corev1.Namespace {
+func setupSpecNamespace(specName string, postNamespaceCreatedFunc func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)) *corev1.Namespace {
 	Byf("Creating a namespace for hosting the %q test spec", specName)
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 		Creator:   bootstrapClusterProxy.GetClient(),
@@ -371,6 +371,8 @@ func setupSpecNamespace(specName string) *corev1.Namespace {
 	})
 
 	namespaces[namespace] = cancelWatches
+
+	postNamespaceCreatedFunc(bootstrapClusterProxy, namespace.Name)
 
 	return namespace
 }

--- a/test/e2e/gpu_pci_passthrough_test.go
+++ b/test/e2e/gpu_pci_passthrough_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Cluster creation with GPU devices as PCI passthrough [speciali
 		)
 		BeforeEach(func() {
 			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-			namespace = setupSpecNamespace(specName)
+			namespace = setupSpecNamespace(specName, testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 		})
 
 		It("should create the cluster with worker nodes having GPU cards added as PCI passthrough devices", func() {

--- a/test/e2e/hardware_upgrade_test.go
+++ b/test/e2e/hardware_upgrade_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Hardware version upgrade", func() {
 
 		BeforeEach(func() {
 			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-			namespace = setupSpecNamespace(specName)
+			namespace = setupSpecNamespace(specName, testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 		})
 
 		AfterEach(func() {

--- a/test/e2e/multivc_test.go
+++ b/test/e2e/multivc_test.go
@@ -46,32 +46,35 @@ type MultiVCenterSpecInput struct {
 }
 
 var _ = Describe("Cluster creation with multivc [specialized-infra]", func() {
-	var namespace *corev1.Namespace
+	const specName = "multi-vc"
+	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
+		var namespace *corev1.Namespace
 
-	BeforeEach(func() {
-		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-		namespace = setupSpecNamespace("capv-e2e")
-	})
+		BeforeEach(func() {
+			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+			namespace = setupSpecNamespace("capv-e2e", testSpecificSettingsGetter().PostNamespaceCreatedFunc)
+		})
 
-	AfterEach(func() {
-		cleanupSpecNamespace(namespace)
-	})
+		AfterEach(func() {
+			cleanupSpecNamespace(namespace)
+		})
 
-	It("should create a cluster successfully", func() {
-		VerifyMultiVC(ctx, MultiVCenterSpecInput{
-			Namespace:  namespace,
-			Datacenter: vsphereDatacenter,
-			InfraClients: InfraClients{
-				Client:     vsphereClient,
-				RestClient: restClient,
-				Finder:     vsphereFinder,
-			},
-			Global: GlobalInput{
-				BootstrapClusterProxy: bootstrapClusterProxy,
-				ClusterctlConfigPath:  clusterctlConfigPath,
-				E2EConfig:             e2eConfig,
-				ArtifactFolder:        artifactFolder,
-			},
+		It("should create a cluster successfully", func() {
+			VerifyMultiVC(ctx, MultiVCenterSpecInput{
+				Namespace:  namespace,
+				Datacenter: vsphereDatacenter,
+				InfraClients: InfraClients{
+					Client:     vsphereClient,
+					RestClient: restClient,
+					Finder:     vsphereFinder,
+				},
+				Global: GlobalInput{
+					BootstrapClusterProxy: bootstrapClusterProxy,
+					ClusterctlConfigPath:  clusterctlConfigPath,
+					E2EConfig:             e2eConfig,
+					ArtifactFolder:        artifactFolder,
+				},
+			})
 		})
 	})
 })

--- a/test/e2e/node_labeling_test.go
+++ b/test/e2e/node_labeling_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/util"
@@ -35,6 +36,9 @@ type NodeLabelingSpecInput struct {
 	Global    GlobalInput
 	SpecName  string
 	Namespace *corev1.Namespace
+	// Allows to inject a function to be run after test namespace is created.
+	// If not specified, this is a no-op.
+	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
 }
 
 var _ = Describe("Label nodes with ESXi host info", func() {
@@ -46,7 +50,7 @@ var _ = Describe("Label nodes with ESXi host info", func() {
 
 		BeforeEach(func() {
 			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-			namespace = setupSpecNamespace("node-labeling-e2e")
+			namespace = setupSpecNamespace("node-labeling-e2e", testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 		})
 
 		AfterEach(func() {

--- a/test/e2e/ownerrefs_finalizers_test.go
+++ b/test/e2e/ownerrefs_finalizers_test.go
@@ -62,6 +62,9 @@ var _ = Describe("Ensure OwnerReferences and Finalizers are resilient [vcsim] [s
 				Flavor:                ptr.To(testSpecificSettingsGetter().FlavorForMode("ownerrefs-finalizers")),
 				PostNamespaceCreated: func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string) {
 					testSpecificSettingsGetter().PostNamespaceCreatedFunc(managementClusterProxy, workloadClusterNamespace)
+
+					// The PostNamespaceCreatedFunc adds the VSPHERE_USERNAME and VSPHERE_PASSWORD
+					// when testing on VCSim so we can only set them after running it.
 					if testMode == GovmomiTestMode {
 						// NOTE: When testing with vcsim VSPHERE_USERNAME and VSPHERE_PASSWORD are provided as a test specific variables,
 						// when running on CI same variables are provided as env variables.

--- a/test/e2e/storage_policy_test.go
+++ b/test/e2e/storage_policy_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Cluster creation with storage policy", func() {
 
 		BeforeEach(func() {
 			Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
-			namespace = setupSpecNamespace("capv-e2e")
+			namespace = setupSpecNamespace("capv-e2e", testSpecificSettingsGetter().PostNamespaceCreatedFunc)
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Part of:
- #2995

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
