### PR TITLE
🌱 test: shutdown clustercache when ctx is done

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -98,6 +98,10 @@ func setup() {
 	if err != nil {
 		panic(fmt.Sprintf("Unable to setup ClusterCache: %v", err))
 	}
+	go func() {
+		<-ctx.Done()
+		clusterCache.(interface{ Shutdown() }).Shutdown()
+	}()
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 

--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -99,6 +99,10 @@ func setup() {
 	if err != nil {
 		panic(fmt.Sprintf("Unable to setup ClusterCache: %v", err))
 	}
+	go func() {
+		<-ctx.Done()
+		clusterCache.(interface{ Shutdown() }).Shutdown()
+	}()
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 

--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vmware
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,18 +61,18 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	setup()
+	testEnv, clusterCache = setup(ctx)
 	code := m.Run()
 	teardown()
 	os.Exit(code)
 }
 
-func setup() {
+func setup(ctx context.Context) (*helpers.TestEnvironment, clustercache.ClusterCache) {
 	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
 
-	testEnv = helpers.NewTestEnvironment(ctx)
+	testEnv := helpers.NewTestEnvironment(ctx)
 
 	secretCachingClient, err := client.New(testEnv.Manager.GetConfig(), client.Options{
 		HTTPClient: testEnv.Manager.GetHTTPClient(),
@@ -131,8 +132,10 @@ func setup() {
 		},
 	}
 	if err := testEnv.Create(ctx, ns); err != nil {
-		panic("unable to create controller namespace")
+		panic(fmt.Sprintf("unable to create controller namespace: %v", err))
 	}
+
+	return testEnv, clusterCache
 }
 
 func teardown() {

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vmware
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -30,22 +31,38 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	helpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
+	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers"
+	vmwareHelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 )
 
 var _ = Describe("ProviderServiceAccount controller integration tests", func() {
-	var intCtx *helpers.IntegrationTestContext
+	// This test suite requires its own management cluster and controllers including clustercache.
+	// Otherwise the workload cluster's kube-apiserver would not shutdown due to the global
+	// test's clustercache still being running.
+	var (
+		intCtx             *vmwareHelpers.IntegrationTestContext
+		testEnv            *helpers.TestEnvironment
+		clusterCache       clustercache.ClusterCache
+		clusterCacheCancel context.CancelFunc
+	)
 
 	BeforeEach(func() {
-		intCtx = helpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
+		var clusterCacheCtx context.Context
+		clusterCacheCtx, clusterCacheCancel = context.WithCancel(ctx)
+		testEnv, clusterCache = setup(clusterCacheCtx)
+		intCtx = vmwareHelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 	})
 
 	AfterEach(func() {
+		// Stop clustercache
+		clusterCacheCancel()
+
 		intCtx.AfterEach()
 	})
 
@@ -56,10 +73,10 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		)
 		BeforeEach(func() {
 			By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
-				helpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwareHelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 
 			By("Verifying that the guest cluster client works")
@@ -142,8 +159,8 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	Context("With non-existent Cluster object", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
 			By("Creating the vSphereCluster and KubeconfigSecret only", func() {
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -164,8 +181,8 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	Context("With non-existent Cluster credentials secret", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
 			By("Creating the Cluster and vSphereCluster only", func() {
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -189,10 +206,10 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		var roleBinding *rbacv1.RoleBinding
 		BeforeEach(func() {
 			By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				helpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
-				helpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwareHelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
 			pSvcAccount.Spec.TargetNamespace = "default"

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -38,7 +38,7 @@ import (
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers"
-	vmwareHelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
+	vmwarehelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 )
 
 var _ = Describe("ProviderServiceAccount controller integration tests", func() {
@@ -46,7 +46,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	// Otherwise the workload cluster's kube-apiserver would not shutdown due to the global
 	// test's clustercache still being running.
 	var (
-		intCtx             *vmwareHelpers.IntegrationTestContext
+		intCtx             *vmwarehelpers.IntegrationTestContext
 		testEnv            *helpers.TestEnvironment
 		clusterCache       clustercache.ClusterCache
 		clusterCacheCancel context.CancelFunc
@@ -56,7 +56,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		var clusterCacheCtx context.Context
 		clusterCacheCtx, clusterCacheCancel = context.WithCancel(ctx)
 		testEnv, clusterCache = setup(clusterCacheCtx)
-		intCtx = vmwareHelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
+		intCtx = vmwarehelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 	})
 
 	AfterEach(func() {
@@ -73,10 +73,10 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		)
 		BeforeEach(func() {
 			By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
-				vmwareHelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwarehelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 
 			By("Verifying that the guest cluster client works")
@@ -159,8 +159,8 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	Context("With non-existent Cluster object", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
 			By("Creating the vSphereCluster and KubeconfigSecret only", func() {
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -181,8 +181,8 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	Context("With non-existent Cluster credentials secret", func() {
 		It("cannot reconcile the ProviderServiceAccount object", func() {
 			By("Creating the Cluster and vSphereCluster only", func() {
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
 			})
 
 			By("Creating the ProviderServiceAccount", func() {
@@ -206,10 +206,10 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		var roleBinding *rbacv1.RoleBinding
 		BeforeEach(func() {
 			By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-				vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
-				vmwareHelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+				vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+				vmwarehelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 			})
 			pSvcAccount = getTestProviderServiceAccount(intCtx.Namespace, intCtx.VSphereCluster)
 			pSvcAccount.Spec.TargetNamespace = "default"

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		clusterCacheCancel()
 
 		intCtx.AfterEach()
-		testEnv.Stop()
+		Expect(testEnv.Stop()).To(Succeed())
 	})
 
 	Describe("When the ProviderServiceAccount is created", func() {

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -64,6 +64,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 		clusterCacheCancel()
 
 		intCtx.AfterEach()
+		testEnv.Stop()
 	})
 
 	Describe("When the ProviderServiceAccount is created", func() {

--- a/controllers/vmware/serviceaccount_controller_unit_test.go
+++ b/controllers/vmware/serviceaccount_controller_unit_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	helpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
+	vmwarehelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 )
 
@@ -35,7 +35,7 @@ var _ = Describe("ServiceAccountReconciler reconcileNormal", unitTestsReconcileN
 
 func unitTestsReconcileNormal() {
 	var (
-		controllerCtx  *helpers.UnitTestContextForController
+		controllerCtx  *vmwarehelpers.UnitTestContextForController
 		vsphereCluster *vmwarev1.VSphereCluster
 		initObjects    []client.Object
 		namespace      string
@@ -43,7 +43,7 @@ func unitTestsReconcileNormal() {
 	)
 
 	JustBeforeEach(func() {
-		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, vsphereCluster, false, initObjects, nil)
+		controllerCtx = vmwarehelpers.NewUnitTestContextForController(ctx, namespace, vsphereCluster, false, initObjects, nil)
 		// Note: The service account provider requires a reference to the vSphereCluster hence the need to create
 		// a fake vSphereCluster in the test and pass it to during context setup.
 		reconciler = ServiceAccountReconciler{
@@ -128,7 +128,7 @@ func unitTestsReconcileNormal() {
 
 // Updates the service account secret similar to how a token controller would act upon a service account
 // and then re-invokes reconcileNormal.
-func updateServiceAccountSecretAndReconcileNormal(ctx context.Context, controllerCtx *helpers.UnitTestContextForController, reconciler ServiceAccountReconciler, object client.Object) {
+func updateServiceAccountSecretAndReconcileNormal(ctx context.Context, controllerCtx *vmwarehelpers.UnitTestContextForController, reconciler ServiceAccountReconciler, object client.Object) {
 	assertServiceAccountAndUpdateSecret(ctx, controllerCtx.ControllerManagerContext.Client, object.GetNamespace(), object.GetName())
 	_, err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		deleteTestResource(ctx, intCtx.Client, intCtx.Cluster)
 		deleteTestResource(ctx, intCtx.Client, intCtx.KubeconfigSecret)
 		intCtx.AfterEach()
+		testEnv.Stop()
 	})
 
 	Context("When VIP is available", func() {

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers"
-	vmwareHelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
+	vmwarehelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 )
 
 var _ = Describe("Service Discovery controller integration tests", func() {
@@ -37,7 +37,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 	// Otherwise the workload cluster's kube-apiserver would not shutdown due to the global
 	// test's clustercache still being running.
 	var (
-		intCtx             *vmwareHelpers.IntegrationTestContext
+		intCtx             *vmwarehelpers.IntegrationTestContext
 		testEnv            *helpers.TestEnvironment
 		clusterCache       clustercache.ClusterCache
 		clusterCacheCancel context.CancelFunc
@@ -47,13 +47,13 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		var clusterCacheCtx context.Context
 		clusterCacheCtx, clusterCacheCancel = context.WithCancel(ctx)
 		testEnv, clusterCache = setup(clusterCacheCtx)
-		intCtx = vmwareHelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
+		intCtx = vmwarehelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 
 		By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {
-			vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
-			vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
-			vmwareHelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
-			vmwareHelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
+			vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.Cluster)
+			vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.VSphereCluster)
+			vmwarehelpers.CreateAndWait(ctx, intCtx.Client, intCtx.KubeconfigSecret)
+			vmwarehelpers.ClusterInfrastructureReady(ctx, intCtx.Client, clusterCache, intCtx.Cluster)
 		})
 
 		By("Verifying that the guest cluster client works")

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 		deleteTestResource(ctx, intCtx.Client, intCtx.Cluster)
 		deleteTestResource(ctx, intCtx.Client, intCtx.KubeconfigSecret)
 		intCtx.AfterEach()
-		testEnv.Stop()
+		Expect(testEnv.Stop()).To(Succeed())
 	})
 
 	Context("When VIP is available", func() {

--- a/controllers/vmware/servicediscovery_controller_unit_test.go
+++ b/controllers/vmware/servicediscovery_controller_unit_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
-	helpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
+	vmwarehelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 )
 
@@ -34,7 +34,7 @@ var _ = Describe("ServiceDiscoveryReconciler reconcileNormal", serviceDiscoveryU
 
 func serviceDiscoveryUnitTestsReconcileNormal() {
 	var (
-		controllerCtx  *helpers.UnitTestContextForController
+		controllerCtx  *vmwarehelpers.UnitTestContextForController
 		vsphereCluster vmwarev1.VSphereCluster
 		initObjects    []client.Object
 		reconciler     serviceDiscoveryReconciler
@@ -42,7 +42,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 	namespace := capiutil.RandomString(6)
 	JustBeforeEach(func() {
 		vsphereCluster = fake.NewVSphereCluster(namespace)
-		controllerCtx = helpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
+		controllerCtx = vmwarehelpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
 		reconciler = serviceDiscoveryReconciler{
 			Client: controllerCtx.ControllerManagerContext.Client,
 		}

--- a/internal/test/helpers/webhook.go
+++ b/internal/test/helpers/webhook.go
@@ -101,7 +101,7 @@ func InitializeWebhookInEnvironment(e *envtest.Environment, configPath string) {
 
 // WaitForWebhooks waits for TestEnvironment's webhooks to accept connections.
 func (t *TestEnvironment) WaitForWebhooks() {
-	port := env.WebhookInstallOptions.LocalServingPort
+	port := t.env.WebhookInstallOptions.LocalServingPort
 
 	klog.Infof("Waiting for webhook port %d to be open prior to running tests", port)
 	timeout := 1 * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Follow-up from bumping due to clustercache changes in https://github.com/kubernetes-sigs/cluster-api/pull/11757

This should get the unit tests back to green.

/assign @sbueringer
/assign @fabriziopandini 

The tests in:

* `controllers/vmware/serviceaccount_controller_intg_test.go`
* `controllers/vmware/servicediscovery_controller_intg_test.go`

Have a special requirement: They require an additional kube-apiserver instance to simulate the workload cluster.
To be able to properly shutoff this kube-apiserver instance (including etcd) we need to stop the clustercache.
This was only possible at the very end of the whole test suite to not break other tests.

Instead now these two test suites get their own management cluster including clustercache controller so everything can be shutdown after the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
