### PR TITLE
🌱 Makefile: set GOTOOLCHAIN=auto for generate-flavors to make it work in cloudbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -790,7 +790,7 @@ e2e-flavors-main: $(RELEASE_DIR)
 
 .PHONY: generate-flavors
 generate-flavors: $(FLAVOR_DIR)
-	cd $(PACKAGING_DIR)/flavorgen; go build -o flavorgen ./
+	cd $(PACKAGING_DIR)/flavorgen; GOTOOLCHAIN=auto go build -o flavorgen ./
 	$(PACKAGING_DIR)/flavorgen/flavorgen --output-dir $(FLAVOR_DIR)
 	rm $(PACKAGING_DIR)/flavorgen/flavorgen
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-api-provider-vsphere-push-images 

is broken since merging:

- #3233 

log says:
```
mkdir -p out/
cd packaging/flavorgen; go build -o flavorgen ./
go: ../go.mod requires go >= 1.22.7 (running go 1.22.0; GOTOOLCHAIN=local)
make[2]: *** [Makefile:793: generate-flavors] Error 1
```
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-api-provider-vsphere-push-images/1849761049792745472

This sets GOTOOLCHAIN=auto for buiilding flavorgen which should make go auto-download a good version.

Alternative: bumping [gcr.io/k8s-staging-test-infra/gcb-docker-gcloud](http://gcr.io/k8s-staging-test-infra/gcb-docker-gcloud) in cloudbuild-nightly.yaml and cloudbuild.yaml does not work because the latest image contains go 1.22.5




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
