### PR TITLE
🌱 vspheredeploymentzone/vsphereclusteridentity: implement v1beta2 conditions, govmomi

### DIFF
--- a/apis/v1beta1/vsphereclusteridentity_types.go
+++ b/apis/v1beta1/vsphereclusteridentity_types.go
@@ -28,25 +28,25 @@ const (
 	VSphereClusterIdentityFinalizer = "vsphereclusteridentity/infrastructure.cluster.x-k8s.io"
 )
 
-// VSphereClusterIdentity's CredentialsAvailable condition and corresponding reasons that will be used in v1Beta2 API version.
+// VSphereClusterIdentity's Available condition and corresponding reasons that will be used in v1Beta2 API version.
 const (
-	// VSphereClusterIdentityCredentialsAvailableV1Beta2Condition documents the status of the credentials for a VSphereClusterIdentity.
-	VSphereClusterIdentityCredentialsAvailableV1Beta2Condition = "CredentialsAvailable"
+	// VSphereClusterIdentityAvailableV1Beta2Condition documents the availability for a VSphereClusterIdentity.
+	VSphereClusterIdentityAvailableV1Beta2Condition = clusterv1.AvailableV1Beta2Condition
 
-	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity credentials are available.
-	VSphereClusterIdentityCredentialsAvailableV1Beta2Reason = clusterv1.AvailableV1Beta2Reason
+	// VSphereClusterIdentityAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity is available.
+	VSphereClusterIdentityAvailableV1Beta2Reason = clusterv1.AvailableV1Beta2Reason
 
-	// VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is not available.
-	VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason = "SecretNotAvailable"
+	// VSphereClusterIdentitySecretNotAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is not available.
+	VSphereClusterIdentitySecretNotAvailableV1Beta2Reason = "SecretNotAvailable"
 
-	// VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason surfaces when the VSphereClusterIdentity secret is already in use.
-	VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason = "SecretAlreadyInUse"
+	// VSphereClusterIdentitySecretAlreadyInUseV1Beta2Reason surfaces when the VSphereClusterIdentity secret is already in use.
+	VSphereClusterIdentitySecretAlreadyInUseV1Beta2Reason = "SecretAlreadyInUse"
 
-	// VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason surfaces when setting the owner reference on the VSphereClusterIdentity secret failed.
-	VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason = "SettingSecretOwnerReferenceFailed"
+	// VSphereClusterIdentitySettingSecretOwnerReferenceFailedV1Beta2Reason surfaces when setting the owner reference on the VSphereClusterIdentity secret failed.
+	VSphereClusterIdentitySettingSecretOwnerReferenceFailedV1Beta2Reason = "SettingSecretOwnerReferenceFailed"
 
-	// VSphereClusterIdentityCredentialsDeletingV1Beta2Reason surfaces when the credentials for a VSphereClusterIdentity are being deleted.
-	VSphereClusterIdentityCredentialsDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
+	// VSphereClusterIdentityDeletingV1Beta2Reason surfaces when the VSphereClusterIdentity is being deleted.
+	VSphereClusterIdentityDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
 )
 
 // VSphereClusterIdentitySpec contains a secret reference and a group of allowed namespaces.
@@ -80,7 +80,7 @@ type VSphereClusterIdentityStatus struct {
 // See https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more context.
 type VSphereClusterIdentityV1Beta2Status struct {
 	// conditions represents the observations of a VSphereClusterIdentity's current state.
-	// Known condition types are CredentialsAvailable and Paused.
+	// Known condition types are Available and Paused.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/apis/v1beta1/vsphereclusteridentity_types.go
+++ b/apis/v1beta1/vsphereclusteridentity_types.go
@@ -39,11 +39,11 @@ const (
 	// VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is not available.
 	VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason = "SecretNotAvailable"
 
-	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is already in use.
+	// VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason surfaces when the VSphereClusterIdentity secret is already in use.
 	VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason = "SecretAlreadyInUse"
 
-	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when setting the owner reference on the VSphereClusterIdentity secret failed.
-	VSphereClusterIdentityCredentialsSecretOwnerReferenceFailedV1Beta2Reason = "SecretOwnerReferenceFailed"
+	// VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason surfaces when setting the owner reference on the VSphereClusterIdentity secret failed.
+	VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason = "SettingSecretOwnerReferenceFailed"
 
 	// VSphereClusterIdentityCredentialsDeletingV1Beta2Reason surfaces when the credentials for a VSphereClusterIdentity are being deleted.
 	VSphereClusterIdentityCredentialsDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
@@ -80,7 +80,7 @@ type VSphereClusterIdentityStatus struct {
 // See https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more context.
 type VSphereClusterIdentityV1Beta2Status struct {
 	// conditions represents the observations of a VSphereClusterIdentity's current state.
-	// Known condition types are Paused.
+	// Known condition types are CredentialsAvailable and Paused.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/apis/v1beta1/vsphereclusteridentity_types.go
+++ b/apis/v1beta1/vsphereclusteridentity_types.go
@@ -28,6 +28,27 @@ const (
 	VSphereClusterIdentityFinalizer = "vsphereclusteridentity/infrastructure.cluster.x-k8s.io"
 )
 
+// VSphereClusterIdentity's CredentialsAvailable condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// VSphereClusterIdentityCredentialsAvailableV1Beta2Condition documents the status of the credentials for a VSphereClusterIdentity.
+	VSphereClusterIdentityCredentialsAvailableV1Beta2Condition = "CredentialsAvailable"
+
+	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity credentials are available.
+	VSphereClusterIdentityCredentialsAvailableV1Beta2Reason = clusterv1.AvailableV1Beta2Reason
+
+	// VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is not available.
+	VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason = "SecretNotAvailable"
+
+	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when the VSphereClusterIdentity secret is already in use.
+	VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason = "SecretAlreadyInUse"
+
+	// VSphereClusterIdentityCredentialsAvailableV1Beta2Reason surfaces when setting the owner reference on the VSphereClusterIdentity secret failed.
+	VSphereClusterIdentityCredentialsSecretOwnerReferenceFailedV1Beta2Reason = "SecretOwnerReferenceFailed"
+
+	// VSphereClusterIdentityCredentialsDeletingV1Beta2Reason surfaces when the credentials for a VSphereClusterIdentity are being deleted.
+	VSphereClusterIdentityCredentialsDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
+)
+
 // VSphereClusterIdentitySpec contains a secret reference and a group of allowed namespaces.
 type VSphereClusterIdentitySpec struct {
 	// SecretName references a Secret inside the controller namespace with the credentials to use

--- a/apis/v1beta1/vspheredeploymentzone_types.go
+++ b/apis/v1beta1/vspheredeploymentzone_types.go
@@ -98,9 +98,6 @@ const (
 	// VSphereDeploymentZoneFailureDomainHostsMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
 	VSphereDeploymentZoneFailureDomainHostsMisconfiguredV1Beta2Reason = "HostsMisconfigured"
 
-	// VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
-	VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason = "HostsAffinityMisconfigured"
-
 	// VSphereDeploymentZoneFailureDomainDatastoreNotFoundV1Beta2Reason surfaces when the failure domain's datastore for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZoneFailureDomainDatastoreNotFoundV1Beta2Reason = "DatastoreNotFound"
 

--- a/apis/v1beta1/vspheredeploymentzone_types.go
+++ b/apis/v1beta1/vspheredeploymentzone_types.go
@@ -28,6 +28,103 @@ const (
 	DeploymentZoneFinalizer = "vspheredeploymentzone.infrastructure.cluster.x-k8s.io"
 )
 
+// VSphereDeploymentZone's Ready condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// VSphereDeploymentZoneReadyV1Beta2Condition is true if the VSphereDeploymentZone's deletionTimestamp is not set, VSphereDeploymentZone's
+	// VCenterAvailable, PlacementConstraintReady and FailureDomainValidated conditions are true.
+	VSphereDeploymentZoneReadyV1Beta2Condition = clusterv1.ReadyV1Beta2Condition
+
+	// VSphereDeploymentZoneReadyV1Beta2Reason surfaces when the VSphereDeploymentZone readiness criteria is met.
+	VSphereDeploymentZoneReadyV1Beta2Reason = clusterv1.ReadyV1Beta2Reason
+
+	// VSphereDeploymentZoneNotReadyV1Beta2Reason surfaces when the VSphereDeploymentZone readiness criteria is not met.
+	VSphereDeploymentZoneNotReadyV1Beta2Reason = clusterv1.NotReadyV1Beta2Reason
+
+	// VSphereDeploymentZoneReadyUnknownV1Beta2Reason surfaces when at least one VSphereDeploymentZone readiness criteria is unknown
+	// and no VSphereDeploymentZone readiness criteria is not met.
+	VSphereDeploymentZoneReadyUnknownV1Beta2Reason = clusterv1.ReadyUnknownV1Beta2Reason
+)
+
+// VSphereDeploymentZone's VCenterAvailable condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// VSphereDeploymentZoneVCenterAvailableV1Beta2Condition documents the status of vCenter for a VSphereDeploymentZone.
+	VSphereDeploymentZoneVCenterAvailableV1Beta2Condition = "VCenterAvailable"
+
+	// VSphereDeploymentZoneVCenterAvailableV1Beta2Reason surfaces when the vCenter for a VSphereDeploymentZone is available.
+	VSphereDeploymentZoneVCenterAvailableV1Beta2Reason = clusterv1.AvailableV1Beta2Reason
+
+	// VSphereDeploymentZoneVCenterUnreachableV1Beta2Reason surfaces when the vCenter for a VSphereDeploymentZone is unreachable.
+	VSphereDeploymentZoneVCenterUnreachableV1Beta2Reason = "VCenterUnreachable"
+
+	// VSphereDeploymentZoneVCenterAvailableDeletingV1Beta2Reason surfaces when the vCenter for a VSphereDeploymentZone is being deleted.
+	VSphereDeploymentZoneVCenterAvailableDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
+)
+
+// VSphereDeploymentZone's PlacementConstraintReady condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// VSphereDeploymentZonePlacementConstraintReadyV1Beta2Condition documents the placement constraint status for a VSphereDeploymentZone.
+	VSphereDeploymentZonePlacementConstraintReadyV1Beta2Condition = "PlacementConstraintReady"
+
+	// VSphereDeploymentZonePlacementConstraintReadyV1Beta2Reason surfaces when the placement status for a VSphereDeploymentZone is ready.
+	VSphereDeploymentZonePlacementConstraintReadyV1Beta2Reason = clusterv1.ReadyV1Beta2Reason
+
+	// VSphereDeploymentZonePlacementConstraintVCenterNotAvailableV1Beta2Reason surfaces when the placement constraint for a VSphereDeploymentZone
+	// can't be verified because of no connectivity to VCenter.
+	VSphereDeploymentZonePlacementConstraintVCenterNotAvailableV1Beta2Reason = "VCenterNotAvailable"
+
+	// VSphereDeploymentZonePlacementConstraintResourcePoolNotFoundV1Beta2Reason surfaces when the resource pool for a VSphereDeploymentZone is not found.
+	VSphereDeploymentZonePlacementConstraintResourcePoolNotFoundV1Beta2Reason = "ResourcePoolNotFound"
+
+	// VSphereDeploymentZonePlacementConstraintFolderNotFoundV1Beta2Reason surfaces when the resource pool for a VSphereDeploymentZone is not found.
+	VSphereDeploymentZonePlacementConstraintFolderNotFoundV1Beta2Reason = "FolderNotFound"
+
+	// VSphereDeploymentZonePlacementConstraintDeletingV1Beta2Reason surfaces when the VSphereDeploymentZone is being deleted.
+	VSphereDeploymentZonePlacementConstraintDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
+)
+
+// VSphereDeploymentZone's FailureDomainValidated condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// VSphereDeploymentZoneFailureDomainValidatedV1Beta2Condition documents failure domain validation status for a VSphereDeploymentZone.
+	VSphereDeploymentZoneFailureDomainValidatedV1Beta2Condition = "FailureDomainValidated"
+
+	// VSphereDeploymentZoneFailureDomainValidatedV1Beta2Reason surfaces when the failure domain for a VSphereDeploymentZone is validated.
+	VSphereDeploymentZoneFailureDomainValidatedV1Beta2Reason = "Validated"
+
+	// VSphereDeploymentZoneFailureDomainVCenterNotAvailableV1Beta2Reason surfaces when the failure domain for a VSphereDeploymentZone
+	// can't be validated because of no connectivity to VCenter.
+	VSphereDeploymentZoneFailureDomainVCenterNotAvailableV1Beta2Reason = "VCenterNotAvailable"
+
+	// VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason surfaces when the failure domain's validation for a VSphereDeploymentZone failed.
+	VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason = "ValidationFailed"
+
+	// VSphereDeploymentZoneFailureDomainRegionMisconfiguredV1Beta2Reason surfaces when the failure domain's region for a VSphereDeploymentZone is misconfigured.
+	VSphereDeploymentZoneFailureDomainRegionMisconfiguredV1Beta2Reason = "RegionMisconfigured"
+
+	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's zone for a VSphereDeploymentZone is misconfigured.
+	VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason = "ZoneMisconfigured"
+
+	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
+	VSphereDeploymentZoneFailureDomainHostsMisconfiguredV1Beta2Reason = "HostsMisconfigured"
+
+	// VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
+	VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason = "HostsAffinityMisconfigured"
+
+	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's datastore for a VSphereDeploymentZone is not found.
+	VSphereDeploymentZoneFailureDomainDatastoreNotFoundV1Beta2Reason = "DatastoreNotFound"
+
+	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's network for a VSphereDeploymentZone is not found.
+	VSphereDeploymentZoneFailureDomainNetworkNotFoundV1Beta2Reason = "NetworkNotFound"
+
+	// VSphereDeploymentZoneFailureDomainComputeClusterNotFoundV1Beta2Reason surfaces when the failure domain's compute cluster for a VSphereDeploymentZone failed.
+	VSphereDeploymentZoneFailureDomainComputeClusterNotFoundV1Beta2Reason = "ComputeClusterNotFound"
+
+	// VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason surfaces when the failure domain's resource pool for a VSphereDeploymentZone failed.
+	VSphereDeploymentZoneFailureDomainResourcePoolNotFoundV1Beta2Reason = "ResourcePoolNotFound"
+
+	// VSphereDeploymentZoneFailureDomainDeletingV1Beta2Reason surfaces when the VSphereDeploymentZone is being deleted.
+	VSphereDeploymentZoneFailureDomainDeletingV1Beta2Reason = clusterv1.DeletingV1Beta2Reason
+)
+
 // VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone.
 type VSphereDeploymentZoneSpec struct {
 
@@ -93,7 +190,7 @@ type VSphereDeploymentZoneStatus struct {
 // See https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more context.
 type VSphereDeploymentZoneV1Beta2Status struct {
 	// conditions represents the observations of a VSphereDeploymentZone's current state.
-	// Known condition types are Paused.
+	// Known condition types are Ready, VCenterAvailable, PlacementConstraintReady, FailureDomainValidated and Paused.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/apis/v1beta1/vspheredeploymentzone_types.go
+++ b/apis/v1beta1/vspheredeploymentzone_types.go
@@ -68,14 +68,10 @@ const (
 	// VSphereDeploymentZonePlacementConstraintReadyV1Beta2Reason surfaces when the placement status for a VSphereDeploymentZone is ready.
 	VSphereDeploymentZonePlacementConstraintReadyV1Beta2Reason = clusterv1.ReadyV1Beta2Reason
 
-	// VSphereDeploymentZonePlacementConstraintVCenterNotAvailableV1Beta2Reason surfaces when the placement constraint for a VSphereDeploymentZone
-	// can't be verified because of no connectivity to VCenter.
-	VSphereDeploymentZonePlacementConstraintVCenterNotAvailableV1Beta2Reason = "VCenterNotAvailable"
-
 	// VSphereDeploymentZonePlacementConstraintResourcePoolNotFoundV1Beta2Reason surfaces when the resource pool for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZonePlacementConstraintResourcePoolNotFoundV1Beta2Reason = "ResourcePoolNotFound"
 
-	// VSphereDeploymentZonePlacementConstraintFolderNotFoundV1Beta2Reason surfaces when the resource pool for a VSphereDeploymentZone is not found.
+	// VSphereDeploymentZonePlacementConstraintFolderNotFoundV1Beta2Reason surfaces when the folder for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZonePlacementConstraintFolderNotFoundV1Beta2Reason = "FolderNotFound"
 
 	// VSphereDeploymentZonePlacementConstraintDeletingV1Beta2Reason surfaces when the VSphereDeploymentZone is being deleted.
@@ -90,10 +86,6 @@ const (
 	// VSphereDeploymentZoneFailureDomainValidatedV1Beta2Reason surfaces when the failure domain for a VSphereDeploymentZone is validated.
 	VSphereDeploymentZoneFailureDomainValidatedV1Beta2Reason = "Validated"
 
-	// VSphereDeploymentZoneFailureDomainVCenterNotAvailableV1Beta2Reason surfaces when the failure domain for a VSphereDeploymentZone
-	// can't be validated because of no connectivity to VCenter.
-	VSphereDeploymentZoneFailureDomainVCenterNotAvailableV1Beta2Reason = "VCenterNotAvailable"
-
 	// VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason surfaces when the failure domain's validation for a VSphereDeploymentZone failed.
 	VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason = "ValidationFailed"
 
@@ -103,22 +95,22 @@ const (
 	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's zone for a VSphereDeploymentZone is misconfigured.
 	VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason = "ZoneMisconfigured"
 
-	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
+	// VSphereDeploymentZoneFailureDomainHostsMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
 	VSphereDeploymentZoneFailureDomainHostsMisconfiguredV1Beta2Reason = "HostsMisconfigured"
 
 	// VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason surfaces when the failure domain's hosts for a VSphereDeploymentZone are misconfigured.
 	VSphereDeploymentZoneFailureDomainHostsAffinityMisconfiguredV1Beta2Reason = "HostsAffinityMisconfigured"
 
-	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's datastore for a VSphereDeploymentZone is not found.
+	// VSphereDeploymentZoneFailureDomainDatastoreNotFoundV1Beta2Reason surfaces when the failure domain's datastore for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZoneFailureDomainDatastoreNotFoundV1Beta2Reason = "DatastoreNotFound"
 
-	// VSphereDeploymentZoneFailureDomainZoneMisconfiguredV1Beta2Reason surfaces when the failure domain's network for a VSphereDeploymentZone is not found.
+	// VSphereDeploymentZoneFailureDomainNetworkNotFoundV1Beta2Reason surfaces when the failure domain's network for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZoneFailureDomainNetworkNotFoundV1Beta2Reason = "NetworkNotFound"
 
-	// VSphereDeploymentZoneFailureDomainComputeClusterNotFoundV1Beta2Reason surfaces when the failure domain's compute cluster for a VSphereDeploymentZone failed.
+	// VSphereDeploymentZoneFailureDomainComputeClusterNotFoundV1Beta2Reason surfaces when the failure domain's compute cluster for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZoneFailureDomainComputeClusterNotFoundV1Beta2Reason = "ComputeClusterNotFound"
 
-	// VSphereDeploymentZoneFailureDomainValidationFailedV1Beta2Reason surfaces when the failure domain's resource pool for a VSphereDeploymentZone failed.
+	// VSphereDeploymentZoneFailureDomainResourcePoolNotFoundV1Beta2Reason surfaces when the failure domain's resource pool for a VSphereDeploymentZone is not found.
 	VSphereDeploymentZoneFailureDomainResourcePoolNotFoundV1Beta2Reason = "ResourcePoolNotFound"
 
 	// VSphereDeploymentZoneFailureDomainDeletingV1Beta2Reason surfaces when the VSphereDeploymentZone is being deleted.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -451,7 +451,7 @@ spec:
                   conditions:
                     description: |-
                       conditions represents the observations of a VSphereClusterIdentity's current state.
-                      Known condition types are Paused.
+                      Known condition types are Available and Paused.
                     items:
                       description: Condition contains details for one aspect of the
                         current state of this API Resource.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -371,7 +371,7 @@ spec:
                   conditions:
                     description: |-
                       conditions represents the observations of a VSphereDeploymentZone's current state.
-                      Known condition types are Paused.
+                      Known condition types are Ready, VCenterAvailable, PlacementConstraintReady, FailureDomainValidated and Paused.
                     items:
                       description: Condition contains details for one aspect of the
                         current state of this API Resource.

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -30,6 +30,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/finalizers"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/paused"
@@ -102,6 +103,7 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 
 		if err := patchHelper.Patch(ctx, identity, patch.WithOwnedV1Beta2Conditions{Conditions: []string{
 			clusterv1.PausedV1Beta2Condition,
+			infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
 		}}); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
@@ -119,12 +121,24 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 	if err := r.Client.Get(ctx, secretKey, secret); err != nil {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretNotAvailableReason, clusterv1.ConditionSeverityWarning, err.Error())
+		v1beta2conditions.Set(identity, metav1.Condition{
+			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason,
+			Message: err.Error(),
+		})
 		return reconcile.Result{}, errors.Wrapf(err, "failed to get Secret %s", klog.KRef(secretKey.Namespace, secretKey.Name))
 	}
 
 	// If this secret is owned by a different VSphereClusterIdentity or a VSphereCluster, mark the identity as not ready and return an error.
 	if !clusterutilv1.IsOwnedByObject(secret, identity) && pkgidentity.IsOwnedByIdentityOrCluster(secret.GetOwnerReferences()) {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretAlreadyInUseReason, clusterv1.ConditionSeverityError, "secret being used by another Cluster/VSphereIdentity")
+		v1beta2conditions.Set(identity, metav1.Condition{
+			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason,
+			Message: "secret being used by another Cluster/VSphereIdentity",
+		})
 		identity.Status.Ready = false
 		return reconcile.Result{}, errors.New("secret being used by another Cluster/VSphereIdentity")
 	}
@@ -145,10 +159,22 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	err = r.Client.Update(ctx, secret)
 	if err != nil {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretOwnerReferenceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+		v1beta2conditions.Set(identity, metav1.Condition{
+			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretOwnerReferenceFailedV1Beta2Reason,
+			Message: err.Error(),
+		})
 		return reconcile.Result{}, err
 	}
 
 	conditions.MarkTrue(identity, infrav1.CredentialsAvailableCondidtion)
+	v1beta2conditions.Set(identity, metav1.Condition{
+		Type:   infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+		Status: metav1.ConditionTrue,
+		Reason: infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Reason,
+	})
+
 	identity.Status.Ready = true
 	return reconcile.Result{}, nil
 }
@@ -160,6 +186,13 @@ func (r clusterIdentityReconciler) reconcileDelete(ctx context.Context, identity
 		Namespace: r.ControllerManagerCtx.Namespace,
 		Name:      identity.Spec.SecretName,
 	}
+
+	v1beta2conditions.Set(identity, metav1.Condition{
+		Type:   infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+		Status: metav1.ConditionFalse,
+		Reason: infrav1.VSphereClusterIdentityCredentialsDeletingV1Beta2Reason,
+	})
+
 	err := r.Client.Get(ctx, secretKey, secret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -162,7 +162,7 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 		v1beta2conditions.Set(identity, metav1.Condition{
 			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretOwnerReferenceFailedV1Beta2Reason,
+			Reason:  infrav1.VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason,
 			Message: err.Error(),
 		})
 		return reconcile.Result{}, err

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -103,7 +103,7 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 
 		if err := patchHelper.Patch(ctx, identity, patch.WithOwnedV1Beta2Conditions{Conditions: []string{
 			clusterv1.PausedV1Beta2Condition,
-			infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 		}}); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
@@ -122,9 +122,9 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	if err := r.Client.Get(ctx, secretKey, secret); err != nil {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretNotAvailableReason, clusterv1.ConditionSeverityWarning, err.Error())
 		v1beta2conditions.Set(identity, metav1.Condition{
-			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Type:    infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretNotAvailableV1Beta2Reason,
+			Reason:  infrav1.VSphereClusterIdentitySecretNotAvailableV1Beta2Reason,
 			Message: err.Error(),
 		})
 		return reconcile.Result{}, errors.Wrapf(err, "failed to get Secret %s", klog.KRef(secretKey.Namespace, secretKey.Name))
@@ -134,9 +134,9 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	if !clusterutilv1.IsOwnedByObject(secret, identity) && pkgidentity.IsOwnedByIdentityOrCluster(secret.GetOwnerReferences()) {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretAlreadyInUseReason, clusterv1.ConditionSeverityError, "secret being used by another Cluster/VSphereIdentity")
 		v1beta2conditions.Set(identity, metav1.Condition{
-			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Type:    infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VSphereClusterIdentityCredentialsSecretAlreadyInUseV1Beta2Reason,
+			Reason:  infrav1.VSphereClusterIdentitySecretAlreadyInUseV1Beta2Reason,
 			Message: "secret being used by another Cluster/VSphereIdentity",
 		})
 		identity.Status.Ready = false
@@ -160,9 +160,9 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	if err != nil {
 		conditions.MarkFalse(identity, infrav1.CredentialsAvailableCondidtion, infrav1.SecretOwnerReferenceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 		v1beta2conditions.Set(identity, metav1.Condition{
-			Type:    infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+			Type:    infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.VSphereClusterIdentityCredentialsSettingSecretOwnerReferenceFailedV1Beta2Reason,
+			Reason:  infrav1.VSphereClusterIdentitySettingSecretOwnerReferenceFailedV1Beta2Reason,
 			Message: err.Error(),
 		})
 		return reconcile.Result{}, err
@@ -170,9 +170,9 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 
 	conditions.MarkTrue(identity, infrav1.CredentialsAvailableCondidtion)
 	v1beta2conditions.Set(identity, metav1.Condition{
-		Type:   infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+		Type:   infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 		Status: metav1.ConditionTrue,
-		Reason: infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Reason,
+		Reason: infrav1.VSphereClusterIdentityAvailableV1Beta2Reason,
 	})
 
 	identity.Status.Ready = true
@@ -188,9 +188,9 @@ func (r clusterIdentityReconciler) reconcileDelete(ctx context.Context, identity
 	}
 
 	v1beta2conditions.Set(identity, metav1.Condition{
-		Type:   infrav1.VSphereClusterIdentityCredentialsAvailableV1Beta2Condition,
+		Type:   infrav1.VSphereClusterIdentityAvailableV1Beta2Condition,
 		Status: metav1.ConditionFalse,
-		Reason: infrav1.VSphereClusterIdentityCredentialsDeletingV1Beta2Reason,
+		Reason: infrav1.VSphereClusterIdentityDeletingV1Beta2Reason,
 	})
 
 	err := r.Client.Get(ctx, secretKey, secret)

--- a/pkg/context/vspheredeploymentzone_context.go
+++ b/pkg/context/vspheredeploymentzone_context.go
@@ -17,11 +17,8 @@ limitations under the License.
 package context
 
 import (
-	"context"
 	"fmt"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
@@ -34,20 +31,6 @@ type VSphereDeploymentZoneContext struct {
 	VSphereDeploymentZone *infrav1.VSphereDeploymentZone
 	PatchHelper           *patch.Helper
 	AuthSession           *session.Session
-}
-
-// Patch patches the VSphereDeploymentZone.
-func (c *VSphereDeploymentZoneContext) Patch(ctx context.Context) error {
-	conditions.SetSummary(c.VSphereDeploymentZone,
-		conditions.WithConditions(
-			infrav1.VCenterAvailableCondition,
-			infrav1.VSphereFailureDomainValidatedCondition,
-			infrav1.PlacementConstraintMetCondition,
-		),
-	)
-	return c.PatchHelper.Patch(ctx, c.VSphereDeploymentZone, patch.WithOwnedV1Beta2Conditions{Conditions: []string{
-		clusterv1.PausedV1Beta2Condition,
-	}})
 }
 
 // String returns a string with the GroupVersionKind and name of the VSphereDeploymentZone.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3221

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
