### PR TITLE
🌱 Switch to using ECR mirror for trivy DB repo

### DIFF
--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -24,6 +24,7 @@ fi
 
 VERSION=${1}
 GO_ARCH="$(go env GOARCH)"
+DB_MIRROR="public.ecr.aws/aquasecurity/trivy-db"
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 "${REPO_ROOT}/hack/ensure-trivy.sh" "${VERSION}"
@@ -35,7 +36,7 @@ make REGISTRY=gcr.io/k8s-staging-capi-vsphere PULL_POLICY=IfNotPresent TAG=dev d
 make clean-release-git
 
 # Scan the images
-"${TRIVY}" image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller-"${GO_ARCH}":dev && R1=$? || R1=$?
+"${TRIVY}" image --db-repository="${DB_MIRROR}" -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-controller-"${GO_ARCH}":dev && R1=$? || R1=$?
 
 echo ""
 BRed='\033[1;31m'


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This was done a while ago in CAPI to keep this working. Let's do the same now in CAPV

xref: https://github.com/sbueringer/cluster-api-provider-vsphere/actions/runs/11554091887

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
