### PR TITLE
🌱 CI: clear /etc/sysconfig/kubelet to ensure --pod-infra-container-image is not set

### DIFF
--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/base/patch-k8s-install-script-kcp.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/base/patch-k8s-install-script-kcp.yaml
@@ -91,6 +91,12 @@
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
         done
+
+        # TODO: remove once we use k8s v1.35 image-builder templates.
+        # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.        
+        echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+        echo "" > /etc/sysconfig/kubelet || true
+        echo "" > /etc/default/kubelet || true
       fi
       echo "* checking binary versions"
       echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/base/patch-k8s-install-script-kct.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/base/patch-k8s-install-script-kct.yaml
@@ -94,6 +94,12 @@
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
         done
+
+        # TODO: remove once we use k8s v1.35 image-builder templates.
+        # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+        echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+        echo "" > /etc/sysconfig/kubelet || true
+        echo "" > /etc/default/kubelet || true
       fi
       echo "* checking binary versions"
       echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/main/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/main/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.11/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.11/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.12/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.12/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.13/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.13/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-govmomi/v1.14/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-govmomi/v1.14/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/base/patch-k8s-install-script-kcp.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/base/patch-k8s-install-script-kcp.yaml
@@ -91,6 +91,12 @@
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
         done
+
+        # TODO: remove once we use k8s v1.35 image-builder templates.
+        # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+        echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+        echo "" > /etc/sysconfig/kubelet || true
+        echo "" > /etc/default/kubelet || true
       fi
       echo "* checking binary versions"
       echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/base/patch-k8s-install-script-kct.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/base/patch-k8s-install-script-kct.yaml
@@ -94,6 +94,12 @@
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
         done
+
+        # TODO: remove once we use k8s v1.35 image-builder templates.
+        # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+        echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+        echo "" > /etc/sysconfig/kubelet || true
+        echo "" > /etc/default/kubelet || true
       fi
       echo "* checking binary versions"
       echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/main/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/main/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.11/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.11/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.12/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.12/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.13/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.13/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"

--- a/test/e2e/data/infrastructure-vsphere-supervisor/v1.14/clusterclass/patch-k8s-install-script.yaml
+++ b/test/e2e/data/infrastructure-vsphere-supervisor/v1.14/clusterclass/patch-k8s-install-script.yaml
@@ -96,6 +96,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"
@@ -203,6 +209,12 @@
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                   $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
                 done
+
+                # TODO: remove once we use k8s v1.35 image-builder templates.
+                # Note: This is a temporary fix to ensure the flag --pod-infra-container-image is not set which was removed in k8s v1.35 and deprecated for a long time.
+                echo "Clearing /etc/sysconfig/kubelet and/or /etc/default/kubelet if they exist"
+                echo "" > /etc/sysconfig/kubelet || true
+                echo "" > /etc/default/kubelet || true
               fi
               echo "* checking binary versions"
               echo "ctr version: " "$(ctr version)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

CI failing when creating a machine with v1.35 due to kubelet flag `--pod-infra-container-image` being set while it was removed for v1.35.

Note: the `/etc/sysconfig/kubelet` file only contains this single flag for CAPV.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
