### PR TITLE
🌱 templates: remove cloud-provider flag for kube-apiserver due to removal in v1.33

### DIFF
--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -451,10 +451,11 @@ func defaultKubeadmInitSpec(files []bootstrapv1.File) bootstrapv1.KubeadmConfigS
 			NodeRegistration: defaultNodeRegistrationOptions(),
 		},
 		ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
-			APIServer: bootstrapv1.APIServer{
-				ControlPlaneComponent: defaultControlPlaneComponent(),
+			ControllerManager: bootstrapv1.ControlPlaneComponent{
+				ExtraArgs: map[string]string{
+					"cloud-provider": "external",
+				},
 			},
-			ControllerManager: defaultControlPlaneComponent(),
 		},
 		Users:              defaultUsers(),
 		PreKubeadmCommands: defaultPreKubeadmCommands(),
@@ -480,10 +481,11 @@ func ignitionKubeadmInitSpec(files []bootstrapv1.File) bootstrapv1.KubeadmConfig
 			NodeRegistration: nro,
 		},
 		ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
-			APIServer: bootstrapv1.APIServer{
-				ControlPlaneComponent: defaultControlPlaneComponent(),
+			ControllerManager: bootstrapv1.ControlPlaneComponent{
+				ExtraArgs: map[string]string{
+					"cloud-provider": "external",
+				},
 			},
-			ControllerManager: defaultControlPlaneComponent(),
 		},
 		Users:              flatcarUsers(),
 		PreKubeadmCommands: flatcarPreKubeadmCommands(),
@@ -555,9 +557,11 @@ func newIgnitionKubeadmConfigTemplate() bootstrapv1.KubeadmConfigTemplate {
 
 func defaultNodeRegistrationOptions() bootstrapv1.NodeRegistrationOptions {
 	return bootstrapv1.NodeRegistrationOptions{
-		Name:             "{{ local_hostname }}",
-		CRISocket:        "/var/run/containerd/containerd.sock",
-		KubeletExtraArgs: defaultExtraArgs(),
+		Name:      "{{ local_hostname }}",
+		CRISocket: "/var/run/containerd/containerd.sock",
+		KubeletExtraArgs: map[string]string{
+			"cloud-provider": "external",
+		},
 	}
 }
 
@@ -585,20 +589,8 @@ func flatcarUsers() []bootstrapv1.User {
 	}
 }
 
-func defaultControlPlaneComponent() bootstrapv1.ControlPlaneComponent {
-	return bootstrapv1.ControlPlaneComponent{
-		ExtraArgs: defaultExtraArgs(),
-	}
-}
-
 func defaultCustomVMXKeys() map[string]string {
 	return map[string]string{}
-}
-
-func defaultExtraArgs() map[string]string {
-	return map[string]string{
-		"cloud-provider": "external",
-	}
 }
 
 func defaultPreKubeadmCommands() []string {

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -96,9 +96,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -69,9 +69,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -106,9 +106,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template-supervisor.yaml
+++ b/templates/cluster-template-supervisor.yaml
@@ -63,9 +63,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -96,9 +96,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/clusterclass-template-supervisor.yaml
+++ b/templates/clusterclass-template-supervisor.yaml
@@ -264,9 +264,6 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          apiServer:
-            extraArgs:
-              cloud-provider: external
           controllerManager:
             extraArgs:
               cloud-provider: external

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -324,9 +324,6 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          apiServer:
-            extraArgs:
-              cloud-provider: external
           controllerManager:
             extraArgs:
               cloud-provider: external


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

xref: https://github.com/kubernetes/kubernetes/pull/130162

Without this, the templates used (also in CI) set the flag `--cloud-provider=external`, leading to apiserver not starting due to unknown flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
