### PR TITLE
✨ enables explicit disabling of cluster module

### DIFF
--- a/apis/v1alpha3/conversion_test.go
+++ b/apis/v1alpha3/conversion_test.go
@@ -79,6 +79,7 @@ func overrideVSphereClusterSpecFieldsFuncs(runtimeserializer.CodecFactory) []int
 			c.FuzzNoCustom(in)
 			in.ClusterModules = nil
 			in.FailureDomainSelector = nil
+			in.DisableClusterModule = false
 		},
 	}
 }

--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1061,6 +1061,7 @@ func autoConvert_v1beta1_VSphereClusterSpec_To_v1alpha3_VSphereClusterSpec(in *v
 	}
 	out.IdentityRef = (*VSphereIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	// WARNING: in.ClusterModules requires manual conversion: does not exist in peer-type
+	// WARNING: in.DisableClusterModule requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureDomainSelector requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1alpha4/conversion_test.go
+++ b/apis/v1alpha4/conversion_test.go
@@ -70,6 +70,7 @@ func overrideVSphereClusterSpecFieldsFuncs(runtimeserializer.CodecFactory) []int
 			c.FuzzNoCustom(in)
 			in.ClusterModules = nil
 			in.FailureDomainSelector = nil
+			in.DisableClusterModule = false
 		},
 	}
 }

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1099,6 +1099,7 @@ func autoConvert_v1beta1_VSphereClusterSpec_To_v1alpha4_VSphereClusterSpec(in *v
 	}
 	out.IdentityRef = (*VSphereIdentityReference)(unsafe.Pointer(in.IdentityRef))
 	// WARNING: in.ClusterModules requires manual conversion: does not exist in peer-type
+	// WARNING: in.DisableClusterModule requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureDomainSelector requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1beta1/vspherecluster_types.go
+++ b/apis/v1beta1/vspherecluster_types.go
@@ -59,6 +59,12 @@ type VSphereClusterSpec struct {
 	// +optional
 	ClusterModules []ClusterModule `json:"clusterModules,omitempty"`
 
+	// DisableClusterModule is used to explicitly turn off the ClusterModule feature.
+	// This should work along side NodeAntiAffinity feature flag.
+	// If the NodeAntiAffinity feature flag is turned off, this will be disregarded.
+	// +optional
+	DisableClusterModule bool `json:"disableClusterModule,omitempty"`
+
 	// FailureDomainSelector is the label selector to use for failure domain selection
 	// for the control plane nodes of the cluster.
 	// If not set (`nil`), selecting failure domains will be disabled.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -694,6 +694,12 @@ spec:
                 - host
                 - port
                 type: object
+              disableClusterModule:
+                description: |-
+                  DisableClusterModule is used to explicitly turn off the ClusterModule feature.
+                  This should work along side NodeAntiAffinity feature flag.
+                  If the NodeAntiAffinity feature flag is turned off, this will be disregarded.
+                type: boolean
               failureDomainSelector:
                 description: |-
                   FailureDomainSelector is the label selector to use for failure domain selection

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -180,6 +180,12 @@ spec:
                         - host
                         - port
                         type: object
+                      disableClusterModule:
+                        description: |-
+                          DisableClusterModule is used to explicitly turn off the ClusterModule feature.
+                          This should work along side NodeAntiAffinity feature flag.
+                          If the NodeAntiAffinity feature flag is turned off, this will be disregarded.
+                        type: boolean
                       failureDomainSelector:
                         description: |-
                           FailureDomainSelector is the label selector to use for failure domain selection

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -359,7 +359,7 @@ func (r *clusterReconciler) reconcileDeploymentZones(ctx context.Context, cluste
 }
 
 func (r *clusterReconciler) reconcileClusterModules(ctx context.Context, clusterCtx *capvcontext.ClusterContext) (reconcile.Result, error) {
-	if feature.Gates.Enabled(feature.NodeAntiAffinity) {
+	if feature.Gates.Enabled(feature.NodeAntiAffinity) && !clusterCtx.VSphereCluster.Spec.DisableClusterModule {
 		return r.clusterModuleReconciler.Reconcile(ctx, clusterCtx)
 	}
 	return reconcile.Result{}, nil

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -314,7 +314,7 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 // This logic was moved to a smaller function outside the main Reconcile() loop
 // for the ease of testing.
 func (r vmReconciler) reconcile(ctx context.Context, vmCtx *capvcontext.VMContext, input fetchClusterModuleInput) (reconcile.Result, error) {
-	if feature.Gates.Enabled(feature.NodeAntiAffinity) {
+	if feature.Gates.Enabled(feature.NodeAntiAffinity) && !input.VSphereCluster.Spec.DisableClusterModule {
 		clusterModuleInfo, err := r.fetchClusterModuleInfo(ctx, input)
 		// If cluster module information cannot be fetched for a VM being deleted,
 		// we should not block VM deletion since the cluster module is updated


### PR DESCRIPTION
What this PR does:

The cluster module is currently enabled for all vSphere clusters based on the anti-affinity feature flag, with no option to disable its creation if the user doesn't want this feature. This PR introduces a DisableClusterModule field to the vSphereCluster API, allowing users to control the creation of a cluster module. However, this field is only applicable when the NodeAntiAffinity feature flag is enabled; otherwise, it is ignored.