### PR TITLE
[release-1.14] 🌱 Makefile: ensure KAL is compiled using golangci-lint v2.7.0

### DIFF
--- a/hack/tools/kal/.custom-gcl.yaml
+++ b/hack/tools/kal/.custom-gcl.yaml
@@ -1,4 +1,4 @@
-version: v2.1.0
+version: v2.7.0
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Github actions had been updated to a newer git cli version.

This broke golangcli-lint when building custom plugins like KAL:

https://github.com/golangci/golangci-lint/issues/6205
v2.7.0 fixed this.

This PR ensures we use the correct version for building KAL, while not bumping golangci-lint used for other linting to control when we do the upgrade and have this as backportable PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
