### PR TITLE
🌱 Replace CAPI's clustercache tracker by the new clustercache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,10 +211,6 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: \"sigs.k8s.io/cluster-api-provider-vsphere/apis/(v1alpha3|v1alpha4)\" is deprecated: This package will be removed in one of the next releases."
-  # Deprecations for Cluster API's ClusterCacheTracker
-  - linters:
-    - staticcheck
-    text: "SA1019: remote.(ClusterCacheTracker|ClusterCacheReconciler|ClusterCacheTrackerOptions|NewClusterCacheTracker) is deprecated: This will be removed in Cluster API v1.10, use clustercache.(ClusterCache|SetupWithManager) instead."
   # Deprecations for Cluster API's predicates.ClusterUnpausedAndInfrastructureReady
   - linters:
     - staticcheck

--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,9 +54,9 @@ func TestControllers(t *testing.T) {
 }
 
 var (
-	testEnv *helpers.TestEnvironment
-	tracker *remote.ClusterCacheTracker
-	ctx     = ctrl.SetupSignalHandler()
+	testEnv      *helpers.TestEnvironment
+	clusterCache clustercache.ClusterCache
+	ctx          = ctrl.SetupSignalHandler()
 )
 
 func TestMain(m *testing.M) {
@@ -82,30 +83,29 @@ func setup() {
 		panic("unable to create secret caching client")
 	}
 
-	tracker, err = remote.NewClusterCacheTracker(
-		testEnv.Manager,
-		remote.ClusterCacheTrackerOptions{
-			SecretCachingClient: secretCachingClient,
-			ControllerName:      "testenv-manager",
+	clusterCache, err = clustercache.SetupWithManager(ctx, testEnv.Manager, clustercache.Options{
+		SecretClient: secretCachingClient,
+		Client: clustercache.ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("testenv-manager"),
+			Cache: clustercache.ClientCacheOptions{
+				DisableFor: []client.Object{
+					// Don't cache ConfigMaps & Secrets.
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+			},
 		},
-	)
+	}, controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)})
 	if err != nil {
-		panic(fmt.Sprintf("unable to setup ClusterCacheTracker: %v", err))
+		panic(fmt.Sprintf("Unable to setup ClusterCache: %v", err))
 	}
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 
-	if err := (&remote.ClusterCacheReconciler{
-		Client:  testEnv.Manager.GetClient(),
-		Tracker: tracker,
-	}).SetupWithManager(ctx, testEnv.Manager, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to create ClusterCacheReconciler controller: %v", err))
-	}
-
-	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ServiceAccount controller: %v", err))
 	}
-	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup SvcDiscovery controller: %v", err))
 	}
 

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -59,13 +59,14 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				helpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 
 			By("Verifying that the guest cluster client works")
 			var guestClient client.Client
 			var err error
 			Eventually(func() error {
-				guestClient, err = tracker.GetClient(ctx, client.ObjectKeyFromObject(intCtx.Cluster))
+				guestClient, err = clusterCache.GetClient(ctx, client.ObjectKeyFromObject(intCtx.Cluster))
 				return err
 			}, time.Minute, 5*time.Second).Should(Succeed())
 			// Note: Create a Service informer, so the test later doesn't fail if this doesn't work.
@@ -191,6 +192,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				helpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
 			pSvcAccount.Spec.TargetNamespace = "default"

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -40,13 +40,14 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
 			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 			helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+			helpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 		})
 
 		By("Verifying that the guest cluster client works")
 		var guestClient client.Client
 		var err error
 		Eventually(func() error {
-			guestClient, err = tracker.GetClient(ctx, client.ObjectKeyFromObject(intCtx.Cluster))
+			guestClient, err = clusterCache.GetClient(ctx, client.ObjectKeyFromObject(intCtx.Cluster))
 			return err
 		}, time.Minute, 5*time.Second).Should(Succeed())
 		// Note: Create a Service informer, so the test later doesn't fail if this doesn't work.

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -71,12 +71,12 @@ import (
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;delete
 
 // AddVMControllerToManager adds the VM controller to the provided manager.
-func AddVMControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, tracker *remote.ClusterCacheTracker, options controller.Options) error {
+func AddVMControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterCache clustercache.ClusterCache, options controller.Options) error {
 	r := vmReconciler{
-		ControllerManagerContext:  controllerManagerCtx,
-		Recorder:                  mgr.GetEventRecorderFor("vspherevm-controller"),
-		VMService:                 &govmomi.VMService{},
-		remoteClusterCacheTracker: tracker,
+		ControllerManagerContext: controllerManagerCtx,
+		Recorder:                 mgr.GetEventRecorderFor("vspherevm-controller"),
+		VMService:                &govmomi.VMService{},
+		clusterCache:             clusterCache,
 	}
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "vspherevm")
 
@@ -132,14 +132,15 @@ func AddVMControllerToManager(ctx context.Context, controllerManagerCtx *capvcon
 			&ipamv1.IPAddressClaim{},
 			handler.EnqueueRequestsFromMapFunc(r.ipAddressClaimToVSphereVM),
 		).
+		WatchesRawSource(r.clusterCache.GetClusterSource("vspherevm", r.clusterToVSphereVMs)).
 		Complete(r)
 }
 
 type vmReconciler struct {
 	Recorder record.EventRecorder
 	*capvcontext.ControllerManagerContext
-	VMService                 services.VirtualMachineService
-	remoteClusterCacheTracker *remote.ClusterCacheTracker
+	VMService    services.VirtualMachineService
+	clusterCache clustercache.ClusterCache
 }
 
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
@@ -388,10 +389,10 @@ func (r vmReconciler) deleteNode(ctx context.Context, vmCtx *capvcontext.VMConte
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	clusterClient, err := r.remoteClusterCacheTracker.GetClient(ctx, ctrlclient.ObjectKeyFromObject(cluster))
+	clusterClient, err := r.clusterCache.GetClient(ctx, ctrlclient.ObjectKeyFromObject(cluster))
 	if err != nil {
-		if errors.Is(err, remote.ErrClusterLocked) {
-			log.V(5).Info("Requeuing because another worker has the lock on the ClusterCacheTracker")
+		if errors.Is(err, clustercache.ErrClusterNotConnected) {
+			log.V(5).Info("Requeuing because connection to the workload cluster is down")
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		return ctrl.Result{}, err

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -49,6 +49,7 @@ func NewControllerManagerContext(initObjects ...client.Object) *capvcontext.Cont
 	clientWithObjects := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
 		&infrav1.VSphereVM{},
 		&vmwarev1.VSphereCluster{},
+		&clusterv1.Cluster{},
 	).WithObjects(initObjects...).Build()
 
 	return &capvcontext.ControllerManagerContext{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Removes usage of the deprecated remote.ClusterCacheTracker and related functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
