### PR TITLE
🐛 Sets character limit for VMService name

### DIFF
--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -35,6 +35,7 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
 const (
@@ -155,7 +156,7 @@ func (s *CPService) ReconcileControlPlaneEndpointService(ctx context.Context, cl
 }
 
 func controlPlaneVMServiceName(ctx *vmware.ClusterContext) string {
-	return fmt.Sprintf("%s-control-plane-service", ctx.Cluster.Name)
+	return util.GenerateResourceName(fmt.Sprintf("%s-control-plane-service", ctx.Cluster.Name))
 }
 
 // ClusterRoleVMLabels returns labels applied to a VirtualMachine in the cluster. The Control Plane

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -103,3 +103,35 @@ func Test_GenerateMachineNameFromTemplate(t *testing.T) {
 		})
 	}
 }
+
+func Test_GenerateResourceName(t *testing.T) {
+	tests := []struct {
+		testName     string
+		providedName string
+		expectedName string
+	}{
+		{
+			testName:     "should return unmodified name if less than max number of characters",
+			providedName: "less-than-max-characters", // 24 characters
+			expectedName: "less-than-max-characters",
+		},
+		{
+			testName:     "should return with a hash suffix when provided name exceeds maximum",
+			providedName: "more-than-max-more-than-max-more-than-max-more-than-max-more-than-max-more-than-max", // 84 characters
+			expectedName: "more-than-max-more-than-max-more-than-max-more-than-m3260568934",
+		},
+		{
+			testName:     "should return a unique name with a different suffix even if the generated prefix is the same",
+			providedName: "more-than-max-more-than-max-more-than-max-more-than-max-more-than-max-more-than", // 80 characters
+			expectedName: "more-than-max-more-than-max-more-than-max-more-than-m1990406901",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			actualName := GenerateResourceName(tt.providedName)
+			g.Expect(actualName).To(Equal(tt.expectedName))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If a supervisor backed cluster is created with a name > 41, it won't go into provisioned state. We attempt to create a VirtualMachineService resource with a name that's <cluster-name>-control-plane-service. This creation will fail as it needs to conform to RFC 1123 label names standard which among other things enforces a max character limit of 63. 

This PR adds a util function that will generate and append a hash suffix if the provided name is too long. Existing healthy clusters won't be affected as the name is returned unchanged if it's less than 63 chars.