### PR TITLE
🌱 [release-1.9] Bump CAPV to from v1.8.10 and v1.7.7 for upgrade tests

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -37,7 +37,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.8=
 			InitWithCoreProvider:              "cluster-api:v1.5.4",
 			InitWithBootstrapProviders:        []string{"kubeadm:v1.5.4"},
 			InitWithControlPlaneProviders:     []string{"kubeadm:v1.5.4"},
-			InitWithInfrastructureProviders:   []string{"vsphere:v1.8.4"},
+			InitWithInfrastructureProviders:   []string{"vsphere:v1.8.10"},
 			InitWithRuntimeExtensionProviders: []string{},
 			// InitWithKubernetesVersion should be the highest kubernetes version supported by the init Cluster API version.
 			// This is to guarantee that both, the old and new CAPI version, support the defined version.
@@ -63,7 +63,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.7=
 			InitWithCoreProvider:              "cluster-api:v1.4.9",
 			InitWithBootstrapProviders:        []string{"kubeadm:v1.4.9"},
 			InitWithControlPlaneProviders:     []string{"kubeadm:v1.4.9"},
-			InitWithInfrastructureProviders:   []string{"vsphere:v1.7.4"},
+			InitWithInfrastructureProviders:   []string{"vsphere:v1.7.7"},
 			InitWithRuntimeExtensionProviders: []string{},
 			// InitWithKubernetesVersion should be the highest kubernetes version supported by the init Cluster API version.
 			// This is to guarantee that both, the old and new CAPI version, support the defined version.

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -8,11 +8,11 @@
 # For creating local images, run ./hack/e2e.sh
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.7
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -28,9 +28,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -62,9 +62,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -96,9 +96,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -156,9 +156,9 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/clusterclass-quick-start.yaml"
           - sourcePath: "../data/shared/main/v1beta1_provider/metadata.yaml"
-      - name: v1.8.4
+      - name: v1.8.10
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.8.4/infrastructure-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.8.10/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -166,9 +166,9 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/v1.8/cluster-template-workload.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/v1.8/clusterclass-quick-start.yaml"
           - sourcePath: "../data/shared/v1.8/v1beta1_provider/metadata.yaml"
-      - name: v1.7.4
+      - name: v1.7.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.7.4/infrastructure-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.7.7/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/e2e/config/vsphere-dev.yaml
+++ b/test/e2e/config/vsphere-dev.yaml
@@ -11,11 +11,11 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.7
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -31,9 +31,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -65,9 +65,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -99,9 +99,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -159,9 +159,9 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/cluster-template.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/clusterclass-quick-start.yaml"
           - sourcePath: "../data/shared/main/v1beta1_provider/metadata.yaml"
-      - name: v1.8.4
+      - name: v1.8.10
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.8.4/infrastructure-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.8.10/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -169,9 +169,9 @@ providers:
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/v1.8/cluster-template-workload.yaml"
           - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/v1.8/clusterclass-quick-start.yaml"
           - sourcePath: "../data/shared/v1.8/v1beta1_provider/metadata.yaml"
-      - name: v1.7.4
+      - name: v1.7.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.7.4/infrastructure-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v1.7.7/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/integration/integration-dev.yaml
+++ b/test/integration/integration-dev.yaml
@@ -11,11 +11,11 @@
 # - from the CAPV repository root, `make e2e` to build the vsphere provider image and run e2e tests.
 
 images:
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.7
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capv-manager:e2e
     loadBehavior: mustLoad
@@ -30,9 +30,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -44,9 +44,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -58,9 +58,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.6.1
+      - name: v1.6.7
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Bumps CAPV to the latest v1.8.10 for upgrade tests, otherwise it fails using the SHA256 thumbprint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
