### PR TITLE
:seedling: Able to export webhooks for external utilization

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,12 +59,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/controllers"
 	"sigs.k8s.io/cluster-api-provider-vsphere/controllers/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
-	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks"
-	vmwarewebhooks "sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/version"
+	"sigs.k8s.io/cluster-api-provider-vsphere/webhooks"
+	vmwarewebhooks "sigs.k8s.io/cluster-api-provider-vsphere/webhooks/vmware"
 )
 
 var (

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks"
+)
+
+// VSphereClusterTemplateWebhook implements a validation and defaulting webhook for VSphereClusterTemplate.
+type VSphereClusterTemplateWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereClusterTemplate webhooks.
+func (webhook *VSphereClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereDeploymentZoneWebhook implements a validation and defaulting webhook for VSphereDeploymentZone.
+type VSphereDeploymentZoneWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereDeploymentZone webhooks.
+func (webhook *VSphereDeploymentZoneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereFailureDomainWebhook implements a validation and defaulting webhook for VSphereFailureDomain.
+type VSphereFailureDomainWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereFailureDomain webhooks.
+func (webhook *VSphereFailureDomainWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachineWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereMachine webhooks.
+func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
+type VSphereMachineTemplateWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
+func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereVMWebhook implements a validation and defaulting webhook for VSphereVM.
+type VSphereVMWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereVM webhooks.
+func (webhook *VSphereVMWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr)
+}

--- a/webhooks/doc.go
+++ b/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains webhooks for the infrastructure v1beta1 API group.
+package webhooks

--- a/webhooks/vmware/alias.go
+++ b/webhooks/vmware/alias.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
+)
+
+// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachineWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereMachine webhooks.
+func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&vmware.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
+}
+
+// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
+type VSphereMachineTemplateWebhook struct{}
+
+// SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
+func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&vmware.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
+}

--- a/webhooks/vmware/doc.go
+++ b/webhooks/vmware/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vmware contains webhooks for the infrastructure vmware v1beta1 API group.
+package vmware


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This fix allows to export web-hook code for use in external projects as well as controllers code.
This  is the same approach as Cluster API web-hooks exporting, when you need to compile code that will include all controllers and their logic, such as web-hooks, in a single binary file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
