### PR TITLE
🌱 Bump to Kubernetes v1.33.0-rc.1

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -303,12 +303,12 @@ providers:
 
 variables:
   # Ensure all Kubernetes versions used here are covered in patch-vsphere-template.yaml
-  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0-rc.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0-rc.1"
   # Note: currently not ci/latest-1.33 because of rate-limiting issues.
-  KUBERNETES_VERSION_MANAGEMENT_LATEST_CI: "v1.33.0-rc.0"
-  KUBERNETES_VERSION: "v1.33.0-rc.0"
+  KUBERNETES_VERSION_MANAGEMENT_LATEST_CI: "v1.33.0-rc.1"
+  KUBERNETES_VERSION: "v1.33.0-rc.1"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0-rc.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0-rc.1"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.33"
   CPI_IMAGE_K8S_VERSION: "v1.33.0-rc.0"
   CNI: "./data/cni/calico/calico.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Keep up with K8s releases

/cherry-pick release-1.13
/hold for CI