### PR TITLE
✨ Improve CRD migration & bump to CAPI release-1.10 (19th March)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ IMPORT_BOSS_VER := v0.28.1
 IMPORT_BOSS := $(abspath $(TOOLS_BIN_DIR)/$(IMPORT_BOSS_BIN))
 IMPORT_BOSS_PKG := k8s.io/code-generator/cmd/import-boss
 
-CAPI_HACK_TOOLS_VER := 9e7afa749358adc7e0c6ae5408d0d8eeb2affa0a # Note: this a commit ID of from CAPI main, supposed to be in v1.10
+CAPI_HACK_TOOLS_VER := 4f022adb6164359b9c414d8c41752b2da27246fe # Note: this a commit ID of from CAPI release-1.0 branch, supposed to be in v1.10
 
 BOSKOSCTL_BIN := boskosctl
 BOSKOSCTL := $(abspath $(TOOLS_BIN_DIR)/$(BOSKOSCTL_BIN))

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164
 
 replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v0.0.0-20240404200847-de75746a9505
 

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358 h1:prMTNmeGPlCYD5YSc3Oi4NuA2dTA7Bj/5G4TaeeWSNg=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164 h1:Oizd0NIHcrm8ltWqLZCnuFVBt3snHbi9iXYG9iyRJGo=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
 sigs.k8s.io/controller-runtime v0.20.3 h1:I6Ln8JfQjHH7JbtCD2HCYHoIzajoRxPNuvhvcDbZgkI=
 sigs.k8s.io/controller-runtime v0.20.3/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/main.go
+++ b/main.go
@@ -336,20 +336,20 @@ func main() {
 		// with the CRDs that should be migrated by this provider.
 		crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{}
 		if isGovmomiCRDLoaded {
-			crdMigratorConfig[&infrav1.VSphereCluster{}] = crdmigrator.ByObjectConfig{UseCache: true}
+			crdMigratorConfig[&infrav1.VSphereCluster{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
 			crdMigratorConfig[&infrav1.VSphereClusterTemplate{}] = crdmigrator.ByObjectConfig{UseCache: false}
-			crdMigratorConfig[&infrav1.VSphereMachine{}] = crdmigrator.ByObjectConfig{UseCache: true}
+			crdMigratorConfig[&infrav1.VSphereMachine{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
 			crdMigratorConfig[&infrav1.VSphereMachineTemplate{}] = crdmigrator.ByObjectConfig{UseCache: true}
-			crdMigratorConfig[&infrav1.VSphereVM{}] = crdmigrator.ByObjectConfig{UseCache: true}
-			crdMigratorConfig[&infrav1.VSphereClusterIdentity{}] = crdmigrator.ByObjectConfig{UseCache: true}
-			crdMigratorConfig[&infrav1.VSphereDeploymentZone{}] = crdmigrator.ByObjectConfig{UseCache: true}
+			crdMigratorConfig[&infrav1.VSphereVM{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+			crdMigratorConfig[&infrav1.VSphereClusterIdentity{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+			crdMigratorConfig[&infrav1.VSphereDeploymentZone{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
 			crdMigratorConfig[&infrav1.VSphereFailureDomain{}] = crdmigrator.ByObjectConfig{UseCache: true}
 		}
 		if isSupervisorCRDLoaded {
-			crdMigratorConfig[&vmwarev1.VSphereCluster{}] = crdmigrator.ByObjectConfig{UseCache: true}
+			crdMigratorConfig[&vmwarev1.VSphereCluster{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
 			crdMigratorConfig[&vmwarev1.VSphereClusterTemplate{}] = crdmigrator.ByObjectConfig{UseCache: false}
-			crdMigratorConfig[&vmwarev1.VSphereMachine{}] = crdmigrator.ByObjectConfig{UseCache: true}
-			crdMigratorConfig[&vmwarev1.VSphereMachineTemplate{}] = crdmigrator.ByObjectConfig{UseCache: true}
+			crdMigratorConfig[&vmwarev1.VSphereMachine{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+			crdMigratorConfig[&vmwarev1.VSphereMachineTemplate{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
 			crdMigratorConfig[&vmwarev1.ProviderServiceAccount{}] = crdmigrator.ByObjectConfig{UseCache: true}
 		}
 

--- a/packaging/go.mod
+++ b/packaging/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere/packaging
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164
 
 replace sigs.k8s.io/cluster-api-provider-vsphere => ../
 

--- a/packaging/go.sum
+++ b/packaging/go.sum
@@ -231,8 +231,8 @@ k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJ
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358 h1:prMTNmeGPlCYD5YSc3Oi4NuA2dTA7Bj/5G4TaeeWSNg=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164 h1:Oizd0NIHcrm8ltWqLZCnuFVBt3snHbi9iXYG9iyRJGo=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
 sigs.k8s.io/controller-runtime v0.20.3 h1:I6Ln8JfQjHH7JbtCD2HCYHoIzajoRxPNuvhvcDbZgkI=
 sigs.k8s.io/controller-runtime v0.20.3/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -27,7 +27,7 @@ providers:
     type: CoreProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250316/core-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/release-1.10/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -76,7 +76,7 @@ providers:
     type: BootstrapProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250316/bootstrap-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/release-1.10/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -125,7 +125,7 @@ providers:
     type: ControlPlaneProvider
     versions:
       - name: "v1.10.99"
-        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_20250316/control-plane-components.yaml"
+        value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/release-1.10/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,9 +2,9 @@ module sigs.k8s.io/cluster-api-provider-vsphere/test
 
 go 1.23.0
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164
 
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250317123349-9e7afa749358
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.10.0-beta.0.0.20250319172205-4f022adb6164
 
 replace sigs.k8s.io/cluster-api-provider-vsphere => ../
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -511,10 +511,10 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358 h1:prMTNmeGPlCYD5YSc3Oi4NuA2dTA7Bj/5G4TaeeWSNg=
-sigs.k8s.io/cluster-api v1.9.0-rc.0.0.20250317123349-9e7afa749358/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
-sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250317123349-9e7afa749358 h1:cJe9rQ48Hsuv1b+Mue7LtEZa1p9bpkPiM0ZoB70WNSA=
-sigs.k8s.io/cluster-api/test v1.9.0-rc.0.0.20250317123349-9e7afa749358/go.mod h1:EUwHeqQ2jUF+ccC2+nyie7JsP0XMX9KyGzbRhM+h5EU=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164 h1:Oizd0NIHcrm8ltWqLZCnuFVBt3snHbi9iXYG9iyRJGo=
+sigs.k8s.io/cluster-api v1.10.0-beta.0.0.20250319172205-4f022adb6164/go.mod h1:ZTghHCPfdpVC1aAAPKd/6GfQRmbJ3WvbJtHFMkOq0ho=
+sigs.k8s.io/cluster-api/test v1.10.0-beta.0.0.20250319172205-4f022adb6164 h1:bSeyqwxLlVQ56HR4Z5wt1WTAsLieH7KSEfBwmxnengU=
+sigs.k8s.io/cluster-api/test v1.10.0-beta.0.0.20250319172205-4f022adb6164/go.mod h1:EUwHeqQ2jUF+ccC2+nyie7JsP0XMX9KyGzbRhM+h5EU=
 sigs.k8s.io/controller-runtime v0.20.3 h1:I6Ln8JfQjHH7JbtCD2HCYHoIzajoRxPNuvhvcDbZgkI=
 sigs.k8s.io/controller-runtime v0.20.3/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/11991

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3407
