### PR TITLE
[release-1.11] 🌱 Use latest CAPI v1.11.x for e2e tests

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -26,7 +26,7 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: "v1.11.99"
+      - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/core-components.yaml"
         type: "url"
         contract: v1beta2
@@ -66,7 +66,7 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: "v1.11.99"
+      - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/bootstrap-components.yaml"
         type: "url"
         contract: v1beta2
@@ -106,7 +106,7 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: "v1.11.99"
+      - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/control-plane-components.yaml"
         type: "url"
         contract: v1beta2


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Looks like the v1.11.1 manifests are gone (probably deletion policy in the bucket)

https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3658

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
