### PR TITLE
🐛 Drop caBundle from CRDs to support Kubernetes 1.31

### DIFF
--- a/config/default/crd/patches/webhook_in_vsphereclusters.yaml
+++ b/config/default/crd/patches/webhook_in_vsphereclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vsphereclustertemplates.yaml
+++ b/config/default/crd/patches/webhook_in_vsphereclustertemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vspheredeploymentzones.yaml
+++ b/config/default/crd/patches/webhook_in_vspheredeploymentzones.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: [ "v1", "v1beta1" ]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vspherefailuredomains.yaml
+++ b/config/default/crd/patches/webhook_in_vspherefailuredomains.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: [ "v1", "v1beta1" ]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vspheremachines.yaml
+++ b/config/default/crd/patches/webhook_in_vspheremachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vspheremachinetemplates.yaml
+++ b/config/default/crd/patches/webhook_in_vspheremachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/default/crd/patches/webhook_in_vspherevms.yaml
+++ b/config/default/crd/patches/webhook_in_vspherevms.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Context: https://github.com/kubernetes-sigs/cluster-api/pull/10972

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
