### PR TITLE
🌱 Bump autoscaler in e2e tests to v1.33.1

### DIFF
--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("When using the autoscaler with Cluster API using ClusterClass 
 				},
 				InfrastructureAPIGroup:            "vmware.infrastructure.cluster.x-k8s.io",
 				InfrastructureMachineTemplateKind: "vspheremachinetemplates",
-				AutoscalerVersion:                 "v1.32.1",
+				AutoscalerVersion:                 "v1.33.1",
 				ScaleToAndFromZero:                true,
 				// We have no connectivity from the workload cluster to the kind management cluster in CI so we
 				// can't deploy the autoscaler to the workload cluster.

--- a/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
@@ -46,7 +46,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: gcr.io/k8s-staging-autoscaling/cluster-autoscaler:v20250814-cluster-autoscaler-chart-9.50.1-4-ga9cb59fdd
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           command:
             - /cluster-autoscaler


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of [#12704
](https://github.com/kubernetes-sigs/cluster-api/issues/12704)