### PR TITLE
[release-1.12] 🐛 fix: use machine's .spec.failureDomain with fallback to vspheremachine's .spec.failureDomain if not defined

### DIFF
--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -230,8 +230,13 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	failureDomain := machine.Spec.FailureDomain
+	if failureDomain == "" && vsphereMachine.Spec.FailureDomain != nil {
+		failureDomain = *vsphereMachine.Spec.FailureDomain
+	}
+
 	var vsphereFailureDomain *infrav1.VSphereFailureDomain
-	if failureDomain := machine.Spec.FailureDomain; failureDomain != nil {
+	if failureDomain != "" {
 		vsphereDeploymentZone := &infrav1.VSphereDeploymentZone{}
 		if err := r.Client.Get(ctx, apitypes.NamespacedName{Name: *failureDomain}, vsphereDeploymentZone); err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed to get VSphereDeploymentZone %s", *failureDomain)


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3576

This commit sets failureDomain string defaulting to `machine.Spec.FailureDomain`. If failureDomain
is an empty string then `vsphereMachine.Spec.FailureDomain` is checked for nil, if defined `failureDomain` is set to `vsphereMachine.Spec.FailureDomain`.

This resolves an issue where virtual machines are not placed within vm-host groups in a timely
manner causing misplacement in the topology.