### PR TITLE
🐛 vmoperator: fix nil pointer when reconciling VM

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -417,11 +417,13 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 			vmOperatorVM.Spec.StorageClass = supervisorMachineCtx.VSphereMachine.Spec.StorageClass
 		}
 		vmOperatorVM.Spec.PowerState = vmoprv1.VirtualMachinePowerStateOn
-		if vmOperatorVM.Spec.Reserved == nil && supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName != "" {
-			vmOperatorVM.Spec.Reserved = &vmoprv1.VirtualMachineReservedSpec{}
-		}
-		if vmOperatorVM.Spec.Reserved.ResourcePolicyName == "" {
-			vmOperatorVM.Spec.Reserved.ResourcePolicyName = supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName
+		if supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName != "" {
+			if vmOperatorVM.Spec.Reserved == nil {
+				vmOperatorVM.Spec.Reserved = &vmoprv1.VirtualMachineReservedSpec{}
+			}
+			if vmOperatorVM.Spec.Reserved.ResourcePolicyName == "" {
+				vmOperatorVM.Spec.Reserved.ResourcePolicyName = supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName
+			}
 		}
 		if vmOperatorVM.Spec.Bootstrap == nil {
 			vmOperatorVM.Spec.Bootstrap = &vmoprv1.VirtualMachineBootstrapSpec{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes nil pointer occured in unit test: 
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/3109/pull-cluster-api-provider-vsphere-test-main/1813959719862145024

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
