### PR TITLE
🐛 Fix flake in reconciliation tests

### DIFF
--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -661,7 +661,9 @@ var _ = Describe("Reconciliation tests", func() {
 
 			By("Expect the VM to have been successfully created")
 			newVM := &vmoprv1.VirtualMachine{}
-			Expect(k8sClient.Get(ctx, machineKey, newVM)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, machineKey, newVM)).Should(Succeed())
+			}, time.Second*10).Should(Succeed())
 
 			By("Modifying the VM to simulate it having been created")
 			Eventually(func() error {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
I hope that fixes:
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-test-main/1954381688561733632
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-test-main/1954017284213182464

I assume the problem is that the cache is sometimes not up-to-date

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
