### PR TITLE
🌱 Inline incorrect APIEndpoint.IsZero() func

### DIFF
--- a/apis/v1beta2/types.go
+++ b/apis/v1beta2/types.go
@@ -375,11 +375,6 @@ type APIEndpoint struct {
 	Port int32 `json:"port,omitempty"`
 }
 
-// IsZero returns true if either the host or the port are zero values.
-func (v APIEndpoint) IsZero() bool {
-	return v.Host == "" || v.Port == 0
-}
-
 // String returns a formatted version HOST:PORT of this APIEndpoint.
 func (v APIEndpoint) String() string {
 	return fmt.Sprintf("%s:%d", v.Host, v.Port)

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -571,7 +571,7 @@ func (r *clusterReconciler) controlPlaneMachineToCluster(ctx context.Context, o 
 		return nil
 	}
 
-	if !vsphereCluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if vsphereCluster.Spec.ControlPlaneEndpoint.Host != "" && vsphereCluster.Spec.ControlPlaneEndpoint.Port != 0 {
 		log.V(6).Info("Skipping VSphereCluster reconcile as VSphereCluster control plane endpoint is already set")
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The current IsZero() func is implemented incorrectly.

Instead of changing the behavior of the func which would lead to surprises for folks using it I chose to simply inline it instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452