### PR TITLE
:sparkles: Add ability to configure data disk provision type during clone

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -220,7 +220,29 @@ type VSphereDisk struct {
 	// SizeGiB is the size of the disk in GiB.
 	// +kubebuilder:validation:Required
 	SizeGiB int32 `json:"sizeGiB"`
+	// ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+	// If not set, the setting will be provided by the default storage policy.
+	// +optional
+	ProvisioningMode ProvisioningMode `json:"provisioningMode,omitempty"`
 }
+
+// ProvisioningMode represents the various provisioning types available to a VMs disk.
+// +kubebuilder:validation:Enum=Thin;Thick;EagerlyZeroed
+type ProvisioningMode string
+
+var (
+	// ThinProvisioningMode creates the disk using thin provisioning. This means a sparse (allocate on demand)
+	// format with additional space optimizations.
+	ThinProvisioningMode ProvisioningMode = "Thin"
+
+	// ThickProvisioningMode creates the disk with all space allocated.
+	ThickProvisioningMode ProvisioningMode = "Thick"
+
+	// EagerlyZeroedProvisioningMode creates the disk using eager zero provisioning. An eager zeroed thick disk
+	// has all space allocated and wiped clean of any previous contents on the physical media at
+	// creation time. Such disks may take longer time during creation compared to other disk formats.
+	EagerlyZeroedProvisioningMode ProvisioningMode = "EagerlyZeroed"
+)
 
 // VSphereMachineTemplateResource describes the data needed to create a VSphereMachine from a template.
 type VSphereMachineTemplateResource struct {

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -986,6 +986,15 @@ spec:
                         Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
                         clearly identify purpose of the disk.
                       type: string
+                    provisioningMode:
+                      description: |-
+                        ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                        If not set, the setting will be provided by the default storage policy.
+                      enum:
+                      - Thin
+                      - Thick
+                      - EagerlyZeroed
+                      type: string
                     sizeGiB:
                       description: SizeGiB is the size of the disk in GiB.
                       format: int32

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -856,6 +856,15 @@ spec:
                                 Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
                                 clearly identify purpose of the disk.
                               type: string
+                            provisioningMode:
+                              description: |-
+                                ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                                If not set, the setting will be provided by the default storage policy.
+                              enum:
+                              - Thin
+                              - Thick
+                              - EagerlyZeroed
+                              type: string
                             sizeGiB:
                               description: SizeGiB is the size of the disk in GiB.
                               format: int32

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1076,6 +1076,15 @@ spec:
                         Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
                         clearly identify purpose of the disk.
                       type: string
+                    provisioningMode:
+                      description: |-
+                        ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                        If not set, the setting will be provided by the default storage policy.
+                      enum:
+                      - Thin
+                      - Thick
+                      - EagerlyZeroed
+                      type: string
                     sizeGiB:
                       description: SizeGiB is the size of the disk in GiB.
                       format: int32

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/multi-disk/data-disks-patch.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/multi-disk/data-disks-patch.yaml
@@ -8,9 +8,11 @@ spec:
     spec:
       dataDisks:
       - name: "disk_1"
-        sizeGiB: 10
+        sizeGiB: 1
+        provisioningType: "Thin"
       - name: "disk_2"
-        sizeGiB: 20
+        sizeGiB: 2
+        provisioningType: "Thick"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
@@ -22,4 +24,13 @@ spec:
     spec:
       dataDisks:
       - name: "disk_1"
-        sizeGiB: 20
+        sizeGiB: 1
+        provisioningType: "Thin"
+      - name: "disk_2"
+        sizeGiB: 2
+        provisioningType: "Thick"
+      - name: "disk_3"
+        sizeGiB: 3
+        provisioningType: "EagerlyZeroed"
+      - name: "disk_4"
+        sizeGiB: 4


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of the data disk feature for creating additional disks on a VirtualMachine dynamically is currently coded to create each disk as a thin provisioned disk.  This may not be suitable for all scenarios.  Administators may require the full disk be allocated (and possibly zeroed out).  This PR is adding a new field to allow the administrators to create data disk that is either: 
- Thin Provisioned
- Thick Provisioned
- EagerlyZeroed
- Left unset to follow the rest of the cloning process

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
