### PR TITLE
🌱 Simplify patch for external CRDs

### DIFF
--- a/pkg/services/network/nsxt_provider.go
+++ b/pkg/services/network/nsxt_provider.go
@@ -19,11 +19,13 @@ package network
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoprv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,44 +136,57 @@ func (np *nsxtNetworkProvider) ProvisionClusterNetwork(ctx context.Context, clus
 		},
 	}
 
-	_, err := ctrlutil.CreateOrPatch(ctx, np.client, vnet, func() error {
-		// add or update vnet spec only if FW is enabled and if WhitelistSourceRanges is empty
-		if np.disableFW != "true" && vnet.Spec.WhitelistSourceRanges == "" {
-			supportFW, err := util.NCPSupportFW(ctx, np.client)
+	vnetExists := true
+	if err := np.client.Get(ctx, client.ObjectKeyFromObject(vnet), vnet); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		vnetExists = false
+	}
+	originalVNET := vnet.DeepCopy()
+
+	// add or update vnet spec only if FW is enabled and if WhitelistSourceRanges is empty
+	if np.disableFW != "true" && vnet.Spec.WhitelistSourceRanges == "" {
+		supportFW, err := util.NCPSupportFW(ctx, np.client)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if NCP supports firewall rules enforcement on GC T1 router")
+		}
+		// specify whitelist_source_ranges if needed and if NCP supports it
+		if supportFW {
+			// Find system namespace snat ip
+			systemNSSnatIP, err := util.GetNamespaceNetSnatIP(ctx, np.client, SystemNamespace)
 			if err != nil {
-				return errors.Wrap(err, "failed to check if NCP supports firewall rules enforcement on GC T1 router")
+				return errors.Wrap(err, "failed to get Snat IP for kube-system")
 			}
-			// specify whitelist_source_ranges if needed and if NCP supports it
-			if supportFW {
-				// Find system namespace snat ip
-				systemNSSnatIP, err := util.GetNamespaceNetSnatIP(ctx, np.client, SystemNamespace)
-				if err != nil {
-					return errors.Wrap(err, "failed to get Snat IP for kube-system")
-				}
-				log.V(4).Info("Got system namespace snat ip", "ip", systemNSSnatIP)
+			log.V(4).Info("Got system namespace snat ip", "ip", systemNSSnatIP)
 
-				// WhitelistSourceRanges accept cidrs only
-				vnet.Spec.WhitelistSourceRanges = systemNSSnatIP + "/32"
-			}
+			// WhitelistSourceRanges accept cidrs only
+			vnet.Spec.WhitelistSourceRanges = systemNSSnatIP + "/32"
 		}
+	}
 
-		if err := ctrlutil.SetOwnerReference(
-			clusterCtx.VSphereCluster,
-			vnet,
-			np.client.Scheme(),
-		); err != nil {
-			return errors.Wrapf(
-				err,
-				"error setting %s/%s as owner of %s/%s",
-				clusterCtx.VSphereCluster.Namespace,
-				clusterCtx.VSphereCluster.Name,
-				vnet.Namespace,
-				vnet.Name,
-			)
-		}
+	if err := ctrlutil.SetOwnerReference(
+		clusterCtx.VSphereCluster,
+		vnet,
+		np.client.Scheme(),
+	); err != nil {
+		return errors.Wrapf(
+			err,
+			"error setting %s/%s as owner of %s/%s",
+			clusterCtx.VSphereCluster.Namespace,
+			clusterCtx.VSphereCluster.Name,
+			vnet.Namespace,
+			vnet.Name,
+		)
+	}
 
-		return nil
-	})
+	var err error
+	if !vnetExists {
+		err = np.client.Create(ctx, vnet)
+	} else if !reflect.DeepEqual(originalVNET, vnet) {
+		patch := client.MergeFrom(originalVNET)
+		err = np.client.Patch(ctx, vnet, patch)
+	}
 	if err != nil {
 		v1beta1conditions.MarkFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition, vmwarev1.ClusterNetworkProvisionFailedReason, clusterv1beta1.ConditionSeverityWarning, "%v", err)
 		v1beta2conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{

--- a/pkg/services/network/nsxt_vpc_provider.go
+++ b/pkg/services/network/nsxt_vpc_provider.go
@@ -19,12 +19,14 @@ package network
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	nsxvpcv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	vmoprv1common "github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -167,17 +169,30 @@ func (vp *nsxtVPCNetworkProvider) ProvisionClusterNetwork(ctx context.Context, c
 		Spec: nsxvpcv1.SubnetSetSpec{},
 	}
 
-	_, err := ctrlutil.CreateOrPatch(ctx, vp.client, subnetset, func() error {
-		if err := ctrlutil.SetOwnerReference(
-			clusterCtx.VSphereCluster,
-			subnetset,
-			vp.client.Scheme(),
-		); err != nil {
-			return errors.Wrapf(err, "error setting %s as owner of %s", klog.KObj(clusterCtx.VSphereCluster), klog.KObj(subnetset))
+	subnetSetExists := true
+	if err := vp.client.Get(ctx, client.ObjectKeyFromObject(subnetset), subnetset); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
 		}
+		subnetSetExists = false
+	}
+	originalSubnetSet := subnetset.DeepCopy()
 
-		return nil
-	})
+	if err := ctrlutil.SetOwnerReference(
+		clusterCtx.VSphereCluster,
+		subnetset,
+		vp.client.Scheme(),
+	); err != nil {
+		return errors.Wrapf(err, "error setting %s as owner of %s", klog.KObj(clusterCtx.VSphereCluster), klog.KObj(subnetset))
+	}
+
+	var err error
+	if !subnetSetExists {
+		err = vp.client.Create(ctx, subnetset)
+	} else if !reflect.DeepEqual(originalSubnetSet, subnetset) {
+		patch := client.MergeFrom(originalSubnetSet)
+		err = vp.client.Patch(ctx, subnetset, patch)
+	}
 	if err != nil {
 		v1beta1conditions.MarkFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition, vmwarev1.ClusterNetworkProvisionFailedReason, clusterv1beta1.ConditionSeverityWarning, "%v", err)
 		v1beta2conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{

--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -19,6 +19,7 @@ package vmoperator
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	vmoprv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
@@ -188,10 +189,6 @@ func newVirtualMachineService(ctx *vmware.ClusterContext) *vmoprv1.VirtualMachin
 			Name:      controlPlaneVMServiceName(ctx.Cluster.Name),
 			Namespace: ctx.Cluster.Namespace,
 		},
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: vmoprv1.GroupVersion.String(),
-			Kind:       "VirtualMachineService",
-		},
 	}
 }
 
@@ -201,47 +198,60 @@ func (s *CPService) createVMControlPlaneService(ctx context.Context, clusterCtx 
 
 	vmService := newVirtualMachineService(clusterCtx)
 
-	_, err := ctrlutil.CreateOrPatch(ctx, s.Client, vmService, func() error {
-		if vmService.Annotations == nil {
-			vmService.Annotations = annotations
-		} else {
-			for k, v := range annotations {
-				vmService.Annotations[k] = v
-			}
+	vmServiceExists := true
+	if err := s.Client.Get(ctx, client.ObjectKeyFromObject(vmService), vmService); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
 		}
+		vmServiceExists = false
+	}
+	originalVMService := vmService.DeepCopy()
+
+	if vmService.Annotations == nil {
 		vmService.Annotations = annotations
-		vmService.Spec = vmoprv1.VirtualMachineServiceSpec{
-			Type: serviceType,
-			Ports: []vmoprv1.VirtualMachineServicePort{
-				{
-					Name:       controlPlaneServiceAPIServerPortName,
-					Protocol:   "TCP",
-					Port:       defaultAPIBindPort,
-					TargetPort: defaultAPIBindPort,
-				},
+	} else {
+		for k, v := range annotations {
+			vmService.Annotations[k] = v
+		}
+	}
+	vmService.Annotations = annotations
+	vmService.Spec = vmoprv1.VirtualMachineServiceSpec{
+		Type: serviceType,
+		Ports: []vmoprv1.VirtualMachineServicePort{
+			{
+				Name:       controlPlaneServiceAPIServerPortName,
+				Protocol:   "TCP",
+				Port:       defaultAPIBindPort,
+				TargetPort: defaultAPIBindPort,
 			},
-			Selector: clusterRoleVMLabels(clusterCtx, true),
-		}
+		},
+		Selector: clusterRoleVMLabels(clusterCtx, true),
+	}
 
-		if err := ctrlutil.SetOwnerReference(
-			clusterCtx.VSphereCluster,
-			vmService,
-			s.Client.Scheme(),
-		); err != nil {
-			return errors.Wrapf(
-				err,
-				"error setting %s/%s as owner of %s/%s",
-				clusterCtx.VSphereCluster.Namespace,
-				clusterCtx.VSphereCluster.Name,
-				vmService.Namespace,
-				vmService.Name,
-			)
-		}
+	if err := ctrlutil.SetOwnerReference(
+		clusterCtx.VSphereCluster,
+		vmService,
+		s.Client.Scheme(),
+	); err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"error setting %s/%s as owner of %s/%s",
+			clusterCtx.VSphereCluster.Namespace,
+			clusterCtx.VSphereCluster.Name,
+			vmService.Namespace,
+			vmService.Name,
+		)
+	}
 
-		return nil
-	})
-	if err != nil {
-		return nil, err
+	if !vmServiceExists {
+		if err := s.Client.Create(ctx, vmService); err != nil {
+			return nil, err
+		}
+	} else if !reflect.DeepEqual(originalVMService, vmService) {
+		patch := client.MergeFrom(originalVMService)
+		if err := s.Client.Patch(ctx, vmService, patch); err != nil {
+			return nil, err
+		}
 	}
 
 	return vmService, nil

--- a/pkg/services/vmoperator/control_plane_endpoint_test.go
+++ b/pkg/services/vmoperator/control_plane_endpoint_test.go
@@ -74,8 +74,14 @@ func createDefaultNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext
 
 func updateVMServiceWithVIP(ctx context.Context, clusterCtx *vmware.ClusterContext, c ctrlclient.Client, cpService CPService, vip string) {
 	vmService := getVirtualMachineService(ctx, clusterCtx, c, cpService)
-	vmService.Status.LoadBalancer.Ingress = []vmoprv1.LoadBalancerIngress{{IP: vip}}
-	err := c.Status().Update(ctx, vmService)
+
+	// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
+	s := &vmoprv1.VirtualMachineService{}
+	err := c.Get(ctx, ctrlclient.ObjectKeyFromObject(vmService), s)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	s.Status.LoadBalancer.Ingress = []vmoprv1.LoadBalancerIngress{{IP: vip}}
+	err = c.Status().Update(ctx, s)
 	Expect(err).ShouldNot(HaveOccurred())
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
When working with external CR, mostly VM operator's CR, CAPV should not use CAPI patch.helper or controller-runtime's CreateOrPatch.

CAPI patch.helper is overkill for the type of changes that CAPV applies to those objects; controller-runtime's CreateOrPatch usually leads to code harder to read/evolve (and also in this case CAPV doesn't need the operation result).

Accordingly, this PR is shifting to use "plain" controller runtime clients in a few places.
This will also help down the line when we are going to implement support for working with different VMoperator versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
