### PR TITLE
🌱 e2e: fix provisioningMode in tests

### DIFF
--- a/docs/proposal/20241003-data-disk-support.md
+++ b/docs/proposal/20241003-data-disk-support.md
@@ -173,10 +173,10 @@ spec:
       dataDisks:
       - name: images
         sizeGiB: 50
-        provisioningType: Thin
+        provisioningMode: Thin
       - name: swap
         sizeGiB: 90
-        provisioningType: Thick
+        provisioningMode: Thick
       cloneMode: linkedClone
       datacenter: cidatacenter
       datastore: /cidatacenter/datastore/vsanDatastore
@@ -202,10 +202,10 @@ spec:
   dataDisks:
   - name: images
     sizeGiB: 50
-    provisioningType: Thin
+    provisioningMode: Thin
   - name: swap
     sizeGiB: 90
-    provisioningType: Thick
+    provisioningMode: Thick
   datacenter: cidatacenter
   datastore: /cidatacenter/datastore/vsanDatastore
   diskGiB: 128

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/multi-disk/data-disks-patch.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/multi-disk/data-disks-patch.yaml
@@ -9,10 +9,10 @@ spec:
       dataDisks:
       - name: "disk_1"
         sizeGiB: 1
-        provisioningType: "Thin"
+        provisioningMode: "Thin"
       - name: "disk_2"
         sizeGiB: 2
-        provisioningType: "Thick"
+        provisioningMode: "Thick"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
@@ -25,12 +25,12 @@ spec:
       dataDisks:
       - name: "disk_1"
         sizeGiB: 1
-        provisioningType: "Thin"
+        provisioningMode: "Thin"
       - name: "disk_2"
         sizeGiB: 2
-        provisioningType: "Thick"
+        provisioningMode: "Thick"
       - name: "disk_3"
         sizeGiB: 3
-        provisioningType: "EagerlyZeroed"
+        provisioningMode: "EagerlyZeroed"
       - name: "disk_4"
         sizeGiB: 4


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Noticed that e2e tests are red.

We did not rename all fields when finishing https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3332 .
That resulted in the applied files to have `provisioningType` which is a not existing field and got dropped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
