### PR TITLE
 🐛 Fix unit tests, improve debuggability

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -53,6 +53,7 @@ func TestControllers(t *testing.T) {
 
 var (
 	testEnv *helpers.TestEnvironment
+	tracker *remote.ClusterCacheTracker
 	ctx     = ctrl.SetupSignalHandler()
 )
 
@@ -80,7 +81,7 @@ func setup() {
 		panic("unable to create secret caching client")
 	}
 
-	tracker, err := remote.NewClusterCacheTracker(
+	tracker, err = remote.NewClusterCacheTracker(
 		testEnv.Manager,
 		remote.ClusterCacheTrackerOptions{
 			SecretCachingClient: secretCachingClient,

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -241,6 +242,12 @@ func (r *ServiceAccountReconciler) reconcileNormal(ctx context.Context, guestClu
 // Ensure service accounts from provider spec is created.
 func (r *ServiceAccountReconciler) ensureProviderServiceAccounts(ctx context.Context, guestClusterCtx *vmwarecontext.GuestClusterContext, pSvcAccounts []vmwarev1.ProviderServiceAccount) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	pSvcAccountNames := []string{}
+	for _, pSvcAccount := range pSvcAccounts {
+		pSvcAccountNames = append(pSvcAccountNames, pSvcAccount.Name)
+	}
+	log.V(5).Info(fmt.Sprintf("Reconcile ProviderServiceAccounts: %v", strings.Join(pSvcAccountNames, ",")))
 
 	for i, pSvcAccount := range pSvcAccounts {
 		// Note: We have to use := here to not overwrite log & ctx outside the for loop.

--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -358,7 +358,11 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 		})
 
 		AfterEach(func() {
-			Expect(testEnv.CleanupAndWait(ctx, instance, zoneOne, capiCluster, namespace)).To(Succeed())
+			// Note: Make sure VSphereCluster is deleted before the Cluster is deleted.
+			// Otherwise reconcileDelete in VSphereCluster reconciler will fail because the Cluster cannot be found.
+			Expect(testEnv.CleanupAndWait(ctx, instance, zoneOne)).To(Succeed())
+			Expect(testEnv.CleanupAndWait(ctx, capiCluster)).To(Succeed())
+			Expect(testEnv.CleanupAndWait(ctx, namespace)).To(Succeed())
 		})
 
 		It("should reconcile a cluster", func() {

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -42,6 +42,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/logs"
+	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
@@ -60,7 +62,14 @@ import (
 )
 
 func init() {
+	// Set log level 5 as default for testing (default for prod is 2).
+	logOptions := logs.NewOptions()
+	logOptions.Verbosity = 5
+	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
+		panic(err)
+	}
 	ctrl.SetLogger(klog.Background())
+
 	// add logger for ginkgo
 	klog.SetOutput(ginkgo.GinkgoWriter)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR should:
* make it easier to debug unit tests by increasing log level to 5, like
  * https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-main/1817859752558858240
  * https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-main/1817874852074229760
* fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-vsphere-test-main/1817981442076971008

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
