### PR TITLE
:bug: Proper ignore IPv6 announcements when IPv6 is not requested

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -36,8 +36,9 @@ network:
       set-name: "eth{{ $i }}"
       {{- end }}
       wakeonlan: true
-      {{- if or $net.DHCP4 $net.DHCP6 }}
       dhcp4: {{ $net.DHCP4 }}
+      dhcp6: {{ $net.DHCP6 }}
+      accept-ra: {{ $net.DHCP6 }}   
 	  {{- if $net.DHCP4Overrides }}
       dhcp4-overrides:
 	    {{- if $net.DHCP4Overrides.Hostname }}
@@ -68,7 +69,6 @@ network:
         use-routes: "{{ $net.DHCP4Overrides.UseRoutes }}"
 	    {{- end }}
 	  {{- end }}
-      dhcp6: {{ $net.DHCP6 }}
 	  {{- if $net.DHCP6Overrides }}
       dhcp6-overrides:
 	    {{- if $net.DHCP6Overrides.Hostname }}
@@ -99,7 +99,6 @@ network:
         use-routes: "{{ $net.DHCP6Overrides.UseRoutes }}"
 	    {{- end }}
 	  {{- end }}
-      {{- end }}
       {{- if $net.IPAddrs }}
       addresses:
       {{- range $net.IPAddrs }}

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -275,6 +275,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
 `,
 		},
 		{
@@ -311,6 +312,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
 `,
 		},
 		{
@@ -346,6 +348,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
 `,
 		},
 		{
@@ -382,6 +385,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: true
+      accept-ra: true
 `,
 		},
 		{
@@ -439,6 +443,8 @@ network:
       set-name: "eth0"
       wakeonlan: true
       dhcp4: true
+      dhcp6: true
+      accept-ra: true
       dhcp4-overrides:
         hostname: "hal"
         route-metric: 12345
@@ -449,7 +455,6 @@ network:
         use-mtu: true
         use-ntp: true
         use-routes: "route"
-      dhcp6: true
       dhcp6-overrides:
         hostname: "hal"
         route-metric: 12345
@@ -498,6 +503,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: true
+      accept-ra: true
 `,
 		},
 		{
@@ -535,6 +541,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
       addresses:
       - "192.168.4.21"
       gateway4: "192.168.4.1"
@@ -582,6 +589,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
       addresses:
       - "192.168.4.21"
       gateway4: "192.168.4.1"
@@ -637,6 +645,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
       routes:
       - to: "192.168.5.1/24"
         via: "192.168.4.254"
@@ -648,6 +657,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
       mtu: 100
 `,
 		},
@@ -692,6 +702,9 @@ network:
         macaddress: "00:00:00:00:00"
       set-name: "eth0"
       wakeonlan: true
+      dhcp4: false
+      dhcp6: false
+      accept-ra: false
       addresses:
       - "192.168.4.21"
       gateway4: "192.168.4.1"
@@ -707,6 +720,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
       nameservers:
         search:
         - "vmware6.ci"
@@ -754,6 +768,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
     id1:
       match:
         macaddress: "00:00:00:00:cd"
@@ -761,6 +776,7 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
 `,
 		},
 		{
@@ -816,6 +832,9 @@ network:
         macaddress: "00:00:00:00:00"
       set-name: "eth0"
       wakeonlan: true
+      dhcp4: false
+      dhcp6: false
+      accept-ra: false
       addresses:
       - "10.10.50.50/24"
       gateway4: "10.10.50.1"
@@ -826,11 +845,15 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
     id2:
       match:
         macaddress: "00:00:00:00:02"
       set-name: "eth2"
       wakeonlan: true
+      dhcp4: false
+      dhcp6: false
+      accept-ra: false
       addresses:
       - "fe80::3/64"
       gateway6: "fe80::1"
@@ -879,6 +902,7 @@ network:
       wakeonlan: true
       dhcp4: true
       dhcp6: false
+      accept-ra: false
     id1:
       match:
         macaddress: "00:00:00:00:cd"
@@ -886,11 +910,15 @@ network:
       wakeonlan: true
       dhcp4: false
       dhcp6: true
+      accept-ra: true
     id2:
       match:
         macaddress: "00:00:00:00:ef"
       set-name: "eth2"
       wakeonlan: true
+      dhcp4: false
+      dhcp6: false
+      accept-ra: false
 `,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: 

On some networks IPv6 is announced via RA. Networkd (and maybe netplan) separates DHCPv6 and RA enablement, meaning that even when users set to ignore/disable DHCPv6, IPv6 is still configured on the Host VM if there is some Route Advertisement for IPv6. 

Turns out on some setups this may break the desired behavior, as DNSv6 and others may also end up being configured on the node using IPv6.

This PR intends to do the following changes:
* Organize cloud-init template to separate DHCPv, DHCPv6 and override flags as they are independent
* Configure cloud-init to pass accept-ra. This enforcement needs cloud-init on at least version 24.2 (see https://github.com/canonical/cloud-init/pull/4928 and https://github.com/canonical/cloud-init/pull/5060)


