### PR TITLE
🐛 Small test fix. Remove OwnerReference & Check for Finalizers being empty

### DIFF
--- a/controllers/vspherecluster_reconciler_test.go
+++ b/controllers/vspherecluster_reconciler_test.go
@@ -60,14 +60,6 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "secret-",
 					Namespace:    "default",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "bitnami.com/v1alpha1",
-							Kind:       "SealedSecret",
-							Name:       "some-name",
-							UID:        "some-uid",
-						},
-					},
 				},
 				Data: map[string][]byte{
 					identity.UsernameKey: []byte(vcURL.User.Username()),
@@ -276,6 +268,13 @@ var _ = Describe("VIM based VSphere ClusterReconciler", func() {
 
 		Expect(testEnv.Create(ctx, instance)).To(Succeed())
 		key := client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}
+
+		Eventually(func() bool {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
+				return false
+			}
+			return len(instance.Finalizers) == 0
+		}, timeout).Should(BeTrue())
 
 		// Make sure the VSphereCluster exists.
 		Eventually(func() bool {


### PR DESCRIPTION
Two small fixes:

- The secret was created with an OwnerReference. Later on (line ~141) it is checked if the controller sets the OwnerReference by counting the number of OwnerReferences. However, this is always > 0 since the OwnerReference was explicitly set before, so this check always passes. Removed the initial OwnerReference and counting the ones set by the controller.

- Line ~237 it is stated: "should remove vspherecluster finalizer if the secret does not exist". However, it was not checked whether the Finalizers are actually empty. Added this check.

