### PR TITLE
🌱 Removed disabled usetesting in golangci.yaml, fixing linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,9 +43,6 @@ linters:
     - usestdlibvars # using variables/constants from the standard library
     - usetesting # report function to be replace by testing
     - whitespace # unnecessary newlines
-  disable:
-    # TODO: It will be dropped when the Go version migration is done.
-    - usetesting
   settings:
     ginkgolinter:
       forbid-focus-container: true

--- a/controllers/vmware/vspherecluster_reconciler_test.go
+++ b/controllers/vmware/vspherecluster_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -126,7 +125,7 @@ var _ = Describe("Cluster Controller Tests", func() {
 
 func TestClusterReconciler_getFailureDomains(t *testing.T) {
 	g := NewWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())

--- a/controllers/vmware/vspheremachinetemplate_controller_test.go
+++ b/controllers/vmware/vspheremachinetemplate_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,7 +35,7 @@ import (
 
 func Test_vSphereMachineTemplateReconciler_Reconcile(t *testing.T) {
 	g := NewWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -199,14 +198,14 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		r := setupReconciler(fakeVMSvc)
 		g := NewWithT(t)
 		// First reconcile should add the paused condition
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(t.Context(), vmKey, vm)).NotTo(HaveOccurred())
 
 		g.Expect(v1beta1conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
 		vmProvisionCondition := v1beta1conditions.Get(vm, infrav1.VMProvisionedCondition)
@@ -235,14 +234,14 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		r := setupReconciler(fakeVMSvc)
 		g := NewWithT(t)
 		// First reconcile should add the paused condition
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(t.Context(), vmKey, vm)).NotTo(HaveOccurred())
 
 		g.Expect(v1beta1conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
 		vmProvisionCondition := v1beta1conditions.Get(vm, infrav1.VMProvisionedCondition)
@@ -285,18 +284,18 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		g := NewWithT(t)
 
 		// First reconcile should add the paused condition
-		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).ToNot(HaveOccurred())
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).ToNot(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(apierrors.IsNotFound(r.Client.Get(context.Background(), vmKey, vm))).To(BeTrue())
+		g.Expect(apierrors.IsNotFound(r.Client.Get(t.Context(), vmKey, vm))).To(BeTrue())
 
 		claim := &ipamv1beta1.IPAddressClaim{}
 		ipacKey := util.ObjectKey(ipAddressClaim)
-		g.Expect(r.Client.Get(context.Background(), ipacKey, claim)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(t.Context(), ipacKey, claim)).NotTo(HaveOccurred())
 		g.Expect(claim.ObjectMeta.Finalizers).NotTo(ContainElement(infrav1.IPAddressClaimFinalizer))
 	})
 }
@@ -369,7 +368,7 @@ func TestVmReconciler_WaitingForStaticIPAllocation(t *testing.T) {
 	}
 
 	controllerManagerCtx := fake.NewControllerManagerContext()
-	vmContext := fake.NewVMContext(context.Background(), controllerManagerCtx)
+	vmContext := fake.NewVMContext(t.Context(), controllerManagerCtx)
 	r := vmReconciler{ControllerManagerContext: controllerManagerCtx}
 
 	for _, tt := range tests {
@@ -492,14 +491,14 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 
 		g := NewWithT(t)
 		// First reconcile should add the paused condition
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).NotTo(HaveOccurred())
 
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
-		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
+		g.Expect(r.Client.Get(t.Context(), vmKey, vm)).NotTo(HaveOccurred())
 		g.Expect(v1beta1conditions.Has(vm, infrav1.VCenterAvailableCondition)).To(BeTrue())
 		vCenterCondition := v1beta1conditions.Get(vm, infrav1.VCenterAvailableCondition)
 		g.Expect(vCenterCondition.Status).To(Equal(corev1.ConditionTrue))
@@ -529,9 +528,9 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 
 		g := NewWithT(t)
 		// First reconcile should add the paused condition
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).ToNot(HaveOccurred())
-		_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
+		_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: util.ObjectKey(vsphereVM)})
 		g.Expect(err).To(HaveOccurred())
 	},
 	)

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -45,7 +44,7 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			VSphereVM:                vsphereVM,
 		}
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("when VSphereVM Spec has address pool references", func(t *testing.T) {
 		vsphereVM := &infrav1.VSphereVM{

--- a/hack/tools/pkg/janitor/janitor_test.go
+++ b/hack/tools/pkg/janitor/janitor_test.go
@@ -112,7 +112,7 @@ const (
 )
 
 func Test_janitor_deleteVSphereVMs(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = ctrl.LoggerInto(ctx, klog.Background())
 
 	// Initialize and start vcsim
@@ -191,7 +191,7 @@ func Test_janitor_deleteVSphereVMs(t *testing.T) {
 }
 
 func Test_janitor_deleteObjectChildren(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = ctrl.LoggerInto(ctx, klog.Background())
 
 	// Initialize and start vcsim
@@ -322,7 +322,7 @@ func Test_janitor_deleteObjectChildren(t *testing.T) {
 }
 
 func TestJanitor_deleteCNSVolumes(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = ctrl.LoggerInto(ctx, klog.Background())
 
 	// Initialize and start vcsim
@@ -389,7 +389,7 @@ func TestJanitor_deleteCNSVolumes(t *testing.T) {
 }
 
 func Test_janitor_CleanupVSphere(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = ctrl.LoggerInto(ctx, klog.Background())
 
 	// Initialize and start vcsim

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -69,7 +68,7 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 			g := NewWithT(t)
 
 			webhook := &VSphereMachine{}
-			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereMachine, tc.vsphereMachine)
+			_, err := webhook.ValidateUpdate(t.Context(), tc.oldVSphereMachine, tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmware
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -88,7 +87,7 @@ func TestVSphereMachineTemplate_Validate(t *testing.T) {
 			}
 
 			webhook := &VSphereMachineTemplate{}
-			_, err := webhook.validate(context.Background(), nil, vSphereMachineTemplate)
+			_, err := webhook.validate(t.Context(), nil, vSphereMachineTemplate)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/webhooks/vspheredeploymentzone_test.go
+++ b/internal/webhooks/vspheredeploymentzone_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -56,7 +55,7 @@ func TestVSphereDeploymentZone_Default(t *testing.T) {
 				},
 			}
 			webhook := VSphereDeploymentZone{}
-			g.Expect(webhook.Default(context.Background(), &vdz)).NotTo(HaveOccurred())
+			g.Expect(webhook.Default(t.Context(), &vdz)).NotTo(HaveOccurred())
 			g.Expect(vdz.Spec.ControlPlane).NotTo(BeNil())
 			g.Expect(*vdz.Spec.ControlPlane).To(Equal(tt.expectedVal))
 		})

--- a/internal/webhooks/vspherefailuredomain_test.go
+++ b/internal/webhooks/vspherefailuredomain_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -32,7 +31,7 @@ func TestVsphereFailureDomain_Default(t *testing.T) {
 		Spec: infrav1.VSphereFailureDomainSpec{},
 	}
 	webhook := &VSphereFailureDomain{}
-	g.Expect(webhook.Default(context.Background(), m)).ToNot(HaveOccurred())
+	g.Expect(webhook.Default(t.Context(), m)).ToNot(HaveOccurred())
 
 	g.Expect(*m.Spec.Zone.AutoConfigure).To(BeFalse())
 	g.Expect(*m.Spec.Region.AutoConfigure).To(BeFalse())
@@ -160,7 +159,7 @@ func TestVSphereFailureDomain_ValidateCreate(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(*testing.T) {
 			webhook := &VSphereFailureDomain{}
-			_, err := webhook.ValidateCreate(context.Background(), &tt.failureDomain)
+			_, err := webhook.ValidateCreate(t.Context(), &tt.failureDomain)
 			if tt.errExpected == nil || *tt.errExpected {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/webhooks/vspheremachine_test.go
+++ b/internal/webhooks/vspheremachine_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,7 +34,7 @@ func TestVsphereMachine_Default(t *testing.T) {
 		Spec: infrav1.VSphereMachineSpec{},
 	}
 	webhook := &VSphereMachine{}
-	g.Expect(webhook.Default(context.Background(), m)).ToNot(HaveOccurred())
+	g.Expect(webhook.Default(t.Context(), m)).ToNot(HaveOccurred())
 
 	g.Expect(m.Spec.Datacenter).To(Equal("*"))
 }
@@ -135,7 +134,7 @@ func TestVSphereMachine_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereMachine{}
-			_, err := webhook.ValidateCreate(context.Background(), tc.vsphereMachine)
+			_, err := webhook.ValidateCreate(t.Context(), tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -212,7 +211,7 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereMachine{}
-			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereMachine, tc.vsphereMachine)
+			_, err := webhook.ValidateUpdate(t.Context(), tc.oldVSphereMachine, tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/webhooks/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vspheremachinetemplate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -128,7 +127,7 @@ func TestVSphereMachineTemplate_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereMachineTemplate{}
-			_, err := webhook.ValidateCreate(context.Background(), tc.vsphereMachine)
+			_, err := webhook.ValidateCreate(t.Context(), tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -200,7 +199,7 @@ func TestVSphereMachineTemplate_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereMachineTemplate{}
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.req != nil {
 				ctx = admission.NewContextWithRequest(ctx, *tc.req)
 			}

--- a/internal/webhooks/vspherevm_test.go
+++ b/internal/webhooks/vspherevm_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -40,7 +39,7 @@ func TestVSphereVM_Default(t *testing.T) {
 	LinuxVM := createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, infrav1.Linux, infrav1.VirtualMachinePowerOpModeTrySoft, nil)
 	NoOSVM := createVSphereVM(linuxVMName, "foo.com", "", "", "", []string{"192.168.0.1/32", "192.168.0.3/32"}, nil, "", infrav1.VirtualMachinePowerOpModeTrySoft, nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	webhook := &VSphereVM{}
 	g.Expect(webhook.Default(ctx, WindowsVM)).ToNot(HaveOccurred())
 	g.Expect(webhook.Default(ctx, LinuxVM)).ToNot(HaveOccurred())
@@ -118,7 +117,7 @@ func TestVSphereVM_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereVM{}
-			_, err := webhook.ValidateCreate(context.Background(), tc.vSphereVM)
+			_, err := webhook.ValidateCreate(t.Context(), tc.vSphereVM)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -213,7 +212,7 @@ func TestVSphereVM_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(*testing.T) {
 			webhook := &VSphereVM{}
-			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereVM, tc.vSphereVM)
+			_, err := webhook.ValidateUpdate(t.Context(), tc.oldVSphereVM, tc.vSphereVM)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/pkg/clustermodule/service_test.go
+++ b/pkg/clustermodule/service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clustermodule
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -33,7 +32,7 @@ import (
 
 func TestService_Create(t *testing.T) {
 	t.Run("creation is skipped", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		t.Run("when wrapper points to template != VSphereMachineTemplate", func(t *testing.T) {
 			md := machineDeployment("md", fake.Namespace, fake.Clusterv1a2Name)
 			md.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
@@ -114,19 +113,19 @@ func TestService_Create(t *testing.T) {
 		}
 
 		controllerManagerContext := fake.NewControllerManagerContext(md, machineTemplate)
-		clusterCtx := fake.NewClusterContext(context.Background(), controllerManagerContext)
+		clusterCtx := fake.NewClusterContext(t.Context(), controllerManagerContext)
 		clusterCtx.VSphereCluster.Spec.Server = simr.ServerURL().Host
 		controllerManagerContext.Username = simr.Username()
 		controllerManagerContext.Password = simr.Password()
 
 		svc := NewService(controllerManagerContext, controllerManagerContext.Client)
-		moduleUUID, err := svc.Create(context.Background(), clusterCtx, mdWrapper{md})
+		moduleUUID, err := svc.Create(t.Context(), clusterCtx, mdWrapper{md})
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(moduleUUID).NotTo(gomega.BeEmpty())
-		exists, err := svc.DoesExist(context.Background(), clusterCtx, mdWrapper{md}, moduleUUID)
+		exists, err := svc.DoesExist(t.Context(), clusterCtx, mdWrapper{md}, moduleUUID)
 		g.Expect(exists).To(gomega.BeTrue())
 		g.Expect(err).NotTo(gomega.HaveOccurred())
-		err = svc.Remove(context.Background(), clusterCtx, moduleUUID)
+		err = svc.Remove(t.Context(), clusterCtx, moduleUUID)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 }

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -43,7 +43,7 @@ username: '%s'
 password: '%s'
 `
 	t.Run("update username & password for CAPV credentials", func(t *testing.T) {
-		tmpFile, err := os.CreateTemp("", "creds")
+		tmpFile, err := os.CreateTemp(t.TempDir(), "creds")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,7 +76,7 @@ password: '%s'
 	})
 
 	t.Run("send an error on watch error channel", func(t *testing.T) {
-		tmpFile, err := os.CreateTemp("", "creds")
+		tmpFile, err := os.CreateTemp(t.TempDir(), "creds")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -112,7 +112,7 @@ password: '%s'
 	})
 
 	t.Run("force fail the watch", func(t *testing.T) {
-		_, err := os.CreateTemp("", "creds")
+		_, err := os.CreateTemp(t.TempDir(), "creds")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/manager/options_test.go
+++ b/pkg/manager/options_test.go
@@ -56,7 +56,7 @@ password: '%s'
 		// for linting reasons
 		test := tt
 		content := fmt.Sprintf(contentFmt, tt.username, tt.password)
-		tmpFile, err := os.CreateTemp("", "creds")
+		tmpFile, err := os.CreateTemp(t.TempDir(), "creds")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/services/govmomi/cluster/rule_test.go
+++ b/pkg/services/govmomi/cluster/rule_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -39,7 +38,7 @@ func TestVerifyAffinityRule(t *testing.T) {
 	}
 	defer sim.Destroy()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	client, _ := govmomi.NewClient(ctx, sim.ServerURL(), true)
 	finder := find.NewFinder(client.Client, false)
 

--- a/pkg/services/govmomi/cluster/service_test.go
+++ b/pkg/services/govmomi/cluster/service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -38,7 +37,7 @@ func TestListHostsFromGroup(t *testing.T) {
 	}
 	defer sim.Destroy()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	client, _ := govmomi.NewClient(ctx, sim.ServerURL(), true)
 	finder := find.NewFinder(client.Client, false)
 

--- a/pkg/services/govmomi/cluster/vmgroup_test.go
+++ b/pkg/services/govmomi/cluster/vmgroup_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,7 +34,7 @@ func Test_VMGroup(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	defer sim.Destroy()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	client, _ := govmomi.NewClient(ctx, sim.ServerURL(), true)
 	finder := find.NewFinder(client.Client, false)
 

--- a/pkg/services/govmomi/create_test.go
+++ b/pkg/services/govmomi/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package govmomi
 
 import (
-	"context"
 	"testing"
 
 	"github.com/vmware/govmomi/find"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	model := simulator.VPX()
 	model.Host = 0 // ClusterHost only

--- a/pkg/services/govmomi/find/object_test.go
+++ b/pkg/services/govmomi/find/object_test.go
@@ -45,7 +45,7 @@ type resourceCount struct {
 func TestObjectFunc(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sim, authSession, resources, err := setupSimulatorAndSession(simulator.VPX())
 	g.Expect(err).ToNot(HaveOccurred(), "a vcsim instance and authSession should be established")

--- a/pkg/services/govmomi/ipam/status_test.go
+++ b/pkg/services/govmomi/ipam/status_test.go
@@ -49,7 +49,7 @@ func Test_buildIPAMDeviceConfigs(t *testing.T) {
 	)
 
 	before := func() {
-		ctx = context.Background()
+		ctx = t.Context()
 		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},
@@ -250,7 +250,7 @@ func Test_BuildState(t *testing.T) {
 	}
 
 	before := func() {
-		ctx = context.Background()
+		ctx = t.Context()
 		vmCtx = *fake.NewVMContext(ctx, fake.NewControllerManagerContext())
 		networkStatus = []infrav1.NetworkStatus{
 			{Connected: true, MACAddr: devMAC},

--- a/pkg/services/govmomi/service_test.go
+++ b/pkg/services/govmomi/service_test.go
@@ -128,7 +128,7 @@ func Test_ReconcileStoragePolicy(t *testing.T) {
 				VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{},
 			},
 		}
-		g.Expect(vms.reconcileStoragePolicy(context.Background(), vmCtx)).ToNot(HaveOccurred())
+		g.Expect(vms.reconcileStoragePolicy(t.Context(), vmCtx)).ToNot(HaveOccurred())
 		g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
 	})
 
@@ -157,7 +157,7 @@ func Test_ReconcileStoragePolicy(t *testing.T) {
 					},
 				},
 			}
-			err = vms.reconcileStoragePolicy(context.Background(), vmCtx)
+			err = vms.reconcileStoragePolicy(t.Context(), vmCtx)
 			g.Expect(err.Error()).To(ContainSubstring("no pbm profile found with name"))
 			return nil
 		}, model)
@@ -190,7 +190,7 @@ func Test_ReconcileStoragePolicy(t *testing.T) {
 					},
 				},
 			}
-			err = vms.reconcileStoragePolicy(context.Background(), vmCtx)
+			err = vms.reconcileStoragePolicy(t.Context(), vmCtx)
 			g.Expect(err).ToNot(HaveOccurred())
 			return nil
 		}, model)

--- a/pkg/services/govmomi/util_test.go
+++ b/pkg/services/govmomi/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package govmomi
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ import (
 )
 
 func Test_ShouldRetryTask(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("when no task is present", func(t *testing.T) {
 		g := NewWithT(t)

--- a/pkg/services/govmomi/vcenter/clone_test.go
+++ b/pkg/services/govmomi/vcenter/clone_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vcenter
 
 import (
-	ctx "context"
 	"crypto/tls"
 	"fmt"
 	"testing"
@@ -42,7 +41,7 @@ func TestGetDiskSpec(t *testing.T) {
 	vm := model.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	machine := object.NewVirtualMachine(session.Client.Client, vm.Reference())
 
-	devices, err := machine.Device(ctx.TODO())
+	devices, err := machine.Device(t.Context())
 	if err != nil {
 		t.Fatalf("Failed to obtain vm devices: %v", err)
 	}
@@ -52,7 +51,7 @@ func TestGetDiskSpec(t *testing.T) {
 	}
 	disk := defaultDisks[0].(*types.VirtualDisk)
 	disk.CapacityInKB = int64(defaultSizeGiB) * 1024 * 1024 // GiB
-	if err := machine.EditDevice(ctx.TODO(), disk); err != nil {
+	if err := machine.EditDevice(t.Context(), disk); err != nil {
 		t.Fatalf("Can't resize disk for specified size")
 	}
 
@@ -160,7 +159,7 @@ func TestCreateDataDisks(t *testing.T) {
 	vm := model.Map().Any("VirtualMachine").(*simulator.VirtualMachine)
 	machine := object.NewVirtualMachine(session.Client.Client, vm.Reference())
 
-	deviceList, err := machine.Device(ctx.TODO())
+	deviceList, err := machine.Device(t.Context())
 	if err != nil {
 		t.Fatalf("Failed to obtain vm devices: %v", err)
 	}
@@ -261,7 +260,7 @@ func TestCreateDataDisks(t *testing.T) {
 			g := gomega.NewWithT(t)
 
 			// Create the data disks
-			newDisks, funcError := createDataDisks(ctx.TODO(), tc.dataDisks, tc.devices)
+			newDisks, funcError := createDataDisks(t.Context(), tc.dataDisks, tc.devices)
 			if (tc.err != "" && funcError == nil) || (tc.err == "" && funcError != nil) || (funcError != nil && tc.err != funcError.Error()) {
 				t.Fatalf("Expected to get '%v' error from assignUnitNumber, got: '%v'", tc.err, funcError)
 			}
@@ -390,7 +389,7 @@ func initSimulator(t *testing.T) (*simulator.Model, *session.Session, *simulator
 	pass, _ := server.URL.User.Password()
 
 	authSession, err := session.GetOrCreate(
-		ctx.TODO(),
+		t.Context(),
 		session.NewParams().
 			WithServer(server.URL.Host).
 			WithUserInfo(server.URL.User.Username(), pass).

--- a/pkg/services/vmoperator/resource_policy_test.go
+++ b/pkg/services/vmoperator/resource_policy_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmoperator
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestRPService(t *testing.T) {
 	cluster := util.CreateCluster(clusterName)
 	vsphereCluster := util.CreateVSphereCluster(vsphereClusterName)
 	clusterCtx, controllerCtx := util.CreateClusterContext(cluster, vsphereCluster)
-	ctx := context.Background()
+	ctx := t.Context()
 	rpService := RPService{
 		Client: controllerCtx.Client,
 	}

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -18,7 +18,6 @@ package session
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -53,7 +52,7 @@ func TestGetSession(t *testing.T) {
 		WithUserInfo(simr.Username(), simr.Password()).WithDatacenter("*")
 
 	// Get first session
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := GetOrCreate(ctx, params)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(s).ToNot(BeNil())

--- a/pkg/util/fetch_object_test.go
+++ b/pkg/util/fetch_object_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -30,7 +29,7 @@ import (
 )
 
 func Test_FetchControlPlaneOwnerObject(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	kcpName, kcpNs := "test-control-plane", "testing"
 	kcp := func(version string) *controlplanev1.KubeadmControlPlane {
 		return &controlplanev1.KubeadmControlPlane{

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -1142,7 +1141,7 @@ func Test_GetVSphereClusterFromVSphereMachine(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.initObjects...).Build()
-			_, err := util.GetVSphereClusterFromVMwareMachine(context.Background(), client, tt.inputMachine)
+			_, err := util.GetVSphereClusterFromVMwareMachine(t.Context(), client, tt.inputMachine)
 			if tt.hasError {
 				g.Expect(err).To(gomega.HaveOccurred())
 			} else {

--- a/pkg/util/networkutil_test.go
+++ b/pkg/util/networkutil_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +88,7 @@ func TestNCPSupportFW(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := NCPSupportFW(ctx, tt.client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NCPSupportFW() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
**What this PR does / why we need it**:
After the PR #3469 has been merged, I removed the disabled "usetesting" in the config file, and fixed all the various linting issues that came across.

Mostly, it has been replacements of `context.Background()` to `t.Context()` and a few `os.CreateTemp("", ...)` to `os.CreateTemp(t.TempDir(), ...)`
**Which issue(s) this PR fixes**:
Fixes #3470 
