### PR TITLE
🌱 test: enable upgrades for scale-test and bump CAPI to d5158c2503c84bcf2fc35cf463fca486892b5fae

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8
 
 replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-20240404200847-de75746a9505
 

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142 h1:P14Lxb0Rz2VlqRaSTcg57Y8pF0gFKVT2UkhonnMM/tU=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142/go.mod h1:HXL41Lwe7Ey+8V8jJAHRl/7G2+UyyR7o1BxbeHT7D6I=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8 h1:vqlOZG5uKc1SKGG65FB0tmO22sMakT+lCzEuKlkXlsA=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8/go.mod h1:mIt2rlw7HjsGpEAXlhWiuWqDdA3YAuHIbqWCKqnKR0M=
 sigs.k8s.io/controller-runtime v0.20.1 h1:JbGMAG/X94NeM3xvjenVUaBjy6Ui4Ogd/J5ZtjZnHaE=
 sigs.k8s.io/controller-runtime v0.20.1/go.mod h1:BrP3w158MwvB3ZbNpaAcIKkHQ7YGpYnzpoSTZ8E14WU=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/packaging/go.mod
+++ b/packaging/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere/packaging
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8
 
 replace sigs.k8s.io/cluster-api-provider-vsphere => ../
 

--- a/packaging/go.sum
+++ b/packaging/go.sum
@@ -232,8 +232,8 @@ k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJ
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142 h1:P14Lxb0Rz2VlqRaSTcg57Y8pF0gFKVT2UkhonnMM/tU=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142/go.mod h1:HXL41Lwe7Ey+8V8jJAHRl/7G2+UyyR7o1BxbeHT7D6I=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8 h1:vqlOZG5uKc1SKGG65FB0tmO22sMakT+lCzEuKlkXlsA=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8/go.mod h1:mIt2rlw7HjsGpEAXlhWiuWqDdA3YAuHIbqWCKqnKR0M=
 sigs.k8s.io/controller-runtime v0.20.1 h1:JbGMAG/X94NeM3xvjenVUaBjy6Ui4Ogd/J5ZtjZnHaE=
 sigs.k8s.io/controller-runtime v0.20.1/go.mod h1:BrP3w158MwvB3ZbNpaAcIKkHQ7YGpYnzpoSTZ8E14WU=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -31,7 +31,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 	const specName = "k8s-upgrade-with-runtimesdk" // aligned to CAPI
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.ClusterUpgradeWithRuntimeSDKSpec(ctx, func() capi_e2e.ClusterUpgradeWithRuntimeSDKSpecInput {
-			version, err := semver.ParseTolerant(e2eConfig.GetVariable(capi_e2e.KubernetesVersionUpgradeFrom))
+			version, err := semver.ParseTolerant(e2eConfig.MustGetVariable(capi_e2e.KubernetesVersionUpgradeFrom))
 			Expect(err).ToNot(HaveOccurred(), "Invalid argument, KUBERNETES_VERSION_UPGRADE_FROM is not a valid version")
 			if version.LT(semver.MustParse("1.24.0")) {
 				Fail("This test only supports upgrades from Kubernetes >= v1.24.0")

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -36,9 +36,9 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass and testi
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 			// The Kubernetes versions have to be resolved as they can be defined like this: stable-1.29, ci/latest-1.30.
-			kubernetesVersionUpgradeFrom, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.GetVariable("KUBERNETES_VERSION_UPGRADE_FROM"))
+			kubernetesVersionUpgradeFrom, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.MustGetVariable("KUBERNETES_VERSION_UPGRADE_FROM"))
 			Expect(err).NotTo(HaveOccurred())
-			kubernetesVersionUpgradeTo, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.GetVariable("KUBERNETES_VERSION_UPGRADE_TO"))
+			kubernetesVersionUpgradeTo, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.MustGetVariable("KUBERNETES_VERSION_UPGRADE_TO"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("KUBERNETES_VERSION_UPGRADE_FROM", kubernetesVersionUpgradeFrom)).To(Succeed())
 			Expect(os.Setenv("KUBERNETES_VERSION_UPGRADE_TO", kubernetesVersionUpgradeTo)).To(Succeed())

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -50,7 +50,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (CAPV 1.12
 			capvVersion := "1.12"
 			capvStableRelease, err := getStableReleaseOfMinor(ctx, capvReleaseMarkerPrefix, capvVersion)
 			Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", capvVersion)
-			initKubernetesVersion, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.GetVariable("KUBERNETES_VERSION_LATEST_CI"))
+			initKubernetesVersion, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.MustGetVariable("KUBERNETES_VERSION_LATEST_CI"))
 			Expect(err).ToNot(HaveOccurred())
 			return capi_e2e.ClusterctlUpgradeSpecInput{
 				E2EConfig:                         e2eConfig,

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -55,7 +55,7 @@ func defaultConfigCluster(clusterName, namespace, flavor string, controlPlaneNod
 		Flavor:                   clusterctl.DefaultFlavor,
 		Namespace:                namespace,
 		ClusterName:              clusterName,
-		KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+		KubernetesVersion:        input.E2EConfig.MustGetVariable(KubernetesVersion),
 		ControlPlaneMachineCount: ptr.To(controlPlaneNodeCount),
 		WorkerMachineCount:       ptr.To(workerNodeCount),
 	}

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -27,7 +27,7 @@ providers:
     type: CoreProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250203/core-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250205/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -76,7 +76,7 @@ providers:
     type: BootstrapProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250203/bootstrap-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250205/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -125,7 +125,7 @@ providers:
     type: ControlPlaneProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250203/control-plane-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250205/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/e2e/dhcp_overrides_test.go
+++ b/test/e2e/dhcp_overrides_test.go
@@ -79,7 +79,7 @@ var _ = Describe("DHCPOverrides configuration test", func() {
 						Flavor:                   testSpecificSettingsGetter().FlavorForMode("dhcp-overrides"),
 						Namespace:                namespace.Name,
 						ClusterName:              clusterName,
-						KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+						KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
 						ControlPlaneMachineCount: ptr.To(int64(1)),
 						WorkerMachineCount:       ptr.To(int64(1)),
 					},

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -122,7 +122,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 		// Update the CLUSTER_CLASS_NAME variable adding the supervisor suffix.
 		if testMode == SupervisorTestMode {
 			if e2eConfig.HasVariable("CLUSTER_CLASS_NAME") {
-				testSpecificVariables["CLUSTER_CLASS_NAME"] = fmt.Sprintf("%s-supervisor", e2eConfig.GetVariable("CLUSTER_CLASS_NAME"))
+				testSpecificVariables["CLUSTER_CLASS_NAME"] = fmt.Sprintf("%s-supervisor", e2eConfig.MustGetVariable("CLUSTER_CLASS_NAME"))
 			}
 		}
 
@@ -382,47 +382,47 @@ func setupNamespaceWithVMOperatorDependenciesVCenter(managementClusterProxy fram
 		Spec: vcsimv1.VMOperatorDependenciesSpec{
 			VCenter: &vcsimv1.VCenterSpec{
 				// NOTE: variables from E2E.sh + presets (or variables overrides when running tests locally)
-				ServerURL:  net.JoinHostPort(e2eConfig.GetVariable("VSPHERE_SERVER"), "443"),
-				Username:   e2eConfig.GetVariable("VSPHERE_USERNAME"),
-				Password:   e2eConfig.GetVariable("VSPHERE_PASSWORD"),
-				Thumbprint: e2eConfig.GetVariable("VSPHERE_TLS_THUMBPRINT"),
+				ServerURL:  net.JoinHostPort(e2eConfig.MustGetVariable("VSPHERE_SERVER"), "443"),
+				Username:   e2eConfig.MustGetVariable("VSPHERE_USERNAME"),
+				Password:   e2eConfig.MustGetVariable("VSPHERE_PASSWORD"),
+				Thumbprint: e2eConfig.MustGetVariable("VSPHERE_TLS_THUMBPRINT"),
 				// NOTE: variables from e2e config (or variables overrides when running tests locally)
-				Datacenter:   e2eConfig.GetVariable("VSPHERE_DATACENTER"),
-				Cluster:      e2eConfig.GetVariable("VSPHERE_COMPUTE_CLUSTER"),
-				Folder:       e2eConfig.GetVariable("VSPHERE_FOLDER"),
-				ResourcePool: e2eConfig.GetVariable("VSPHERE_RESOURCE_POOL"),
+				Datacenter:   e2eConfig.MustGetVariable("VSPHERE_DATACENTER"),
+				Cluster:      e2eConfig.MustGetVariable("VSPHERE_COMPUTE_CLUSTER"),
+				Folder:       e2eConfig.MustGetVariable("VSPHERE_FOLDER"),
+				ResourcePool: e2eConfig.MustGetVariable("VSPHERE_RESOURCE_POOL"),
 				ContentLibrary: vcsimv1.ContentLibraryConfig{
-					Name:      e2eConfig.GetVariable("VSPHERE_CONTENT_LIBRARY"),
-					Datastore: e2eConfig.GetVariable("VSPHERE_DATASTORE"),
+					Name:      e2eConfig.MustGetVariable("VSPHERE_CONTENT_LIBRARY"),
+					Datastore: e2eConfig.MustGetVariable("VSPHERE_DATASTORE"),
 					// NOTE: when running on vCenter the vm-operator automatically creates VirtualMachine objects for the content library.
 					Items: []vcsimv1.ContentLibraryItemConfig{},
 				},
-				DistributedPortGroupName: e2eConfig.GetVariable("VSPHERE_DISTRIBUTED_PORT_GROUP"),
+				DistributedPortGroupName: e2eConfig.MustGetVariable("VSPHERE_DISTRIBUTED_PORT_GROUP"),
 			},
 			StorageClasses: []vcsimv1.StorageClass{
 				{
-					Name:          e2eConfig.GetVariable("VSPHERE_STORAGE_CLASS"),
-					StoragePolicy: e2eConfig.GetVariable("VSPHERE_STORAGE_POLICY"),
+					Name:          e2eConfig.MustGetVariable("VSPHERE_STORAGE_CLASS"),
+					StoragePolicy: e2eConfig.MustGetVariable("VSPHERE_STORAGE_POLICY"),
 				},
 			},
 			VirtualMachineClasses: []vcsimv1.VirtualMachineClass{
 				{
-					Name:   e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_NAME"),
-					Cpus:   mustParseInt64(e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_CPU")),
-					Memory: resource.MustParse(e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_MEMORY")),
+					Name:   e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_NAME"),
+					Cpus:   mustParseInt64(e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_CPU")),
+					Memory: resource.MustParse(e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_MEMORY")),
 				},
 				{
-					Name:   e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_NAME_CONFORMANCE"),
-					Cpus:   mustParseInt64(e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_CPU_CONFORMANCE")),
-					Memory: resource.MustParse(e2eConfig.GetVariable("VSPHERE_MACHINE_CLASS_MEMORY_CONFORMANCE")),
+					Name:   e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_NAME_CONFORMANCE"),
+					Cpus:   mustParseInt64(e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_CPU_CONFORMANCE")),
+					Memory: resource.MustParse(e2eConfig.MustGetVariable("VSPHERE_MACHINE_CLASS_MEMORY_CONFORMANCE")),
 				},
 			},
 		},
 	}
 
-	items := e2eConfig.GetVariable("VSPHERE_CONTENT_LIBRARY_ITEMS")
+	items := e2eConfig.MustGetVariable("VSPHERE_CONTENT_LIBRARY_ITEMS")
 	if items != "" {
-		for _, i := range strings.Split(e2eConfig.GetVariable("VSPHERE_CONTENT_LIBRARY_ITEMS"), ",") {
+		for _, i := range strings.Split(e2eConfig.MustGetVariable("VSPHERE_CONTENT_LIBRARY_ITEMS"), ",") {
 			dependenciesConfig.Spec.VCenter.ContentLibrary.Items = append(dependenciesConfig.Spec.VCenter.ContentLibrary.Items, vcsimv1.ContentLibraryItemConfig{
 				Name:     i,
 				ItemType: "ovf",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -310,7 +310,7 @@ var _ = SynchronizedAfterSuite(func() {
 		switch testTarget {
 		case VCenterTestTarget:
 			// Cleanup the in cluster address manager
-			vSphereFolderName := e2eConfig.GetVariable("VSPHERE_FOLDER")
+			vSphereFolderName := e2eConfig.MustGetVariable("VSPHERE_FOLDER")
 			err := inClusterAddressManager.Teardown(ctx, vsphereip.MachineFolder(vSphereFolderName), vsphereip.VSphereClient(vsphereClient))
 			if err != nil {
 				Byf("Ignoring Teardown error: %v", err)

--- a/test/e2e/gpu_pci_passthrough_test.go
+++ b/test/e2e/gpu_pci_passthrough_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Cluster creation with GPU devices as PCI passthrough [speciali
 					Flavor:                   testSpecificSettingsGetter().FlavorForMode("pci"),
 					Namespace:                namespace.Name,
 					ClusterName:              clusterName,
-					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
 					ControlPlaneMachineCount: ptr.To(int64(1)),
 					WorkerMachineCount:       ptr.To(int64(1)),
 				},

--- a/test/e2e/hardware_upgrade_test.go
+++ b/test/e2e/hardware_upgrade_test.go
@@ -59,12 +59,12 @@ var _ = Describe("Hardware version upgrade", func() {
 		})
 
 		It("creates a cluster with VM hardware versions upgraded", func() {
-			Expect(e2eConfig.GetVariable("VSPHERE_TEMPLATE")).NotTo(BeEmpty())
+			Expect(e2eConfig.MustGetVariable("VSPHERE_TEMPLATE")).NotTo(BeEmpty())
 
 			VerifyHardwareUpgrade(ctx, HardwareUpgradeSpecInput{
 				SpecName:  specName,
 				Namespace: namespace,
-				Template:  e2eConfig.GetVariable("VSPHERE_TEMPLATE"),
+				Template:  e2eConfig.MustGetVariable("VSPHERE_TEMPLATE"),
 				ToVersion: "vmx-17",
 				InfraClients: InfraClients{
 					Client:     vsphereClient,

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -51,7 +51,7 @@ var _ = Describe("When testing K8S conformance with K8S latest ci [supervisor] [
 	const specName = "k8s-conformance-ci-latest" // prefix copied from CAPI
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.K8SConformanceSpec(ctx, func() capi_e2e.K8SConformanceSpecInput {
-			kubernetesVersion, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.GetVariable("KUBERNETES_VERSION_LATEST_CI"))
+			kubernetesVersion, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.MustGetVariable("KUBERNETES_VERSION_LATEST_CI"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("KUBERNETES_VERSION", kubernetesVersion)).To(Succeed())
 			return capi_e2e.K8SConformanceSpecInput{

--- a/test/e2e/multivc_test.go
+++ b/test/e2e/multivc_test.go
@@ -169,14 +169,14 @@ func VerifyMultiVC(ctx context.Context, input MultiVCenterSpecInput) {
 
 	wlClusterName := fmt.Sprintf("%s-%s", "wlcluster", util.RandomString(6))
 
-	_ = os.Setenv("VSPHERE_SERVER", e2eConfig.GetVariable("VSPHERE2_SERVER"))
+	_ = os.Setenv("VSPHERE_SERVER", e2eConfig.MustGetVariable("VSPHERE2_SERVER"))
 
-	_ = os.Setenv("VSPHERE_TLS_THUMBPRINT", e2eConfig.GetVariable("VSPHERE2_TLS_THUMBPRINT"))
+	_ = os.Setenv("VSPHERE_TLS_THUMBPRINT", e2eConfig.MustGetVariable("VSPHERE2_TLS_THUMBPRINT"))
 	_ = os.Setenv("VSPHERE_USERNAME", os.Getenv("VSPHERE2_USERNAME"))
 	_ = os.Setenv("VSPHERE_PASSWORD", os.Getenv("VSPHERE2_PASSWORD"))
-	_ = os.Setenv("VSPHERE_RESOURCE_POOL", e2eConfig.GetVariable("VSPHERE2_RESOURCE_POOL"))
-	_ = os.Setenv("VSPHERE_TEMPLATE", e2eConfig.GetVariable("VSPHERE2_TEMPLATE"))
-	_ = os.Setenv(vsphereip.ControlPlaneEndpointIPVariable, e2eConfig.GetVariable("VSPHERE2_CONTROL_PLANE_ENDPOINT_IP"))
+	_ = os.Setenv("VSPHERE_RESOURCE_POOL", e2eConfig.MustGetVariable("VSPHERE2_RESOURCE_POOL"))
+	_ = os.Setenv("VSPHERE_TEMPLATE", e2eConfig.MustGetVariable("VSPHERE2_TEMPLATE"))
+	_ = os.Setenv(vsphereip.ControlPlaneEndpointIPVariable, e2eConfig.MustGetVariable("VSPHERE2_CONTROL_PLANE_ENDPOINT_IP"))
 
 	By("creating a workload cluster from vsphere hosted management cluster")
 	wlConfigCluster := defaultConfigCluster(wlClusterName, namespace.Name, specName, 1, 1, GlobalInput{

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -53,7 +53,7 @@ var _ = Describe("When testing the machinery for scale testing using vcsim provi
 				BootstrapClusterProxy:  bootstrapClusterProxy,
 				ArtifactFolder:         artifactFolder,
 				Flavor:                 ptr.To(testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk")),
-				SkipUpgrade:            true,
+				SkipUpgrade:            false,
 				SkipCleanup:            skipCleanup,
 				ClusterClassName:       getVariableOrFallback(testSpecificSettingsGetter().Variables["CLUSTER_CLASS_NAME"], e2eConfig.MustGetVariable("CLUSTER_CLASS_NAME")),
 

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -55,7 +55,7 @@ var _ = Describe("When testing the machinery for scale testing using vcsim provi
 				Flavor:                 ptr.To(testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk")),
 				SkipUpgrade:            true,
 				SkipCleanup:            skipCleanup,
-				ClusterClassName:       getVariableOrFallback(testSpecificSettingsGetter().Variables["CLUSTER_CLASS_NAME"], e2eConfig.GetVariable("CLUSTER_CLASS_NAME")),
+				ClusterClassName:       getVariableOrFallback(testSpecificSettingsGetter().Variables["CLUSTER_CLASS_NAME"], e2eConfig.MustGetVariable("CLUSTER_CLASS_NAME")),
 
 				// ClusterCount can be overwritten via `CAPI_SCALE_CLUSTER_COUNT`.
 				ClusterCount: ptr.To[int64](10),

--- a/test/e2e/storage_policy_test.go
+++ b/test/e2e/storage_policy_test.go
@@ -108,7 +108,7 @@ func VerifyStoragePolicy(ctx context.Context, input StoragePolicySpecInput) {
 	Expect(err).NotTo(HaveOccurred())
 	var res []pbmypes.PbmServerObjectRef
 	if pbmClient != nil {
-		spName := input.Global.E2EConfig.GetVariable(VsphereStoragePolicy)
+		spName := input.Global.E2EConfig.MustGetVariable(VsphereStoragePolicy)
 		if spName == "" {
 			Fail("storage policy test run without setting VSPHERE_STORAGE_POLICY")
 		}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -191,7 +191,7 @@ func SetupBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, sc
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
 			RequiresDockerSock: config.HasDockerProvider(),
-			KubernetesVersion:  config.GetVariable(capi_e2e.KubernetesVersionManagement),
+			KubernetesVersion:  config.MustGetVariable(capi_e2e.KubernetesVersionManagement),
 			Images:             config.Images,
 		})
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,9 +2,9 @@ module sigs.k8s.io/cluster-api-provider-vsphere/test
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8
 
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250204082500-5ccaeb33b142
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250205112616-d5158c2503c8
 
 replace sigs.k8s.io/cluster-api-provider-vsphere => ../
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -506,10 +506,10 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142 h1:P14Lxb0Rz2VlqRaSTcg57Y8pF0gFKVT2UkhonnMM/tU=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250204082500-5ccaeb33b142/go.mod h1:HXL41Lwe7Ey+8V8jJAHRl/7G2+UyyR7o1BxbeHT7D6I=
-sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250204082500-5ccaeb33b142 h1:xnh6NohYYtgv+7980FwV3rWGPrda510k+EmMcV6qER0=
-sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250204082500-5ccaeb33b142/go.mod h1:0Q/fLhmdccHZTHr1XLX5a4guK69vnoK82oTvehd8cGA=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8 h1:vqlOZG5uKc1SKGG65FB0tmO22sMakT+lCzEuKlkXlsA=
+sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250205112616-d5158c2503c8/go.mod h1:mIt2rlw7HjsGpEAXlhWiuWqDdA3YAuHIbqWCKqnKR0M=
+sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250205112616-d5158c2503c8 h1:h6qcY5JldPgGVlzTe2Hkpw23KMSPFjX43w8PbpGXpHA=
+sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250205112616-d5158c2503c8/go.mod h1:0Q/fLhmdccHZTHr1XLX5a4guK69vnoK82oTvehd8cGA=
 sigs.k8s.io/controller-runtime v0.20.1 h1:JbGMAG/X94NeM3xvjenVUaBjy6Ui4Ogd/J5ZtjZnHaE=
 sigs.k8s.io/controller-runtime v0.20.1/go.mod h1:BrP3w158MwvB3ZbNpaAcIKkHQ7YGpYnzpoSTZ8E14WU=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Bump is required to have https://github.com/kubernetes-sigs/cluster-api/pull/11798

Variable renaming was due to CAPI PR https://github.com/kubernetes-sigs/cluster-api/pull/11743

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
