### PR TITLE
[release-1.12] 🌱 Bump to Go 1.23.8 to fix CVEs + ignore CVE CVE-2025-22872 via trivy

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -29,6 +29,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # tag=v6.1.1
         with:
-          version: v1.59.0
+          version: v1.60.2
           args: --out-format=colored-line-number
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  go: "1.22"
+  go: "1.23"
   skip-files:
     - "zz_generated.*\\.go$"
     - "_conversion\\.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,10 @@ linters:
   - whitespace
 
 linters-settings:
+  gosec:
+    excludes:
+      # integer overflow conversion int -> int32
+      - G115
   gci:
     sections:
       - standard # Standard section: captures all standard packages.
@@ -324,3 +328,6 @@ issues:
     - stylecheck
     text: ST1021|ST1020
     path: ^(apis/(v1alpha3|v1alpha4)\/.*)\.go$
+  - linters:
+      - govet
+    text: "non-constant format string in call to sigs\\.k8s\\.io\\/cluster-api\\/util\\/conditions\\."

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# According to govulncheck we are not using code that is affected by CVEs
+CVE-2025-22870
+CVE-2025-22872

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,0 @@
-# According to govulncheck we are not using code that is affected by CVEs
-CVE-2025-22870

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,13 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.22.12
+GO_VERSION ?= 1.23.8
 GO_DIRECTIVE_VERSION ?= 1.22.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
+
+# Ensure correct toolchain is used
+GOTOOLCHAIN = go$(GO_VERSION)
+export GOTOOLCHAIN
 
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
@@ -537,7 +541,7 @@ verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
 	if [ "$$R1" -ne "0" ] || [ "$$R2" -ne "0" ] || [ "$$R3" -ne "0" ]; then \
 		exit 1; \
 	fi
-	git restore "test/framework/log/collector.go" 
+	git restore "test/framework/log/collector.go"
 
 .PHONY: verify-security
 verify-security: ## Verify code and images for vulnerabilities

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -165,14 +165,14 @@ func (r *clusterReconciler) reconcileDelete(ctx context.Context, clusterCtx *cap
 		if ctrlutil.RemoveFinalizer(secret, infrav1.SecretIdentitySetFinalizer) {
 			log.Info(fmt.Sprintf("Removing finalizer %s", infrav1.SecretIdentitySetFinalizer), "Secret", klog.KObj(secret))
 			if err := r.Client.Update(ctx, secret); err != nil {
-				return reconcile.Result{}, pkgerrors.Wrapf(err, fmt.Sprintf("failed to update Secret %s", klog.KObj(secret)))
+				return reconcile.Result{}, pkgerrors.Wrapf(err, "failed to update Secret %s", klog.KObj(secret))
 			}
 		}
 
 		if secret.DeletionTimestamp.IsZero() {
 			log.Info("Deleting Secret", "Secret", klog.KObj(secret))
 			if err := r.Client.Delete(ctx, secret); err != nil {
-				return reconcile.Result{}, pkgerrors.Wrapf(err, fmt.Sprintf("failed to delete Secret %s", klog.KObj(secret)))
+				return reconcile.Result{}, pkgerrors.Wrapf(err, "failed to delete Secret %s", klog.KObj(secret))
 			}
 		}
 	}

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -174,14 +174,14 @@ func (r clusterIdentityReconciler) reconcileDelete(ctx context.Context, identity
 	if ctrlutil.RemoveFinalizer(secret, infrav1.SecretIdentitySetFinalizer) {
 		log.Info(fmt.Sprintf("Removing finalizer %s", infrav1.SecretIdentitySetFinalizer), "Secret", klog.KObj(secret))
 		if err := r.Client.Update(ctx, secret); err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("failed to update Secret %s", klog.KObj(secret)))
+			return errors.Wrapf(err, "failed to update Secret %s", klog.KObj(secret))
 		}
 	}
 
 	if secret.DeletionTimestamp.IsZero() {
 		log.Info("Deleting Secret", "Secret", klog.KObj(secret))
 		if err := r.Client.Delete(ctx, secret); err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("failed to delete Secret %s", klog.KObj(secret)))
+			return errors.Wrapf(err, "failed to delete Secret %s", klog.KObj(secret))
 		}
 	}
 

--- a/controllers/vspherevm_ipaddress_reconciler.go
+++ b/controllers/vspherevm_ipaddress_reconciler.go
@@ -199,13 +199,13 @@ func (r vmReconciler) deleteIPAddressClaims(ctx context.Context, vmCtx *capvcont
 				if apierrors.IsNotFound(err) {
 					continue
 				}
-				return errors.Wrapf(err, fmt.Sprintf("failed to get IPAddressClaim %q to remove the finalizer", ipAddrClaimName))
+				return errors.Wrapf(err, "failed to get IPAddressClaim %q to remove the finalizer", ipAddrClaimName)
 			}
 
 			if ctrlutil.RemoveFinalizer(ipAddrClaim, infrav1.IPAddressClaimFinalizer) {
 				log.Info(fmt.Sprintf("Removing finalizer %s", infrav1.IPAddressClaimFinalizer), "IPAddressClaim", klog.KObj(ipAddrClaim))
 				if err := vmCtx.Client.Update(ctx, ipAddrClaim); err != nil {
-					return errors.Wrapf(err, fmt.Sprintf("failed to update IPAddressClaim %s", klog.KObj(ipAddrClaim)))
+					return errors.Wrapf(err, "failed to update IPAddressClaim %s", klog.KObj(ipAddrClaim))
 				}
 			}
 		}

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -38,7 +38,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.22
+  minimum_go_version=go1.23
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/test/framework/log/collector.go
+++ b/test/framework/log/collector.go
@@ -219,7 +219,7 @@ func newSSHConfig() (*ssh.ClientConfig, error) {
 
 	signer, err := ssh.ParsePrivateKey(sshPrivateKeyContent)
 	if err != nil {
-		return nil, errors.Wrapf(err, fmt.Sprintf("error parsing private key: %s", sshPrivateKeyContent))
+		return nil, errors.Wrapf(err, "error parsing private key: %s", sshPrivateKeyContent)
 	}
 
 	config := &ssh.ClientConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
