### PR TITLE
🌱 Update InterfaceSpec MTU minimum value

### DIFF
--- a/apis/vmware/v1beta1/vspheremachine_types.go
+++ b/apis/vmware/v1beta1/vspheremachine_types.go
@@ -172,7 +172,7 @@ type InterfaceSpec struct {
 
 	// mtu is the Maximum Transmission Unit size in bytes.
 	//
-	// +kubebuilder:validation:Minimum=68
+	// +kubebuilder:validation:Minimum=576
 	// +kubebuilder:validation:Maximum=9000
 	// +optional
 	MTU int32 `json:"mtu,omitempty"`

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -122,7 +122,7 @@ spec:
                               in bytes.
                             format: int32
                             maximum: 9000
-                            minimum: 68
+                            minimum: 576
                             type: integer
                           network:
                             description: |-
@@ -211,7 +211,7 @@ spec:
                                 in bytes.
                               format: int32
                               maximum: 9000
-                              minimum: 68
+                              minimum: 576
                               type: integer
                             name:
                               description: |-

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -119,7 +119,7 @@ spec:
                                       size in bytes.
                                     format: int32
                                     maximum: 9000
-                                    minimum: 68
+                                    minimum: 576
                                     type: integer
                                   network:
                                     description: |-
@@ -208,7 +208,7 @@ spec:
                                         Unit size in bytes.
                                       format: int32
                                       maximum: 9000
-                                      minimum: 68
+                                      minimum: 576
                                       type: integer
                                     name:
                                       description: |-


### PR DESCRIPTION
Update the value from 68 to 576

**What this PR does / why we need it**:
Update InterfaceSpec MTU minimum value.
68 bytes is the minimum size of IPv4 datagram every device must be able to forward without further fragmentation.
576 bytes is the minimum size of IPv4 datagram every device has to be able to receive.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
