### PR TITLE
🌱 test: bump core-CAPI v1.8.0-beta.0 to nightly image build

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -27,7 +27,7 @@ providers:
     type: CoreProvider
     versions:
       - name: "v1.8.0" # supported release in the v1beta1 series
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.0-beta.0/core-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20240722/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

To get `periodic-e2e-supervisor-main-1-29-1-30` back green ([xref testgrid](https://testgrid.k8s.io/vmware-cluster-api-provider-vsphere#periodic-e2e-supervisor-main-1-29-1-30))

Via having:

- https://github.com/kubernetes-sigs/cluster-api/pull/10903

In the used CAPI controller image.

Also to deflake `periodic-e2e-govmomi-main-1-30-1-31` ([xref testgrid](https://testgrid.k8s.io/vmware-cluster-api-provider-vsphere#periodic-e2e-govmomi-main-1-30-1-31))

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
