### PR TITLE
:sparkles: add function to remove VSphere VM object from VM Group

### DIFF
--- a/pkg/services/govmomi/cluster/vmgroup.go
+++ b/pkg/services/govmomi/cluster/vmgroup.go
@@ -84,3 +84,25 @@ func (vg VMGroup) HasVM(vmObj types.ManagedObjectReference) (bool, error) {
 func (vg VMGroup) listVMs() []types.ManagedObjectReference {
 	return vg.ClusterVmGroup.Vm
 }
+
+// Remove a VSphere VM object from the VM Group.
+func (vg VMGroup) Remove(ctx context.Context, vmObj types.ManagedObjectReference) (*object.Task, error) {
+	for i, vm := range vg.ClusterVmGroup.Vm {
+		if vm == vmObj {
+			vg.ClusterVmGroup.Vm = append(vg.ClusterVmGroup.Vm[:i], vg.ClusterVmGroup.Vm[i+1:]...)
+			break
+		}
+	}
+
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationEdit,
+				},
+				Info: vg.ClusterVmGroup,
+			},
+		},
+	}
+	return vg.ClusterComputeResource.Reconfigure(ctx, spec, true)
+}

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -70,6 +70,15 @@ func Test_VMGroup(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(hasVM).To(BeTrue())
 
+	task, err = vmGrp.Remove(ctx, vmRef)
+	g.Expect(task.Wait(ctx)).To(Succeed())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(vmGrp.listVMs()).To(HaveLen(2))
+
+	hasVM, err = vmGrp.HasVM(vmRef)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(hasVM).To(BeFalse())
+
 	vmGroupName = "incorrect-vm-group"
 	_, err = FindVMGroup(ctx, computeClusterCtx, computeClusterName, vmGroupName)
 	g.Expect(err).To(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a function to remove VSphere VM object from VM Group

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
