### PR TITLE
🌱 test: wait for nodes being ready before testing resource versions being stable

### DIFF
--- a/test/e2e/ownerrefs_finalizers_test.go
+++ b/test/e2e/ownerrefs_finalizers_test.go
@@ -41,6 +41,7 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -126,6 +127,23 @@ var _ = Describe("Ensure OwnerReferences and Finalizers are resilient [vcsim] [s
 					if forceCancelFunc != nil {
 						forceCancelFunc()
 					}
+
+					// This check ensures that the rollout to the machines finished before
+					// checking resource version stability.
+					Eventually(func() error {
+						machineList := &clusterv1.MachineList{}
+						if err := proxy.GetClient().List(ctx, machineList, ctrlclient.InNamespace(namespace)); err != nil {
+							return errors.Wrap(err, "list machines")
+						}
+
+						for _, machine := range machineList.Items {
+							if !conditions.IsTrue(&machine, clusterv1.MachineNodeHealthyCondition) {
+								return errors.Errorf("machine %q does not have %q condition set to true", machine.GetName(), clusterv1.MachineNodeHealthyCondition)
+							}
+						}
+
+						return nil
+					}, 5*time.Minute, 15*time.Second).Should(Succeed(), "Waiting for nodes to be ready")
 
 					// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 					// continuous reconciles when everything should be stable.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

xref: https://storage.googleapis.com/k8s-triage/index.html?text=Resource%20versions%20didn%27t%20stay%20stable&job=.*-cluster-api-provider-vsphere.*

TLDR:
* resource version is sometimes not stable for machines
* reason for that is that while its expected to be stable, the node gets healthy (because CNI finished to start)
* this leads to an update of the machine's status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
