### PR TITLE
[release-1.11] :seedling: Fix web-hook structure names and descriptions

### DIFF
--- a/main.go
+++ b/main.go
@@ -351,27 +351,27 @@ func main() {
 }
 
 func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, tracker *remote.ClusterCacheTracker) error {
-	if err := (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereVM{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereDeploymentZone{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
-	if err := (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.VSphereFailureDomain{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 
@@ -392,10 +392,10 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 }
 
 func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, tracker *remote.ClusterCacheTracker) error {
-	if err := (&vmwarewebhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
-	if err := (&vmwarewebhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
 	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereClusterConcurrency)); err != nil {

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -22,50 +22,50 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks"
 )
 
-// VSphereClusterTemplateWebhook implements a validation and defaulting webhook for VSphereClusterTemplate.
-type VSphereClusterTemplateWebhook struct{}
+// VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
+type VSphereClusterTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereClusterTemplate webhooks.
-func (webhook *VSphereClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereClusterTemplateWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereDeploymentZoneWebhook implements a validation and defaulting webhook for VSphereDeploymentZone.
-type VSphereDeploymentZoneWebhook struct{}
+// VSphereDeploymentZone implements a defaulting webhook for VSphereDeploymentZone.
+type VSphereDeploymentZone struct{}
 
 // SetupWebhookWithManager sets up VSphereDeploymentZone webhooks.
-func (webhook *VSphereDeploymentZoneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereDeploymentZone) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereDeploymentZoneWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereFailureDomainWebhook implements a validation and defaulting webhook for VSphereFailureDomain.
-type VSphereFailureDomainWebhook struct{}
+// VSphereFailureDomain implements a validation and defaulting webhook for VSphereFailureDomain.
+type VSphereFailureDomain struct{}
 
 // SetupWebhookWithManager sets up VSphereFailureDomain webhooks.
-func (webhook *VSphereFailureDomainWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereFailureDomain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereFailureDomainWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
 // SetupWebhookWithManager sets up VSphereMachine webhooks.
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereVMWebhook implements a validation and defaulting webhook for VSphereVM.
-type VSphereVMWebhook struct{}
+// VSphereVM implements a validation and defaulting webhook for VSphereVM.
+type VSphereVM struct{}
 
 // SetupWebhookWithManager sets up VSphereVM webhooks.
-func (webhook *VSphereVMWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereVM) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.VSphereVMWebhook{}).SetupWebhookWithManager(mgr)
 }

--- a/webhooks/vmware/alias.go
+++ b/webhooks/vmware/alias.go
@@ -22,18 +22,18 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
 )
 
-// VSphereMachineWebhook implements a validation and defaulting webhook for VSphereMachine.
-type VSphereMachineWebhook struct{}
+// VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
+type VSphereMachine struct{}
 
 // SetupWebhookWithManager sets up VSphereMachine webhooks.
-func (webhook *VSphereMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&vmware.VSphereMachineWebhook{}).SetupWebhookWithManager(mgr)
 }
 
-// VSphereMachineTemplateWebhook implements a validation and defaulting webhook for VSphereMachineTemplate.
-type VSphereMachineTemplateWebhook struct{}
+// VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
+type VSphereMachineTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
-func (webhook *VSphereMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&vmware.VSphereMachineTemplateWebhook{}).SetupWebhookWithManager(mgr)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This is manual backport of the #3462 to release-1.11

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
