### PR TITLE
🌱 e2e: properly label and cleanup created PVCs during e2e tests in prow

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/dougm/pretty v0.0.0-20160325215624-add1dbc86daf h1:A2XbJkAuMMFy/9EftoubSKBUIyiOm6Z8+X5G7QpS6so=
+github.com/dougm/pretty v0.0.0-20160325215624-add1dbc86daf/go.mod h1:7NQ3kWOx2cZOSjtcveTa5nqupVr2s6/83sG+rTlI7uA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/hack/tools/boskosctl/main.go
+++ b/hack/tools/boskosctl/main.go
@@ -364,7 +364,7 @@ func release(ctx context.Context, client *boskos.Client, resourceName, vSphereUs
 	log.Info("Cleaning up vSphere")
 	// Note: We intentionally want to skip clusterModule cleanup. If we run this too often we might hit race conditions
 	// when other tests are creating cluster modules in parallel.
-	if err := j.CleanupVSphere(ctx, []string{vSphereFolder}, []string{vSphereResourcePool}, []string{vSphereFolder}, true); err != nil {
+	if err := j.CleanupVSphere(ctx, []string{vSphereFolder}, []string{vSphereResourcePool}, []string{vSphereFolder}, resourceName, true); err != nil {
 		log.Info("Cleaning up vSphere failed")
 
 		// Try to release resource as dirty.

--- a/hack/tools/janitor/main.go
+++ b/hack/tools/janitor/main.go
@@ -162,7 +162,7 @@ func run(ctx context.Context) error {
 			j := janitor.NewJanitor(vSphereClients, false)
 
 			log.Info("Cleaning up vSphere")
-			if err := j.CleanupVSphere(ctx, []string{folder.(string)}, []string{resourcePool.(string)}, []string{folder.(string)}, false); err != nil {
+			if err := j.CleanupVSphere(ctx, []string{folder.(string)}, []string{resourcePool.(string)}, []string{folder.(string)}, res.Name, false); err != nil {
 				log.Info("Cleaning up vSphere failed")
 
 				// Intentionally keep this resource in cleaning state. The reaper will move it from cleaning to dirty

--- a/hack/tools/pkg/janitor/janitor.go
+++ b/hack/tools/pkg/janitor/janitor.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/object"
 	govmomicluster "github.com/vmware/govmomi/vapi/cluster"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -52,8 +53,12 @@ type virtualMachine struct {
 	object        *object.VirtualMachine
 }
 
+// boskosResourceLabel is used to identify volumes created in e2e tests.
+// The value should contain the boskos resource name.
+const boskosResourceLabel = "capv-e2e-test-boskos-resource"
+
 // CleanupVSphere cleans up vSphere VMs, folders and resource pools.
-func (s *Janitor) CleanupVSphere(ctx context.Context, folders, resourcePools, vmFolders []string, skipClusterModule bool) error {
+func (s *Janitor) CleanupVSphere(ctx context.Context, folders, resourcePools, vmFolders []string, boskosResourceName string, skipClusterModule bool) error {
 	errList := []error{}
 
 	// Delete vms to cleanup folders and resource pools.
@@ -84,6 +89,11 @@ func (s *Janitor) CleanupVSphere(ctx context.Context, folders, resourcePools, vm
 	}
 	if err := kerrors.NewAggregate(errList); err != nil {
 		return errors.Wrap(err, "cleaning up folders")
+	}
+
+	// Delete CNS volumes.
+	if err := s.DeleteCNSVolumes(ctx, boskosResourceName); err != nil {
+		return errors.Wrap(err, "cleaning up volumes")
 	}
 
 	if skipClusterModule {
@@ -192,6 +202,118 @@ func (s *Janitor) deleteVSphereVMs(ctx context.Context, folder string) error {
 	// Wait for all destroy tasks to succeed.
 	if err := waitForTasksFinished(ctx, destroyTasks, false); err != nil {
 		return errors.Wrap(err, "failed to wait for vm destroy task to finish")
+	}
+
+	return nil
+}
+
+// DeleteCNSVolumes deletes all volumes from tests.
+func (s *Janitor) DeleteCNSVolumes(ctx context.Context, boskosResourceName string) error {
+	log := ctrl.LoggerFrom(ctx).WithName("volumes")
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	log.Info("Deleting volumes")
+
+	type cnsVolumeToDelete struct {
+		volumeID     cnstypes.CnsVolumeId
+		pvcName      string
+		pvcNamespace string
+	}
+	volumesToDelete := []cnsVolumeToDelete{}
+
+	queryFilter := cnstypes.CnsQueryFilter{
+		Labels: []types.KeyValue{
+			{
+				Key:   boskosResourceLabel,
+				Value: boskosResourceName,
+			},
+		},
+	}
+
+	for {
+		res, err := s.vSphereClients.CNS.QueryVolume(ctx, queryFilter)
+		if err != nil {
+			return err
+		}
+
+		for _, volume := range res.Volumes {
+			var pvcMetadata *cnstypes.CnsKubernetesEntityMetadata
+			for _, meta := range volume.Metadata.EntityMetadata {
+				k8sMetadata, ok := meta.(*cnstypes.CnsKubernetesEntityMetadata)
+				if !ok {
+					continue
+				}
+				if k8sMetadata.EntityType != string(cnstypes.CnsKubernetesEntityTypePVC) {
+					continue
+				}
+				pvcMetadata = k8sMetadata
+			}
+
+			if pvcMetadata == nil {
+				// Ignoring non-PVC volumes.
+				continue
+			}
+
+			var matchesBoskosResourcename bool
+			// Check again that the volume has a matching label.
+			for _, v := range pvcMetadata.Labels {
+				if v.Key != boskosResourceLabel {
+					continue
+				}
+				if v.Value != boskosResourceName {
+					continue
+				}
+				matchesBoskosResourcename = true
+			}
+
+			// Ignore not matching volume.
+			if !matchesBoskosResourcename {
+				continue
+			}
+
+			volumesToDelete = append(volumesToDelete, cnsVolumeToDelete{
+				volumeID:     volume.VolumeId,
+				pvcName:      pvcMetadata.EntityName,
+				pvcNamespace: pvcMetadata.Namespace,
+			})
+		}
+
+		if res.Cursor.Offset == res.Cursor.TotalRecords || len(res.Volumes) == 0 {
+			break
+		}
+
+		queryFilter.Cursor = &res.Cursor
+	}
+
+	if len(volumesToDelete) == 0 {
+		log.Info("No CNS Volumes to delete")
+		return nil
+	}
+
+	deleteTasks := []*object.Task{}
+	for _, volume := range volumesToDelete {
+		log := log.WithValues("volumeID", volume.volumeID, "pvcName", volume.pvcName, "pvcNamespace", volume.pvcNamespace)
+
+		log.Info("Deleting CNS Volume in vSphere", "volumeID", volume.volumeID)
+
+		if s.dryRun {
+			// Skipping actual delete on dryRun.
+			continue
+		}
+
+		// Trigger deletion of the CNS Volume
+		task, err := s.vSphereClients.CNS.DeleteVolume(ctx, []cnstypes.CnsVolumeId{volume.volumeID}, true)
+		if err != nil {
+			return errors.Wrap(err, "failed to create CNS Volume deletion task")
+		}
+
+		log.Info("Created CNS Volume deletion task", "task", task.Reference().Value)
+		deleteTasks = append(deleteTasks, task)
+	}
+
+	// Wait for all delete tasks to succeed.
+	if err := waitForTasksFinished(ctx, deleteTasks, false); err != nil {
+		return errors.Wrap(err, "failed to wait for CNS Volume deletion task to finish")
 	}
 
 	return nil

--- a/hack/tools/pkg/janitor/janitor.go
+++ b/hack/tools/pkg/janitor/janitor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -292,9 +293,9 @@ func (s *Janitor) DeleteCNSVolumes(ctx context.Context, boskosResourceName strin
 
 	deleteTasks := []*object.Task{}
 	for _, volume := range volumesToDelete {
-		log := log.WithValues("volumeID", volume.volumeID, "pvcName", volume.pvcName, "pvcNamespace", volume.pvcNamespace)
+		log := log.WithValues("volumeID", volume.volumeID, "PersistentVolumeClaim", klog.KRef(volume.pvcName, volume.pvcNamespace))
 
-		log.Info("Deleting CNS Volume in vSphere", "volumeID", volume.volumeID)
+		log.Info("Deleting CNS Volume in vSphere")
 
 		if s.dryRun {
 			// Skipping actual delete on dryRun.
@@ -313,7 +314,7 @@ func (s *Janitor) DeleteCNSVolumes(ctx context.Context, boskosResourceName strin
 
 	// Wait for all delete tasks to succeed.
 	if err := waitForTasksFinished(ctx, deleteTasks, false); err != nil {
-		return errors.Wrap(err, "failed to wait for CNS Volume deletion task to finish")
+		return errors.Wrap(err, "failed to wait for CNS Volume deletion tasks to finish")
 	}
 
 	return nil

--- a/hack/tools/pkg/janitor/janitor.go
+++ b/hack/tools/pkg/janitor/janitor.go
@@ -293,7 +293,7 @@ func (s *Janitor) DeleteCNSVolumes(ctx context.Context, boskosResourceName strin
 
 	deleteTasks := []*object.Task{}
 	for _, volume := range volumesToDelete {
-		log := log.WithValues("volumeID", volume.volumeID, "PersistentVolumeClaim", klog.KRef(volume.pvcName, volume.pvcNamespace))
+		log := log.WithValues("volumeID", volume.volumeID, "PersistentVolumeClaim", klog.KRef(volume.pvcNamespace, volume.pvcName))
 
 		log.Info("Deleting CNS Volume in vSphere")
 

--- a/hack/tools/pkg/janitor/vsphere.go
+++ b/hack/tools/pkg/janitor/vsphere.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/list"
 	"github.com/vmware/govmomi/object"
@@ -52,6 +53,7 @@ type VSphereClients struct {
 	FieldsManager *object.CustomFieldsManager
 	Finder        *find.Finder
 	ViewManager   *view.Manager
+	CNS           *cns.Client
 }
 
 // Logout logs out all clients. It logs errors if the context contains a logger.
@@ -110,6 +112,16 @@ func NewVSphereClients(ctx context.Context, input NewVSphereClientsInput) (*VSph
 
 	viewManager := view.NewManager(vimClient)
 	finder := find.NewFinder(vimClient, false)
+	dc, err := finder.Datacenter(ctx, "*")
+	if err != nil {
+		return nil, err
+	}
+	finder.SetDatacenter(dc)
+
+	cnsClient, err := cns.NewClient(ctx, vimClient)
+	if err != nil {
+		return nil, err
+	}
 
 	return &VSphereClients{
 		Vim:           vimClient,
@@ -118,6 +130,7 @@ func NewVSphereClients(ctx context.Context, input NewVSphereClientsInput) (*VSph
 		FieldsManager: fieldsManager,
 		Finder:        finder,
 		ViewManager:   viewManager,
+		CNS:           cnsClient,
 	}, nil
 }
 

--- a/test/e2e/node_drain_test.go
+++ b/test/e2e/node_drain_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -41,6 +42,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const boskosResourceLabel = "capv-e2e-test-boskos-resource"
 
 var _ = Describe("When testing Node drain [supervisor]", func() {
 	const specName = "node-drain" // copied from CAPI
@@ -170,6 +173,7 @@ func deployStatefulSetAndBlockCSI(ctx context.Context, bootstrapClusterProxy fra
 			WaitForStatefulSetAvailableInterval: e2eConfig.GetIntervals("node-drain", "wait-statefulset-available"),
 		})
 	}
+	Expect(true).To(BeFalse())
 
 	By("Scaling down the CSI controller to block lifecycle of PVC's")
 	csiController := &appsv1.Deployment{}
@@ -291,15 +295,19 @@ func generateStatefulset(input generateStatefulsetInput) *appsv1.StatefulSet {
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":         "nonstop",
-					"statefulset": input.Name,
+					"app":               "nonstop",
+					"e2e-test":          "node-drain",
+					boskosResourceLabel: os.Getenv("BOSKOS_RESOURCE_NAME"),
+					"statefulset":       input.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":         "nonstop",
-						"statefulset": input.Name,
+						"app":               "nonstop",
+						"e2e-test":          "node-drain",
+						boskosResourceLabel: os.Getenv("BOSKOS_RESOURCE_NAME"),
+						"statefulset":       input.Name,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/test/e2e/node_drain_test.go
+++ b/test/e2e/node_drain_test.go
@@ -173,7 +173,6 @@ func deployStatefulSetAndBlockCSI(ctx context.Context, bootstrapClusterProxy fra
 			WaitForStatefulSetAvailableInterval: e2eConfig.GetIntervals("node-drain", "wait-statefulset-available"),
 		})
 	}
-	Expect(true).To(BeFalse())
 
 	By("Scaling down the CSI controller to block lifecycle of PVC's")
 	csiController := &appsv1.Deployment{}
@@ -295,19 +294,23 @@ func generateStatefulset(input generateStatefulsetInput) *appsv1.StatefulSet {
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app":               "nonstop",
-					"e2e-test":          "node-drain",
+					"app":         "nonstop",
+					"statefulset": input.Name,
+					"e2e-test":    "node-drain",
+					// All labels get propagated down to CNS Volumes in vSphere.
+					// This label will be used by the janitor to cleanup orphaned CNS volumes.
 					boskosResourceLabel: os.Getenv("BOSKOS_RESOURCE_NAME"),
-					"statefulset":       input.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":               "nonstop",
-						"e2e-test":          "node-drain",
+						"app":         "nonstop",
+						"statefulset": input.Name,
+						"e2e-test":    "node-drain",
+						// All labels get propagated down to CNS Volumes in vSphere.
+						// This label will be used by the janitor to cleanup orphaned CNS volumes.
 						boskosResourceLabel: os.Getenv("BOSKOS_RESOURCE_NAME"),
-						"statefulset":       input.Name,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds cleanup of CNS volumes which are currently only created during node-drain tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
