### PR TITLE
🌱 Drop defaulting from PowerOffMode API fields (govmomi)

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -115,11 +115,6 @@ linters:
       text: "optionalfields: field (NumCPUs|NumCoresPerSocket) has a valid zero value"
       linters:
         - kubeapilinter
-    ## TODO: Discuss if we want to drop the default from PowerOffMode field (while avoiding rollouts)
-    - path: "apis/v1beta2/(vspheremachine_types.go|vspherevm_types.go)"
-      text: "forbiddenmarkers: field PowerOffMode has forbidden marker"
-      linters:
-        - kubeapilinter
 
 issues:
   max-same-issues: 0

--- a/apis/v1beta2/vspheremachine_types.go
+++ b/apis/v1beta2/vspheremachine_types.go
@@ -139,7 +139,6 @@ type VSphereMachineSpec struct {
 	// If omitted, the mode defaults to hard.
 	//
 	// +optional
-	// +kubebuilder:default=hard
 	PowerOffMode VirtualMachinePowerOpMode `json:"powerOffMode,omitempty"`
 
 	// guestSoftPowerOffTimeoutSeconds sets the wait timeout for shutdown in the VM guest.

--- a/apis/v1beta2/vspherevm_types.go
+++ b/apis/v1beta2/vspherevm_types.go
@@ -209,7 +209,6 @@ type VSphereVMSpec struct {
 	// If omitted, the mode defaults to hard.
 	//
 	// +optional
-	// +kubebuilder:default=hard
 	PowerOffMode VirtualMachinePowerOpMode `json:"powerOffMode,omitempty"`
 
 	// guestSoftPowerOffTimeoutSeconds sets the wait timeout for shutdown in the VM guest.

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1528,7 +1528,6 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               powerOffMode:
-                default: hard
                 description: |-
                   powerOffMode describes the desired behavior when powering off a VM.
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1346,7 +1346,6 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       powerOffMode:
-                        default: hard
                         description: |-
                           powerOffMode describes the desired behavior when powering off a VM.
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1549,7 +1549,6 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               powerOffMode:
-                default: hard
                 description: |-
                   powerOffMode describes the desired behavior when powering off a VM.
 

--- a/pkg/services/govmomi/power.go
+++ b/pkg/services/govmomi/power.go
@@ -76,7 +76,8 @@ func (vms *VMService) isSoftPowerOffTimeoutExceeded(vm *infrav1.VSphereVM) bool 
 // triggerSoftPowerOff tries to trigger a soft power off for a VM to shut down the guest.
 // It returns true if the soft power off operation is pending.
 func (vms *VMService) triggerSoftPowerOff(ctx context.Context, virtualMachineCtx *virtualMachineContext) (bool, error) {
-	if virtualMachineCtx.VSphereVM.Spec.PowerOffMode == infrav1.VirtualMachinePowerOpModeHard {
+	if virtualMachineCtx.VSphereVM.Spec.PowerOffMode == "" || // hard is default
+		virtualMachineCtx.VSphereVM.Spec.PowerOffMode == infrav1.VirtualMachinePowerOpModeHard {
 		// hard power off is expected.
 		return false, nil
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
