### PR TITLE
🌱 test: dump resources before ValidateResourceVersionStable test

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package e2e
 
 import (
+	"path/filepath"
+
 	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,6 +44,12 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 				ArtifactFolder:        artifactFolder,
 				SkipCleanup:           skipCleanup,
 				PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+					// Dump all Cluster API related resources to artifacts before checking for resource versions being stable.
+					framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+						Lister:    proxy.GetClient(),
+						Namespace: namespace,
+						LogPath:   filepath.Join(artifactFolder, "clusters-beforeValidateResourceVersions", proxy.GetName(), "resources")})
+
 					// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 					// continuous reconciles when everything should be stable.
 					framework.ValidateResourceVersionStable(ctx, proxy, namespace, FilterObjectsWithKindAndName(clusterName))

--- a/test/e2e/ownerrefs_finalizers_test.go
+++ b/test/e2e/ownerrefs_finalizers_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -148,6 +149,12 @@ var _ = Describe("Ensure OwnerReferences and Finalizers are resilient [vcsim] [s
 
 						return nil
 					}, 5*time.Minute, 15*time.Second).Should(Succeed(), "Waiting for nodes to be ready")
+
+					// Dump all Cluster API related resources to artifacts before checking for resource versions being stable.
+					framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+						Lister:    proxy.GetClient(),
+						Namespace: namespace,
+						LogPath:   filepath.Join(artifactFolder, "clusters-beforeValidateResourceVersions", proxy.GetName(), "resources")})
 
 					// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 					// continuous reconciles when everything should be stable.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/3119/pull-cluster-api-provider-vsphere-e2e-supervisor-main/1815834140377878528

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
