### PR TITLE
Update glossary reference

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -193,7 +193,7 @@ vsphere-quickstart-9qtfd                                      Ready      master 
 
 ## Custom cluster templates
 
-the provided cluster templates are quickstarts. If you need anything specific that requires a more complex setup, we recommand to use custom templates:
+the provided cluster templates are quickstarts. If you need anything specific that requires a more complex setup, we recommend to use custom templates:
 
 ```shell
 $ clusterctl generate custom-cluster vsphere-quickstart \
@@ -209,7 +209,7 @@ $ clusterctl generate custom-cluster vsphere-quickstart \
 [cluster-api-book]: https://cluster-api.sigs.k8s.io/
 [glossary-bootstrapping]: https://cluster-api.sigs.k8s.io/reference/glossary.html#bootstrap
 [kind]: https://kind.sigs.k8s.io
-[glossary-management-cluster]: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/GLOSSARY.md#management-cluster
+[glossary-management-cluster]: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/reference/glossary.md#management-cluster
 [releases]: https://github.com/kubernetes-sigs/cluster-api/releases
 [docker]: https://docs.docker.com/glossary/?term=install
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/


### PR DESCRIPTION
# PR Summary
Small PR - File `docs/book/GLOSSARY.md` was renamed to `docs/book/src/reference/glossary.md` in `kubernetes-sigs/cluster-api` repo. This PR adjusts sources to changes. See this commit for more info: https://github.com/kubernetes-sigs/cluster-api/commit/340aba88a519809392fe2a508e10f942e420ad2a