### PR TITLE
:seedling: Fix web-hook structure names and descriptions

### DIFF
--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -262,10 +262,10 @@ func getManager(cfg *rest.Config, networkProvider string, withWebhooks bool) man
 		}
 
 		if withWebhooks {
-			if err := (&vmwarewebhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
-			if err := (&vmwarewebhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
 		}

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -195,27 +195,27 @@ func NewTestEnvironment(ctx context.Context) *TestEnvironment {
 		Password:   simr.Password(),
 	}
 	managerOpts.AddToManager = func(_ context.Context, _ *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-		if err := (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&webhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
 
-		if err := (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&webhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
 
-		if err := (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&webhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
 
-		if err := (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&webhooks.VSphereVM{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
 
-		if err := (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&webhooks.VSphereDeploymentZone{}).SetupWebhookWithManager(mgr); err != nil {
 			return err
 		}
 
-		return (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr)
+		return (&webhooks.VSphereFailureDomain{}).SetupWebhookWithManager(mgr)
 	}
 
 	mgr, err := manager.New(ctx, managerOpts)

--- a/internal/webhooks/vmware/vspheremachine.go
+++ b/internal/webhooks/vmware/vspheremachine.go
@@ -35,13 +35,13 @@ import (
 // +kubebuilder:webhook:verbs=create;update,path=/validate-vmware-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta1,name=validation.vspheremachine.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-vmware-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta1,name=default.vspheremachine.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
-var _ webhook.CustomValidator = &VSphereMachineWebhook{}
-var _ webhook.CustomDefaulter = &VSphereMachineWebhook{}
+var _ webhook.CustomValidator = &VSphereMachine{}
+var _ webhook.CustomDefaulter = &VSphereMachine{}
 
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&vmwarev1.VSphereMachine{}).
 		WithValidator(webhook).
@@ -50,17 +50,17 @@ func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) 
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (webhook *VSphereMachine) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	newTyped, ok := newRaw.(*vmwarev1.VSphereMachine)
@@ -100,6 +100,6 @@ func (webhook *VSphereMachineWebhook) ValidateUpdate(_ context.Context, oldRaw r
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -68,7 +68,7 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			webhook := &VSphereMachineWebhook{}
+			webhook := &VSphereMachine{}
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereMachine, tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vmware/vspheremachinetemplate.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate.go
@@ -35,12 +35,12 @@ import (
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-vmware-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates,versions=v1beta1,name=validation.vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereMachineTemplateWebhook implements a validation webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
-var _ webhook.CustomValidator = &VSphereMachineTemplateWebhook{}
+var _ webhook.CustomValidator = &VSphereMachineTemplate{}
 
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&vmwarev1.VSphereMachineTemplate{}).
 		WithValidator(webhook).
@@ -48,7 +48,7 @@ func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.M
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	vSphereMachineTemplate, ok := obj.(*vmwarev1.VSphereMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereMachineTemplate but got a %T", obj))
@@ -57,7 +57,7 @@ func (webhook *VSphereMachineTemplateWebhook) ValidateCreate(ctx context.Context
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateUpdate(ctx context.Context, _, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateUpdate(ctx context.Context, _, newRaw runtime.Object) (admission.Warnings, error) {
 	vSphereMachineTemplate, ok := newRaw.(*vmwarev1.VSphereMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereMachineTemplate but got a %T", newRaw))
@@ -65,7 +65,7 @@ func (webhook *VSphereMachineTemplateWebhook) ValidateUpdate(ctx context.Context
 	return webhook.validate(ctx, nil, vSphereMachineTemplate)
 }
 
-func (webhook *VSphereMachineTemplateWebhook) validate(_ context.Context, _, newVSphereMachineTemplate *vmwarev1.VSphereMachineTemplate) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) validate(_ context.Context, _, newVSphereMachineTemplate *vmwarev1.VSphereMachineTemplate) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	// Validate namingStrategy
@@ -103,6 +103,6 @@ func (webhook *VSphereMachineTemplateWebhook) validate(_ context.Context, _, new
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -87,7 +87,7 @@ func TestVSphereMachineTemplate_Validate(t *testing.T) {
 				},
 			}
 
-			webhook := &VSphereMachineTemplateWebhook{}
+			webhook := &VSphereMachineTemplate{}
 			_, err := webhook.validate(context.Background(), nil, vSphereMachineTemplate)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vsphereclustertemplate.go
+++ b/internal/webhooks/vsphereclustertemplate.go
@@ -33,12 +33,12 @@ import (
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-vsphereclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vsphereclustertemplates,versions=v1beta1,name=validation.vsphereclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereClusterTemplateWebhook implements a validation and defaulting webhook for VSphereClusterTemplate.
-type VSphereClusterTemplateWebhook struct{}
+// VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
+type VSphereClusterTemplate struct{}
 
-var _ webhook.CustomValidator = &VSphereClusterTemplateWebhook{}
+var _ webhook.CustomValidator = &VSphereClusterTemplate{}
 
-func (webhook *VSphereClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereClusterTemplate{}).
 		WithValidator(webhook).
@@ -46,12 +46,12 @@ func (webhook *VSphereClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.M
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereClusterTemplateWebhook) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereClusterTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereClusterTemplate) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	oldTyped, ok := oldRaw.(*infrav1.VSphereClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereClusterTemplate but got a %T", oldRaw))
@@ -67,6 +67,6 @@ func (webhook *VSphereClusterTemplateWebhook) ValidateUpdate(_ context.Context, 
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereClusterTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereClusterTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/internal/webhooks/vspheredeploymentzone.go
+++ b/internal/webhooks/vspheredeploymentzone.go
@@ -32,12 +32,12 @@ import (
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-vspheredeploymentzone,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheredeploymentzones,versions=v1beta1,name=default.vspheredeploymentzone.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereDeploymentZoneWebhook implements a validation and defaulting webhook for VSphereDeploymentZone.
-type VSphereDeploymentZoneWebhook struct{}
+// VSphereDeploymentZone implements a defaulting webhook for VSphereDeploymentZone.
+type VSphereDeploymentZone struct{}
 
-var _ webhook.CustomDefaulter = &VSphereDeploymentZoneWebhook{}
+var _ webhook.CustomDefaulter = &VSphereDeploymentZone{}
 
-func (webhook *VSphereDeploymentZoneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereDeploymentZone) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereDeploymentZone{}).
 		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
@@ -45,7 +45,7 @@ func (webhook *VSphereDeploymentZoneWebhook) SetupWebhookWithManager(mgr ctrl.Ma
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereDeploymentZoneWebhook) Default(_ context.Context, obj runtime.Object) error {
+func (webhook *VSphereDeploymentZone) Default(_ context.Context, obj runtime.Object) error {
 	typedObj, ok := obj.(*infrav1.VSphereDeploymentZone)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereDeploymentZone but got a %T", obj))

--- a/internal/webhooks/vspheredeploymentzone_test.go
+++ b/internal/webhooks/vspheredeploymentzone_test.go
@@ -55,7 +55,7 @@ func TestVSphereDeploymentZone_Default(t *testing.T) {
 					ControlPlane: tt.boolPtr,
 				},
 			}
-			webhook := VSphereDeploymentZoneWebhook{}
+			webhook := VSphereDeploymentZone{}
 			g.Expect(webhook.Default(context.Background(), &vdz)).NotTo(HaveOccurred())
 			g.Expect(vdz.Spec.ControlPlane).NotTo(BeNil())
 			g.Expect(*vdz.Spec.ControlPlane).To(Equal(tt.expectedVal))

--- a/internal/webhooks/vspherefailuredomain.go
+++ b/internal/webhooks/vspherefailuredomain.go
@@ -35,13 +35,13 @@ import (
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspherefailuredomain,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspherefailuredomains,versions=v1beta1,name=validation.vspherefailuredomain.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-vspherefailuredomain,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspherefailuredomains,verbs=create;update,versions=v1beta1,name=default.vspherefailuredomain.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereFailureDomainWebhook implements a validation and defaulting webhook for VSphereFailureDomain.
-type VSphereFailureDomainWebhook struct{}
+// VSphereFailureDomain implements a validation and defaulting webhook for VSphereFailureDomain.
+type VSphereFailureDomain struct{}
 
-var _ webhook.CustomValidator = &VSphereFailureDomainWebhook{}
-var _ webhook.CustomDefaulter = &VSphereFailureDomainWebhook{}
+var _ webhook.CustomValidator = &VSphereFailureDomain{}
+var _ webhook.CustomDefaulter = &VSphereFailureDomain{}
 
-func (webhook *VSphereFailureDomainWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereFailureDomain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereFailureDomain{}).
 		WithValidator(webhook).
@@ -50,7 +50,7 @@ func (webhook *VSphereFailureDomainWebhook) SetupWebhookWithManager(mgr ctrl.Man
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereFailureDomainWebhook) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereFailureDomain) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	obj, ok := raw.(*infrav1.VSphereFailureDomain)
@@ -91,7 +91,7 @@ func (webhook *VSphereFailureDomainWebhook) ValidateCreate(_ context.Context, ra
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereFailureDomainWebhook) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereFailureDomain) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	oldTyped, ok := oldRaw.(*infrav1.VSphereFailureDomain)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereFailureDomain but got a %T", oldRaw))
@@ -107,12 +107,12 @@ func (webhook *VSphereFailureDomainWebhook) ValidateUpdate(_ context.Context, ol
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereFailureDomainWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereFailureDomain) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereFailureDomainWebhook) Default(_ context.Context, obj runtime.Object) error {
+func (webhook *VSphereFailureDomain) Default(_ context.Context, obj runtime.Object) error {
 	typedObj, ok := obj.(*infrav1.VSphereFailureDomain)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereFailureDomain but got a %T", obj))

--- a/internal/webhooks/vspherefailuredomain_test.go
+++ b/internal/webhooks/vspherefailuredomain_test.go
@@ -31,7 +31,7 @@ func TestVsphereFailureDomain_Default(t *testing.T) {
 	m := &infrav1.VSphereFailureDomain{
 		Spec: infrav1.VSphereFailureDomainSpec{},
 	}
-	webhook := &VSphereFailureDomainWebhook{}
+	webhook := &VSphereFailureDomain{}
 	g.Expect(webhook.Default(context.Background(), m)).ToNot(HaveOccurred())
 
 	g.Expect(*m.Spec.Zone.AutoConfigure).To(BeFalse())
@@ -159,7 +159,7 @@ func TestVSphereFailureDomain_ValidateCreate(t *testing.T) {
 		// Need to reinit the test variable
 		tt := tt
 		t.Run(tt.name, func(*testing.T) {
-			webhook := &VSphereFailureDomainWebhook{}
+			webhook := &VSphereFailureDomain{}
 			_, err := webhook.ValidateCreate(context.Background(), &tt.failureDomain)
 			if tt.errExpected == nil || *tt.errExpected {
 				g.Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vspheremachine.go
+++ b/internal/webhooks/vspheremachine.go
@@ -36,13 +36,13 @@ import (
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta1,name=validation.vspheremachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta1,name=default.vspheremachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
-var _ webhook.CustomValidator = &VSphereMachineWebhook{}
-var _ webhook.CustomDefaulter = &VSphereMachineWebhook{}
+var _ webhook.CustomValidator = &VSphereMachine{}
+var _ webhook.CustomDefaulter = &VSphereMachine{}
 
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereMachine{}).
 		WithValidator(webhook).
@@ -51,7 +51,7 @@ func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) 
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) Default(_ context.Context, obj runtime.Object) error {
+func (webhook *VSphereMachine) Default(_ context.Context, obj runtime.Object) error {
 	objValue, ok := obj.(*infrav1.VSphereMachine)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereMachine but got a %T", obj))
@@ -63,7 +63,7 @@ func (webhook *VSphereMachineWebhook) Default(_ context.Context, obj runtime.Obj
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	obj, ok := raw.(*infrav1.VSphereMachine)
@@ -99,7 +99,7 @@ func (webhook *VSphereMachineWebhook) ValidateCreate(_ context.Context, raw runt
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	newTyped, ok := newRaw.(*infrav1.VSphereMachine)
@@ -159,7 +159,7 @@ func (webhook *VSphereMachineWebhook) ValidateUpdate(_ context.Context, oldRaw r
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/internal/webhooks/vspheremachine_test.go
+++ b/internal/webhooks/vspheremachine_test.go
@@ -34,7 +34,7 @@ func TestVsphereMachine_Default(t *testing.T) {
 	m := &infrav1.VSphereMachine{
 		Spec: infrav1.VSphereMachineSpec{},
 	}
-	webhook := &VSphereMachineWebhook{}
+	webhook := &VSphereMachine{}
 	g.Expect(webhook.Default(context.Background(), m)).ToNot(HaveOccurred())
 
 	g.Expect(m.Spec.Datacenter).To(Equal("*"))
@@ -134,7 +134,7 @@ func TestVSphereMachine_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereMachineWebhook{}
+			webhook := &VSphereMachine{}
 			_, err := webhook.ValidateCreate(context.Background(), tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -211,7 +211,7 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereMachineWebhook{}
+			webhook := &VSphereMachine{}
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereMachine, tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vspheremachinetemplate.go
+++ b/internal/webhooks/vspheremachinetemplate.go
@@ -39,12 +39,12 @@ const machineTemplateImmutableMsg = "VSphereMachineTemplate spec.template.spec f
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates,versions=v1beta1,name=validation.vspheremachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
-var _ webhook.CustomValidator = &VSphereMachineTemplateWebhook{}
+var _ webhook.CustomValidator = &VSphereMachineTemplate{}
 
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereMachineTemplate{}).
 		WithValidator(webhook).
@@ -52,7 +52,7 @@ func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.M
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateCreate(ctx context.Context, raw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateCreate(ctx context.Context, raw runtime.Object) (admission.Warnings, error) {
 	obj, ok := raw.(*infrav1.VSphereMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereMachineTemplate but got a %T", raw))
@@ -97,7 +97,7 @@ func (webhook *VSphereMachineTemplateWebhook) ValidateCreate(ctx context.Context
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	oldTyped, ok := oldRaw.(*infrav1.VSphereMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereMachineTemplate but got a %T", oldRaw))
@@ -126,7 +126,7 @@ func (webhook *VSphereMachineTemplateWebhook) ValidateUpdate(ctx context.Context
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachineTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/internal/webhooks/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vspheremachinetemplate_test.go
@@ -127,7 +127,7 @@ func TestVSphereMachineTemplate_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereMachineTemplateWebhook{}
+			webhook := &VSphereMachineTemplate{}
 			_, err := webhook.ValidateCreate(context.Background(), tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -199,7 +199,7 @@ func TestVSphereMachineTemplate_ValidateUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereMachineTemplateWebhook{}
+			webhook := &VSphereMachineTemplate{}
 			ctx := context.Background()
 			if tc.req != nil {
 				ctx = admission.NewContextWithRequest(ctx, *tc.req)

--- a/internal/webhooks/vspherevm.go
+++ b/internal/webhooks/vspherevm.go
@@ -36,13 +36,13 @@ import (
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspherevm,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspherevms,versions=v1beta1,name=validation.vspherevm.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-vspherevm,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=vspherevms,versions=v1beta1,name=default.vspherevm.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// VSphereVMWebhook implements a validation and defaulting webhook for VSphereVM.
-type VSphereVMWebhook struct{}
+// VSphereVM implements a validation and defaulting webhook for VSphereVM.
+type VSphereVM struct{}
 
-var _ webhook.CustomValidator = &VSphereVMWebhook{}
-var _ webhook.CustomDefaulter = &VSphereVMWebhook{}
+var _ webhook.CustomValidator = &VSphereVM{}
+var _ webhook.CustomDefaulter = &VSphereVM{}
 
-func (webhook *VSphereVMWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereVM) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&infrav1.VSphereVM{}).
 		WithValidator(webhook).
@@ -51,7 +51,7 @@ func (webhook *VSphereVMWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereVMWebhook) Default(_ context.Context, obj runtime.Object) error {
+func (webhook *VSphereVM) Default(_ context.Context, obj runtime.Object) error {
 	typedObj, ok := obj.(*infrav1.VSphereVM)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereVM but got a %T", obj))
@@ -64,7 +64,7 @@ func (webhook *VSphereVMWebhook) Default(_ context.Context, obj runtime.Object) 
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereVMWebhook) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereVM) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	objValue, ok := raw.(*infrav1.VSphereVM)
 	if !ok {
@@ -99,7 +99,7 @@ func (webhook *VSphereVMWebhook) ValidateCreate(_ context.Context, raw runtime.O
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereVMWebhook) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereVM) ValidateUpdate(_ context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	oldTyped, ok := oldRaw.(*infrav1.VSphereVM)
@@ -160,11 +160,11 @@ func (webhook *VSphereVMWebhook) ValidateUpdate(_ context.Context, oldRaw runtim
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereVMWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *VSphereVM) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (webhook *VSphereVMWebhook) deleteSpecKeys(spec map[string]interface{}, keys []string) {
+func (webhook *VSphereVM) deleteSpecKeys(spec map[string]interface{}, keys []string) {
 	if len(spec) == 0 || len(keys) == 0 {
 		return
 	}

--- a/internal/webhooks/vspherevm_test.go
+++ b/internal/webhooks/vspherevm_test.go
@@ -41,7 +41,7 @@ func TestVSphereVM_Default(t *testing.T) {
 	NoOSVM := createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, "", infrav1.VirtualMachinePowerOpModeTrySoft, nil)
 
 	ctx := context.Background()
-	webhook := &VSphereVMWebhook{}
+	webhook := &VSphereVM{}
 	g.Expect(webhook.Default(ctx, WindowsVM)).ToNot(HaveOccurred())
 	g.Expect(webhook.Default(ctx, LinuxVM)).ToNot(HaveOccurred())
 	g.Expect(webhook.Default(ctx, NoOSVM)).ToNot(HaveOccurred())
@@ -117,7 +117,7 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereVMWebhook{}
+			webhook := &VSphereVM{}
 			_, err := webhook.ValidateCreate(context.Background(), tc.vSphereVM)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -212,7 +212,7 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
-			webhook := &VSphereVMWebhook{}
+			webhook := &VSphereVM{}
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereVM, tc.vSphereVM)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -415,27 +415,27 @@ func main() {
 }
 
 func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache) error {
-	if err := (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereVM{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereDeploymentZone{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereFailureDomain{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
@@ -456,10 +456,10 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 }
 
 func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache) error {
-	if err := (&vmwarewebhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
-	if err := (&vmwarewebhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereClusterConcurrency)); err != nil {

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -22,50 +22,50 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks"
 )
 
-// VSphereClusterTemplateWebhook implements a validation and defaulting webhook for VSphereClusterTemplate.
-type VSphereClusterTemplateWebhook struct{}
+// VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
+type VSphereClusterTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereClusterTemplate webhooks.
-func (webhook *VSphereClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereDeploymentZoneWebhook implements a validation and defaulting webhook for VSphereDeploymentZone.
-type VSphereDeploymentZoneWebhook struct{}
+// VSphereDeploymentZone implements a defaulting webhook for VSphereDeploymentZone.
+type VSphereDeploymentZone struct{}
 
 // SetupWebhookWithManager sets up VSphereDeploymentZone webhooks.
-func (webhook *VSphereDeploymentZoneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereDeploymentZone) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereDeploymentZone{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereFailureDomainWebhook implements a validation and defaulting webhook for VSphereFailureDomain.
-type VSphereFailureDomainWebhook struct{}
+// VSphereFailureDomain implements a validation and defaulting webhook for VSphereFailureDomain.
+type VSphereFailureDomain struct{}
 
 // SetupWebhookWithManager sets up VSphereFailureDomain webhooks.
-func (webhook *VSphereFailureDomainWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereFailureDomain) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereFailureDomain{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
 // SetupWebhookWithManager sets up VSphereMachine webhooks.
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereMachine{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereVMWebhook implements a validation and defaulting webhook for VSphereVM.
-type VSphereVMWebhook struct{}
+// VSphereVM implements a validation and defaulting webhook for VSphereVM.
+type VSphereVM struct{}
 
 // SetupWebhookWithManager sets up VSphereVM webhooks.
-func (webhook *VSphereVMWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereVM) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.VSphereVM{}).SetupWebhookWithManager(mgr)
 }

--- a/webhooks/vmware/alias.go
+++ b/webhooks/vmware/alias.go
@@ -22,18 +22,18 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
 )
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
 // SetupWebhookWithManager sets up VSphereMachine webhooks.
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&vmware.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&vmware.VSphereMachine{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&vmware.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&vmware.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR removes "Webhook" suffix from the all web-hook related structures and aligns comments with web-hook implementations (defaulting and/or validating) according to following comments:
https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3434#discussion_r2084753659
https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3434#discussion_r2084756517 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
