### PR TITLE
🌱 vspheremachinetemplate: don't reconcile if className is not set

### DIFF
--- a/controllers/vmware/vspheremachinetemplate_controller.go
+++ b/controllers/vmware/vspheremachinetemplate_controller.go
@@ -74,6 +74,11 @@ func (r *vSphereMachineTemplateReconciler) Reconcile(ctx context.Context, req ct
 		return reconcile.Result{}, err
 	}
 
+	// If ClassName is not set, there is nothing to do.
+	if vSphereMachineTemplate.Spec.Template.Spec.ClassName == "" {
+		return reconcile.Result{}, nil
+	}
+
 	// Fetch the VirtualMachineClass
 	vmClass := &vmoprv1.VirtualMachineClass{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: vSphereMachineTemplate.Spec.Template.Spec.ClassName}, vmClass); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

```
E0307 10:18:06.090143       1 controller.go:316] "Reconciler error" err="failed to get VirtualMachineClass \"\" for VSphereMachineTemplate: VirtualMachineClass.vmoperator.vmware.com \"\" not found" controller="vspheremachinetemplate" controllerGroup="vmware.infrastructure.cluster.x-k8s.io" controllerKind="VSphereMachineTemplate" VSphereMachineTemplate="vksns303/tkc-md-v3.2.0" namespace="vksns303" name="tkc-md-v3.2.0" reconcileID="18bc210a-a59f-47d3-bfe9-4ef76cac3349"
```

Prevents the above error which could e.g. happen for VSphereMachineTemplates which are referenced by a ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
