### PR TITLE
🐛 govmomi: fix additional printer columns for ControlPlaneEndpoint

### DIFF
--- a/apis/v1alpha3/vspherecluster_types.go
+++ b/apis/v1alpha3/vspherecluster_types.go
@@ -90,7 +90,7 @@ type VSphereClusterStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
 // +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint"
-// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API

--- a/apis/v1alpha4/vspherecluster_types.go
+++ b/apis/v1alpha4/vspherecluster_types.go
@@ -67,7 +67,7 @@ type VSphereClusterStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
 // +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint"
-// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API

--- a/apis/v1beta1/vspherecluster_types.go
+++ b/apis/v1beta1/vspherecluster_types.go
@@ -197,7 +197,7 @@ type VSphereClusterV1Beta2Status struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for VSphereMachine"
 // +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint."
-// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint[0]",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Machine"
 
 // VSphereCluster is the Schema for the vsphereclusters API.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -26,7 +26,7 @@ spec:
       name: Server
       type: string
     - description: API Endpoint
-      jsonPath: .spec.controlPlaneEndpoint[0]
+      jsonPath: .spec.controlPlaneEndpoint.host
       name: ControlPlaneEndpoint
       priority: 1
       type: string
@@ -451,7 +451,7 @@ spec:
       name: Server
       type: string
     - description: API Endpoint
-      jsonPath: .spec.controlPlaneEndpoint[0]
+      jsonPath: .spec.controlPlaneEndpoint.host
       name: ControlPlaneEndpoint
       priority: 1
       type: string
@@ -616,7 +616,7 @@ spec:
       name: Server
       type: string
     - description: API Endpoint
-      jsonPath: .spec.controlPlaneEndpoint[0]
+      jsonPath: .spec.controlPlaneEndpoint.host
       name: ControlPlaneEndpoint
       priority: 1
       type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The old printercolumn did never work because it never was a list, it was always an object.

Fixes #3362

New output uses `.spec.controlPlaneEndpoint.host` as other providers also do (e.g. CAPZ, CAPO).

CAPA diverges: it has some instances using `.spec.controlPlaneEndpoint.host` (ManagedAWSCluster, RosaAWSCluster), others `.spec.controlPlaneEndpoint`.

This PR renders out as e.g.:

```
❯ kubectl get vspherecluster -o wide
NAME   READY   SERVER   CONTROLPLANEENDPOINT   AGE
foo                     1.2.3.4                18m
```

An alternative would be to use `.spec.controlPlaneEndpoint` which would result in json output:

```
❯ kubectl get vspherecluster -o wide
NAME   READY   SERVER   CONTROLPLANEENDPOINT             AGE
foo                     {"host":"1.2.3.4","port":8443}   19m
```

Combining host and port would require CEL in additional print columns which needs https://github.com/kubernetes/enhancements/issues/4595 first and in a k8s version which is the lowest supported kubernetes version for the management cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
