### PR TITLE
[release-1.15] 🌱 Bump CPI to v1.35.0

### DIFF
--- a/packaging/flavorgen/cloudprovider/cpi/cpi.yaml
+++ b/packaging/flavorgen/cloudprovider/cpi/cpi.yaml
@@ -159,7 +159,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: vsphere-cpi
-        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0-beta.0
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
         imagePullPolicy: IfNotPresent
         args:
           - --cloud-provider=vsphere

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -282,7 +282,7 @@ variables:
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.34.0"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.35.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.35"
-  CPI_IMAGE_K8S_VERSION: "v1.35.0-rc.0"
+  CPI_IMAGE_K8S_VERSION: "v1.35.0"
   CNI: "./data/cni/calico/calico.yaml"
   AUTOSCALER_WORKLOAD: "./data/autoscaler/autoscaler-to-management-workload.yaml"
   CONTROL_PLANE_MACHINE_COUNT: 1


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3736

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3620