### PR TITLE
🌱 Set startup taint for autoscaler in e2e tests

### DIFF
--- a/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
@@ -70,6 +70,9 @@ spec:
             # Note: The E2E test should only go up to 4 (assuming it starts with a min node group size of 2).
             # Using 6 for additional some buffer and to allow different starting min node group sizes.
             - --max-nodes-total=6
+            # CABPK sets this taint on startup, so we should configure it here accordingly
+            - --startup-taint=node.cluster.x-k8s.io/uninitialized
+            # Set the log verbosity
             - --v=4
           volumeMounts:
             - name: kubeconfig-management-cluster


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Noticed that we forgot to configure this

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
