### PR TITLE
:sparkles: Allow using moid

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -93,7 +93,7 @@ const (
 
 // VirtualMachineCloneSpec is information used to clone a virtual machine.
 type VirtualMachineCloneSpec struct {
-	// Template is the name or inventory path of the template used to clone
+	// Template is the name, inventory path or the MOID of the template used to clone
 	// the virtual machine.
 	// +kubebuilder:validation:MinLength=1
 	Template string `json:"template"`
@@ -127,18 +127,18 @@ type VirtualMachineCloneSpec struct {
 	// +optional
 	Thumbprint string `json:"thumbprint,omitempty"`
 
-	// Datacenter is the name or inventory path of the datacenter in which the
+	// Datacenter is the name, inventory path or MOID of the datacenter in which the
 	// virtual machine is created/located.
 	// Defaults to * which selects the default datacenter.
 	// +optional
 	Datacenter string `json:"datacenter,omitempty"`
 
-	// Folder is the name or inventory path of the folder in which the
+	// Folder is the name, inventory path or MOID of the folder in which the
 	// virtual machine is created/located.
 	// +optional
 	Folder string `json:"folder,omitempty"`
 
-	// Datastore is the name or inventory path of the datastore in which the
+	// Datastore is the name, inventory path or MOID of the datastore in which the
 	// virtual machine is created/located.
 	// +optional
 	Datastore string `json:"datastore,omitempty"`
@@ -148,7 +148,7 @@ type VirtualMachineCloneSpec struct {
 	// +optional
 	StoragePolicyName string `json:"storagePolicyName,omitempty"`
 
-	// ResourcePool is the name or inventory path of the resource pool in which
+	// ResourcePool is the name, inventory path or MOID of the resource pool in which
 	// the virtual machine is created/located.
 	// +optional
 	ResourcePool string `json:"resourcePool,omitempty"`
@@ -299,7 +299,7 @@ type NetworkSpec struct {
 // NetworkDeviceSpec defines the network configuration for a virtual machine's
 // network device.
 type NetworkDeviceSpec struct {
-	// NetworkName is the name of the vSphere network to which the device
+	// NetworkName is the name or MOID of the vSphere network to which the device
 	// will be connected.
 	NetworkName string `json:"networkName"`
 

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -93,8 +93,8 @@ const (
 
 // VirtualMachineCloneSpec is information used to clone a virtual machine.
 type VirtualMachineCloneSpec struct {
-	// Template is the name, inventory path or the MOID of the template used to clone
-	// the virtual machine.
+	// Template is the name, inventory path, managed object reference or the managed
+	// object ID of the template used to clone the virtual machine.
 	// +kubebuilder:validation:MinLength=1
 	Template string `json:"template"`
 
@@ -127,19 +127,19 @@ type VirtualMachineCloneSpec struct {
 	// +optional
 	Thumbprint string `json:"thumbprint,omitempty"`
 
-	// Datacenter is the name, inventory path or MOID of the datacenter in which the
-	// virtual machine is created/located.
+	// Datacenter is the name, inventory path, managed object reference or the managed
+	// object ID of the datacenter in which the virtual machine is created/located.
 	// Defaults to * which selects the default datacenter.
 	// +optional
 	Datacenter string `json:"datacenter,omitempty"`
 
-	// Folder is the name, inventory path or MOID of the folder in which the
-	// virtual machine is created/located.
+	// Folder is the name, inventory path, managed object reference or the managed
+	// object ID of the folder in which the virtual machine is created/located.
 	// +optional
 	Folder string `json:"folder,omitempty"`
 
-	// Datastore is the name, inventory path or MOID of the datastore in which the
-	// virtual machine is created/located.
+	// Datastore is the name, inventory path, managed object reference or the managed
+	// object ID of the datastore in which the virtual machine is created/located.
 	// +optional
 	Datastore string `json:"datastore,omitempty"`
 
@@ -148,8 +148,8 @@ type VirtualMachineCloneSpec struct {
 	// +optional
 	StoragePolicyName string `json:"storagePolicyName,omitempty"`
 
-	// ResourcePool is the name, inventory path or MOID of the resource pool in which
-	// the virtual machine is created/located.
+	// ResourcePool is the name, inventory path, managed object reference or the managed
+	// object ID in which the virtual machine is created/located.
 	// +optional
 	ResourcePool string `json:"resourcePool,omitempty"`
 
@@ -299,8 +299,8 @@ type NetworkSpec struct {
 // NetworkDeviceSpec defines the network configuration for a virtual machine's
 // network device.
 type NetworkDeviceSpec struct {
-	// NetworkName is the name or MOID of the vSphere network to which the device
-	// will be connected.
+	// NetworkName is the name, managed object reference or the managed
+	// object ID of the vSphere network to which the device will be connected.
 	NetworkName string `json:"networkName"`
 
 	// DeviceName may be used to explicitly assign a name to the network device

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -976,13 +976,13 @@ spec:
                 type: object
               datacenter:
                 description: |-
-                  Datacenter is the name or inventory path of the datacenter in which the
+                  Datacenter is the name, inventory path or MOID of the datacenter in which the
                   virtual machine is created/located.
                   Defaults to * which selects the default datacenter.
                 type: string
               datastore:
                 description: |-
-                  Datastore is the name or inventory path of the datastore in which the
+                  Datastore is the name, inventory path or MOID of the datastore in which the
                   virtual machine is created/located.
                 type: string
               diskGiB:
@@ -999,7 +999,7 @@ spec:
                 type: string
               folder:
                 description: |-
-                  Folder is the name or inventory path of the folder in which the
+                  Folder is the name, inventory path or MOID of the folder in which the
                   virtual machine is created/located.
                 type: string
               guestSoftPowerOffTimeout:
@@ -1237,7 +1237,7 @@ spec:
                           type: array
                         networkName:
                           description: |-
-                            NetworkName is the name of the vSphere network to which the device
+                            NetworkName is the name or MOID of the vSphere network to which the device
                             will be connected.
                           type: string
                         routes:
@@ -1400,7 +1400,7 @@ spec:
                 type: string
               resourcePool:
                 description: |-
-                  ResourcePool is the name or inventory path of the resource pool in which
+                  ResourcePool is the name, inventory path or MOID of the resource pool in which
                   the virtual machine is created/located.
                 type: string
               server:
@@ -1428,7 +1428,7 @@ spec:
                 type: array
               template:
                 description: |-
-                  Template is the name or inventory path of the template used to clone
+                  Template is the name, inventory path or the MOID of the template used to clone
                   the virtual machine.
                 minLength: 1
                 type: string

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -976,14 +976,14 @@ spec:
                 type: object
               datacenter:
                 description: |-
-                  Datacenter is the name, inventory path or MOID of the datacenter in which the
-                  virtual machine is created/located.
+                  Datacenter is the name, inventory path, managed object reference or the managed
+                  object ID of the datacenter in which the virtual machine is created/located.
                   Defaults to * which selects the default datacenter.
                 type: string
               datastore:
                 description: |-
-                  Datastore is the name, inventory path or MOID of the datastore in which the
-                  virtual machine is created/located.
+                  Datastore is the name, inventory path, managed object reference or the managed
+                  object ID of the datastore in which the virtual machine is created/located.
                 type: string
               diskGiB:
                 description: |-
@@ -999,8 +999,8 @@ spec:
                 type: string
               folder:
                 description: |-
-                  Folder is the name, inventory path or MOID of the folder in which the
-                  virtual machine is created/located.
+                  Folder is the name, inventory path, managed object reference or the managed
+                  object ID of the folder in which the virtual machine is created/located.
                 type: string
               guestSoftPowerOffTimeout:
                 description: |-
@@ -1237,8 +1237,8 @@ spec:
                           type: array
                         networkName:
                           description: |-
-                            NetworkName is the name or MOID of the vSphere network to which the device
-                            will be connected.
+                            NetworkName is the name, managed object reference or the managed
+                            object ID of the vSphere network to which the device will be connected.
                           type: string
                         routes:
                           description: Routes is a list of optional, static routes
@@ -1400,8 +1400,8 @@ spec:
                 type: string
               resourcePool:
                 description: |-
-                  ResourcePool is the name, inventory path or MOID of the resource pool in which
-                  the virtual machine is created/located.
+                  ResourcePool is the name, inventory path, managed object reference or the managed
+                  object ID in which the virtual machine is created/located.
                 type: string
               server:
                 description: |-
@@ -1428,8 +1428,8 @@ spec:
                 type: array
               template:
                 description: |-
-                  Template is the name, inventory path or the MOID of the template used to clone
-                  the virtual machine.
+                  Template is the name, inventory path, managed object reference or the managed
+                  object ID of the template used to clone the virtual machine.
                 minLength: 1
                 type: string
               thumbprint:

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -846,13 +846,13 @@ spec:
                         type: object
                       datacenter:
                         description: |-
-                          Datacenter is the name or inventory path of the datacenter in which the
+                          Datacenter is the name, inventory path or MOID of the datacenter in which the
                           virtual machine is created/located.
                           Defaults to * which selects the default datacenter.
                         type: string
                       datastore:
                         description: |-
-                          Datastore is the name or inventory path of the datastore in which the
+                          Datastore is the name, inventory path or MOID of the datastore in which the
                           virtual machine is created/located.
                         type: string
                       diskGiB:
@@ -869,7 +869,7 @@ spec:
                         type: string
                       folder:
                         description: |-
-                          Folder is the name or inventory path of the folder in which the
+                          Folder is the name, inventory path or MOID of the folder in which the
                           virtual machine is created/located.
                         type: string
                       guestSoftPowerOffTimeout:
@@ -1110,7 +1110,7 @@ spec:
                                   type: array
                                 networkName:
                                   description: |-
-                                    NetworkName is the name of the vSphere network to which the device
+                                    NetworkName is the name or MOID of the vSphere network to which the device
                                     will be connected.
                                   type: string
                                 routes:
@@ -1276,7 +1276,7 @@ spec:
                         type: string
                       resourcePool:
                         description: |-
-                          ResourcePool is the name or inventory path of the resource pool in which
+                          ResourcePool is the name, inventory path or MOID of the resource pool in which
                           the virtual machine is created/located.
                         type: string
                       server:
@@ -1304,7 +1304,7 @@ spec:
                         type: array
                       template:
                         description: |-
-                          Template is the name or inventory path of the template used to clone
+                          Template is the name, inventory path or the MOID of the template used to clone
                           the virtual machine.
                         minLength: 1
                         type: string

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -846,14 +846,14 @@ spec:
                         type: object
                       datacenter:
                         description: |-
-                          Datacenter is the name, inventory path or MOID of the datacenter in which the
-                          virtual machine is created/located.
+                          Datacenter is the name, inventory path, managed object reference or the managed
+                          object ID of the datacenter in which the virtual machine is created/located.
                           Defaults to * which selects the default datacenter.
                         type: string
                       datastore:
                         description: |-
-                          Datastore is the name, inventory path or MOID of the datastore in which the
-                          virtual machine is created/located.
+                          Datastore is the name, inventory path, managed object reference or the managed
+                          object ID of the datastore in which the virtual machine is created/located.
                         type: string
                       diskGiB:
                         description: |-
@@ -869,8 +869,8 @@ spec:
                         type: string
                       folder:
                         description: |-
-                          Folder is the name, inventory path or MOID of the folder in which the
-                          virtual machine is created/located.
+                          Folder is the name, inventory path, managed object reference or the managed
+                          object ID of the folder in which the virtual machine is created/located.
                         type: string
                       guestSoftPowerOffTimeout:
                         description: |-
@@ -1110,8 +1110,8 @@ spec:
                                   type: array
                                 networkName:
                                   description: |-
-                                    NetworkName is the name or MOID of the vSphere network to which the device
-                                    will be connected.
+                                    NetworkName is the name, managed object reference or the managed
+                                    object ID of the vSphere network to which the device will be connected.
                                   type: string
                                 routes:
                                   description: Routes is a list of optional, static
@@ -1276,8 +1276,8 @@ spec:
                         type: string
                       resourcePool:
                         description: |-
-                          ResourcePool is the name, inventory path or MOID of the resource pool in which
-                          the virtual machine is created/located.
+                          ResourcePool is the name, inventory path, managed object reference or the managed
+                          object ID in which the virtual machine is created/located.
                         type: string
                       server:
                         description: |-
@@ -1304,8 +1304,8 @@ spec:
                         type: array
                       template:
                         description: |-
-                          Template is the name, inventory path or the MOID of the template used to clone
-                          the virtual machine.
+                          Template is the name, inventory path, managed object reference or the managed
+                          object ID of the template used to clone the virtual machine.
                         minLength: 1
                         type: string
                       thumbprint:

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1066,13 +1066,13 @@ spec:
                 type: object
               datacenter:
                 description: |-
-                  Datacenter is the name or inventory path of the datacenter in which the
+                  Datacenter is the name, inventory path or MOID of the datacenter in which the
                   virtual machine is created/located.
                   Defaults to * which selects the default datacenter.
                 type: string
               datastore:
                 description: |-
-                  Datastore is the name or inventory path of the datastore in which the
+                  Datastore is the name, inventory path or MOID of the datastore in which the
                   virtual machine is created/located.
                 type: string
               diskGiB:
@@ -1084,7 +1084,7 @@ spec:
                 type: integer
               folder:
                 description: |-
-                  Folder is the name or inventory path of the folder in which the
+                  Folder is the name, inventory path or MOID of the folder in which the
                   virtual machine is created/located.
                 type: string
               guestSoftPowerOffTimeout:
@@ -1322,7 +1322,7 @@ spec:
                           type: array
                         networkName:
                           description: |-
-                            NetworkName is the name of the vSphere network to which the device
+                            NetworkName is the name or MOID of the vSphere network to which the device
                             will be connected.
                           type: string
                         routes:
@@ -1480,7 +1480,7 @@ spec:
                 type: string
               resourcePool:
                 description: |-
-                  ResourcePool is the name or inventory path of the resource pool in which
+                  ResourcePool is the name, inventory path or MOID of the resource pool in which
                   the virtual machine is created/located.
                 type: string
               server:
@@ -1508,7 +1508,7 @@ spec:
                 type: array
               template:
                 description: |-
-                  Template is the name or inventory path of the template used to clone
+                  Template is the name, inventory path or the MOID of the template used to clone
                   the virtual machine.
                 minLength: 1
                 type: string

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1066,14 +1066,14 @@ spec:
                 type: object
               datacenter:
                 description: |-
-                  Datacenter is the name, inventory path or MOID of the datacenter in which the
-                  virtual machine is created/located.
+                  Datacenter is the name, inventory path, managed object reference or the managed
+                  object ID of the datacenter in which the virtual machine is created/located.
                   Defaults to * which selects the default datacenter.
                 type: string
               datastore:
                 description: |-
-                  Datastore is the name, inventory path or MOID of the datastore in which the
-                  virtual machine is created/located.
+                  Datastore is the name, inventory path, managed object reference or the managed
+                  object ID of the datastore in which the virtual machine is created/located.
                 type: string
               diskGiB:
                 description: |-
@@ -1084,8 +1084,8 @@ spec:
                 type: integer
               folder:
                 description: |-
-                  Folder is the name, inventory path or MOID of the folder in which the
-                  virtual machine is created/located.
+                  Folder is the name, inventory path, managed object reference or the managed
+                  object ID of the folder in which the virtual machine is created/located.
                 type: string
               guestSoftPowerOffTimeout:
                 description: |-
@@ -1322,8 +1322,8 @@ spec:
                           type: array
                         networkName:
                           description: |-
-                            NetworkName is the name or MOID of the vSphere network to which the device
-                            will be connected.
+                            NetworkName is the name, managed object reference or the managed
+                            object ID of the vSphere network to which the device will be connected.
                           type: string
                         routes:
                           description: Routes is a list of optional, static routes
@@ -1480,8 +1480,8 @@ spec:
                 type: string
               resourcePool:
                 description: |-
-                  ResourcePool is the name, inventory path or MOID of the resource pool in which
-                  the virtual machine is created/located.
+                  ResourcePool is the name, inventory path, managed object reference or the managed
+                  object ID in which the virtual machine is created/located.
                 type: string
               server:
                 description: |-
@@ -1508,8 +1508,8 @@ spec:
                 type: array
               template:
                 description: |-
-                  Template is the name, inventory path or the MOID of the template used to clone
-                  the virtual machine.
+                  Template is the name, inventory path, managed object reference or the managed
+                  object ID of the template used to clone the virtual machine.
                 minLength: 1
                 type: string
               thumbprint:

--- a/pkg/context/fake/fake_vm_context.go
+++ b/pkg/context/fake/fake_vm_context.go
@@ -54,7 +54,6 @@ func newVSphereVM() infrav1.VSphereVM {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: Namespace,
 			Name:      VSphereVMName,
-			UID:       VSphereVMUUID,
 		},
 		Spec: infrav1.VSphereVMSpec{
 			VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -72,7 +72,7 @@ func TestCreate(t *testing.T) {
 
 		vimClient, err := vim25.NewClient(ctx, vmContext.Session.RoundTripper)
 		if err != nil {
-			t.Fatal("could not make vim25 client.")
+			t.Fatalf("could not create vim25 client: %v", err)
 		}
 
 		if replaceFunc != nil {
@@ -89,9 +89,8 @@ func TestCreate(t *testing.T) {
 		}
 
 		task := object.NewTask(vimClient, taskRef)
-		err = task.Wait(ctx)
-		if err != nil {
-			t.Fatal("error waiting for task:", err)
+		if err := task.Wait(ctx); err != nil {
+			t.Fatalf("error waiting for task: %v", err)
 		}
 	}
 
@@ -101,7 +100,7 @@ func TestCreate(t *testing.T) {
 		t.Error("failed to clone vm")
 	}
 
-	t.Log("executing with moid")
+	t.Log("executing with MOID")
 	replaceFuncMOID := func(vmContext *vmcontext.VMContext, vimClient *vim25.Client) {
 		finderClient := find.NewFinder(vimClient)
 		dc, err := finderClient.DatacenterOrDefault(ctx, "")

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -20,17 +20,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vcsim"
+	vmcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
 func TestCreate(t *testing.T) {
+	ctx := context.Background()
+
 	model := simulator.VPX()
 	model.Host = 0 // ClusterHost only
 
@@ -39,51 +43,155 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("unable to create simulator: %s", err)
 	}
 	defer simr.Destroy()
-
-	ctx := context.Background()
-	vmContext := fake.NewVMContext(ctx, fake.NewControllerManagerContext())
-	vmContext.VSphereVM.Spec.Server = simr.ServerURL().Host
-
-	authSession, err := session.GetOrCreate(
-		ctx,
-		session.NewParams().
-			WithServer(vmContext.VSphereVM.Spec.Server).
-			WithUserInfo(simr.Username(), simr.Password()).
-			WithDatacenter("*"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	vmContext.Session = authSession
-
 	vmRef := simulator.Map.Any("VirtualMachine")
 	vm, ok := vmRef.(*simulator.VirtualMachine)
 	if !ok {
 		t.Fatal("failed to get reference to an existing VM on the vcsim instance")
 	}
-	vmContext.VSphereVM.Spec.Template = vm.Name
 
-	disk := object.VirtualDeviceList(vm.Config.Hardware.Device).SelectByType((*types.VirtualDisk)(nil))[0].(*types.VirtualDisk)
-	disk.CapacityInKB = int64(vmContext.VSphereVM.Spec.DiskGiB) * 1024 * 1024
+	executeTest := func(vmname string, replaceFunc func(vmContext *vmcontext.VMContext, vimClient *vim25.Client)) {
+		vmContext := fake.NewVMContext(ctx, fake.NewControllerManagerContext())
+		vmContext.VSphereVM.Spec.Server = simr.ServerURL().Host
+		vmContext.VSphereVM.SetName(vmname)
 
-	if err := createVM(ctx, vmContext, []byte(""), ""); err != nil {
-		t.Fatal(err)
+		authSession, err := session.GetOrCreate(
+			ctx,
+			session.NewParams().
+				WithServer(vmContext.VSphereVM.Spec.Server).
+				WithUserInfo(simr.Username(), simr.Password()).
+				WithDatacenter("*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		vmContext.Session = authSession
+
+		vmContext.VSphereVM.Spec.Template = vm.Name
+
+		disk := object.VirtualDeviceList(vm.Config.Hardware.Device).SelectByType((*types.VirtualDisk)(nil))[0].(*types.VirtualDisk)
+		disk.CapacityInKB = int64(vmContext.VSphereVM.Spec.DiskGiB) * 1024 * 1024
+
+		vimClient, err := vim25.NewClient(ctx, vmContext.Session.RoundTripper)
+		if err != nil {
+			t.Fatal("could not make vim25 client.")
+		}
+
+		if replaceFunc != nil {
+			replaceFunc(vmContext, vimClient)
+		}
+
+		if err := createVM(ctx, vmContext, []byte(""), ""); err != nil {
+			t.Fatal(err)
+		}
+
+		taskRef := types.ManagedObjectReference{
+			Type:  morefTypeTask,
+			Value: vmContext.VSphereVM.Status.TaskRef,
+		}
+
+		task := object.NewTask(vimClient, taskRef)
+		err = task.Wait(ctx)
+		if err != nil {
+			t.Fatal("error waiting for task:", err)
+		}
 	}
 
-	taskRef := types.ManagedObjectReference{
-		Type:  morefTypeTask,
-		Value: vmContext.VSphereVM.Status.TaskRef,
-	}
-	vimClient, err := vim25.NewClient(ctx, vmContext.Session.RoundTripper)
-	if err != nil {
-		t.Fatal("could not make vim25 client.")
-	}
-	task := object.NewTask(vimClient, taskRef)
-	err = task.Wait(ctx)
-	if err != nil {
-		t.Fatal("error waiting for task:", err)
-	}
-
+	t.Log("executing with canonical name")
+	executeTest("canonical", nil)
 	if model.Machine+1 != model.Count().Machine {
+		t.Error("failed to clone vm")
+	}
+
+	t.Log("executing with moid")
+	replaceFuncMOID := func(vmContext *vmcontext.VMContext, vimClient *vim25.Client) {
+		finderClient := find.NewFinder(vimClient)
+		dc, err := finderClient.DatacenterOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		folder, err := finderClient.FolderOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rp, err := finderClient.ResourcePoolOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ds, err := finderClient.DatastoreOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		netw, err := finderClient.NetworkOrDefault(ctx, "VM Network")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmContext.VSphereVM.Spec.Datacenter = dc.Reference().String()
+		vmContext.VSphereVM.Spec.Folder = folder.Reference().String()
+		vmContext.VSphereVM.Spec.ResourcePool = rp.Reference().String()
+		vmContext.VSphereVM.Spec.Datastore = ds.Reference().String()
+		vmContext.VSphereVM.Spec.Network.Devices[0].NetworkName = netw.Reference().String()
+		vmContext.VSphereVM.Spec.Template = vmRef.Reference().String()
+
+		t.Logf("creating using MOID. Datacenter: %s, Datastore: %s, Folder: %s, ResourcePool: %s, Network %s, Template %s",
+			vmContext.VSphereVM.Spec.Datacenter,
+			vmContext.VSphereVM.Spec.Datastore,
+			vmContext.VSphereVM.Spec.Folder,
+			vmContext.VSphereVM.Spec.ResourcePool,
+			vmContext.VSphereVM.Spec.Network.Devices[0].NetworkName,
+			vmContext.VSphereVM.Spec.Template)
+	}
+
+	executeTest("moid", replaceFuncMOID)
+	if model.Machine+2 != model.Count().Machine {
+		t.Error("failed to clone vm")
+	}
+
+	t.Log("executing with mixed, moref, etc")
+	replaceFuncMixed := func(vmContext *vmcontext.VMContext, vimClient *vim25.Client) {
+		finderClient := find.NewFinder(vimClient)
+		dc, err := finderClient.DatacenterOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		folder, err := finderClient.FolderOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rp, err := finderClient.ResourcePoolOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ds, err := finderClient.DatastoreOrDefault(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		netw, err := finderClient.NetworkOrDefault(ctx, "VM Network")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vmContext.VSphereVM.Spec.Datacenter = dc.Reference().Value   // moref
+		vmContext.VSphereVM.Spec.Datastore = ds.Reference().String() // moid
+		vmContext.VSphereVM.Spec.Folder = folder.InventoryPath       // inventory path
+		vmContext.VSphereVM.Spec.ResourcePool = rp.Name()
+		vmContext.VSphereVM.Spec.Network.Devices[0].NetworkName = netw.Reference().String()
+
+		t.Logf("creating using mixed entries. Datacenter: %s, Datastore: %s, Folder: %s, ResourcePool: %s, Network %s, Template %s",
+			vmContext.VSphereVM.Spec.Datacenter,
+			vmContext.VSphereVM.Spec.Datastore,
+			vmContext.VSphereVM.Spec.Folder,
+			vmContext.VSphereVM.Spec.ResourcePool,
+			vmContext.VSphereVM.Spec.Network.Devices[0].NetworkName,
+			vmContext.VSphereVM.Spec.Template)
+	}
+	executeTest("mixed", replaceFuncMixed)
+	if model.Machine+3 != model.Count().Machine {
 		t.Error("failed to clone vm")
 	}
 }

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -47,6 +47,7 @@ type setupOptions struct {
 	gatewayIPVariableName     string
 	prefixVariableName        string
 	additionalVCSimServer     bool
+	useMOID                   bool
 }
 
 // SetupOption is a configuration option supplied to Setup.
@@ -79,6 +80,14 @@ func WithPrefix(variableName string) SetupOption {
 func WithAdditionalVCSimServer(t bool) SetupOption {
 	return func(o *setupOptions) {
 		o.additionalVCSimServer = t
+	}
+}
+
+// WithMOID instructs Setup to use the MOID of resources instead of
+// the real name.
+func WithMOID(t bool) SetupOption {
+	return func(o *setupOptions) {
+		o.useMOID = t
 	}
 }
 
@@ -163,7 +172,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 
 			// Get variables required when running on VCSim like VSphere Server address, user, etc.
 			if testTarget == VCSimTestTarget {
-				addVCSimTestVariables(managementClusterProxy, specName, testSpecificIPAddressClaims, testSpecificVariables)
+				addVCSimTestVariables(managementClusterProxy, specName, testSpecificIPAddressClaims, testSpecificVariables, options.useMOID)
 			}
 
 			// Re-write the clusterctl config file and add the new variables created above (ip addresses, VCSim variables).
@@ -268,7 +277,7 @@ func allocateIPAddresses(managementClusterProxy framework.ClusterProxy, options 
 	return testSpecificIPAddressManager, testSpecificIPAddressClaims, testSpecificVariables
 }
 
-func addVCSimTestVariables(managementClusterProxy framework.ClusterProxy, specName string, testSpecificIPAddressClaims vsphereip.AddressClaims, testSpecificVariables map[string]string) {
+func addVCSimTestVariables(managementClusterProxy framework.ClusterProxy, specName string, testSpecificIPAddressClaims vsphereip.AddressClaims, testSpecificVariables map[string]string, useMOID bool) {
 	// variables derived from the vCenterSimulator
 	vCenterSimulator, err := vspherevcsim.Get(ctx, managementClusterProxy.GetClient())
 	Expect(err).ToNot(HaveOccurred(), "Failed to get VCenterSimulator")
@@ -288,6 +297,7 @@ func addVCSimTestVariables(managementClusterProxy framework.ClusterProxy, specNa
 				Namespace: testSpecificIPAddressClaims[0].Namespace,
 				Name:      testSpecificIPAddressClaims[0].Name,
 			},
+			UseMOID: useMOID,
 			// NOTE: we are omitting VMOperatorDependencies because it is not created yet (it will be created by the PostNamespaceCreated hook)
 			// But this is not a issue because a default dependenciesConfig that works for vcsim will be automatically used.
 		},

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -83,8 +83,7 @@ func WithAdditionalVCSimServer(t bool) SetupOption {
 	}
 }
 
-// WithMOID instructs Setup to use the MOID of resources instead of
-// the real name.
+// WithMOID instructs Setup to use the MOID of resources instead of the real name.
 func WithMOID(t bool) SetupOption {
 	return func(o *setupOptions) {
 		o.useMOID = t

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -48,6 +48,23 @@ var _ = Describe("Cluster Creation using Cluster API quick-start test [vcsim] [s
 	})
 })
 
+var _ = Describe("Cluster Creation using Cluster API quick-start test and MOID [vcsim]", func() {
+	const specName = "quick-start-moid"
+	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
+		capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
+			return capi_e2e.QuickStartSpecInput{
+				E2EConfig:             e2eConfig,
+				ClusterctlConfigPath:  testSpecificSettingsGetter().ClusterctlConfigPath,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ArtifactFolder:        artifactFolder,
+				SkipCleanup:           skipCleanup,
+				Flavor:                ptr.To(testSpecificSettingsGetter().FlavorForMode(clusterctl.DefaultFlavor)),
+				PostNamespaceCreated:  testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+			}
+		})
+	}, WithMOID(true))
+})
+
 var _ = Describe("ClusterClass Creation using Cluster API quick-start test [vcsim] [supervisor] [PR-Blocking] [ClusterClass]", func() {
 	const specName = "quick-start-cluster-class" // prefix (quick-start) copied from CAPI
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {

--- a/test/infrastructure/vcsim/api/v1alpha1/envvar_types.go
+++ b/test/infrastructure/vcsim/api/v1alpha1/envvar_types.go
@@ -39,7 +39,7 @@ type EnvVarSpec struct {
 	// - the system automatically picks the first Image from the content library defined in the VMOperatorDependencies
 	VMOperatorDependencies *NamespacedRef `json:"vmOperatorDependencies,omitempty"`
 
-	// UseMOID defines if envvar status should be filled with the name or MOID of objects
+	// UseMOID defines if envvar status should be filled with the name or MOID of objects.
 	UseMOID bool `json:"useMOID,omitempty"`
 }
 

--- a/test/infrastructure/vcsim/api/v1alpha1/envvar_types.go
+++ b/test/infrastructure/vcsim/api/v1alpha1/envvar_types.go
@@ -38,6 +38,9 @@ type EnvVarSpec struct {
 	// - the system automatically picks the first VirtualMachine class defined in the VMOperatorDependencies
 	// - the system automatically picks the first Image from the content library defined in the VMOperatorDependencies
 	VMOperatorDependencies *NamespacedRef `json:"vmOperatorDependencies,omitempty"`
+
+	// UseMOID defines if envvar status should be filled with the name or MOID of objects
+	UseMOID bool `json:"useMOID,omitempty"`
 }
 
 // NamespacedRef defines a reference to an object of a well known API Group and kind.

--- a/test/infrastructure/vcsim/config/crd/bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
+++ b/test/infrastructure/vcsim/config/crd/bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
@@ -113,6 +113,10 @@ spec:
                       If empty, it defaults to the namespace of the parent object.
                     type: string
                 type: object
+              useMOID:
+                description: UseMOID defines if envvar status should be filled with
+                  the name or MOID of objects
+                type: boolean
               vCenterSimulator:
                 description: Name of the VCenterSimulator instance to use as source
                   for EnvVar values.

--- a/test/infrastructure/vcsim/config/crd/bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
+++ b/test/infrastructure/vcsim/config/crd/bases/vcsim.infrastructure.cluster.x-k8s.io_envvars.yaml
@@ -115,7 +115,7 @@ spec:
                 type: object
               useMOID:
                 description: UseMOID defines if envvar status should be filled with
-                  the name or MOID of objects
+                  the name or MOID of objects.
                 type: boolean
               vCenterSimulator:
                 description: Name of the VCenterSimulator instance to use as source

--- a/test/infrastructure/vcsim/controllers/envvar_controller.go
+++ b/test/infrastructure/vcsim/controllers/envvar_controller.go
@@ -303,7 +303,6 @@ func clusterEnvVarSpecGovmomiVariables(ctx context.Context, c *vcsimv1.ClusterEn
 		vars["VSPHERE_RESOURCE_POOL"] = vcsimhelpers.ResourcePoolPath(datacenter, cluster)
 		vars["VSPHERE_NETWORK"] = vcsimhelpers.NetworkPath(datacenter, vcsimhelpers.DefaultNetworkName)
 		vars["VSPHERE_TEMPLATE"] = vcsimhelpers.VMPath(datacenter, template)
-
 		return vars, nil
 	}
 

--- a/test/infrastructure/vcsim/controllers/vspherevm_controller.go
+++ b/test/infrastructure/vcsim/controllers/vspherevm_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -288,8 +287,8 @@ func (r *VSphereVMReconciler) getVMIpReconciler(vSphereCluster *infrav1.VSphereC
 			return !vSphereVM.Status.Ready && conditions.IsFalse(vSphereVM, infrav1.VMProvisionedCondition) && conditions.GetReason(vSphereVM, infrav1.VMProvisionedCondition) == infrav1.WaitingForIPAllocationReason
 		},
 		GetVMPath: func() string {
-			// Return the path where the VM is stored.
-			return path.Join(vSphereVM.Spec.Folder, vSphereVM.Name)
+			// Return vmref of the VM as it is populated already by CAPV
+			return vSphereVM.Status.VMRef
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Allow users passing MOID as part of the spec

In some cases, passing the name of an object may not be enough. There may be disambiguation problems on name usage, or special characters that are accepted by vSphere but not properly encoded to be used during VM provisioning.

This change allows users that can rely on passing MOID  (eg.: automation, terraform, vSphere UI) to pass the MOID of an object instead of passing the canonical name

Note: This change doesn't cover yet Network Name and the Failure Domain fields, that can be either covered by this same change, or on a follow up PR.
