### PR TITLE
🌱 e2e: servicediscovery controller to have an ip to discover in tests

### DIFF
--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -62,9 +62,7 @@ import (
 const (
 	clusterNotReadyRequeueTime = time.Minute * 2
 
-	supervisorLoadBalancerSvcNamespace = "kube-system"
-	supervisorLoadBalancerSvcName      = "kube-apiserver-lb-svc"
-	supervisorAPIServerPort            = 6443
+	supervisorAPIServerPort = 6443
 
 	supervisorHeadlessSvcNamespace = "default"
 	supervisorHeadlessSvcName      = "supervisor"

--- a/controllers/vmware/servicediscovery_controller_suite_test.go
+++ b/controllers/vmware/servicediscovery_controller_suite_test.go
@@ -177,8 +177,8 @@ func newTestSupervisorLBServiceWithHostnameStatus() *corev1.Service {
 func newTestSupervisorLBService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      supervisorLoadBalancerSvcName,
-			Namespace: supervisorLoadBalancerSvcNamespace,
+			Name:      vmwarev1.SupervisorLoadBalancerSvcName,
+			Namespace: vmwarev1.SupervisorLoadBalancerSvcNamespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -402,8 +402,8 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 	supervisorAPIServerVIPService.Status = corev1.ServiceStatus{
 		LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
 			// Note: this creates a unusable service. During test no application should try to reach out to this.
-			// 169.254.0.1 is part of the link-local subnet	169.254.0.0/16.
-			{IP: "169.254.0.1"},
+			// 192.0.2.2 is part of the link-local subnet 192.0.2.0/24 which is reserved for documentation and testing.
+			{IP: "192.0.2.2"},
 		}},
 	}
 	_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -402,7 +402,8 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 	supervisorAPIServerVIPService.Status = corev1.ServiceStatus{
 		LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
 			// Note: this creates a unusable service. During test no application should try to reach out to this.
-			{IP: "127.0.0.255"},
+			// 169.254.0.1 is part of the link-local subnet	169.254.0.0/16.
+			{IP: "169.254.0.1"},
 		}},
 	}
 	_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -363,7 +363,8 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 	}
 
 	// Create the supervisor service in kube-system for the servicediscovery controller to discover and set an IP address
-	// for the headless service.
+	// for the headless service. When using kind as management cluster, the cluster-info configmap in kube-public contains a
+	// hostname instead of an IP address which does not work for the servicediscovery controller.
 	supervisorAPIServerVIPService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vmwarev1.SupervisorLoadBalancerSvcName,
@@ -400,7 +401,8 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 	}
 	supervisorAPIServerVIPService.Status = corev1.ServiceStatus{
 		LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
-			{IP: "192.168.1.99"},
+			// Note: this creates a unusable service. During test no application should try to reach out to this.
+			{IP: "127.0.0.255"},
 		}},
 	}
 	_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -43,6 +43,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	topologyv1 "sigs.k8s.io/cluster-api-provider-vsphere/internal/apis/topology/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	vcsimv1 "sigs.k8s.io/cluster-api-provider-vsphere/test/infrastructure/vcsim/api/v1alpha1"
@@ -355,6 +356,60 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 			}
 			log.Info("Created vm-operator ConfigMap", "ConfigMap", klog.KObj(providerConfigMap))
 		}
+		return true, nil
+	})
+	if retryError != nil {
+		return retryError
+	}
+
+	// Create the supervisor service in kube-system for the servicediscovery controller to discover and set an IP address
+	// for the headless service.
+	supervisorAPIServerVIPService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmwarev1.SupervisorLoadBalancerSvcName,
+			Namespace: vmwarev1.SupervisorLoadBalancerSvcNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "kube-apiserver",
+					Protocol: corev1.ProtocolTCP,
+					Port:     6443,
+				},
+			},
+		},
+	}
+	_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		retryError = nil
+		if err := c.Get(ctx, client.ObjectKeyFromObject(supervisorAPIServerVIPService), supervisorAPIServerVIPService); err != nil {
+			if !apierrors.IsNotFound(err) {
+				retryError = errors.Wrapf(err, "failed to get vm-operator service %s", klog.KObj(supervisorAPIServerVIPService))
+				return false, nil
+			}
+			if err := c.Create(ctx, supervisorAPIServerVIPService); err != nil {
+				retryError = errors.Wrapf(err, "failed to create vm-operator service %s", klog.KObj(supervisorAPIServerVIPService))
+				return false, nil
+			}
+			log.Info("Created vm-operator service", "Service", klog.KObj(supervisorAPIServerVIPService))
+		}
+		return true, nil
+	})
+	if retryError != nil {
+		return retryError
+	}
+	supervisorAPIServerVIPService.Status = corev1.ServiceStatus{
+		LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
+			{IP: "192.168.1.99"},
+		}},
+	}
+	_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		retryError = nil
+		if err := c.Status().Update(ctx, supervisorAPIServerVIPService); err != nil {
+			retryError = errors.Wrapf(err, "failed to update vm-operator service status %s", klog.KObj(supervisorAPIServerVIPService))
+			return false, nil
+		}
+		log.Info("Updated vm-operator service status", "Service", klog.KObj(supervisorAPIServerVIPService))
 		return true, nil
 	})
 	if retryError != nil {

--- a/test/infrastructure/vcsim/config/rbac/role.yaml
+++ b/test/infrastructure/vcsim/config/rbac/role.yaml
@@ -24,6 +24,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/test/infrastructure/vcsim/controllers/vmip_controller.go
+++ b/test/infrastructure/vcsim/controllers/vmip_controller.go
@@ -112,11 +112,11 @@ func (r *vmIPReconciler) ReconcileIP(ctx context.Context) (ctrl.Result, error) {
 				MacAddress: macAddress,
 				Adapter: types.CustomizationIPSettings{
 					Ip: &types.CustomizationFixedIp{
-						IpAddress: "192.168.1.100",
+						IpAddress: "192.0.2.100",
 					},
 					SubnetMask:    "255.255.255.0",
-					Gateway:       []string{"192.168.1.1"},
-					DnsServerList: []string{"192.168.1.1"},
+					Gateway:       []string{"192.0.2.1"},
+					DnsServerList: []string{"192.0.2.1"},
 					DnsDomain:     "ad.domain",
 				},
 			},

--- a/test/infrastructure/vcsim/controllers/vmoperatordependencies_controller.go
+++ b/test/infrastructure/vcsim/controllers/vmoperatordependencies_controller.go
@@ -41,6 +41,7 @@ type VMOperatorDependenciesReconciler struct {
 
 // +kubebuilder:rbac:groups=vcsim.infrastructure.cluster.x-k8s.io,resources=vmoperatordependencies,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=vcsim.infrastructure.cluster.x-k8s.io,resources=vmoperatordependencies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=services;services/status,verbs=get;list;watch;create;update;patch
 
 func (r *VMOperatorDependenciesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	// Fetch the VMOperatorDependencies instance

--- a/test/infrastructure/vcsim/main.go
+++ b/test/infrastructure/vcsim/main.go
@@ -159,10 +159,10 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
+	fs.Float32Var(&restConfigQPS, "kube-api-qps", 100,
 		"Maximum queries per second from the controller client to the Kubernetes API server.")
 
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
+	fs.IntVar(&restConfigBurst, "kube-api-burst", 200,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes red e2e tests (especially around upgrades).

Error is/was:

```
* ServiceDiscoveryReady: failed to create or patch service Endpoints: Endpoints "supervisor" is   
  invalid: [subsets[0].addresses[0].ip: Invalid value: "": must be a valid IP address, (e.g.      
  10.9.8.7 or 2001:db8::ffff), subsets[0].addresses[0].ip: Invalid value: "": must be a valid IP  
  address]                                                                                        
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
