### PR TITLE
🌱 VSphereClusterIdentity: ensure namespace in tests exists when not using the default

### DIFF
--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -20,16 +20,28 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
 var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 	controllerNamespace := testEnv.Manager.GetControllerManagerContext().Namespace
+	if controllerNamespace != manager.DefaultPodNamespace {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: controllerNamespace,
+			},
+		}
+		if err := testEnv.Client.Create(ctx, ns); !apierrors.IsAlreadyExists(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
 
 	Context("Reconcile Normal", func() {
 		It("should set the ownerRef on a secret and set Ready condition", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The unit tests for VSphereClusterIdentity fail if the `POD_NAMESPACE` variable is set and so the tests are not using the default namespace (`capv-system`).

This PR ensures that if there's a custom namespace used, that it gets created before running the unit tests.

Turns out these are the only tests where this happens.

Reproduce:

```sh
export POD_NAMESPACE=foo
go test ./pkg/controllers/
```

```
------------------------------                                                                                                                                          13:10:12 [3531/9834]
• [FAILED] [0.051 seconds]
VSphereClusterIdentity Reconciler Reconcile Normal [It] should set the ownerRef on a secret and set Ready condition
/Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:35

  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x1400193c000>:
      namespaces "foo" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "namespaces \"foo\" not found",
              Reason: "NotFound",
              Details: {Name: "foo", Group: "", Kind: "namespaces", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 404,
          },
      }
  In [It] at: /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:43 @ 09/11/25 13:09:29.508
------------------------------
• [FAILED] [0.052 seconds]
VSphereClusterIdentity Reconciler Reconcile Normal [It] should set the ownerRef on a secret and set Ready condition, if owned by an external identity
/Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:76

  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x14001428a00>:
      namespaces "foo" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "namespaces \"foo\" not found",
              Reason: "NotFound",
              Details: {Name: "foo", Group: "", Kind: "namespaces", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 404,
          },
      }
  In [It] at: /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:92 @ 09/11/25 13:09:29.56
------------------------------
• [FAILED] [0.052 seconds]
VSphereClusterIdentity Reconciler Reconcile Normal [It] should error if secret has another owner reference
/Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:125

  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x14001113220>:
      namespaces "foo" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "namespaces \"foo\" not found",
              Reason: "NotFound",
              Details: {Name: "foo", Group: "", Kind: "namespaces", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 404,
          },
      }
  In [It] at: /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:141 @ 09/11/25 13:09:29.611
------------------------------

...

Summarizing 3 Failures:
  [FAIL] VSphereClusterIdentity Reconciler Reconcile Normal [It] should set the ownerRef on a secret and set Ready condition
  /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:43
  [FAIL] VSphereClusterIdentity Reconciler Reconcile Normal [It] should set the ownerRef on a secret and set Ready condition, if owned by an external identity
  /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:92
  [FAIL] VSphereClusterIdentity Reconciler Reconcile Normal [It] should error if secret has another owner reference
  /Users/cschlott/go/src/sigs.k8s.io/cluster-api-provider-vsphere/controllers/vsphereclusteridentity_controller_test.go:141
```