### PR TITLE
✨ Deprecate v1beta1 API packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -224,6 +224,9 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: clusterv1\.(Condition|Conditions|ConditionSeverity|ConditionType) is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .* is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
         # Excludes for controller-runtime deprecations that we should migrate away from sooner or later
       - linters:
           - staticcheck

--- a/apis/v1beta1/doc.go
+++ b/apis/v1beta1/doc.go
@@ -18,4 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
+//
+// Deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.
 package v1beta1

--- a/apis/vmware/v1beta1/doc.go
+++ b/apis/vmware/v1beta1/doc.go
@@ -18,4 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta2
 // +kubebuilder:object:generate=true
 // +groupName=vmware.infrastructure.cluster.x-k8s.io
+//
+// Deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.
 package v1beta1


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
