### PR TITLE
🌱 test: check failureDomains on VSphereCluster in e2e test

### DIFF
--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/ownerrefs-finalizers/kustomization.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/ownerrefs-finalizers/kustomization.yaml
@@ -9,3 +9,4 @@ patchesStrategicMerge:
   - ../commons/cluster-network-CIDR.yaml
   - vsphereclusteridentity.yaml
   - drop-existing-identity-secret.yaml
+  - vspherecluster-failuredomainselector.yaml

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/ownerrefs-finalizers/vspherecluster-failuredomainselector.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/ownerrefs-finalizers/vspherecluster-failuredomainselector.yaml
@@ -1,0 +1,7 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  failureDomainSelector: {}

--- a/test/infrastructure/vcsim/controllers/envvar_controller.go
+++ b/test/infrastructure/vcsim/controllers/envvar_controller.go
@@ -288,6 +288,7 @@ func clusterEnvVarSpecGovmomiVariables(c *vcsimv1.ClusterEnvVarSpec) map[string]
 
 	// NOTE: omitting cluster Name intentionally because E2E tests provide this value in other ways
 	vars["VSPHERE_DATACENTER"] = vcsimhelpers.DatacenterName(datacenter)
+	vars["VSPHERE_COMPUTE_CLUSTER"] = vcsimhelpers.ClusterName(datacenter, cluster)
 	vars["VSPHERE_DATASTORE"] = vcsimhelpers.DatastoreName(datastore)
 	vars["VSPHERE_FOLDER"] = vcsimhelpers.VMFolderName(datacenter)
 	vars["VSPHERE_NETWORK"] = vcsimhelpers.NetworkPath(datacenter, vcsimhelpers.DefaultNetworkName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
