### PR TITLE
🌱 Temporary fix for ResourceVersion flake

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -55,7 +55,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 
 					// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 					// continuous reconciles when everything should be stable.
-					framework.ValidateResourceVersionStable(ctx, proxy, namespace, FilterObjectsWithKindAndName(clusterName))
+					framework.ValidateResourceVersionStable(ctx, proxy, namespace, TMPDropVSphereMachineAndFilterObjectsWithKindAndName(clusterName))
 				},
 				// "topology-runtimesdk" is the same as the "topology" flavor but with an additional RuntimeExtension.
 				Flavor:                    ptr.To(testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk")),

--- a/test/e2e/ownerrefs_finalizers_test.go
+++ b/test/e2e/ownerrefs_finalizers_test.go
@@ -489,6 +489,20 @@ func forcePeriodicDeploymentZoneReconcile(ctx context.Context, c ctrlclient.Clie
 	}()
 }
 
+func TMPDropVSphereMachineAndFilterObjectsWithKindAndName(clusterName string) func(u unstructured.Unstructured) bool {
+	f := FilterObjectsWithKindAndName(clusterName)
+
+	return func(u unstructured.Unstructured) bool {
+		if testMode == SupervisorTestMode {
+			// temporarily drop VSphereMachine while we found a fix for https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3592
+			if sets.NewString("VSphereMachine").Has(u.GetKind()) {
+				return false
+			}
+		}
+		return f(u)
+	}
+}
+
 func FilterObjectsWithKindAndName(clusterName string) func(u unstructured.Unstructured) bool {
 	f := clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName)
 


### PR DESCRIPTION
Temporarily ignore resource version changes in VSphereMachine while we found a fix for https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3592

Note: we consider this temporary fix ok given that we are validating ResourceVersionStable also in other tests where this flake does not happen (so we don't lose coverage entirely) + from a first investigation this seems more an issue of the test setup than a production code issue.