### PR TITLE
:seedling: Fix return messages to contain proper VM information

### DIFF
--- a/pkg/services/govmomi/power.go
+++ b/pkg/services/govmomi/power.go
@@ -44,7 +44,7 @@ func (vms *VMService) getPowerState(ctx context.Context, virtualMachineCtx *virt
 	case types.VirtualMachinePowerStateSuspended:
 		return infrav1.VirtualMachinePowerStateSuspended, nil
 	default:
-		return "", errors.Errorf("unexpected power state %q for vm %s", powerState, ctx)
+		return "", errors.Errorf("unexpected power state %q for vm %s", powerState, virtualMachineCtx)
 	}
 }
 

--- a/pkg/services/govmomi/util.go
+++ b/pkg/services/govmomi/util.go
@@ -194,11 +194,11 @@ func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx
 			// Wait for the VM to be powered on.
 			powerOnTaskInfo, err := powerOnTask.WaitForResult(ctx)
 			if err != nil && powerOnTaskInfo == nil {
-				return nil, nil, errors.Wrapf(err, "failed to wait for power on op for vm %s", ctx)
+				return nil, nil, errors.Wrapf(err, "failed to wait for power on op for vm %s", virtualMachineCtx)
 			}
 			powerState, err := virtualMachineCtx.Obj.PowerState(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "failed to get power state for vm %s", ctx)
+				return nil, nil, errors.Wrapf(err, "failed to get power state for vm %s", virtualMachineCtx)
 			}
 			if powerState != types.VirtualMachinePowerStatePoweredOn {
 				return nil, nil, errors.Errorf(
@@ -208,7 +208,7 @@ func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx
 
 			// Wait for all NICs to have valid MAC addresses.
 			if err := waitForMacAddresses(ctx, virtualMachineCtx); err != nil {
-				return nil, nil, errors.Wrapf(err, "failed to wait for mac addresses for vm %s", ctx)
+				return nil, nil, errors.Wrapf(err, "failed to wait for mac addresses for vm %s", virtualMachineCtx)
 			}
 
 			// Get all the MAC addresses. This is done separately from waiting
@@ -217,7 +217,7 @@ func reconcileVSphereVMWhenNetworkIsReady(ctx context.Context, virtualMachineCtx
 			// specs, and not the propery change order.
 			_, macToDeviceIndex, deviceToMacIndex, err := getMacAddresses(ctx, virtualMachineCtx)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "failed to get mac addresses for vm %s", ctx)
+				return nil, nil, errors.Wrapf(err, "failed to get mac addresses for vm %s", virtualMachineCtx)
 			}
 
 			// Wait for the IP addresses to show up for the VM.

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -120,17 +120,17 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 
 	folder, err := vmCtx.Session.Finder.FolderOrDefault(ctx, vmCtx.VSphereVM.Spec.Folder)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get folder for %q", ctx)
+		return errors.Wrapf(err, "unable to get folder for %q", vmCtx)
 	}
 
 	pool, err := vmCtx.Session.Finder.ResourcePoolOrDefault(ctx, vmCtx.VSphereVM.Spec.ResourcePool)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get resource pool for %q", ctx)
+		return errors.Wrapf(err, "unable to get resource pool for %q", vmCtx)
 	}
 
 	devices, err := tpl.Device(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "error getting devices for %q", ctx)
+		return errors.Wrapf(err, "error getting devices for %q", vmCtx)
 	}
 
 	// Create a new list of device specs for cloning the VM.
@@ -140,14 +140,14 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	if snapshotRef == nil {
 		diskSpecs, err := getDiskSpec(vmCtx, devices)
 		if err != nil {
-			return errors.Wrapf(err, "error getting disk spec for %q", ctx)
+			return errors.Wrapf(err, "error getting disk spec for %q", vmCtx)
 		}
 		deviceSpecs = append(deviceSpecs, diskSpecs...)
 	}
 
 	networkSpecs, err := getNetworkSpecs(ctx, vmCtx, devices)
 	if err != nil {
-		return errors.Wrapf(err, "error getting network specs for %q", ctx)
+		return errors.Wrapf(err, "error getting network specs for %q", vmCtx)
 	}
 
 	deviceSpecs = append(deviceSpecs, networkSpecs...)
@@ -207,7 +207,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	if vmCtx.VSphereVM.Spec.Datastore != "" {
 		datastore, err := vmCtx.Session.Finder.Datastore(ctx, vmCtx.VSphereVM.Spec.Datastore)
 		if err != nil {
-			return errors.Wrapf(err, "unable to get datastore %s for %q", vmCtx.VSphereVM.Spec.Datastore, ctx)
+			return errors.Wrapf(err, "unable to get datastore %s for %q", vmCtx.VSphereVM.Spec.Datastore, vmCtx)
 		}
 		datastoreRef = types.NewReference(datastore.Reference())
 		spec.Location.Datastore = datastoreRef
@@ -217,12 +217,12 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	if vmCtx.VSphereVM.Spec.StoragePolicyName != "" {
 		pbmClient, err := pbm.NewClient(ctx, vmCtx.Session.Client.Client)
 		if err != nil {
-			return errors.Wrapf(err, "unable to create pbm client for %q", ctx)
+			return errors.Wrapf(err, "unable to create pbm client for %q", vmCtx)
 		}
 
 		storageProfileID, err = pbmClient.ProfileIDByName(ctx, vmCtx.VSphereVM.Spec.StoragePolicyName)
 		if err != nil {
-			return errors.Wrapf(err, "unable to get storageProfileID from name %s for %q", vmCtx.VSphereVM.Spec.StoragePolicyName, ctx)
+			return errors.Wrapf(err, "unable to get storageProfileID from name %s for %q", vmCtx.VSphereVM.Spec.StoragePolicyName, vmCtx)
 		}
 
 		var hubs []pbmTypes.PbmPlacementHub
@@ -279,7 +279,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 		// if no datastore defined through VM spec or storage policy, use default
 		datastore, err := vmCtx.Session.Finder.DefaultDatastore(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "unable to get default datastore for %q", ctx)
+			return errors.Wrapf(err, "unable to get default datastore for %q", vmCtx)
 		}
 		datastoreRef = types.NewReference(datastore.Reference())
 	}
@@ -292,7 +292,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	log.Info(fmt.Sprintf("Cloning Machine with clone mode %s", vmCtx.VSphereVM.Status.CloneMode))
 	task, err := tpl.Clone(ctx, folder, vmCtx.VSphereVM.Name, spec)
 	if err != nil {
-		return errors.Wrapf(err, "error trigging clone op for machine %s", ctx)
+		return errors.Wrapf(err, "error trigging clone op for machine %s", vmCtx)
 	}
 
 	vmCtx.VSphereVM.Status.TaskRef = task.Reference().Value
@@ -415,11 +415,11 @@ func getNetworkSpecs(ctx context.Context, vmCtx *capvcontext.VMContext, devices 
 		}
 		backing, err := ref.EthernetCardBackingInfo(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create new ethernet card backing info for network %q on %q", netSpec.NetworkName, ctx)
+			return nil, errors.Wrapf(err, "unable to create new ethernet card backing info for network %q on %q", netSpec.NetworkName, vmCtx)
 		}
 		dev, err := object.EthernetCardTypes().CreateEthernetCard(ethCardType, backing)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create new ethernet card %q for network %q on %q", ethCardType, netSpec.NetworkName, ctx)
+			return nil, errors.Wrapf(err, "unable to create new ethernet card %q for network %q on %q", ethCardType, netSpec.NetworkName, vmCtx)
 		}
 
 		// Get the actual NIC object. This is safe to assert without a check


### PR DESCRIPTION
**What this PR does / why we need it**:
During the "context" usage refactoring, we have missed the error return messages/fields.

This way the return of an error message was containing the "context" field, and not the real "Virtual Machine context" (which is a stringer).

