### PR TITLE
⚠️ Remove DefaulterRemoveUnknownOrOmitableFields mutating webhook option

### DIFF
--- a/config/supervisor/webhook/manifests.yaml
+++ b/config/supervisor/webhook/manifests.yaml
@@ -1,32 +1,5 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vspheremachine
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.vspheremachine.vmware.infrastructure.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - vmware.infrastructure.cluster.x-k8s.io
-    apiVersions:
-    - v1beta2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - vspheremachines
-  sideEffects: None
----
-apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/supervisor/webhook/webhookcainjection_patch.yaml
+++ b/config/supervisor/webhook/webhookcainjection_patch.yaml
@@ -6,10 +6,3 @@ metadata:
   name: validating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/internal/webhooks/vmware/vspheremachine.go
+++ b/internal/webhooks/vmware/vspheremachine.go
@@ -34,7 +34,6 @@ import (
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vspheremachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta2,name=validation.vspheremachine.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vspheremachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vspheremachines,versions=v1beta2,name=default.vspheremachine.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
 
 // VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
 type VSphereMachine struct {
@@ -43,18 +42,11 @@ type VSphereMachine struct {
 }
 
 var _ admission.Validator[*vmwarev1.VSphereMachine] = &VSphereMachine{}
-var _ admission.Defaulter[*vmwarev1.VSphereMachine] = &VSphereMachine{}
 
 func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &vmwarev1.VSphereMachine{}).
 		WithValidator(webhook).
-		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
 		Complete()
-}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *VSphereMachine) Default(_ context.Context, _ *vmwarev1.VSphereMachine) error {
-	return nil
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.

--- a/internal/webhooks/vspheredeploymentzone.go
+++ b/internal/webhooks/vspheredeploymentzone.go
@@ -35,7 +35,7 @@ var _ admission.Defaulter[*infrav1.VSphereDeploymentZone] = &VSphereDeploymentZo
 
 func (webhook *VSphereDeploymentZone) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &infrav1.VSphereDeploymentZone{}).
-		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
+		WithDefaulter(webhook).
 		Complete()
 }
 

--- a/internal/webhooks/vspheremachine.go
+++ b/internal/webhooks/vspheremachine.go
@@ -44,7 +44,7 @@ var _ admission.Defaulter[*infrav1.VSphereMachine] = &VSphereMachine{}
 func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &infrav1.VSphereMachine{}).
 		WithValidator(webhook).
-		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
+		WithDefaulter(webhook).
 		Complete()
 }
 

--- a/internal/webhooks/vspherevm.go
+++ b/internal/webhooks/vspherevm.go
@@ -44,7 +44,7 @@ var _ admission.Defaulter[*infrav1.VSphereVM] = &VSphereVM{}
 func (webhook *VSphereVM) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &infrav1.VSphereVM{}).
 		WithValidator(webhook).
-		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
+		WithDefaulter(webhook).
 		Complete()
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
No template webhooks, no rollout trouble

The VSphereFailureDomain mutating webhook is removed via #3762 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
