### PR TITLE
✨ Switch from vm-operator v1alpha2 API to v1alpha5

### DIFF
--- a/config/deployments/integration-tests/crds/topology.tanzu.vmware.com_availabilityzones.yaml
+++ b/config/deployments/integration-tests/crds/topology.tanzu.vmware.com_availabilityzones.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: availabilityzones.topology.tanzu.vmware.com
 spec:
   group: topology.tanzu.vmware.com
@@ -19,18 +19,24 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AvailabilityZone is the schema for the AvailabilityZone resource
-          for the vSphere topology API.
+        description: |-
+          AvailabilityZone is the schema for the AvailabilityZone resource for the
+          vSphere topology API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,44 +44,46 @@ spec:
             description: AvailabilityZoneSpec defines the desired state of AvailabilityZone.
             properties:
               clusterComputeResourceMoIDs:
-                description: ClusterComputeResourceMoIDs are the managed object IDs
-                  of the vSphere ClusterComputeResources represented by this availability
-                  zone.
+                description: |-
+                  ClusterComputeResourceMoIDs are the managed object IDs of the vSphere
+                  ClusterComputeResources represented by this availability zone.
                 items:
                   type: string
                 type: array
               clusterComputeResourceMoId:
-                description: ClusterComputeResourceMoId is the managed object ID of
-                  the vSphere ClusterComputeResource represented by this availability
-                  zone.
+                description: |-
+                  ClusterComputeResourceMoId is the managed object ID of the vSphere
+                  ClusterComputeResource represented by this availability zone.
                 type: string
               namespaces:
                 additionalProperties:
-                  description: NamespaceInfo contains identifying information about
-                    the vSphere resources used to represent a Kubernetes namespace
-                    on individual vSphere Zones.
+                  description: |-
+                    NamespaceInfo contains identifying information about the vSphere resources
+                    used to represent a Kubernetes namespace on individual vSphere Zones.
                   properties:
                     folderMoId:
-                      description: FolderMoId is the managed object ID of the vSphere
-                        Folder for a Namespace. Folders are global and not per-vSphere
-                        Cluster, but the FolderMoId is stored here, alongside the
-                        PoolMoId for convenience.
+                      description: |-
+                        FolderMoId is the managed object ID of the vSphere Folder for a
+                        Namespace. Folders are global and not per-vSphere Cluster, but the
+                        FolderMoId is stored here, alongside the PoolMoId for convenience.
                       type: string
                     poolMoIDs:
-                      description: PoolMoIDs are the managed object ID of the vSphere
-                        ResourcePools for a Namespace in an individual vSphere Zone.
-                        A zone may be comprised of multiple ResourcePools.
+                      description: |-
+                        PoolMoIDs are the managed object ID of the vSphere ResourcePools for a
+                        Namespace in an individual vSphere Zone. A zone may be comprised of
+                        multiple ResourcePools.
                       items:
                         type: string
                       type: array
                     poolMoId:
-                      description: PoolMoId is the managed object ID of the vSphere
-                        ResourcePool for a Namespace on an individual vSphere Cluster.
+                      description: |-
+                        PoolMoId is the managed object ID of the vSphere ResourcePool for a
+                        Namespace on an individual vSphere Cluster.
                       type: string
                   type: object
-                description: Namespaces is a map that enables querying information
-                  about the vSphere objects that make up a Kubernetes Namespace based
-                  on its name.
+                description: |-
+                  Namespaces is a map that enables querying information about the vSphere
+                  objects that make up a Kubernetes Namespace based on its name.
                 type: object
             type: object
           status:
@@ -86,9 +94,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_clustervirtualmachineimages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: clustervirtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -39,6 +39,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -225,6 +226,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to disambiguate is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -232,7 +234,6 @@ spec:
               contentLibraryRef:
                 description: |-
                   ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource.
-
 
                   Deprecated: This field is provider specific but the VirtualMachineImage types are intended to be provider generic.
                   This field does not exist in later API versions. Instead, the Spec.ProviderRef field should be used to look up the
@@ -370,18 +371,15 @@ spec:
                 description: |-
                   Capabilities describes the image's observed capabilities.
 
-
                   The capabilities are discerned when VM Operator reconciles an image.
                   If the source of an image is an OVF in Content Library, then the
                   capabilities are parsed from the OVF property
                   capabilities.image.vmoperator.vmware.com as a comma-separated list of
                   values. Well-known capabilities include:
 
-
                   * cloud-init
                   * nvidia-gpu
                   * sriov-net
-
 
                   Every capability is also added to the resource's labels as
                   VirtualMachineImageCapabilityLabel + Value. For example, if the
@@ -395,16 +393,8 @@ spec:
                 description: Conditions describes the observed conditions for this
                   image.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -445,12 +435,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -482,14 +467,12 @@ spec:
                   OSInfo describes the observed operating system information for this
                   image.
 
-
                   The OS information is also added to the image resource's labels. Please
                   refer to VirtualMachineImageOSInfo for more information.
                 properties:
                   id:
                     description: |-
                       ID describes the operating system ID.
-
 
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSIDLabel.
@@ -498,14 +481,12 @@ spec:
                     description: |-
                       Type describes the operating system type.
 
-
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSTypeLabel.
                     type: string
                   version:
                     description: |-
                       Version describes the operating system version.
-
 
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSVersionLabel.
@@ -565,6 +546,958 @@ spec:
                   ProviderItemID describes the ID of the provider item that this image corresponds to.
                   If the provider of this image is a Content Library, this ID will be that of the
                   corresponding Content Library item.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterVirtualMachineImage is the schema for the clustervirtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    capacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Capacity is the virtual disk capacity in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Size is the estimated populated size of the virtual
+                        disk in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type: array
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: Type describes the content library item type (OVF or
+                  ISO) of the image.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterVirtualMachineImage is the schema for the clustervirtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    capacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Capacity is the virtual disk capacity in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Size is the estimated populated size of the virtual
+                        disk in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type: array
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: |-
+                  Type describes the content library item type (OVF, ISO, or VM) of the
+                  image.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterVirtualMachineImage is the schema for the clustervirtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    limit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Limit is the total virtual disk capacity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the unique identifier for the virtual disk.
+                      type: string
+                    requested:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Requested is the minimum storage requirements for
+                        the virtual disk.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: |-
+                  Type describes the content library item type (OVF, ISO, or VM) of the
+                  image.
                 type: string
               vmwareSystemProperties:
                 description: |-

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentlibraryproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: contentlibraryproviders.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -19,6 +19,9 @@ spec:
       jsonPath: .spec.uuid
       name: Content-Library-UUID
       type: string
+    deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsourcebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: contentsourcebindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_contentsources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: contentsources.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -14,7 +14,10 @@ spec:
     singular: contentsource
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachineclassbindings.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachineclasses.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -34,6 +34,7 @@ spec:
       name: Passthrough-DeviceIDs
       priority: 1
       type: string
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -79,12 +80,10 @@ spec:
                   reconciling VirtualMachine resources that are realized from this
                   VirtualMachineClass.
 
-
                   When omitted, controllers reconciling VirtualMachine resources determine
                   the default controller name from the environment variable
                   DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
                   defined or empty, it defaults to vmoperator.vmware.com/vsphere.
-
 
                   Once a non-empty value is assigned to this field, attempts to set this
                   field to an empty value will be silently ignored.
@@ -223,6 +222,19 @@ spec:
                         type: object
                     type: object
                 type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
             type: object
           status:
             description: |-
@@ -288,12 +300,10 @@ spec:
                   reconciling VirtualMachine resources that are realized from this
                   VirtualMachineClass.
 
-
                   When omitted, controllers reconciling VirtualMachine resources determine
                   the default controller name from the environment variable
                   DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
                   defined or empty, it defaults to vmoperator.vmware.com/vsphere.
-
 
                   Once a non-empty value is assigned to this field, attempts to set this
                   field to an empty value will be silently ignored.
@@ -442,6 +452,703 @@ spec:
                         type: object
                     type: object
                 type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineClass is the schema for the virtualmachineclasses API and
+          represents the desired state and observed status of a virtualmachineclasses
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
+            properties:
+              configSpec:
+                description: |-
+                  ConfigSpec describes additional configuration information for a
+                  VirtualMachine.
+                  The contents of this field are the VirtualMachineConfigSpec data object
+                  (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator
+                  field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: |-
+                  ControllerName describes the name of the controller responsible for
+                  reconciling VirtualMachine resources that are realized from this
+                  VirtualMachineClass.
+
+                  When omitted, controllers reconciling VirtualMachine resources determine
+                  the default controller name from the environment variable
+                  DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+                  defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+
+                  Once a non-empty value is assigned to this field, attempts to set this
+                  field to an empty value will be silently ignored.
+                type: string
+              description:
+                description: |-
+                  Description describes the configuration of the VirtualMachineClass which
+                  is not related to virtual hardware or infrastructure policy. This field
+                  is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: |-
+                  Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified in
+                  this field is used to customize the virtual hardware characteristics of
+                  any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: |-
+                      VirtualDevices contains information about the virtual devices associated
+                      with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: |-
+                            DynamicDirectPathIODevice contains the configuration corresponding to a
+                            Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: |-
+                      InstanceStorage provides information used to configure instance
+                      storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: |-
+                          StorageClass refers to the name of a StorageClass resource used to
+                          provide the storage for the configured instance storage volumes.
+                          The value of this field has no relationship to or bearing on the field
+                          virtualMachine.spec.storageClass. Please note the referred StorageClass
+                          must be available in the same namespace as the VirtualMachineClass that
+                          uses it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: |-
+                          Volumes describes instance storage volumes created for a VirtualMachine
+                          instance that use this VirtualMachineClass.
+                        items:
+                          description: |-
+                            InstanceStorageVolume contains information required to create an
+                            instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: |-
+                  Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related to
+                  infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: |-
+                      VirtualMachineClassResources describes the virtual hardware resource
+                      reservations and limits configuration to be used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineClass is the schema for the virtualmachineclasses API and
+          represents the desired state and observed status of a virtualmachineclasses
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
+            properties:
+              configSpec:
+                description: |-
+                  ConfigSpec describes additional configuration information for a
+                  VirtualMachine.
+                  The contents of this field are the VirtualMachineConfigSpec data object
+                  (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator
+                  field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: |-
+                  ControllerName describes the name of the controller responsible for
+                  reconciling VirtualMachine resources that are realized from this
+                  VirtualMachineClass.
+
+                  When omitted, controllers reconciling VirtualMachine resources determine
+                  the default controller name from the environment variable
+                  DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+                  defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+
+                  Once a non-empty value is assigned to this field, attempts to set this
+                  field to an empty value will be silently ignored.
+                type: string
+              description:
+                description: |-
+                  Description describes the configuration of the VirtualMachineClass which
+                  is not related to virtual hardware or infrastructure policy. This field
+                  is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: |-
+                  Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified in
+                  this field is used to customize the virtual hardware characteristics of
+                  any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: |-
+                      VirtualDevices contains information about the virtual devices associated
+                      with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: |-
+                            DynamicDirectPathIODevice contains the configuration corresponding to a
+                            Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: |-
+                      InstanceStorage provides information used to configure instance
+                      storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: |-
+                          StorageClass refers to the name of a StorageClass resource used to
+                          provide the storage for the configured instance storage volumes.
+                          The value of this field has no relationship to or bearing on the field
+                          virtualMachine.spec.storageClass. Please note the referred StorageClass
+                          must be available in the same namespace as the VirtualMachineClass that
+                          uses it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: |-
+                          Volumes describes instance storage volumes created for a VirtualMachine
+                          instance that use this VirtualMachineClass.
+                        items:
+                          description: |-
+                            InstanceStorageVolume contains information required to create an
+                            instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: |-
+                  Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related to
+                  infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: |-
+                      VirtualMachineClassResources describes the virtual hardware resource
+                      reservations and limits configuration to be used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      priority: 1
+      type: string
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineClass is the schema for the virtualmachineclasses API and
+          represents the desired state and observed status of a virtualmachineclasses
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineClassSpec defines the desired state of VirtualMachineClass.
+            properties:
+              configSpec:
+                description: |-
+                  ConfigSpec describes additional configuration information for a
+                  VirtualMachine.
+                  The contents of this field are the VirtualMachineConfigSpec data object
+                  (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator
+                  field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: |-
+                  ControllerName describes the name of the controller responsible for
+                  reconciling VirtualMachine resources that are realized from this
+                  VirtualMachineClass.
+
+                  When omitted, controllers reconciling VirtualMachine resources determine
+                  the default controller name from the environment variable
+                  DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+                  defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+
+                  Once a non-empty value is assigned to this field, attempts to set this
+                  field to an empty value will be silently ignored.
+                type: string
+              description:
+                description: |-
+                  Description describes the configuration of the VirtualMachineClass which
+                  is not related to virtual hardware or infrastructure policy. This field
+                  is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: |-
+                  Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified in
+                  this field is used to customize the virtual hardware characteristics of
+                  any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: |-
+                      VirtualDevices contains information about the virtual devices associated
+                      with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: |-
+                            DynamicDirectPathIODevice contains the configuration corresponding to a
+                            Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: |-
+                      InstanceStorage provides information used to configure instance
+                      storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: |-
+                          StorageClass refers to the name of a StorageClass resource used to
+                          provide the storage for the configured instance storage volumes.
+                          The value of this field has no relationship to or bearing on the field
+                          virtualMachine.spec.storageClass. Please note the referred StorageClass
+                          must be available in the same namespace as the VirtualMachineClass that
+                          uses it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: |-
+                          Volumes describes instance storage volumes created for a VirtualMachine
+                          instance that use this VirtualMachineClass.
+                        items:
+                          description: |-
+                            InstanceStorageVolume contains information required to create an
+                            instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: |-
+                  Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related to
+                  infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: |-
+                      VirtualMachineClassResources describes the virtual hardware resource
+                      reservations and limits configuration to be used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
             type: object
           status:
             description: VirtualMachineClassStatus defines the observed state of VirtualMachineClass.

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassinstances.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineclassinstances.yaml
@@ -1,0 +1,478 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachineclassinstances.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineClassInstance
+    listKind: VirtualMachineClassInstanceList
+    plural: virtualmachineclassinstances
+    shortNames:
+    - vmclassinstance
+    singular: virtualmachineclassinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .metadata.labels['vmoperator\.vmware\.com/active']
+      name: Active
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineClassInstance is the schema for the virtualmachineclassinstances API and
+          represents the desired state and observed status of a virtualmachineclassinstance
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineClassInstanceSpec defines the desired state of VirtualMachineClassInstance.
+              It is a composite of VirtualMachineClassSpec.
+            properties:
+              configSpec:
+                description: |-
+                  ConfigSpec describes additional configuration information for a
+                  VirtualMachine.
+                  The contents of this field are the VirtualMachineConfigSpec data object
+                  (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator
+                  field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: |-
+                  ControllerName describes the name of the controller responsible for
+                  reconciling VirtualMachine resources that are realized from this
+                  VirtualMachineClass.
+
+                  When omitted, controllers reconciling VirtualMachine resources determine
+                  the default controller name from the environment variable
+                  DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+                  defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+
+                  Once a non-empty value is assigned to this field, attempts to set this
+                  field to an empty value will be silently ignored.
+                type: string
+              description:
+                description: |-
+                  Description describes the configuration of the VirtualMachineClass which
+                  is not related to virtual hardware or infrastructure policy. This field
+                  is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: |-
+                  Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified in
+                  this field is used to customize the virtual hardware characteristics of
+                  any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: |-
+                      VirtualDevices contains information about the virtual devices associated
+                      with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: |-
+                            DynamicDirectPathIODevice contains the configuration corresponding to a
+                            Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: |-
+                      InstanceStorage provides information used to configure instance
+                      storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: |-
+                          StorageClass refers to the name of a StorageClass resource used to
+                          provide the storage for the configured instance storage volumes.
+                          The value of this field has no relationship to or bearing on the field
+                          virtualMachine.spec.storageClass. Please note the referred StorageClass
+                          must be available in the same namespace as the VirtualMachineClass that
+                          uses it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: |-
+                          Volumes describes instance storage volumes created for a VirtualMachine
+                          instance that use this VirtualMachineClass.
+                        items:
+                          description: |-
+                            InstanceStorageVolume contains information required to create an
+                            instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: |-
+                  Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related to
+                  infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: |-
+                      VirtualMachineClassResources describes the virtual hardware resource
+                      reservations and limits configuration to be used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachineClassInstanceStatus defines the observed state
+              of VirtualMachineClassInstance.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hardware.cpus
+      name: CPU
+      type: string
+    - jsonPath: .spec.hardware.memory
+      name: Memory
+      type: string
+    - jsonPath: .metadata.labels['vmoperator\.vmware\.com/active']
+      name: Active
+      type: string
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineClassInstance is the schema for the virtualmachineclassinstances API and
+          represents the desired state and observed status of a virtualmachineclassinstance
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineClassInstanceSpec defines the desired state of VirtualMachineClassInstance.
+              It is a composite of VirtualMachineClassSpec.
+            properties:
+              configSpec:
+                description: |-
+                  ConfigSpec describes additional configuration information for a
+                  VirtualMachine.
+                  The contents of this field are the VirtualMachineConfigSpec data object
+                  (https://bit.ly/3HDtiRu) marshaled to JSON using the discriminator
+                  field "_typeName" to preserve type information.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              controllerName:
+                description: |-
+                  ControllerName describes the name of the controller responsible for
+                  reconciling VirtualMachine resources that are realized from this
+                  VirtualMachineClass.
+
+                  When omitted, controllers reconciling VirtualMachine resources determine
+                  the default controller name from the environment variable
+                  DEFAULT_VM_CLASS_CONTROLLER_NAME. If this environment variable is not
+                  defined or empty, it defaults to vmoperator.vmware.com/vsphere.
+
+                  Once a non-empty value is assigned to this field, attempts to set this
+                  field to an empty value will be silently ignored.
+                type: string
+              description:
+                description: |-
+                  Description describes the configuration of the VirtualMachineClass which
+                  is not related to virtual hardware or infrastructure policy. This field
+                  is used to address remaining specs about this VirtualMachineClass.
+                type: string
+              hardware:
+                description: |-
+                  Hardware describes the configuration of the VirtualMachineClass
+                  attributes related to virtual hardware. The configuration specified in
+                  this field is used to customize the virtual hardware characteristics of
+                  any VirtualMachine associated with this VirtualMachineClass.
+                properties:
+                  cpus:
+                    format: int64
+                    type: integer
+                  devices:
+                    description: |-
+                      VirtualDevices contains information about the virtual devices associated
+                      with a VirtualMachineClass.
+                    properties:
+                      dynamicDirectPathIODevices:
+                        items:
+                          description: |-
+                            DynamicDirectPathIODevice contains the configuration corresponding to a
+                            Dynamic DirectPath I/O device.
+                          properties:
+                            customLabel:
+                              type: string
+                            deviceID:
+                              format: int64
+                              type: integer
+                            vendorID:
+                              format: int64
+                              type: integer
+                          required:
+                          - deviceID
+                          - vendorID
+                          type: object
+                        type: array
+                      vgpuDevices:
+                        items:
+                          description: VGPUDevice contains the configuration corresponding
+                            to a vGPU device.
+                          properties:
+                            profileName:
+                              type: string
+                          required:
+                          - profileName
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - profileName
+                        x-kubernetes-list-type: map
+                    type: object
+                  instanceStorage:
+                    description: |-
+                      InstanceStorage provides information used to configure instance
+                      storage volumes for a VirtualMachine.
+                    properties:
+                      storageClass:
+                        description: |-
+                          StorageClass refers to the name of a StorageClass resource used to
+                          provide the storage for the configured instance storage volumes.
+                          The value of this field has no relationship to or bearing on the field
+                          virtualMachine.spec.storageClass. Please note the referred StorageClass
+                          must be available in the same namespace as the VirtualMachineClass that
+                          uses it for configuring instance storage.
+                        type: string
+                      volumes:
+                        description: |-
+                          Volumes describes instance storage volumes created for a VirtualMachine
+                          instance that use this VirtualMachineClass.
+                        items:
+                          description: |-
+                            InstanceStorageVolume contains information required to create an
+                            instance storage volume on a VirtualMachine.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - size
+                          type: object
+                        type: array
+                    type: object
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              policies:
+                description: |-
+                  Policies describes the configuration of the VirtualMachineClass
+                  attributes related to virtual infrastructure policy. The configuration
+                  specified in this field is used to customize various policies related to
+                  infrastructure resource consumption.
+                properties:
+                  resources:
+                    description: |-
+                      VirtualMachineClassResources describes the virtual hardware resource
+                      reservations and limits configuration to be used by a VirtualMachineClass.
+                    properties:
+                      limits:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: VirtualMachineResourceSpec describes a virtual
+                          hardware policy specification.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              reservedProfileID:
+                description: |-
+                  ReservedProfileID describes the reservation profile associated with
+                  the namespace-scoped VirtualMachineClass object.
+                type: string
+              reservedSlots:
+                description: |-
+                  ReservedSlots describes the number of slots reserved for VMs that use
+                  this VirtualMachineClass.
+                  This field is only valid in conjunction with reservedProfileID.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: VirtualMachineClassInstanceStatus defines the observed state
+              of VirtualMachineClassInstance.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinegrouppublishrequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinegrouppublishrequests.yaml
@@ -1,0 +1,289 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachinegrouppublishrequests.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineGroupPublishRequest
+    listKind: VirtualMachineGroupPublishRequestList
+    plural: virtualmachinegrouppublishrequests
+    shortNames:
+    - vmgpub
+    singular: virtualmachinegrouppublishrequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineGroupPublishRequest defines the information necessary to
+          publish the VirtualMachines in a VirtualMachineGroup as VirtualMachineImages
+          to an image registry.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineGroupPublishRequestSpec defines the desired state of a
+              VirtualMachineGroupPublishRequest.
+
+              All the fields in this spec are optional. This is especially useful when a
+              DevOps persona wants to publish a VM Group without doing anything more than
+              applying a VirtualMachineGroupPublishRequest resource that has the same name
+              as said VMs in the same namespace as said VMs in VM Group.
+            properties:
+              source:
+                description: |-
+                  Source is the name of the VirtualMachineGroup to be published.
+
+                  If this value is omitted then the publication controller checks to
+                  see if there is a VirtualMachineGroup with the same name as this
+                  VirtualMachineGroupPublishRequest resource. If such a resource exists,
+                  then it is the source of the publication.
+                type: string
+              target:
+                description: |-
+                  Target is the name of the ContentLibrary resource to which the
+                  VirtualMachines from the VirtualMachineGroup should be published.
+
+                  When this value is omitted, the controller attempts to identify the
+                  target location by matching a ContentLibrary resource with the label
+                  "imageregistry.vmware.com/default".
+
+                  Please note that while optional, if a VirtualMachineGroupPublishRequest
+                  sans target information is applied to a namespace without a default
+                  publication target, then the VirtualMachineGroupPublishRequest resource
+                  will be marked in error.
+                type: string
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished is the time-to-live duration for how long this
+                  resource will be allowed to exist once the publication operation
+                  completes. After the TTL expires, the resource will be automatically
+                  deleted without the user having to take any direct action.
+                  This will be passed into each VirtualMachinePublishRequestSpec.
+
+                  If this field is unset then the request resource will not be
+                  automatically deleted. If this field is set to zero then the request
+                  resource is eligible for deletion immediately after it finishes.
+                format: int64
+                minimum: 0
+                type: integer
+              virtualMachines:
+                description: |-
+                  VirtualMachines is a list of the VirtualMachine objects from the source
+                  VirtualMachineGroup that are included in this publish request.
+
+                  If omitted, this field defaults to the names of all of the VMs currently
+                  a member of the group, either directly or indirectly via a nested group.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: |-
+              VirtualMachineGroupPublishRequestStatus defines the observed state of a
+              VirtualMachineGroupPublishRequest.
+            properties:
+              completionTime:
+                description: |-
+                  CompletionTime represents when the request was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+
+                  The value of this field should be equal to the value of the
+                  LastTransitionTime for the status condition Type=Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions is a list of the latest, available observations of the
+                  request's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              images:
+                description: |-
+                  Images describes the observed status of the individual VirtualMachine
+                  publications.
+                items:
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions is a copy of the conditions from the
+                        VirtualMachinePublishRequest object created to publish the VM.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    imageName:
+                      description: |-
+                        ImageName is the name of the VirtualMachineImage resource that is
+                        eventually realized after the publication operation completes.
+
+                        This field will not be set until the VirtualMachineImage resource
+                        is realized.
+                      type: string
+                    publishRequestName:
+                      description: |-
+                        PublishRequestName is the name of the VirtualMachinePublishRequest object
+                        created to publish the VM.
+                      type: string
+                    source:
+                      description: Source is the name of the published VirtualMachine.
+                      type: string
+                  required:
+                  - publishRequestName
+                  - source
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - source
+                x-kubernetes-list-type: map
+              source:
+                description: Source is the name of the published VirtualMachineGroup.
+                type: string
+              startTime:
+                description: |-
+                  StartTime represents when the request was acknowledged by the
+                  controller. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and is
+                  in UTC.
+
+                  Please note that the group will not be published until the group's Ready
+                  condition is true.
+                format: date-time
+                type: string
+              target:
+                description: Target is the name of the ContentLibrary to which the
+                  group is published.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinegroups.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinegroups.yaml
@@ -1,0 +1,1566 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachinegroups.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineGroup
+    listKind: VirtualMachineGroupList
+    plural: virtualmachinegroups
+    shortNames:
+    - vmg
+    singular: virtualmachinegroup
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineGroup is the schema for the VirtualMachineGroup API and
+          represents the desired state and observed status of a VirtualMachineGroup
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineGroupSpec defines the desired state of VirtualMachineGroup.
+            properties:
+              bootOrder:
+                description: |-
+                  BootOrder describes the boot sequence for this group members. Each boot
+                  order contains a set of members that will be powered on simultaneously,
+                  with an optional delay before powering on. The orders are processed
+                  sequentially in the order they appear in this list, with delays being
+                  cumulative across orders.
+
+                  When powering off, all members are stopped immediately without delays.
+                items:
+                  description: |-
+                    VirtualMachineGroupBootOrderGroup describes a boot order group within a
+                    VirtualMachineGroup.
+                  properties:
+                    members:
+                      description: |-
+                        Members describes the names of VirtualMachine or VirtualMachineGroup
+                        objects that are members of this boot order group. The VM or VM Group
+                        objects must be in the same namespace as this group.
+                      items:
+                        description: GroupMember describes a member of a VirtualMachineGroup.
+                        properties:
+                          kind:
+                            default: VirtualMachine
+                            description: |-
+                              Kind is the kind of member of this group, which can be either
+                              VirtualMachine or VirtualMachineGroup.
+
+                              If omitted, it defaults to VirtualMachine.
+                            enum:
+                            - VirtualMachine
+                            - VirtualMachineGroup
+                            type: string
+                          name:
+                            description: Name is the name of member of this group.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - kind
+                      - name
+                      x-kubernetes-list-type: map
+                    powerOnDelay:
+                      description: |-
+                        PowerOnDelay is the amount of time to wait before powering on all the
+                        members of this boot order group.
+
+                        If omitted, the members will be powered on immediately when the group's
+                        power state changes to PoweredOn.
+                      type: string
+                  type: object
+                type: array
+              groupName:
+                description: |-
+                  GroupName describes the name of the group that this group belongs to.
+
+                  When this field is set to a valid group that contains this VM Group as a
+                  member, an owner reference to that group is added to this VM Group.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM Group.
+                type: string
+              nextForcePowerStateSyncTime:
+                description: |-
+                  NextForcePowerStateSyncTime may be used to force sync the power state of
+                  the group to all of its members, by setting the value of this field to
+                  "now" (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM Group controller then uses to trigger a sync of the group's power
+                  state to its members.
+
+                  Please note it is not possible to schedule future syncs using this field.
+                  The only value that users may set is the string "now" (case-insensitive).
+                type: string
+              powerOffMode:
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM Group.
+                  Refer to the VirtualMachine.PowerOffMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachineGroup.
+
+                  Please note this field may be omitted when creating a new VM group. This
+                  ensures that the power states of any existing VMs that are added to the
+                  group do not have their power states changed until the group's power
+                  state is explicitly altered.
+
+                  However, once the field is set to a non-empty value, it may no longer be
+                  set to an empty value. This means that if the group's power state is
+                  PoweredOn, and a VM whose power state is PoweredOff is added to the
+                  group, that VM will be powered on.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              suspendMode:
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM Group.
+                  Refer to the VirtualMachine.SuspendMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+            type: object
+          status:
+            description: VirtualMachineGroupStatus defines the observed state of VirtualMachineGroup.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this VM Group.
+
+                  - The ReadyType condition is True when all of the group members have
+                    all of their expected conditions set to True.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdatedPowerStateTime:
+                description: |-
+                  LastUpdatedPowerStateTime describes the observed time when the power
+                  state of the group was last updated.
+                format: date-time
+                type: string
+              members:
+                description: Members describes the observed status of group members.
+                items:
+                  description: |-
+                    VirtualMachineGroupMemberStatus describes the observed status of a group
+                    member.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this member.
+
+                        - The GroupLinked condition is True when the member exists and has its
+                          "Spec.GroupName" field set to the group's name.
+                        - The PowerStateSynced condition is True for the VirtualMachine member
+                          when the member's power state matches the group's power state.
+                        - The PlacementReady condition is True for the VirtualMachine member
+                          when the member has a placement decision ready.
+                        - The ReadyType condition is True for the VirtualMachineGroup member
+                          when all of its members' conditions are True.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    kind:
+                      description: |-
+                        Kind is the kind of this member, which can be either VirtualMachine or
+                        VirtualMachineGroup.
+                      enum:
+                      - VirtualMachine
+                      - VirtualMachineGroup
+                      type: string
+                    name:
+                      description: Name is the name of this member.
+                      type: string
+                    placement:
+                      description: |-
+                        Placement describes the placement results for this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      properties:
+                        datastores:
+                          description: |-
+                            Datastores describe the recommended datastores for this VM.
+                            This includes the recommendations for each of the VM's disks
+                            and files.
+                          items:
+                            properties:
+                              diskKey:
+                                description: |-
+                                  DiskKey describes the device key to which this recommendation applies.
+                                  When omitted, this recommendation is for the VM's home directory.
+                                format: int32
+                                type: integer
+                              id:
+                                description: ID describes the datastore ID.
+                                type: string
+                              name:
+                                description: Name describes the name of a datastore.
+                                type: string
+                              supportedDiskFormats:
+                                description: |-
+                                  SupportedDiskFormat describes the list of disk formats supported by this
+                                  datastore.
+                                items:
+                                  type: string
+                                type: array
+                              url:
+                                description: URL describes the datastore URL.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        node:
+                          description: Node describes the recommended node for this
+                            VM.
+                          type: string
+                        pool:
+                          description: Pool describes the recommended resource pool
+                            for this VM.
+                          type: string
+                        zoneID:
+                          description: Zone describes the recommended zone for this
+                            VM.
+                          type: string
+                      type: object
+                    powerState:
+                      description: |-
+                        PowerState describes the observed power state of this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      enum:
+                      - PoweredOff
+                      - PoweredOn
+                      - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - kind
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineGroup is the schema for the VirtualMachineGroup API and
+          represents the desired state and observed status of a VirtualMachineGroup
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineGroupSpec defines the desired state of VirtualMachineGroup.
+            properties:
+              bootOrder:
+                description: |-
+                  BootOrder describes the boot sequence for this group members. Each boot
+                  order contains a set of members that will be powered on simultaneously,
+                  with an optional delay before powering on. The orders are processed
+                  sequentially in the order they appear in this list, with delays being
+                  cumulative across orders.
+
+                  When powering off, all members are stopped immediately without delays.
+                items:
+                  description: |-
+                    VirtualMachineGroupBootOrderGroup describes a boot order group within a
+                    VirtualMachineGroup.
+                  properties:
+                    members:
+                      description: |-
+                        Members describes the names of VirtualMachine or VirtualMachineGroup
+                        objects that are members of this boot order group. The VM or VM Group
+                        objects must be in the same namespace as this group.
+                      items:
+                        description: GroupMember describes a member of a VirtualMachineGroup.
+                        properties:
+                          kind:
+                            default: VirtualMachine
+                            description: |-
+                              Kind is the kind of member of this group, which can be either
+                              VirtualMachine or VirtualMachineGroup.
+
+                              If omitted, it defaults to VirtualMachine.
+                            enum:
+                            - VirtualMachine
+                            - VirtualMachineGroup
+                            type: string
+                          name:
+                            description: Name is the name of member of this group.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - kind
+                      - name
+                      x-kubernetes-list-type: map
+                    powerOnDelay:
+                      description: |-
+                        PowerOnDelay is the amount of time to wait before powering on all the
+                        members of this boot order group.
+
+                        If omitted, the members will be powered on immediately when the group's
+                        power state changes to PoweredOn.
+                      type: string
+                  type: object
+                type: array
+              groupName:
+                description: |-
+                  GroupName describes the name of the group that this group belongs to.
+
+                  When this field is set to a valid group that contains this VM Group as a
+                  member, an owner reference to that group is added to this VM Group.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM Group.
+                type: string
+              nextForcePowerStateSyncTime:
+                description: |-
+                  NextForcePowerStateSyncTime may be used to force sync the power state of
+                  the group to all of its members, by setting the value of this field to
+                  "now" (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM Group controller then uses to trigger a sync of the group's power
+                  state to its members.
+
+                  Please note it is not possible to schedule future syncs using this field.
+                  The only value that users may set is the string "now" (case-insensitive).
+                type: string
+              powerOffMode:
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM Group.
+                  Refer to the VirtualMachine.PowerOffMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachineGroup.
+
+                  Please note this field may be omitted when creating a new VM group. This
+                  ensures that the power states of any existing VMs that are added to the
+                  group do not have their power states changed until the group's power
+                  state is explicitly altered.
+
+                  However, once the field is set to a non-empty value, it may no longer be
+                  set to an empty value. This means that if the group's power state is
+                  PoweredOn, and a VM whose power state is PoweredOff is added to the
+                  group, that VM will be powered on.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              suspendMode:
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM Group.
+                  Refer to the VirtualMachine.SuspendMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+            type: object
+          status:
+            description: VirtualMachineGroupStatus defines the observed state of VirtualMachineGroup.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this VM Group.
+
+                  - The ReadyType condition is True when all of the group members have
+                    all of their expected conditions set to True.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdatedPowerStateTime:
+                description: |-
+                  LastUpdatedPowerStateTime describes the observed time when the power
+                  state of the group was last updated.
+                format: date-time
+                type: string
+              members:
+                description: Members describes the observed status of group members.
+                items:
+                  description: |-
+                    VirtualMachineGroupMemberStatus describes the observed status of a group
+                    member.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this member.
+
+                        - The GroupLinked condition is True when the member exists and has its
+                          "Spec.GroupName" field set to the group's name.
+                        - The PowerStateSynced condition is True for the VirtualMachine member
+                          when the member's power state matches the group's power state.
+                        - The PlacementReady condition is True for the VirtualMachine member
+                          when the member has a placement decision ready.
+                        - The ReadyType condition is True for the VirtualMachineGroup member
+                          when all of its members' conditions are True.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    kind:
+                      description: |-
+                        Kind is the kind of this member, which can be either VirtualMachine or
+                        VirtualMachineGroup.
+                      enum:
+                      - VirtualMachine
+                      - VirtualMachineGroup
+                      type: string
+                    name:
+                      description: Name is the name of this member.
+                      type: string
+                    placement:
+                      description: |-
+                        Placement describes the placement results for this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      properties:
+                        datastores:
+                          description: |-
+                            Datastores describe the recommended datastores for this VM.
+                            This includes the recommendations for each of the VM's disks
+                            and files.
+                          items:
+                            properties:
+                              diskKey:
+                                description: |-
+                                  DiskKey describes the device key to which this recommendation applies.
+                                  When omitted, this recommendation is for the VM's home directory.
+                                format: int32
+                                type: integer
+                              id:
+                                description: ID describes the datastore ID.
+                                type: string
+                              name:
+                                description: Name describes the name of a datastore.
+                                type: string
+                              supportedDiskFormats:
+                                description: |-
+                                  SupportedDiskFormat describes the list of disk formats supported by this
+                                  datastore.
+                                items:
+                                  type: string
+                                type: array
+                              url:
+                                description: URL describes the datastore URL.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        node:
+                          description: Node describes the recommended node for this
+                            VM.
+                          type: string
+                        pool:
+                          description: Pool describes the recommended resource pool
+                            for this VM.
+                          type: string
+                        zoneID:
+                          description: Zone describes the recommended zone for this
+                            VM.
+                          type: string
+                      type: object
+                    powerState:
+                      description: |-
+                        PowerState describes the observed power state of this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      enum:
+                      - PoweredOff
+                      - PoweredOn
+                      - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - kind
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineGroup is the schema for the VirtualMachineGroup API and
+          represents the desired state and observed status of a VirtualMachineGroup
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineGroupSpec defines the desired state of VirtualMachineGroup.
+            properties:
+              bootOrder:
+                description: |-
+                  BootOrder describes the boot sequence for this group members. Each boot
+                  order contains a set of members that will be powered on simultaneously,
+                  with an optional delay before powering on. The orders are processed
+                  sequentially in the order they appear in this list, with delays being
+                  cumulative across orders.
+
+                  When powering off, all members are stopped immediately without delays.
+                items:
+                  description: |-
+                    VirtualMachineGroupBootOrderGroup describes a boot order group within a
+                    VirtualMachineGroup.
+                  properties:
+                    members:
+                      description: |-
+                        Members describes the names of VirtualMachine or VirtualMachineGroup
+                        objects that are members of this boot order group. The VM or VM Group
+                        objects must be in the same namespace as this group.
+                      items:
+                        description: GroupMember describes a member of a VirtualMachineGroup.
+                        properties:
+                          kind:
+                            default: VirtualMachine
+                            description: |-
+                              Kind is the kind of member of this group, which can be either
+                              VirtualMachine or VirtualMachineGroup.
+
+                              If omitted, it defaults to VirtualMachine.
+                            enum:
+                            - VirtualMachine
+                            - VirtualMachineGroup
+                            type: string
+                          name:
+                            description: Name is the name of member of this group.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - kind
+                      - name
+                      x-kubernetes-list-type: map
+                    powerOnDelay:
+                      description: |-
+                        PowerOnDelay is the amount of time to wait before powering on all the
+                        members of this boot order group.
+
+                        If omitted, the members will be powered on immediately when the group's
+                        power state changes to PoweredOn.
+                      type: string
+                  type: object
+                type: array
+              groupName:
+                description: |-
+                  GroupName describes the name of the group that this group belongs to.
+
+                  When this field is set to a valid group that contains this VM Group as a
+                  member, an owner reference to that group is added to this VM Group.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM Group.
+                type: string
+              nextForcePowerStateSyncTime:
+                description: |-
+                  NextForcePowerStateSyncTime may be used to force sync the power state of
+                  the group to all of its members, by setting the value of this field to
+                  "now" (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM Group controller then uses to trigger a sync of the group's power
+                  state to its members.
+
+                  Please note it is not possible to schedule future syncs using this field.
+                  The only value that users may set is the string "now" (case-insensitive).
+                type: string
+              powerOffMode:
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM Group.
+                  Refer to the VirtualMachine.PowerOffMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachineGroup.
+
+                  Please note this field may be omitted when creating a new VM group. This
+                  ensures that the power states of any existing VMs that are added to the
+                  group do not have their power states changed until the group's power
+                  state is explicitly altered.
+
+                  However, once the field is set to a non-empty value, it may no longer be
+                  set to an empty value. This means that if the group's power state is
+                  PoweredOn, and a VM whose power state is PoweredOff is added to the
+                  group, that VM will be powered on.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              suspendMode:
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM Group.
+                  Refer to the VirtualMachine.SuspendMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+            type: object
+          status:
+            description: VirtualMachineGroupStatus defines the observed state of VirtualMachineGroup.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this VM Group.
+
+                  - The ReadyType condition is True when all of the group members have
+                    all of their expected conditions set to True.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdatedPowerStateTime:
+                description: |-
+                  LastUpdatedPowerStateTime describes the observed time when the power
+                  state of the group was last updated.
+                format: date-time
+                type: string
+              members:
+                description: Members describes the observed status of group members.
+                items:
+                  description: |-
+                    VirtualMachineGroupMemberStatus describes the observed status of a group
+                    member.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this member.
+
+                        - The GroupLinked condition is True when the member exists and has its
+                          "Spec.GroupName" field set to the group's name.
+                        - The PowerStateSynced condition is True for the VirtualMachine member
+                          when the member's power state matches the group's power state.
+                        - The PlacementReady condition is True for the VirtualMachine member
+                          when the member has a placement decision ready.
+                        - The ReadyType condition is True for the VirtualMachineGroup member
+                          when all of its members' conditions are True.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    kind:
+                      description: |-
+                        Kind is the kind of this member, which can be either VirtualMachine or
+                        VirtualMachineGroup.
+                      enum:
+                      - VirtualMachine
+                      - VirtualMachineGroup
+                      type: string
+                    name:
+                      description: Name is the name of this member.
+                      type: string
+                    placement:
+                      description: |-
+                        Placement describes the placement results for this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      properties:
+                        datastores:
+                          description: |-
+                            Datastores describe the recommended datastores for this VM.
+                            This includes the recommendations for each of the VM's disks
+                            and files.
+                          items:
+                            properties:
+                              diskKey:
+                                description: |-
+                                  DiskKey describes the device key to which this recommendation applies.
+                                  When omitted, this recommendation is for the VM's home directory.
+                                format: int32
+                                type: integer
+                              id:
+                                description: ID describes the datastore ID.
+                                type: string
+                              name:
+                                description: Name describes the name of a datastore.
+                                type: string
+                              supportedDiskFormats:
+                                description: |-
+                                  SupportedDiskFormat describes the list of disk formats supported by this
+                                  datastore.
+                                items:
+                                  type: string
+                                type: array
+                              url:
+                                description: URL describes the datastore URL.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        node:
+                          description: Node describes the recommended node for this
+                            VM.
+                          type: string
+                        pool:
+                          description: Pool describes the recommended resource pool
+                            for this VM.
+                          type: string
+                        zoneID:
+                          description: Zone describes the recommended zone for this
+                            VM.
+                          type: string
+                      type: object
+                    powerState:
+                      description: |-
+                        PowerState describes the observed power state of this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      enum:
+                      - PoweredOff
+                      - PoweredOn
+                      - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - kind
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineGroup is the schema for the VirtualMachineGroup API and
+          represents the desired state and observed status of a VirtualMachineGroup
+          resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineGroupSpec defines the desired state of VirtualMachineGroup.
+            properties:
+              bootOrder:
+                description: |-
+                  BootOrder describes the boot sequence for this group members. Each boot
+                  order contains a set of members that will be powered on simultaneously,
+                  with an optional delay before powering on. The orders are processed
+                  sequentially in the order they appear in this list, with delays being
+                  cumulative across orders.
+
+                  When powering off, all members are stopped immediately without delays.
+                items:
+                  description: |-
+                    VirtualMachineGroupBootOrderGroup describes a boot order group within a
+                    VirtualMachineGroup.
+                  properties:
+                    members:
+                      description: |-
+                        Members describes the names of VirtualMachine or VirtualMachineGroup
+                        objects that are members of this boot order group. The VM or VM Group
+                        objects must be in the same namespace as this group.
+                      items:
+                        description: GroupMember describes a member of a VirtualMachineGroup.
+                        properties:
+                          kind:
+                            default: VirtualMachine
+                            description: |-
+                              Kind is the kind of member of this group, which can be either
+                              VirtualMachine or VirtualMachineGroup.
+
+                              If omitted, it defaults to VirtualMachine.
+                            enum:
+                            - VirtualMachine
+                            - VirtualMachineGroup
+                            type: string
+                          name:
+                            description: Name is the name of member of this group.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - kind
+                      - name
+                      x-kubernetes-list-type: map
+                    powerOnDelay:
+                      description: |-
+                        PowerOnDelay is the amount of time to wait before powering on all the
+                        members of this boot order group.
+
+                        If omitted, the members will be powered on immediately when the group's
+                        power state changes to PoweredOn.
+                      type: string
+                  type: object
+                type: array
+              groupName:
+                description: |-
+                  GroupName describes the name of the group that this group belongs to.
+
+                  When this field is set to a valid group that contains this VM Group as a
+                  member, an owner reference to that group is added to this VM Group.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM Group.
+                type: string
+              nextForcePowerStateSyncTime:
+                description: |-
+                  NextForcePowerStateSyncTime may be used to force sync the power state of
+                  the group to all of its members, by setting the value of this field to
+                  "now" (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM Group controller then uses to trigger a sync of the group's power
+                  state to its members.
+
+                  Please note it is not possible to schedule future syncs using this field.
+                  The only value that users may set is the string "now" (case-insensitive).
+                type: string
+              powerOffMode:
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM Group.
+                  Refer to the VirtualMachine.PowerOffMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachineGroup.
+
+                  Please note this field may be omitted when creating a new VM group. This
+                  ensures that the power states of any existing VMs that are added to the
+                  group do not have their power states changed until the group's power
+                  state is explicitly altered.
+
+                  However, once the field is set to a non-empty value, it may no longer be
+                  set to an empty value. This means that if the group's power state is
+                  PoweredOn, and a VM whose power state is PoweredOff is added to the
+                  group, that VM will be powered on.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              suspendMode:
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM Group.
+                  Refer to the VirtualMachine.SuspendMode field for more details.
+
+                  Please note this field is only propagated to the group's members when
+                  the group's power state is changed or the nextForcePowerStateSyncTime
+                  field is set to "now".
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+            type: object
+          status:
+            description: VirtualMachineGroupStatus defines the observed state of VirtualMachineGroup.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this VM Group.
+
+                  - The ReadyType condition is True when all of the group members have
+                    all of their expected conditions set to True.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdatedPowerStateTime:
+                description: |-
+                  LastUpdatedPowerStateTime describes the observed time when the power
+                  state of the group was last updated.
+                format: date-time
+                type: string
+              members:
+                description: Members describes the observed status of group members.
+                items:
+                  description: |-
+                    VirtualMachineGroupMemberStatus describes the observed status of a group
+                    member.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this member.
+
+                        - The GroupLinked condition is True when the member exists and has its
+                          "Spec.GroupName" field set to the group's name.
+                        - The PowerStateSynced condition is True for the VirtualMachine member
+                          when the member's power state matches the group's power state.
+                        - The PlacementReady condition is True for the VirtualMachine member
+                          when the member has a placement decision ready.
+                        - The ReadyType condition is True for the VirtualMachineGroup member
+                          when all of its members' conditions are True.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    kind:
+                      description: |-
+                        Kind is the kind of this member, which can be either VirtualMachine or
+                        VirtualMachineGroup.
+                      enum:
+                      - VirtualMachine
+                      - VirtualMachineGroup
+                      type: string
+                    name:
+                      description: Name is the name of this member.
+                      type: string
+                    placement:
+                      description: |-
+                        Placement describes the placement results for this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      properties:
+                        datastores:
+                          description: |-
+                            Datastores describe the recommended datastores for this VM.
+                            This includes the recommendations for each of the VM's disks
+                            and files.
+                          items:
+                            properties:
+                              diskKey:
+                                description: |-
+                                  DiskKey describes the device key to which this recommendation applies.
+                                  When omitted, this recommendation is for the VM's home directory.
+                                format: int32
+                                type: integer
+                              id:
+                                description: ID describes the datastore ID.
+                                type: string
+                              name:
+                                description: Name describes the name of a datastore.
+                                type: string
+                              supportedDiskFormats:
+                                description: |-
+                                  SupportedDiskFormat describes the list of disk formats supported by this
+                                  datastore.
+                                items:
+                                  type: string
+                                type: array
+                              url:
+                                description: URL describes the datastore URL.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        node:
+                          description: Node describes the recommended node for this
+                            VM.
+                          type: string
+                        pool:
+                          description: Pool describes the recommended resource pool
+                            for this VM.
+                          type: string
+                        zoneID:
+                          description: Zone describes the recommended zone for this
+                            VM.
+                          type: string
+                      type: object
+                    powerState:
+                      description: |-
+                        PowerState describes the observed power state of this member.
+
+                        Please note this field is only set for VirtualMachine members.
+                      enum:
+                      - PoweredOff
+                      - PoweredOn
+                      - Suspended
+                      type: string
+                    uid:
+                      description: UID is the K8s metadata UID of this current member
+                        object.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - kind
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimagecaches.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimagecaches.yaml
@@ -1,0 +1,926 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachineimagecaches.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineImageCache
+    listKind: VirtualMachineImageCacheList
+    plural: virtualmachineimagecaches
+    shortNames:
+    - vmic
+    - vmicache
+    - vmimagecache
+    singular: virtualmachineimagecache
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: v1alpha3 VirtualMachineImageCache is deprecated; use v1alpha5
+      VirtualMachineImageCache
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineImageCache is the schema for the
+          virtualmachineimagecaches API.
+
+          Deprecated: This type is deprecated and will be removed in a future release.
+          Please use v1alpha5.VirtualMachineImageCache instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineImageCacheSpec defines the desired state of
+              VirtualMachineImageCache.
+            properties:
+              locations:
+                description: Locations describes the locations where the image should
+                  be cached.
+                items:
+                  properties:
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter to which the image should
+                        be cached.
+                      type: string
+                    datastoreID:
+                      description: |-
+                        DatastoreID describes the ID of the datastore to which the image should
+                        be cached.
+                      type: string
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                        Please note, this profile *must* include the datastore specified by the
+                        datastoreID field.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              providerID:
+                description: |-
+                  ProviderID describes the ID of the provider item to which the image
+                  corresponds.
+                  If the provider is Content Library, the ID refers to a Content Library
+                  item.
+                type: string
+              providerVersion:
+                description: |-
+                  ProviderVersion describes the version of the provider item to which the
+                  image corresponds.
+                  The provider is Content Library, the version is the content version.
+                type: string
+            required:
+            - providerID
+            type: object
+          status:
+            description: |-
+              VirtualMachineImageCacheStatus defines the observed state of
+              VirtualMachineImageCache.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this cached image.
+
+                  Generally this should just include the ReadyType condition, which will
+                  only be True if all of the cached locations also have True ReadyType
+                  condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              locations:
+                description: Locations describe the observed locations where the image
+                  is cached.
+                items:
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this cache location.
+
+                        Generally this should just include the ReadyType condition.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter where the image is
+                        cached.
+                      type: string
+                    datastoreID:
+                      description: DatastoreID describes the ID of the datastore where
+                        the image is cached.
+                      type: string
+                    files:
+                      description: Files describes the image's files cached on this
+                        datastore.
+                      items:
+                        properties:
+                          diskType:
+                            description: |-
+                              DiskType describes the type of disk.
+                              This field is only non-empty when Type=Disk.
+                            enum:
+                            - Classic
+                            - Managed
+                            type: string
+                          id:
+                            description: |-
+                              ID describes the value used to locate the file.
+                              The value of this field depends on the type of file:
+
+                              - Type=Other                  -- The ID value describes a datastore path,
+                                                               ex. "[my-datastore-1] .contentlib-cache/1234/5678/my-disk-1.vmdk"
+                              - Type=Disk, DiskType=Classic -- The ID value describes a datastore
+                                                               path.
+                              - Type=Disk, DiskType=Managed -- The ID value describes a First Class
+                                                               Disk (FCD).
+                            type: string
+                          type:
+                            description: Type describes the type of file.
+                            enum:
+                            - Disk
+                            - Other
+                            type: string
+                        required:
+                        - id
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - id
+                      - type
+                      x-kubernetes-list-type: map
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              ovf:
+                description: OVF describes the observed status of the cached OVF content.
+                properties:
+                  configMapName:
+                    description: |-
+                      ConfigMapName describes the name of the ConfigMap resource that contains
+                      the image's OVF envelope encoded as YAML. The data is located in the
+                      ConfigMap key "value".
+                    type: string
+                  providerVersion:
+                    description: |-
+                      ProviderVersion describes the observed provider version at which the OVF
+                      is cached.
+                      The provider is Content Library, the version is the content version.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: v1alpha4 VirtualMachineImageCache is deprecated; use v1alpha5
+      VirtualMachineImageCache
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineImageCache is the schema for the
+          virtualmachineimagecaches API.
+
+          Deprecated: This type is deprecated and will be removed in a future release.
+          Please use v1alpha5.VirtualMachineImageCache instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineImageCacheSpec defines the desired state of
+              VirtualMachineImageCache.
+            properties:
+              locations:
+                description: Locations describes the locations where the image should
+                  be cached.
+                items:
+                  properties:
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter to which the image should
+                        be cached.
+                      type: string
+                    datastoreID:
+                      description: |-
+                        DatastoreID describes the ID of the datastore to which the image should
+                        be cached.
+                      type: string
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                        Please note, this profile *must* include the datastore specified by the
+                        datastoreID field.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              providerID:
+                description: |-
+                  ProviderID describes the ID of the provider item to which the image
+                  corresponds.
+                  If the provider is Content Library, the ID refers to a Content Library
+                  item.
+                type: string
+              providerVersion:
+                description: |-
+                  ProviderVersion describes the version of the provider item to which the
+                  image corresponds.
+                  The provider is Content Library, the version is the content version.
+                type: string
+            required:
+            - providerID
+            type: object
+          status:
+            description: |-
+              VirtualMachineImageCacheStatus defines the observed state of
+              VirtualMachineImageCache.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this cached image.
+
+                  Generally this should just include the ReadyType condition, which will
+                  only be True if all of the cached locations also have True ReadyType
+                  condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              locations:
+                description: Locations describe the observed locations where the image
+                  is cached.
+                items:
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this cache location.
+
+                        Generally this should just include the ReadyType condition.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter where the image is
+                        cached.
+                      type: string
+                    datastoreID:
+                      description: DatastoreID describes the ID of the datastore where
+                        the image is cached.
+                      type: string
+                    files:
+                      description: Files describes the image's files cached on this
+                        datastore.
+                      items:
+                        properties:
+                          diskType:
+                            description: |-
+                              DiskType describes the type of disk.
+                              This field is only non-empty when Type=Disk.
+                            enum:
+                            - Classic
+                            - Managed
+                            type: string
+                          id:
+                            description: |-
+                              ID describes the value used to locate the file.
+                              The value of this field depends on the type of file:
+
+                              - Type=Other                  -- The ID value describes a datastore path,
+                                                               ex. "[my-datastore-1] .contentlib-cache/1234/5678/my-disk-1.vmdk"
+                              - Type=Disk, DiskType=Classic -- The ID value describes a datastore
+                                                               path.
+                              - Type=Disk, DiskType=Managed -- The ID value describes a First Class
+                                                               Disk (FCD).
+                            type: string
+                          type:
+                            description: Type describes the type of file.
+                            enum:
+                            - Disk
+                            - Other
+                            type: string
+                        required:
+                        - id
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - id
+                      - type
+                      x-kubernetes-list-type: map
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              ovf:
+                description: OVF describes the observed status of the cached OVF content.
+                properties:
+                  configMapName:
+                    description: |-
+                      ConfigMapName describes the name of the ConfigMap resource that contains
+                      the image's OVF envelope encoded as YAML. The data is located in the
+                      ConfigMap key "value".
+                    type: string
+                  providerVersion:
+                    description: |-
+                      ProviderVersion describes the observed provider version at which the OVF
+                      is cached.
+                      The provider is Content Library, the version is the content version.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineImageCache is the schema for the
+          virtualmachineimagecaches API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineImageCacheSpec defines the desired state of
+              VirtualMachineImageCache.
+            properties:
+              locations:
+                description: Locations describes the locations where the image should
+                  be cached.
+                items:
+                  properties:
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter to which the image should
+                        be cached.
+                      type: string
+                    datastoreID:
+                      description: |-
+                        DatastoreID describes the ID of the datastore to which the image should
+                        be cached.
+                      type: string
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                        Please note, this profile *must* include the datastore specified by the
+                        datastoreID field.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              providerID:
+                description: |-
+                  ProviderID describes the ID of the provider item to which the image
+                  corresponds.
+                  If the provider is Content Library, the ID refers to a Content Library
+                  item.
+                type: string
+              providerVersion:
+                description: |-
+                  ProviderVersion describes the version of the provider item to which the
+                  image corresponds.
+                  The provider is Content Library, the version is the content version.
+                type: string
+            required:
+            - providerID
+            type: object
+          status:
+            description: |-
+              VirtualMachineImageCacheStatus defines the observed state of
+              VirtualMachineImageCache.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes any conditions associated with this cached image.
+
+                  Generally this should just include the ReadyType condition, which will
+                  only be True if all of the cached locations also have True ReadyType
+                  condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              locations:
+                description: Locations describe the observed locations where the image
+                  is cached.
+                items:
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes any conditions associated with this cache location.
+
+                        Generally this should just include the ReadyType condition.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    datacenterID:
+                      description: |-
+                        DatacenterID describes the ID of the datacenter where the image is
+                        cached.
+                      type: string
+                    datastoreID:
+                      description: DatastoreID describes the ID of the datastore where
+                        the image is cached.
+                      type: string
+                    files:
+                      description: Files describes the image's files cached on this
+                        datastore.
+                      items:
+                        properties:
+                          diskType:
+                            description: |-
+                              DiskType describes the type of disk.
+                              This field is only non-empty when Type=Disk.
+                            enum:
+                            - Classic
+                            - Managed
+                            type: string
+                          id:
+                            description: |-
+                              ID describes the value used to locate the file.
+                              The value of this field depends on the type of file:
+
+                              - Type=Other                  -- The ID value describes a datastore path,
+                                                               ex. "[my-datastore-1] .contentlib-cache/1234/5678/my-disk-1.vmdk"
+                              - Type=Disk, DiskType=Classic -- The ID value describes a datastore
+                                                               path.
+                              - Type=Disk, DiskType=Managed -- The ID value describes a First Class
+                                                               Disk (FCD).
+                            type: string
+                          type:
+                            description: Type describes the type of file.
+                            enum:
+                            - Disk
+                            - Other
+                            type: string
+                        required:
+                        - id
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - id
+                      - type
+                      x-kubernetes-list-type: map
+                    profileID:
+                      description: |-
+                        ProfileID describes the ID of the storage profile used to cache the
+                        image.
+                      type: string
+                  required:
+                  - datacenterID
+                  - datastoreID
+                  - profileID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - datacenterID
+                - datastoreID
+                - profileID
+                x-kubernetes-list-type: map
+              ovf:
+                description: OVF describes the observed status of the cached OVF content.
+                properties:
+                  configMapName:
+                    description: |-
+                      ConfigMapName describes the name of the ConfigMap resource that contains
+                      the image's OVF envelope encoded as YAML. The data is located in the
+                      ConfigMap key "value".
+                    type: string
+                  providerVersion:
+                    description: |-
+                      ProviderVersion describes the observed provider version at which the OVF
+                      is cached.
+                      The provider is Content Library, the version is the content version.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineimages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachineimages.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -37,6 +37,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -224,6 +225,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to disambiguate is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -231,7 +233,6 @@ spec:
               contentLibraryRef:
                 description: |-
                   ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource.
-
 
                   Deprecated: This field is provider specific but the VirtualMachineImage types are intended to be provider generic.
                   This field does not exist in later API versions. Instead, the Spec.ProviderRef field should be used to look up the
@@ -371,18 +372,15 @@ spec:
                 description: |-
                   Capabilities describes the image's observed capabilities.
 
-
                   The capabilities are discerned when VM Operator reconciles an image.
                   If the source of an image is an OVF in Content Library, then the
                   capabilities are parsed from the OVF property
                   capabilities.image.vmoperator.vmware.com as a comma-separated list of
                   values. Well-known capabilities include:
 
-
                   * cloud-init
                   * nvidia-gpu
                   * sriov-net
-
 
                   Every capability is also added to the resource's labels as
                   VirtualMachineImageCapabilityLabel + Value. For example, if the
@@ -396,16 +394,8 @@ spec:
                 description: Conditions describes the observed conditions for this
                   image.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -446,12 +436,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -483,14 +468,12 @@ spec:
                   OSInfo describes the observed operating system information for this
                   image.
 
-
                   The OS information is also added to the image resource's labels. Please
                   refer to VirtualMachineImageOSInfo for more information.
                 properties:
                   id:
                     description: |-
                       ID describes the operating system ID.
-
 
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSIDLabel.
@@ -499,14 +482,12 @@ spec:
                     description: |-
                       Type describes the operating system type.
 
-
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSTypeLabel.
                     type: string
                   version:
                     description: |-
                       Version describes the operating system version.
-
 
                       This value is also added to the image resource's labels as
                       VirtualMachineImageOSVersionLabel.
@@ -566,6 +547,964 @@ spec:
                   ProviderItemID describes the ID of the provider item that this image corresponds to.
                   If the provider of this image is a Content Library, this ID will be that of the
                   corresponding Content Library item.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineImage is the schema for the virtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    capacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Capacity is the virtual disk capacity in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Size is the estimated populated size of the virtual
+                        disk in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type: array
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: Type describes the content library item type (OVF or
+                  ISO) of the image.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineImage is the schema for the virtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    capacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Capacity is the virtual disk capacity in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Size is the estimated populated size of the virtual
+                        disk in bytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type: array
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: |-
+                  Type describes the content library item type (OVF, ISO, or VM) of the
+                  image.
+                type: string
+              vmwareSystemProperties:
+                description: |-
+                  VMwareSystemProperties describes the observed VMware system properties defined for
+                  this image.
+                items:
+                  description: |-
+                    KeyValuePair is useful when wanting to realize a map as a list of key/value
+                    pairs.
+                  properties:
+                    key:
+                      description: Key is the key part of the key/value pair.
+                      type: string
+                    value:
+                      description: Value is the optional value part of the key/value
+                        pair.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: Display Name
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.productInfo.version
+      name: Image Version
+      type: string
+    - jsonPath: .status.osInfo.type
+      name: OS Name
+      type: string
+    - jsonPath: .status.osInfo.version
+      name: OS Version
+      type: string
+    - jsonPath: .status.hardwareVersion
+      name: Hardware Version
+      type: string
+    - jsonPath: .status.capabilities
+      name: Capabilities
+      type: string
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineImage is the schema for the virtualmachineimages
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineImageSpec defines the desired state of VirtualMachineImage.
+            properties:
+              providerRef:
+                description: |-
+                  ProviderRef is a reference to the resource that contains the source of
+                  this image's information.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: VirtualMachineImageStatus defines the observed state of VirtualMachineImage.
+            properties:
+              capabilities:
+                description: |-
+                  Capabilities describes the image's observed capabilities.
+
+                  The capabilities are discerned when VM Operator reconciles an image.
+                  If the source of an image is an OVF in Content Library, then the
+                  capabilities are parsed from the OVF property
+                  capabilities.image.vmoperator.vmware.com as a comma-separated list of
+                  values. Well-known capabilities include:
+
+                  * cloud-init
+                  * nvidia-gpu
+                  * sriov-net
+
+                  Every capability is also added to the resource's labels as
+                  VirtualMachineImageCapabilityLabel + Value. For example, if the
+                  capability is "cloud-init" then the following label will be added to the
+                  resource: capability.image.vmoperator.vmware.com/cloud-init.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: Conditions describes the observed conditions for this
+                  image.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              disks:
+                description: Disks describes the observed disk information for this
+                  image.
+                items:
+                  description: |-
+                    VirtualMachineImageDiskInfo describes information about any disks associated with
+                    this image.
+                  properties:
+                    limit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Limit is the total virtual disk capacity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the unique identifier for the virtual disk.
+                      type: string
+                    requested:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Requested is the minimum storage requirements for
+                        the virtual disk.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              firmware:
+                description: Firmware describe the firmware type used by this image,
+                  ex. BIOS, EFI.
+                type: string
+              hardwareVersion:
+                description: HardwareVersion describes the observed hardware version
+                  of this image.
+                format: int32
+                type: integer
+              name:
+                description: Name describes the display name of this image.
+                type: string
+              osInfo:
+                description: |-
+                  OSInfo describes the observed operating system information for this
+                  image.
+
+                  The OS information is also added to the image resource's labels. Please
+                  refer to VirtualMachineImageOSInfo for more information.
+                properties:
+                  id:
+                    description: |-
+                      ID describes the operating system ID.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSIDLabel.
+                    type: string
+                  type:
+                    description: |-
+                      Type describes the operating system type.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSTypeLabel.
+                    type: string
+                  version:
+                    description: |-
+                      Version describes the operating system version.
+
+                      This value is also added to the image resource's labels as
+                      VirtualMachineImageOSVersionLabel.
+                    type: string
+                type: object
+              ovfProperties:
+                description: |-
+                  OVFProperties describes the observed user configurable OVF properties defined for this
+                  image.
+                items:
+                  description: |-
+                    OVFProperty describes an OVF property associated with an image.
+                    OVF properties may be used in conjunction with the vAppConfig bootstrap
+                    provider to customize a VM during its creation.
+                  properties:
+                    default:
+                      description: Default describes the OVF property's default value.
+                      type: string
+                    key:
+                      description: Key describes the OVF property's key.
+                      type: string
+                    type:
+                      description: Type describes the OVF property's type.
+                      type: string
+                  required:
+                  - key
+                  - type
+                  type: object
+                type: array
+              productInfo:
+                description: ProductInfo describes the observed product information
+                  for this image.
+                properties:
+                  fullVersion:
+                    description: FullVersion describes the long-form version of the
+                      image.
+                    type: string
+                  product:
+                    description: Product is a general descriptor for the image.
+                    type: string
+                  vendor:
+                    description: Vendor describes the organization/user that produced
+                      the image.
+                    type: string
+                  version:
+                    description: Version describes the short-form version of the image.
+                    type: string
+                type: object
+              providerContentVersion:
+                description: |-
+                  ProviderContentVersion describes the content version from the provider item
+                  that this image corresponds to. If the provider of this image is a Content
+                  Library, this will be the version of the corresponding Content Library item.
+                type: string
+              providerItemID:
+                description: |-
+                  ProviderItemID describes the ID of the provider item that this image corresponds to.
+                  If the provider of this image is a Content Library, this ID will be that of the
+                  corresponding Content Library item.
+                type: string
+              type:
+                description: |-
+                  Type describes the content library item type (OVF, ISO, or VM) of the
+                  image.
                 type: string
               vmwareSystemProperties:
                 description: |-

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachinepublishrequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -16,7 +16,8 @@ spec:
     singular: virtualmachinepublishrequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -45,7 +46,6 @@ spec:
               VirtualMachinePublishRequestSpec defines the desired state of a
               VirtualMachinePublishRequest.
 
-
               All the fields in this spec are optional. This is especially useful when a
               DevOps persona wants to publish a VM without doing anything more than
               applying a VirtualMachinePublishRequest resource that has the same name
@@ -55,7 +55,6 @@ spec:
                 description: |-
                   Source is the source of the publication request, ex. a VirtualMachine
                   resource.
-
 
                   If this value is omitted then the publication controller checks to
                   see if there is a resource with the same name as this
@@ -75,7 +74,6 @@ spec:
                     description: |-
                       Name is the name of the referenced object.
 
-
                       If omitted this value defaults to the name of the
                       VirtualMachinePublishRequest resource.
                     type: string
@@ -85,14 +83,12 @@ spec:
                   Target is the target of the publication request, ex. item
                   information and a ContentLibrary resource.
 
-
                   If this value is omitted, the controller uses spec.source.name + "-image"
                   as the name of the published item. Additionally, when omitted the
                   controller attempts to identify the target location by matching a
                   resource with an API version equal to spec.target.location.apiVersion, a
                   kind equal to spec.target.location.kind, w/ the label
                   "imageregistry.vmware.com/default".
-
 
                   Please note that while optional, if a VirtualMachinePublishRequest sans
                   target information is applied to a namespace without a default
@@ -103,7 +99,6 @@ spec:
                     description: |-
                       Item contains information about the name of the object to which
                       the VM is published.
-
 
                       Please note this value is optional and if omitted, the controller
                       will use spec.source.name + "-image" as the name of the published
@@ -117,13 +112,11 @@ spec:
                         description: |-
                           Name is the display name of the published object.
 
-
                           If the spec.target.location.apiVersion equals
                           imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
                           equals ContentLibrary, then this should be the name that will
                           show up in vCenter Content Library, not the custom resource name
                           in the namespace.
-
 
                           If omitted then the controller will use spec.source.name + "-image".
                         type: string
@@ -146,10 +139,8 @@ spec:
                         description: |-
                           Name is the name of the referenced object.
 
-
                           Please note an error will be returned if this field is not
                           set in a namespace that lacks a default publication target.
-
 
                           A default publication target is a resource with an API version
                           equal to spec.target.location.apiVersion, a kind equal to
@@ -164,7 +155,6 @@ spec:
                   resource will be allowed to exist once the publication operation
                   completes. After the TTL expires, the resource will be automatically
                   deleted without the user having to take any direct action.
-
 
                   If this field is unset then the request resource will not be
                   automatically deleted. If this field is set to zero then the request
@@ -189,7 +179,6 @@ spec:
                   CompletionTime represents time when the request was completed. It is not
                   guaranteed to be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
-
 
                   The value of this field should be equal to the value of the
                   LastTransitionTime for the status condition Type=Complete.
@@ -237,6 +226,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to disambiguate is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -246,7 +236,6 @@ spec:
                   ImageName is the name of the VirtualMachineImage resource that is
                   eventually realized in the same namespace as the VM and publication
                   request after the publication operation completes.
-
 
                   This field will not be set until the VirtualMachineImage resource
                   is realized.
@@ -261,11 +250,9 @@ spec:
                   Ready is set to true only when the VM has been published successfully
                   and the new VirtualMachineImage resource is ready.
 
-
                   Readiness is determined by waiting until there is status condition
                   Type=Complete and ensuring it and all other status conditions present
                   have a Status=True. The conditions present will be:
-
 
                     * SourceValid
                     * TargetValid
@@ -290,7 +277,6 @@ spec:
                     description: |-
                       Name is the name of the referenced object.
 
-
                       If omitted this value defaults to the name of the
                       VirtualMachinePublishRequest resource.
                     type: string
@@ -313,7 +299,6 @@ spec:
                       Item contains information about the name of the object to which
                       the VM is published.
 
-
                       Please note this value is optional and if omitted, the controller
                       will use spec.source.name + "-image" as the name of the published
                       item.
@@ -326,13 +311,11 @@ spec:
                         description: |-
                           Name is the display name of the published object.
 
-
                           If the spec.target.location.apiVersion equals
                           imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
                           equals ContentLibrary, then this should be the name that will
                           show up in vCenter Content Library, not the custom resource name
                           in the namespace.
-
 
                           If omitted then the controller will use spec.source.name + "-image".
                         type: string
@@ -355,10 +338,8 @@ spec:
                         description: |-
                           Name is the name of the referenced object.
 
-
                           Please note an error will be returned if this field is not
                           set in a namespace that lacks a default publication target.
-
 
                           A default publication target is a resource with an API version
                           equal to spec.target.location.apiVersion, a kind equal to
@@ -402,7 +383,6 @@ spec:
               VirtualMachinePublishRequestSpec defines the desired state of a
               VirtualMachinePublishRequest.
 
-
               All the fields in this spec are optional. This is especially useful when a
               DevOps persona wants to publish a VM without doing anything more than
               applying a VirtualMachinePublishRequest resource that has the same name
@@ -412,7 +392,6 @@ spec:
                 description: |-
                   Source is the source of the publication request, ex. a VirtualMachine
                   resource.
-
 
                   If this value is omitted then the publication controller checks to
                   see if there is a resource with the same name as this
@@ -432,7 +411,6 @@ spec:
                     description: |-
                       Name is the name of the referenced object.
 
-
                       If omitted this value defaults to the name of the
                       VirtualMachinePublishRequest resource.
                     type: string
@@ -442,14 +420,12 @@ spec:
                   Target is the target of the publication request, ex. item
                   information and a ContentLibrary resource.
 
-
                   If this value is omitted, the controller uses spec.source.name + "-image"
                   as the name of the published item. Additionally, when omitted the
                   controller attempts to identify the target location by matching a
                   resource with an API version equal to spec.target.location.apiVersion, a
                   kind equal to spec.target.location.kind, w/ the label
                   "imageregistry.vmware.com/default".
-
 
                   Please note that while optional, if a VirtualMachinePublishRequest sans
                   target information is applied to a namespace without a default
@@ -460,7 +436,6 @@ spec:
                     description: |-
                       Item contains information about the name of the object to which
                       the VM is published.
-
 
                       Please note this value is optional and if omitted, the controller
                       will use spec.source.name + "-image" as the name of the published
@@ -474,13 +449,11 @@ spec:
                         description: |-
                           Name is the name of the published object.
 
-
                           If the spec.target.location.apiVersion equals
                           imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
                           equals ContentLibrary, then this should be the name that will
                           show up in vCenter Content Library, not the custom resource name
                           in the namespace.
-
 
                           If omitted then the controller will use spec.source.name + "-image".
                         type: string
@@ -503,10 +476,8 @@ spec:
                         description: |-
                           Name is the name of the referenced object.
 
-
                           Please note an error will be returned if this field is not
                           set in a namespace that lacks a default publication target.
-
 
                           A default publication target is a resource with an API version
                           equal to spec.target.location.apiVersion, a kind equal to
@@ -521,7 +492,6 @@ spec:
                   resource will be allowed to exist once the publication operation
                   completes. After the TTL expires, the resource will be automatically
                   deleted without the user having to take any direct action.
-
 
                   If this field is unset then the request resource will not be
                   automatically deleted. If this field is set to zero then the request
@@ -547,7 +517,6 @@ spec:
                   guaranteed to be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
 
-
                   The value of this field should be equal to the value of the
                   LastTransitionTime for the status condition Type=Complete.
                 format: date-time
@@ -557,16 +526,8 @@ spec:
                   Conditions is a list of the latest, available observations of the
                   request's current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -607,12 +568,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -630,7 +586,6 @@ spec:
                   eventually realized in the same namespace as the VM and publication
                   request after the publication operation completes.
 
-
                   This field will not be set until the VirtualMachineImage resource
                   is realized.
                 type: string
@@ -644,11 +599,9 @@ spec:
                   Ready is set to true only when the VM has been published successfully
                   and the new VirtualMachineImage resource is ready.
 
-
                   Readiness is determined by waiting until there is status condition
                   Type=Complete and ensuring it and all other status conditions present
                   have a Status=True. The conditions present will be:
-
 
                     * SourceValid
                     * TargetValid
@@ -673,6 +626,354 @@ spec:
                     description: |-
                       Name is the name of the referenced object.
 
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              startTime:
+                description: |-
+                  StartTime represents time when the request was acknowledged by the
+                  controller. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and is
+                  in UTC.
+                format: date-time
+                type: string
+              targetRef:
+                description: |-
+                  TargetRef is the reference to the target of the publication request,
+                  ex. item information and a ContentLibrary resource.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
+
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachinePublishRequest defines the information necessary to publish a
+          VirtualMachine as a VirtualMachineImage to an image registry.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachinePublishRequestSpec defines the desired state of a
+              VirtualMachinePublishRequest.
+
+              All the fields in this spec are optional. This is especially useful when a
+              DevOps persona wants to publish a VM without doing anything more than
+              applying a VirtualMachinePublishRequest resource that has the same name
+              as said VM in the same namespace as said VM.
+            properties:
+              source:
+                description: |-
+                  Source is the source of the publication request, ex. a VirtualMachine
+                  resource.
+
+                  If this value is omitted then the publication controller checks to
+                  see if there is a resource with the same name as this
+                  VirtualMachinePublishRequest resource, an API version equal to
+                  spec.source.apiVersion, and a kind equal to spec.source.kind. If such
+                  a resource exists, then it is the source of the publication.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
+
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              target:
+                description: |-
+                  Target is the target of the publication request, ex. item
+                  information and a ContentLibrary resource.
+
+                  If this value is omitted, the controller uses spec.source.name + "-image"
+                  as the name of the published item. Additionally, when omitted the
+                  controller attempts to identify the target location by matching a
+                  resource with an API version equal to spec.target.location.apiVersion, a
+                  kind equal to spec.target.location.kind, w/ the label
+                  "imageregistry.vmware.com/default".
+
+                  Please note that while optional, if a VirtualMachinePublishRequest sans
+                  target information is applied to a namespace without a default
+                  publication target, then the VirtualMachinePublishRequest resource
+                  will be marked in error.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
+
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished is the time-to-live duration for how long this
+                  resource will be allowed to exist once the publication operation
+                  completes. After the TTL expires, the resource will be automatically
+                  deleted without the user having to take any direct action.
+
+                  If this field is unset then the request resource will not be
+                  automatically deleted. If this field is set to zero then the request
+                  resource is eligible for deletion immediately after it finishes.
+                format: int64
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: |-
+              VirtualMachinePublishRequestStatus defines the observed state of a
+              VirtualMachinePublishRequest.
+            properties:
+              attempts:
+                description: |-
+                  Attempts represents the number of times the request to publish the VM
+                  has been attempted.
+                format: int64
+                type: integer
+              completionTime:
+                description: |-
+                  CompletionTime represents time when the request was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+
+                  The value of this field should be equal to the value of the
+                  LastTransitionTime for the status condition Type=Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions is a list of the latest, available observations of the
+                  request's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: |-
+                  ImageName is the name of the VirtualMachineImage resource that is
+                  eventually realized in the same namespace as the VM and publication
+                  request after the publication operation completes.
+
+                  This field will not be set until the VirtualMachineImage resource
+                  is realized.
+                type: string
+              lastAttemptTime:
+                description: LastAttemptTime represents the time when the latest request
+                  was sent.
+                format: date-time
+                type: string
+              ready:
+                description: |-
+                  Ready is set to true only when the VM has been published successfully
+                  and the new VirtualMachineImage resource is ready.
+
+                  Readiness is determined by waiting until there is status condition
+                  Type=Complete and ensuring it and all other status conditions present
+                  have a Status=True. The conditions present will be:
+
+                    * SourceValid
+                    * TargetValid
+                    * Uploaded
+                    * ImageAvailable
+                    * Complete
+                type: boolean
+              sourceRef:
+                description: |-
+                  SourceRef is the reference to the source of the publication request,
+                  ex. a VirtualMachine resource.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
 
                       If omitted this value defaults to the name of the
                       VirtualMachinePublishRequest resource.
@@ -696,7 +997,6 @@ spec:
                       Item contains information about the name of the object to which
                       the VM is published.
 
-
                       Please note this value is optional and if omitted, the controller
                       will use spec.source.name + "-image" as the name of the published
                       item.
@@ -709,13 +1009,11 @@ spec:
                         description: |-
                           Name is the name of the published object.
 
-
                           If the spec.target.location.apiVersion equals
                           imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
                           equals ContentLibrary, then this should be the name that will
                           show up in vCenter Content Library, not the custom resource name
                           in the namespace.
-
 
                           If omitted then the controller will use spec.source.name + "-image".
                         type: string
@@ -738,10 +1036,715 @@ spec:
                         description: |-
                           Name is the name of the referenced object.
 
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachinePublishRequest defines the information necessary to publish a
+          VirtualMachine as a VirtualMachineImage to an image registry.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachinePublishRequestSpec defines the desired state of a
+              VirtualMachinePublishRequest.
+
+              All the fields in this spec are optional. This is especially useful when a
+              DevOps persona wants to publish a VM without doing anything more than
+              applying a VirtualMachinePublishRequest resource that has the same name
+              as said VM in the same namespace as said VM.
+            properties:
+              source:
+                description: |-
+                  Source is the source of the publication request, ex. a VirtualMachine
+                  resource.
+
+                  If this value is omitted then the publication controller checks to
+                  see if there is a resource with the same name as this
+                  VirtualMachinePublishRequest resource, an API version equal to
+                  spec.source.apiVersion, and a kind equal to spec.source.kind. If such
+                  a resource exists, then it is the source of the publication.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
+
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              target:
+                description: |-
+                  Target is the target of the publication request, ex. item
+                  information and a ContentLibrary resource.
+
+                  If this value is omitted, the controller uses spec.source.name + "-image"
+                  as the name of the published item. Additionally, when omitted the
+                  controller attempts to identify the target location by matching a
+                  resource with an API version equal to spec.target.location.apiVersion, a
+                  kind equal to spec.target.location.kind, w/ the label
+                  "imageregistry.vmware.com/default".
+
+                  Please note that while optional, if a VirtualMachinePublishRequest sans
+                  target information is applied to a namespace without a default
+                  publication target, then the VirtualMachinePublishRequest resource
+                  will be marked in error.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
 
                           Please note an error will be returned if this field is not
                           set in a namespace that lacks a default publication target.
 
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished is the time-to-live duration for how long this
+                  resource will be allowed to exist once the publication operation
+                  completes. After the TTL expires, the resource will be automatically
+                  deleted without the user having to take any direct action.
+
+                  If this field is unset then the request resource will not be
+                  automatically deleted. If this field is set to zero then the request
+                  resource is eligible for deletion immediately after it finishes.
+                format: int64
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: |-
+              VirtualMachinePublishRequestStatus defines the observed state of a
+              VirtualMachinePublishRequest.
+            properties:
+              attempts:
+                description: |-
+                  Attempts represents the number of times the request to publish the VM
+                  has been attempted.
+                format: int64
+                type: integer
+              completionTime:
+                description: |-
+                  CompletionTime represents time when the request was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+
+                  The value of this field should be equal to the value of the
+                  LastTransitionTime for the status condition Type=Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions is a list of the latest, available observations of the
+                  request's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: |-
+                  ImageName is the name of the VirtualMachineImage resource that is
+                  eventually realized in the same namespace as the VM and publication
+                  request after the publication operation completes.
+
+                  This field will not be set until the VirtualMachineImage resource
+                  is realized.
+                type: string
+              lastAttemptTime:
+                description: LastAttemptTime represents the time when the latest request
+                  was sent.
+                format: date-time
+                type: string
+              ready:
+                description: |-
+                  Ready is set to true only when the VM has been published successfully
+                  and the new VirtualMachineImage resource is ready.
+
+                  Readiness is determined by waiting until there is status condition
+                  Type=Complete and ensuring it and all other status conditions present
+                  have a Status=True. The conditions present will be:
+
+                    * SourceValid
+                    * TargetValid
+                    * Uploaded
+                    * ImageAvailable
+                    * Complete
+                type: boolean
+              sourceRef:
+                description: |-
+                  SourceRef is the reference to the source of the publication request,
+                  ex. a VirtualMachine resource.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
+
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              startTime:
+                description: |-
+                  StartTime represents time when the request was acknowledged by the
+                  controller. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and is
+                  in UTC.
+                format: date-time
+                type: string
+              targetRef:
+                description: |-
+                  TargetRef is the reference to the target of the publication request,
+                  ex. item information and a ContentLibrary resource.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
+
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachinePublishRequest defines the information necessary to publish a
+          VirtualMachine as a VirtualMachineImage to an image registry.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachinePublishRequestSpec defines the desired state of a
+              VirtualMachinePublishRequest.
+
+              All the fields in this spec are optional. This is especially useful when a
+              DevOps persona wants to publish a VM without doing anything more than
+              applying a VirtualMachinePublishRequest resource that has the same name
+              as said VM in the same namespace as said VM.
+            properties:
+              backoffLimit:
+                default: 3
+                description: |-
+                  BackoffLimit is the number of status.attempts that should be allowed
+                  before failing the VirtualMachinePublishRequest and halting any
+                  future processing.
+                format: int64
+                minimum: 0
+                type: integer
+              source:
+                description: |-
+                  Source is the source of the publication request, ex. a VirtualMachine
+                  resource.
+
+                  If this value is omitted then the publication controller checks to
+                  see if there is a resource with the same name as this
+                  VirtualMachinePublishRequest resource, an API version equal to
+                  spec.source.apiVersion, and a kind equal to spec.source.kind. If such
+                  a resource exists, then it is the source of the publication.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
+
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              target:
+                description: |-
+                  Target is the target of the publication request, ex. item
+                  information and a ContentLibrary resource.
+
+                  If this value is omitted, the controller uses spec.source.name + "-image"
+                  as the name of the published item. Additionally, when omitted the
+                  controller attempts to identify the target location by matching a
+                  resource with an API version equal to spec.target.location.apiVersion, a
+                  kind equal to spec.target.location.kind, w/ the label
+                  "imageregistry.vmware.com/default".
+
+                  Please note that while optional, if a VirtualMachinePublishRequest sans
+                  target information is applied to a namespace without a default
+                  publication target, then the VirtualMachinePublishRequest resource
+                  will be marked in error.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
+
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
+
+                          A default publication target is a resource with an API version
+                          equal to spec.target.location.apiVersion, a kind equal to
+                          spec.target.location.kind, and has the label
+                          "imageregistry.vmware.com/default".
+                        type: string
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished is the time-to-live duration for how long this
+                  resource will be allowed to exist once the publication operation
+                  completes. After the TTL expires, the resource will be automatically
+                  deleted without the user having to take any direct action.
+
+                  If this field is unset then the request resource will not be
+                  automatically deleted. If this field is set to zero then the request
+                  resource is eligible for deletion immediately after it finishes.
+                format: int64
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: |-
+              VirtualMachinePublishRequestStatus defines the observed state of a
+              VirtualMachinePublishRequest.
+            properties:
+              attempts:
+                description: |-
+                  Attempts represents the number of times the request to publish the VM
+                  has been attempted.
+                format: int64
+                type: integer
+              completionTime:
+                description: |-
+                  CompletionTime represents time when the request was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+
+                  The value of this field should be equal to the value of the
+                  LastTransitionTime for the status condition Type=Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions is a list of the latest, available observations of the
+                  request's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageName:
+                description: |-
+                  ImageName is the name of the VirtualMachineImage resource that is
+                  eventually realized in the same namespace as the VM and publication
+                  request after the publication operation completes.
+
+                  This field will not be set until the VirtualMachineImage resource
+                  is realized.
+                type: string
+              lastAttemptTime:
+                description: LastAttemptTime represents the time when the latest request
+                  was sent.
+                format: date-time
+                type: string
+              ready:
+                description: |-
+                  Ready is set to true only when the VM has been published successfully
+                  and the new VirtualMachineImage resource is ready.
+
+                  Readiness is determined by waiting until there is status condition
+                  Type=Complete and ensuring it and all other status conditions present
+                  have a Status=True. The conditions present will be:
+
+                    * SourceValid
+                    * TargetValid
+                    * Uploaded
+                    * ImageAvailable
+                    * Complete
+                type: boolean
+              sourceRef:
+                description: |-
+                  SourceRef is the reference to the source of the publication request,
+                  ex. a VirtualMachine resource.
+                properties:
+                  apiVersion:
+                    default: vmoperator.vmware.com/v1alpha1
+                    description: APIVersion is the API version of the referenced object.
+                    type: string
+                  kind:
+                    default: VirtualMachine
+                    description: Kind is the kind of referenced object.
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the referenced object.
+
+                      If omitted this value defaults to the name of the
+                      VirtualMachinePublishRequest resource.
+                    type: string
+                type: object
+              startTime:
+                description: |-
+                  StartTime represents time when the request was acknowledged by the
+                  controller. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and is
+                  in UTC.
+                format: date-time
+                type: string
+              targetRef:
+                description: |-
+                  TargetRef is the reference to the target of the publication request,
+                  ex. item information and a ContentLibrary resource.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the name of the object to which
+                      the VM is published.
+
+                      Please note this value is optional and if omitted, the controller
+                      will use spec.source.name + "-image" as the name of the published
+                      item.
+                    properties:
+                      description:
+                        description: Description is the description to assign to the
+                          published object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the published object.
+
+                          If the spec.target.location.apiVersion equals
+                          imageregistry.vmware.com/v1alpha1 and the spec.target.location.kind
+                          equals ContentLibrary, then this should be the name that will
+                          show up in vCenter Content Library, not the custom resource name
+                          in the namespace.
+
+                          If omitted then the controller will use spec.source.name + "-image".
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Location contains information about the location to which to publish
+                      the VM.
+                    properties:
+                      apiVersion:
+                        default: imageregistry.vmware.com/v1alpha1
+                        description: APIVersion is the API version of the referenced
+                          object.
+                        type: string
+                      kind:
+                        default: ContentLibrary
+                        description: Kind is the kind of referenced object.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referenced object.
+
+                          Please note an error will be returned if this field is not
+                          set in a namespace that lacks a default publication target.
 
                           A default publication target is a resource with an API version
                           equal to spec.target.location.apiVersion, a kind equal to

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinereplicasets.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinereplicasets.yaml
@@ -1,0 +1,7701 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachinereplicasets.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineReplicaSet
+    listKind: VirtualMachineReplicaSetList
+    plural: virtualmachinereplicasets
+    shortNames:
+    - vmrs
+    - vmreplicaset
+    singular: virtualmachinereplicaset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated virtual machines targeted by this
+        VirtualMachineReplicaSet
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready virtual machines targeted by this VirtualMachineReplicaSet
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Time duration since creation of VirtualMachineReplicaSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1alpha3 VirtualMachineReplicaSet is deprecated; use v1alpha5
+      VirtualMachineReplicaSet
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
+
+          Deprecated: This type is deprecated and will be removed in a future release.
+          Please use v1alpha5.VirtualMachineReplicaSet instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineReplicaSetSpec is the specification of a VirtualMachineReplicaSet.
+            properties:
+              deletePolicy:
+                description: |-
+                  DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Only supported deletion policy is "Random".
+                enum:
+                - Random
+                type: string
+              replicas:
+                default: 1
+                description: |-
+                  Replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label to query over virtual machines that should match the
+                  replica count. A virtual machine's label keys and values must match in order
+                  to be controlled by this VirtualMachineReplicaSet.
+
+                  It must match the VirtualMachine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  Template is the object that describes the virtual machine that will be
+                  created if insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta contains the desired Labels and Annotations that must be
+                      applied to each replica virtual machine.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: Specification of the desired behavior of each replica
+                      virtual machine.
+                    properties:
+                      advanced:
+                        description: Advanced describes a set of optional, advanced
+                          VM configuration options.
+                        properties:
+                          bootDiskCapacity:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                              from the VirtualMachineImage from which the VM was deployed.
+
+                              Please note it is not advised to change this value while the VM is
+                              running. Also, resizing the VM's boot disk may require actions inside of
+                              the guest to take advantage of the additional capacity. Finally, changing
+                              the size of the VM's boot disk, even increasing it, could adversely
+                              affect the VM.
+
+                              Please note this field is ignored if the VM is deployed from an ISO with
+                              CD-ROM devices attached.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          changeBlockTracking:
+                            description: |-
+                              ChangeBlockTracking is a flag that enables incremental backup support
+                              for this VM, a feature utilized by external backup systems such as
+                              VMware Data Recovery.
+                            type: boolean
+                          defaultVolumeProvisioningMode:
+                            description: |-
+                              DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                              persistent volumes managed by this VM.
+                            enum:
+                            - Thin
+                            - Thick
+                            - ThickEagerZero
+                            type: string
+                        type: object
+                      affinity:
+                        description: Affinity describes the VM's scheduling constraints.
+                        properties:
+                          vmAffinity:
+                            description: VMAffinity describes affinity scheduling
+                              rules related to other VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the affinity expressions specified by this
+                                  field, but it may choose to violate one or more of the expressions.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          vmAntiAffinity:
+                            description: |-
+                              VMAntiAffinity describes anti-affinity scheduling rules related to other
+                              VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the anti-affinity expressions specified by
+                                  this field, but it may choose to violate one or more of the expressions.
+                                  Additionally, it also describes the anti-affinity requirements that
+                                  should be met during run-time, but the VM can still be run if the
+                                  requirements cannot be satisfied.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      biosUUID:
+                        description: |-
+                          BiosUUID describes the desired BIOS UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          When the bootstrap provider is Cloud-Init, this value is used as the
+                          default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                        format: uuid
+                        type: string
+                      bootstrap:
+                        description: |-
+                          Bootstrap describes the desired state of the guest's bootstrap
+                          configuration.
+
+                          If omitted, a default bootstrap method may be selected based on the
+                          guest OS identifier. If Linux, then the LinuxPrep method is used.
+                        properties:
+                          cloudInit:
+                            description: |-
+                              CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                              Windows guests that support Cloudbase-Init.
+
+                              The guest's networking stack is configured by Cloud-Init on Linux guests
+                              and Cloudbase-Init on Windows guests.
+
+                              Please note this bootstrap provider may not be used in conjunction with
+                              the other bootstrap providers.
+                            properties:
+                              cloudConfig:
+                                description: |-
+                                  CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                                  bootstrap the VM.
+
+                                  Please note this field and RawCloudConfig are mutually exclusive.
+                                properties:
+                                  defaultUserEnabled:
+                                    description: |-
+                                      DefaultUserEnabled may be set to true to ensure even if the Users field
+                                      is not empty, the default user is still created on systems that have one
+                                      defined. By default, Cloud-Init ignores the default user if the
+                                      CloudConfig provides one or more non-default users via the Users field.
+                                    type: boolean
+                                  runcmd:
+                                    description: |-
+                                      RunCmd allows running one or more commands on the guest.
+                                      The entries in this list can adhere to two, different formats:
+
+                                      Format 1 -- a string that contains the command and its arguments, ex.
+
+                                          runcmd:
+                                          - "ls -al"
+
+                                      Format 2 -- a list of the command and its arguments, ex.
+
+                                          runcmd:
+                                          - - echo
+                                            - "Hello, world."
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  ssh_pwauth:
+                                    description: |-
+                                      SSHPwdAuth sets whether or not to accept password authentication.
+                                      In order for this config to be applied, SSH may need to be restarted.
+                                      On systemd systems, this restart will only happen if the SSH service has
+                                      already been started. On non-systemd systems, a restart will be attempted
+                                      regardless of the service state.
+                                    type: boolean
+                                  timezone:
+                                    description: Timezone describes the timezone represented
+                                      in /usr/share/zoneinfo.
+                                    type: string
+                                  users:
+                                    description: Users allows adding/configuring one
+                                      or more users on the guest.
+                                    items:
+                                      description: User is a CloudConfig user data
+                                        structure.
+                                      properties:
+                                        create_groups:
+                                          description: |-
+                                            CreateGroups is a flag that may be set to false to disable creation of
+                                            specified user groups.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        expiredate:
+                                          description: ExpireData is the date on which
+                                            the user's account will be disabled.
+                                          type: string
+                                        gecos:
+                                          description: |-
+                                            Gecos is an optional comment about the user, usually a comma-separated
+                                            string of the user's real name and contact information.
+                                          type: string
+                                        groups:
+                                          description: Groups is an optional list
+                                            of groups to add to the user.
+                                          items:
+                                            type: string
+                                          type: array
+                                        hashed_passwd:
+                                          description: |-
+                                            HashedPasswd is a hash of the user's password that will be applied even
+                                            if the specified user already exists.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        homedir:
+                                          description: |-
+                                            Homedir is the optional home directory for the user.
+
+                                            Defaults to "/home/<username>" when Name is not "default".
+                                          type: string
+                                        inactive:
+                                          description: |-
+                                            Inactive optionally represents the number of days until the user is
+                                            disabled.
+                                          format: int32
+                                          type: integer
+                                        lock_passwd:
+                                          description: |-
+                                            LockPasswd disables password login.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        name:
+                                          description: |-
+                                            Name is the user's login name.
+
+                                            Please note this field may be set to the special value of "default" when
+                                            this User is the first element in the Users list from the CloudConfig.
+                                            When set to "default", all other fields from this User must be nil.
+                                          type: string
+                                        no_create_home:
+                                          description: |-
+                                            NoCreateHome prevents the creation of the home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_log_init:
+                                          description: |-
+                                            NoLogInit prevents the initialization of lastlog and faillog for the
+                                            user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_user_group:
+                                          description: |-
+                                            NoUserGroup prevents the creation of the group named after the user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        passwd:
+                                          description: |-
+                                            Passwd is a hash of the user's password that will be applied only to
+                                            a newly created user. To apply a new, hashed password to an existing user
+                                            please use HashedPasswd instead.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        primary_group:
+                                          description: |-
+                                            PrimaryGroup is the primary group for the user.
+
+                                            Defaults to the value of the Name field when it is not "default".
+                                          type: string
+                                        selinux_user:
+                                          description: SELinuxUser is the SELinux
+                                            user for the user's login.
+                                          type: string
+                                        shell:
+                                          description: |-
+                                            Shell is the path to the user's login shell.
+
+                                            Please note the default is to set no shell, which results in a
+                                            system-specific default being used.
+                                          type: string
+                                        snapuser:
+                                          description: |-
+                                            SnapUser specifies an e-mail address to create the user as a Snappy user
+                                            through "snap create-user".
+
+                                            If an Ubuntu SSO account is associated with the address, the username and
+                                            SSH keys will be requested from there.
+                                          type: string
+                                        ssh_authorized_keys:
+                                          description: |-
+                                            SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                            keys file.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_import_id:
+                                          description: |-
+                                            SSHImportID is a list of SSH IDs to import for the user.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_redirect_user:
+                                          description: |-
+                                            SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                            Please note that when specified, all SSH keys from cloud meta-data will
+                                            be configured in a disabled state for this user. Any SSH login as this
+                                            user will timeout with a message to login instead as the default user.
+
+                                            This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        sudo:
+                                          description: |-
+                                            Sudo is a sudo rule to apply to the user.
+
+                                            When omitted, no sudo rules will be applied to the user.
+                                          type: string
+                                        system:
+                                          description: |-
+                                            System is an optional flag that indicates the user should be created as
+                                            a system user with no home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        uid:
+                                          description: |-
+                                            UID is the user's ID.
+
+                                            When omitted the guest will default to the next available number.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  write_files:
+                                    description: WriteFiles allows adding files to
+                                      the guest file system.
+                                    items:
+                                      description: WriteFile is a CloudConfig write_file
+                                        data structure.
+                                      properties:
+                                        append:
+                                          description: |-
+                                            Append specifies whether or not to append the content to an existing file
+                                            if the file specified by Path already exists.
+                                          type: boolean
+                                        content:
+                                          description: |-
+                                            Content is the optional content to write to the provided Path.
+
+                                            When omitted an empty file will be created or existing file will be
+                                            modified.
+
+                                            The value for this field can adhere to two, different formats:
+
+                                            Format 1 -- a string that contains the command and its arguments, ex.
+
+                                                content: Hello, world.
+
+                                            Please note that format 1 supports all of the manners of specifying a
+                                            YAML string.
+
+                                            Format 2 -- a secret reference with the name of the key that contains
+                                                        the content for the file, ex.
+
+                                                content:
+                                                  name: my-bootstrap-secret
+                                                  key: my-file-content
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        defer:
+                                          description: |-
+                                            Defer indicates to defer writing the file until Cloud-Init's "final"
+                                            stage, after users are created and packages are installed.
+                                          type: boolean
+                                        encoding:
+                                          default: text/plain
+                                          description: Encoding is an optional encoding
+                                            type of the content.
+                                          enum:
+                                          - b64
+                                          - base64
+                                          - gz
+                                          - gzip
+                                          - gz+b64
+                                          - gz+base64
+                                          - gzip+b64
+                                          - gzip+base64
+                                          - text/plain
+                                          type: string
+                                        owner:
+                                          default: root:root
+                                          description: Owner is an optional "owner:group"
+                                            to chown the file.
+                                          type: string
+                                        path:
+                                          description: Path is the path of the file
+                                            to which the content is decoded and written.
+                                          type: string
+                                        permissions:
+                                          default: "0644"
+                                          description: |-
+                                            Permissions an optional set of file permissions to set.
+
+                                            Please note the permissions should be specified as an octal string, ex.
+                                            "0###".
+
+                                            When omitted the guest will default this value to "0644".
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - path
+                                    x-kubernetes-list-type: map
+                                type: object
+                              instanceID:
+                                description: |-
+                                  InstanceID is the cloud-init metadata instance ID.
+                                  If omitted, this field defaults to the VM's BiosUUID.
+                                type: string
+                              rawCloudConfig:
+                                description: |-
+                                  RawCloudConfig describes a key in a Secret resource that contains the
+                                  CloudConfig data used to bootstrap the VM.
+
+                                  The CloudConfig data specified by the key may be plain-text,
+                                  base64-encoded, or gzipped and base64-encoded.
+
+                                  Please note this field and CloudConfig are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sshAuthorizedKeys:
+                                description: |-
+                                  SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                                  the guest's default user.
+                                items:
+                                  type: string
+                                type: array
+                              useGlobalNameserversAsDefault:
+                                description: |-
+                                  UseGlobalNameserversAsDefault will use the global nameservers specified in
+                                  the NetworkSpec as the per-interface nameservers when the per-interface
+                                  nameservers is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                              useGlobalSearchDomainsAsDefault:
+                                description: |-
+                                  UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                                  in the NetworkSpec as the per-interface search domains when the per-interface
+                                  search domains is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                            type: object
+                          linuxPrep:
+                            description: |-
+                              LinuxPrep may be used to bootstrap Linux guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or Sysprep bootstrap providers.
+                            properties:
+                              hardwareClockIsUTC:
+                                description: |-
+                                  HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                                  local time.
+                                type: boolean
+                              timeZone:
+                                description: |-
+                                  TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                                  Valid values are based on the tz (timezone) database used by Linux and
+                                  other Unix systems. The values are strings in the form of
+                                  "Area/Location," in which Area is a continent or ocean name, and
+                                  Location is the city, island, or other regional designation.
+
+                                  Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                                  time zones for Linux systems.
+                                type: string
+                            type: object
+                          sysprep:
+                            description: |-
+                              Sysprep may be used to bootstrap Windows guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or LinuxPrep bootstrap providers.
+                            properties:
+                              rawSysprep:
+                                description: |-
+                                  RawSysprep describes a key in a Secret resource that contains an XML
+                                  string of the Sysprep text used to bootstrap the VM.
+
+                                  The data specified by the Secret key may be plain-text, base64-encoded,
+                                  or gzipped and base64-encoded.
+
+                                  Please note this field and Sysprep are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sysprep:
+                                description: |-
+                                  Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                                  This field encloses all the individual keys listed in a sysprep.xml file.
+
+                                  For more detailed information please see
+                                  https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                                  Please note this field and RawSysprep are mutually exclusive.
+                                properties:
+                                  guiRunOnce:
+                                    description: GUIRunOnce is a representation of
+                                      the Sysprep GuiRunOnce key.
+                                    properties:
+                                      commands:
+                                        description: |-
+                                          Commands is a list of commands to run at first user logon, after guest
+                                          customization.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  guiUnattended:
+                                    description: GUIUnattended is a representation
+                                      of the Sysprep GUIUnattended key.
+                                    properties:
+                                      autoLogon:
+                                        description: |-
+                                          AutoLogon determine whether the machine automatically logs on as
+                                          Administrator.
+
+                                          Please note if AutoLogon is true, then Password must be set or guest
+                                          customization will fail.
+                                        type: boolean
+                                      autoLogonCount:
+                                        description: |-
+                                          AutoLogonCount specifies the number of times the machine should
+                                          automatically log on as Administrator.
+
+                                          Generally it should be 1, but if your setup requires a number of reboots,
+                                          you may want to increase it. This number may be determined by the list of
+                                          commands executed by the GuiRunOnce command.
+
+                                          Please note this field must be specified with a non-zero positive integer
+                                          if AutoLogon is true.
+                                        format: int32
+                                        type: integer
+                                      password:
+                                        description: |-
+                                          Password is the new administrator password for the machine.
+
+                                          To specify that the password should be set to blank (that is, no
+                                          password), set the password value to NULL. Because of encryption, "" is
+                                          NOT a valid value.
+
+                                          Please note if the password is set to blank and AutoLogon is true, the
+                                          guest customization will fail.
+
+                                          If the XML file is generated by the VirtualCenter Customization Wizard,
+                                          then the password is encrypted. Otherwise, the client should set the
+                                          plainText attribute to true, so that the customization process does not
+                                          attempt to decrypt the string.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `password`.
+                                        properties:
+                                          key:
+                                            default: password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      timeZone:
+                                        default: 85
+                                        description: |-
+                                          TimeZone is the time zone index for the virtual machine.
+
+                                          Please note that numbers correspond to time zones listed at
+                                          https://bit.ly/3Rzv8oL.
+
+                                          Defaults to UTC.
+                                        format: int32
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - timeZone
+                                    type: object
+                                  identification:
+                                    description: Identification is a representation
+                                      of the Sysprep Identification key.
+                                    properties:
+                                      domainAdmin:
+                                        description: |-
+                                          DomainAdmin is the domain user account used for authentication if the
+                                          virtual machine is joining a domain. The user does not need to be a
+                                          domain administrator, but the account must have the privileges required
+                                          to add computers to the domain.
+                                        type: string
+                                      domainAdminPassword:
+                                        description: |-
+                                          DomainAdminPassword is the password for the domain user account used for
+                                          authentication if the virtual machine is joining a domain.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: domain_admin_password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      domainOU:
+                                        description: |-
+                                          DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                          the OU to which the computer belongs.
+                                        type: string
+                                      joinWorkgroup:
+                                        description: |-
+                                          JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                          this value is supplied, then the fields spec.network.domain,
+                                          spec.bootstrap.sysprep.identification.domainAdmin, and
+                                          spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                        type: string
+                                    type: object
+                                  licenseFilePrintData:
+                                    description: |-
+                                      LicenseFilePrintData is a representation of the Sysprep
+                                      LicenseFilePrintData key.
+
+                                      Please note this is required only for Windows 2000 Server and Windows
+                                      Server 2003.
+                                    properties:
+                                      autoMode:
+                                        description: AutoMode specifies the server
+                                          licensing mode.
+                                        enum:
+                                        - perSeat
+                                        - perServer
+                                        type: string
+                                      autoUsers:
+                                        description: |-
+                                          AutoUsers indicates the number of client licenses purchased for the
+                                          VirtualCenter server being installed.
+
+                                          Please note this value is ignored unless AutoMode is PerServer.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - autoMode
+                                    type: object
+                                  userData:
+                                    description: UserData is a representation of the
+                                      Sysprep UserData key.
+                                    properties:
+                                      fullName:
+                                        description: FullName is the user's full name.
+                                        type: string
+                                      orgName:
+                                        description: OrgName is the name of the user's
+                                          organization.
+                                        type: string
+                                      productID:
+                                        description: |-
+                                          ProductID is a valid serial number.
+
+                                          Please note unless the VirtualMachineImage was installed with a volume
+                                          license key, ProductID must be set or guest customization will fail.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: product_id
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                    required:
+                                    - fullName
+                                    - orgName
+                                    type: object
+                                required:
+                                - userData
+                                type: object
+                            type: object
+                          vAppConfig:
+                            description: |-
+                              VAppConfig may be used to bootstrap guests that rely on vApp properties
+                              (how VMware surfaces OVF properties on guests) to transport data into the
+                              guest.
+
+                              The guest's networking stack may be configured using either vApp
+                              properties or GOSC.
+
+                              Many OVFs define one or more properties that are used by the guest to
+                              bootstrap its networking stack. If the VirtualMachineImage defines one or
+                              more properties like this, then they can be configured to use the network
+                              data provided for this VM at runtime by setting these properties to Go
+                              template strings.
+
+                              It is also possible to use GOSC to bootstrap this VM's network stack by
+                              configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                              Please note the VAppConfig bootstrap provider in conjunction with the
+                              LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                              VM metadata transport to "OvfEnv".
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              bootstrap provider.
+                            properties:
+                              properties:
+                                description: |-
+                                  Properties is a list of vApp/OVF property key/value pairs.
+
+                                  Please note this field and RawProperties are mutually exclusive.
+                                items:
+                                  description: |-
+                                    KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                                    list of key/value pairs where each value could also reference data stored in
+                                    a Secret resource.
+                                  properties:
+                                    key:
+                                      description: Key is the key part of the key/value
+                                        pair.
+                                      type: string
+                                    value:
+                                      description: Value is the optional value part
+                                        of the key/value pair.
+                                      properties:
+                                        from:
+                                          description: |-
+                                            From is specified to reference a value from a Secret resource.
+
+                                            Please note this field is mutually exclusive with the Value field.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        value:
+                                          description: |-
+                                            Value is used to directly specify a value.
+
+                                            Please note this field is mutually exclusive with the From field.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - key
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              rawProperties:
+                                description: |-
+                                  RawProperties is the name of a Secret resource in the same Namespace as
+                                  this VM where each key/value pair from the Secret is used as a vApp
+                                  key/value pair.
+
+                                  Please note this field and Properties are mutually exclusive.
+                                type: string
+                            type: object
+                        type: object
+                      cdrom:
+                        description: |-
+                          Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                          Each CD-ROM device requires a reference to an ISO-type
+                          VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                          Multiple CD-ROM devices using the same backing image, regardless of image
+                          kinds (namespace or cluster scope), are not allowed.
+
+                          CD-ROM devices can be added, updated, or removed when the VM is powered
+                          off. When the VM is powered on, only the connection state of existing
+                          CD-ROM devices can be changed.
+                          CD-ROM devices are attached to the VM in the specified list-order.
+                        items:
+                          description: VirtualMachineCdromSpec describes the desired
+                            state of a CD-ROM device.
+                          properties:
+                            allowGuestControl:
+                              default: true
+                              description: |-
+                                AllowGuestControl describes whether or not a web console connection
+                                may be used to connect/disconnect the CD-ROM device.
+
+                                Defaults to true if omitted.
+                              type: boolean
+                            connected:
+                              default: true
+                              description: |-
+                                Connected describes the desired connection state of the CD-ROM device.
+
+                                When true, the CD-ROM device is added and connected to the VM.
+                                If the device already exists, it is updated to a connected state.
+
+                                When explicitly set to false, the CD-ROM device is added but remains
+                                disconnected from the VM. If the CD-ROM device already exists, it is
+                                updated to a disconnected state.
+
+                                Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                                in the guest OS. Refer to the following KB article for more details:
+                                https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                                Defaults to true if omitted.
+                              type: boolean
+                            image:
+                              description: |-
+                                Image describes the reference to an ISO type VirtualMachineImage or
+                                ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                                If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                                This field is immutable when the VM is powered on.
+
+                                Please note, unlike the spec.imageName field, the value of this
+                                spec.cdrom.image.name MUST be a Kubernetes object name.
+                              properties:
+                                kind:
+                                  description: |-
+                                    Kind describes the type of image, either a namespace-scoped
+                                    VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name refers to the name of a VirtualMachineImage resource in the same
+                                    namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            name:
+                              description: |-
+                                Name consists of at least two lowercase letters or digits of this CD-ROM.
+                                It must be unique among all CD-ROM devices attached to the VM.
+
+                                This field is immutable when the VM is powered on.
+                              pattern: ^[a-z0-9]{2,}$
+                              type: string
+                          required:
+                          - image
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      className:
+                        description: |-
+                          ClassName describes the name of the VirtualMachineClass resource used to
+                          deploy this VM.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM class.
+                        type: string
+                      crypto:
+                        description: Crypto describes the desired encryption state
+                          of the VirtualMachine.
+                        properties:
+                          encryptionClassName:
+                            description: |-
+                              EncryptionClassName describes the name of the EncryptionClass resource
+                              used to encrypt this VM.
+
+                              Please note, this field is not required to encrypt the VM. If the
+                              underlying platform has a default key provider, the VM may still be fully
+                              or partially encrypted depending on the specified storage and VM classes.
+
+                              If there is a default key provider and an encryption storage class is
+                              selected, the files in the VM's home directory and non-PVC virtual disks
+                              will be encrypted
+
+                              If there is a default key provider and a VM Class with a virtual, trusted
+                              platform module (vTPM) is selected, the files in the VM's home directory,
+                              minus any virtual disks, will be encrypted.
+
+                              If the underlying vSphere platform does not have a default key provider,
+                              then this field is required when specifying an encryption storage class
+                              and/or a VM Class with a vTPM.
+
+                              If this field is set, spec.storageClass must use an encryption-enabled
+                              storage class.
+                            type: string
+                          useDefaultKeyProvider:
+                            default: true
+                            description: |-
+                              UseDefaultKeyProvider describes the desired behavior for when an explicit
+                              EncryptionClass is not provided.
+
+                              When an explicit EncryptionClass is not provided and this value is true:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will be encrypted using the default key provider.
+
+                              - If a VirtualMachine is not encrypted, uses an encryption storage
+                                policy or has a virtual, trusted platform module (vTPM), there is a
+                                default key provider, the VM will be encrypted using the default key
+                                provider.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be rekeyed using the default key provider.
+
+                              When an explicit EncryptionClass is not provided and this value is false:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will fail.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be not be rekeyed.
+
+                                Please note, this could result in a VirtualMachine that cannot be
+                                powered on since it is encrypted using a provider or key that may have
+                                been removed. Without the key, the VM cannot be decrypted and thus
+                                cannot be powered on.
+
+                              Defaults to true if omitted.
+                            type: boolean
+                        type: object
+                      groupName:
+                        description: |-
+                          GroupName indicates the name of the VirtualMachineGroup to which this
+                          VM belongs.
+
+                          VMs that belong to a group do not drive their own placement, rather that
+                          is handled by the group.
+
+                          When this field is set to a valid group that contains this VM as a
+                          member, an owner reference to that group is added to this VM.
+
+                          When this field is deleted or changed, any existing owner reference to
+                          the previous group will be removed from this VM.
+                        type: string
+                      guestID:
+                        description: |-
+                          GuestID describes the desired guest operating system identifier for a VM.
+
+                          The logic that determines the guest ID is as follows:
+
+                          If this field is set, then its value is used.
+                          Otherwise, if the VM is deployed from an OVF template that defines a
+                          guest ID, then that value is used.
+                          The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                          For a complete list of supported values, please refer to
+                          https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                          Please note that some guest ID values may require a minimal hardware
+                          version, which can be set using the `spec.minHardwareVersion` field.
+                          To see the mapping between virtual hardware versions and the product
+                          versions that support a specific guest ID, please refer to
+                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                          Please note that this field is immutable after the VM is powered on.
+                          To change the guest ID after the VM is powered on, the VM must be powered
+                          off and then powered on again with the updated guest ID spec.
+
+                          This field is required when the VM has any CD-ROM devices attached.
+                        type: string
+                      image:
+                        description: |-
+                          Image describes the reference to the VirtualMachineImage or
+                          ClusterVirtualMachineImage resource used to deploy this VM.
+
+                          Please note, unlike the field spec.imageName, the value of
+                          spec.image.name MUST be a Kubernetes object name.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.imageName are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind describes the type of image, either a namespace-scoped
+                              VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                          name:
+                            description: |-
+                              Name refers to the name of a VirtualMachineImage resource in the same
+                              namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      imageName:
+                        description: |-
+                          ImageName describes the name of the image resource used to deploy this
+                          VM.
+
+                          This field may be used to specify the name of a VirtualMachineImage
+                          or ClusterVirtualMachineImage resource. The resolver first checks to see
+                          if there is a VirtualMachineImage with the specified name in the
+                          same namespace as the VM being deployed. If no such resource exists, the
+                          resolver then checks to see if there is a ClusterVirtualMachineImage
+                          resource with the specified name.
+
+                          This field may also be used to specify the display name (vSphere name) of
+                          a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                          display name unambiguously resolves to a distinct VM image (among all
+                          existing VirtualMachineImages in the VM's namespace and all existing
+                          ClusterVirtualMachineImages), then a mutation webhook updates the
+                          spec.image field with the reference to the resolved VM image. If the
+                          display name resolves to multiple or no VM images, then the mutation
+                          webhook denies the request and returns an error.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.image are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        type: string
+                      instanceUUID:
+                        description: |-
+                          InstanceUUID describes the desired Instance UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          This value is only used for the VM Instance UUID,
+                          it is not used within cloudInit.
+                          This identifier is used by VirtualCenter to uniquely identify all
+                          virtual machine instances, including those that may share the same BIOS UUID.
+                        format: uuid
+                        type: string
+                      minHardwareVersion:
+                        description: |-
+                          MinHardwareVersion describes the desired, minimum hardware version.
+
+                          The logic that determines the hardware version is as follows:
+
+                          1. If this field is set, then its value is used.
+                          2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                             non-empty hardware version, then it is used.
+                          3. Finally, if the hardware version is still undetermined, the value is
+                             set to the default hardware version for the Datacenter/Cluster/Host
+                             where the VM is provisioned.
+
+                          This field is never updated to reflect the derived hardware version.
+                          Instead, VirtualMachineStatus.HardwareVersion surfaces
+                          the observed hardware version.
+
+                          Please note, setting this field's value to N ensures a VM's hardware
+                          version is equal to or greater than N. For example, if a VM's observed
+                          hardware version is 10 and this field's value is 13, then the VM will be
+                          upgraded to hardware version 13. However, if the observed hardware
+                          version is 17 and this field's value is 13, no change will occur.
+
+                          Several features are hardware version dependent, for example:
+
+                          * NVMe Controllers                >= 14
+                          * Dynamic Direct Path I/O devices >= 17
+
+                          Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                          hardware versions.
+
+                          It is important to remember that a VM's hardware version may not be
+                          downgraded and upgrading a VM deployed from an image based on an older
+                          hardware version to a more recent one may result in unpredictable
+                          behavior. In other words, please be careful when choosing to upgrade a
+                          VM to a newer hardware version.
+                        format: int32
+                        minimum: 13
+                        type: integer
+                      network:
+                        description: |-
+                          Network describes the desired network configuration for the VM.
+
+                          Please note this value may be omitted entirely and the VM will be
+                          assigned a single, virtual network interface that is connected to the
+                          Namespace's default network.
+                        properties:
+                          disabled:
+                            description: |-
+                              Disabled is a flag that indicates whether or not to disable networking
+                              for this VM.
+
+                              When set to true, the VM is not configured with a default interface nor
+                              any specified from the Interfaces field.
+                            type: boolean
+                          domainName:
+                            description: |-
+                              DomainName describes the value the guest uses as its domain name.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS names:
+
+                                * When joined with the host name, the total length is restricted to 255
+                                  characters or less.
+                                * Individual segments must be 63 characters or less.
+                                * The top-level domain( ex. ".com"), is at least two letters with no
+                                  special characters.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Long, top-level domain names (ex. ".london") are permitted.
+                                * Symbol unicode points, such as emoji, are disallowed in the top-level
+                                  domain.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+
+                              When deploying a guest running Microsoft Windows, this field describes
+                              the domain the computer should join.
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName describes the value the guest uses as its host name. If omitted,
+                              the name of the VM will be used.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS labels:
+
+                                * The total length is restricted to 63 characters or less.
+                                * The total length is restricted to 15 characters or less on Windows
+                                  systems.
+                                * The value may begin with a digit per RFC-1123.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                                  please note that the use of emoji, even where allowed, may not
+                                  compatible with the guest operating system, so it recommended to
+                                  stick with more common characters for this value.
+                                * The value may be a valid IP4 or IP6 address. Please note, the use of
+                                  an IP address for a host name is not compatible with all guest
+                                  operating systems and is discouraged. Additionally, using an IP
+                                  address for the host name is disallowed if spec.network.domainName is
+                                  non-empty.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+                            type: string
+                          interfaces:
+                            description: |-
+                              Interfaces is the list of network interfaces used by this VM.
+
+                              If the Interfaces field is empty and the Disabled field is false, then
+                              a default interface with the name eth0 will be created.
+
+                              The maximum number of network interface allowed is 10 because a vSphere
+                              virtual machine may not have more than 10 virtual ethernet card devices.
+                            items:
+                              description: |-
+                                VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                                network interface.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                                    interface.
+
+                                    Please note this field is only supported if the connected network
+                                    supports manual IP allocation.
+
+                                    Please note IP4 and IP6 addresses must include the network prefix length,
+                                    ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                                    Please note this field may not contain IP4 addresses if DHCP4 is set
+                                    to true or IP6 addresses if DHCP6 is set to true.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 indicates whether or not this interface uses DHCP for IP4
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP4 addresses in the
+                                    Addresses field and the Gateway4 field.
+                                  type: boolean
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 indicates whether or not this interface uses DHCP for IP6
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP6 addresses in the
+                                    Addresses field and the Gateway6 field.
+                                  type: boolean
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the default, IP4 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP4.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 is the primary IP6 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP6.
+                                  type: string
+                                guestDeviceName:
+                                  description: |-
+                                    GuestDeviceName is used to rename the device inside the guest when the
+                                    bootstrap provider is Cloud-Init. Please note it is up to the user to
+                                    ensure the provided device name does not conflict with any other devices
+                                    inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^\w\w+$
+                                  type: string
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the optional MAC address of this interface.
+
+                                    If no MAC address is provided, one will be generated by either the network
+                                    provider or vCenter.
+
+                                    Please note this field is only supported when the Network API Group is
+                                    crd.nsx.vmware.com.
+                                  pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                                  type: string
+                                mtu:
+                                  description: |-
+                                    MTU is the Maximum Transmission Unit size in bytes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  format: int64
+                                  type: integer
+                                name:
+                                  description: |-
+                                    Name describes the unique name of this network interface, used to
+                                    distinguish it from other network interfaces attached to this VM.
+
+                                    When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                                    specified, the device inside the guest will be renamed to this value.
+                                    Please note it is up to the user to ensure the provided name does not
+                                    conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^[a-z0-9]{2,}$
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                                    nameservers.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit and Sysprep.
+
+                                    When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                                    true, if nameservers is not provided, the global nameservers will be used
+                                    instead.
+
+                                    Please note that Linux allows only three nameservers
+                                    (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                network:
+                                  description: |-
+                                    Network is the name of the network resource to which this interface is
+                                    connected.
+
+                                    If no network is provided, then this interface will be connected to the
+                                    Namespace's default network.
+                                  properties:
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion defines the versioned schema of this representation of an object.
+                                        Servers should convert recognized schemas to the latest internal value, and
+                                        may reject unrecognized values.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind is a string value representing the REST resource this object represents.
+                                        Servers may infer this from the endpoint the client submits requests to.
+                                        Cannot be updated.
+                                        In CamelCase.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name refers to a unique resource in the current namespace.
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                routes:
+                                  description: |-
+                                    Routes is a list of optional, static routes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  items:
+                                    description: VirtualMachineNetworkRouteSpec defines
+                                      a static route for a guest.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        minimum: 1
+                                        type: integer
+                                      to:
+                                        description: To is either "default", or an
+                                          IP4 or IP6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IP4 or IP6 address.
+                                        type: string
+                                    required:
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+
+                                    When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                                    or true, if search domains is not provided, the global search domains
+                                    will be used instead.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                              nameservers. These are applied globally.
+
+                              Please note global nameservers are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface nameservers. However, when Cloud-Init
+                              is used and UseGlobalNameserversAsDefault is true, the global
+                              nameservers will be used when the per-interface nameservers is not
+                              provided.
+
+                              Please note that Linux allows only three nameservers
+                              (https://linux.die.net/man/5/resolv.conf).
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of search domains used when resolving IP
+                              addresses with DNS. These are applied globally.
+
+                              Please note global search domains are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface search domains. However, when Cloud-Init
+                              is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                              domains will be used when the per-interface search domains is not provided.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      nextRestartTime:
+                        description: |-
+                          NextRestartTime may be used to restart the VM, in accordance with
+                          RestartMode, by setting the value of this field to "now"
+                          (case-insensitive).
+
+                          A mutating webhook changes this value to the current time (UTC), which
+                          the VM controller then uses to determine the VM should be restarted by
+                          comparing the value to the timestamp of the last time the VM was
+                          restarted.
+
+                          Please note it is not possible to schedule future restarts using this
+                          field. The only value that users may set is the string "now"
+                          (case-insensitive).
+                        type: string
+                      powerOffMode:
+                        default: TrySoft
+                        description: |-
+                          PowerOffMode describes the desired behavior when powering off a VM.
+
+                          There are three, supported power off modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is the equivalent of a physical
+                          system's power cord being ripped from the wall. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                          a graceful shutdown, and if that fails or the VM is not in a powered off
+                          state after five minutes, the VM is halted.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      powerState:
+                        description: |-
+                          PowerState describes the desired power state of a VirtualMachine.
+
+                          Please note this field may be omitted when creating a new VM and will
+                          default to "PoweredOn." However, once the field is set to a non-empty
+                          value, it may no longer be set to an empty value.
+
+                          Additionally, setting this value to "Suspended" is not supported when
+                          creating a new VM. The valid values when creating a new VM are
+                          "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                          since this value defaults to "PoweredOn" for new VMs.
+                        enum:
+                        - PoweredOff
+                        - PoweredOn
+                        - Suspended
+                        type: string
+                      readinessProbe:
+                        description: ReadinessProbe describes a probe used to determine
+                          the VM's ready state.
+                        properties:
+                          guestHeartbeat:
+                            description: GuestHeartbeat specifies an action involving
+                              the guest heartbeat status.
+                            properties:
+                              thresholdStatus:
+                                default: green
+                                description: |-
+                                  ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                                  considered successful.
+                                enum:
+                                - yellow
+                                - green
+                                type: string
+                            type: object
+                          guestInfo:
+                            description: |-
+                              GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                              The elements are evaluated with the logical AND operator, meaning
+                              all expressions must evaluate as true for the probe to succeed.
+
+                              For example, a VM resource's probe definition could be specified as the
+                              following:
+
+                                      guestInfo:
+                                      - key:   ready
+                                        value: true
+
+                              With the above configuration in place, the VM would not be considered
+                              ready until the GuestInfo key "ready" was set to the value "true".
+
+                              From within the guest operating system it is possible to set GuestInfo
+                              key/value pairs using the program "vmware-rpctool," which is included
+                              with VM Tools. For example, the following command will set the key
+                              "guestinfo.ready" to the value "true":
+
+                                      vmware-rpctool "info-set guestinfo.ready true"
+
+                              Once executed, the VM's readiness probe will be signaled and the
+                              VM resource will be marked as ready.
+                            items:
+                              description: |-
+                                GuestInfoAction describes a key from GuestInfo that must match the associated
+                                value expression.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key is the name of the GuestInfo key.
+
+                                    The key is automatically prefixed with "guestinfo." before being
+                                    evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                                    evaluated as "guestinfo.guestinfo.mykey".
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value is a regular expression that is matched against the value of the
+                                    specified key.
+
+                                    An empty value is the equivalent of "match any" or ".*".
+
+                                    All values must adhere to the RE2 regular expression syntax as documented
+                                    at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                                    ignored depending on the implementation of this API. Either way, invalid
+                                    values will not be considered when evaluating the ready state of a VM.
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                          periodSeconds:
+                            description: |-
+                              PeriodSeconds specifics how often (in seconds) to perform the probe.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          tcpSocket:
+                            description: |-
+                              TCPSocket specifies an action involving a TCP port.
+
+                              Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                              This field will be removed in a later API version.
+                            properties:
+                              host:
+                                description: Host is an optional host name to connect
+                                  to. Host defaults to the VM IP.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Port specifies a number or name of the port to access on the VM.
+                                  If the format of port is a number, it must be in the range 1 to 65535.
+                                  If the format of name is a string, it must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          timeoutSeconds:
+                            description: |-
+                              TimeoutSeconds specifies a number of seconds after which the probe times out.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            maximum: 60
+                            minimum: 1
+                            type: integer
+                        type: object
+                      reserved:
+                        description: |-
+                          Reserved describes a set of VM configuration options reserved for system
+                          use.
+
+                          Please note attempts to modify the value of this field by a DevOps user
+                          will result in a validation error.
+                        properties:
+                          resourcePolicyName:
+                            type: string
+                        type: object
+                      restartMode:
+                        default: TrySoft
+                        description: |-
+                          RestartMode describes the desired behavior for restarting a VM when
+                          spec.nextRestartTime is set to "now" (case-insensitive).
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                          interaction inside of the guest. The Soft mode requires the VM's guest to
+                          have VM Tools installed and asks the guest to restart the VM. Its
+                          variant, TrySoft, first attempts a soft restart, and if that fails or
+                          does not complete within five minutes, the VM is hard reset.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      storageClass:
+                        description: |-
+                          StorageClass describes the name of a Kubernetes StorageClass resource
+                          used to configure this VM's storage-related attributes.
+
+                          Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                          for more information on Kubernetes storage classes.
+                        type: string
+                      suspendMode:
+                        default: TrySoft
+                        description: |-
+                          SuspendMode describes the desired behavior when suspending a VM.
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                          disk without any interaction inside of the guest. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully suspend the VM. Its variant, TrySoft, first attempts
+                          a graceful suspend, and if that fails or the VM is not in a put into
+                          standby by the guest after five minutes, the VM is suspended.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      volumes:
+                        description: Volumes describes a list of volumes that can
+                          be mounted to the VM.
+                        items:
+                          description: VirtualMachineVolume represents a named volume
+                            in a VM.
+                          properties:
+                            name:
+                              description: |-
+                                Name represents the volume's name. Must be a DNS_LABEL and unique within
+                                the VM.
+                              type: string
+                            persistentVolumeClaim:
+                              description: |-
+                                PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                                in the same namespace.
+
+                                More information is available at
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                instanceVolumeClaim:
+                                  description: InstanceVolumeClaim is set if the PVC
+                                    is backed by instance storage.
+                                  properties:
+                                    size:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Size is the size of the requested
+                                        instance storage volume.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      description: |-
+                                        StorageClass is the name of the Kubernetes StorageClass that provides
+                                        the backing storage for this instance storage volume.
+                                      type: string
+                                  required:
+                                  - size
+                                  - storageClass
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineReplicaSetStatus represents the observed state of a
+              VirtualMachineReplicaSet resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represents the latest available observations of a
+                  VirtualMachineReplicaSet's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              fullyLabeledReplicas:
+                description: |-
+                  FullyLabeledReplicas is the number of replicas that have labels matching the
+                  labels of the virtual machine template of the VirtualMachineReplicaSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: |-
+                  ObservedGeneration reflects the generation of the most recently observed
+                  VirtualMachineReplicaSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is the number of ready replicas for this VirtualMachineReplicaSet. A
+                  virtual machine is considered ready when it's "Ready" condition is marked as
+                  true.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated virtual machines targeted by this
+        VirtualMachineReplicaSet
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready virtual machines targeted by this VirtualMachineReplicaSet
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Time duration since creation of VirtualMachineReplicaSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1alpha4 VirtualMachineReplicaSet is deprecated; use v1alpha5
+      VirtualMachineReplicaSet
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets API.
+
+          Deprecated: This type is deprecated and will be removed in a future release.
+          Please use v1alpha5.VirtualMachineReplicaSet instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineReplicaSetSpec is the specification of a VirtualMachineReplicaSet.
+            properties:
+              deletePolicy:
+                description: |-
+                  DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Only supported deletion policy is "Random".
+                enum:
+                - Random
+                type: string
+              replicas:
+                default: 1
+                description: |-
+                  Replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label to query over virtual machines that should match the
+                  replica count. A virtual machine's label keys and values must match in order
+                  to be controlled by this VirtualMachineReplicaSet.
+
+                  It must match the VirtualMachine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  Template is the object that describes the virtual machine that will be
+                  created if insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta contains the desired Labels and Annotations that must be
+                      applied to each replica virtual machine.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: Specification of the desired behavior of each replica
+                      virtual machine.
+                    properties:
+                      advanced:
+                        description: Advanced describes a set of optional, advanced
+                          VM configuration options.
+                        properties:
+                          bootDiskCapacity:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                              from the VirtualMachineImage from which the VM was deployed.
+
+                              Please note it is not advised to change this value while the VM is
+                              running. Also, resizing the VM's boot disk may require actions inside of
+                              the guest to take advantage of the additional capacity. Finally, changing
+                              the size of the VM's boot disk, even increasing it, could adversely
+                              affect the VM.
+
+                              Please note this field is ignored if the VM is deployed from an ISO with
+                              CD-ROM devices attached.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          changeBlockTracking:
+                            description: |-
+                              ChangeBlockTracking is a flag that enables incremental backup support
+                              for this VM, a feature utilized by external backup systems such as
+                              VMware Data Recovery.
+                            type: boolean
+                          defaultVolumeProvisioningMode:
+                            description: |-
+                              DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                              persistent volumes managed by this VM.
+                            enum:
+                            - Thin
+                            - Thick
+                            - ThickEagerZero
+                            type: string
+                        type: object
+                      affinity:
+                        description: Affinity describes the VM's scheduling constraints.
+                        properties:
+                          vmAffinity:
+                            description: VMAffinity describes affinity scheduling
+                              rules related to other VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the affinity expressions specified by this
+                                  field, but it may choose to violate one or more of the expressions.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          vmAntiAffinity:
+                            description: |-
+                              VMAntiAffinity describes anti-affinity scheduling rules related to other
+                              VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the anti-affinity expressions specified by
+                                  this field, but it may choose to violate one or more of the expressions.
+                                  Additionally, it also describes the anti-affinity requirements that
+                                  should be met during run-time, but the VM can still be run if the
+                                  requirements cannot be satisfied.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      biosUUID:
+                        description: |-
+                          BiosUUID describes the desired BIOS UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          When the bootstrap provider is Cloud-Init, this value is used as the
+                          default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                        format: uuid
+                        type: string
+                      bootstrap:
+                        description: |-
+                          Bootstrap describes the desired state of the guest's bootstrap
+                          configuration.
+
+                          If omitted, a default bootstrap method may be selected based on the
+                          guest OS identifier. If Linux, then the LinuxPrep method is used.
+                        properties:
+                          cloudInit:
+                            description: |-
+                              CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                              Windows guests that support Cloudbase-Init.
+
+                              The guest's networking stack is configured by Cloud-Init on Linux guests
+                              and Cloudbase-Init on Windows guests.
+
+                              Please note this bootstrap provider may not be used in conjunction with
+                              the other bootstrap providers.
+                            properties:
+                              cloudConfig:
+                                description: |-
+                                  CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                                  bootstrap the VM.
+
+                                  Please note this field and RawCloudConfig are mutually exclusive.
+                                properties:
+                                  defaultUserEnabled:
+                                    description: |-
+                                      DefaultUserEnabled may be set to true to ensure even if the Users field
+                                      is not empty, the default user is still created on systems that have one
+                                      defined. By default, Cloud-Init ignores the default user if the
+                                      CloudConfig provides one or more non-default users via the Users field.
+                                    type: boolean
+                                  runcmd:
+                                    description: |-
+                                      RunCmd allows running one or more commands on the guest.
+                                      The entries in this list can adhere to two, different formats:
+
+                                      Format 1 -- a string that contains the command and its arguments, ex.
+
+                                          runcmd:
+                                          - "ls -al"
+
+                                      Format 2 -- a list of the command and its arguments, ex.
+
+                                          runcmd:
+                                          - - echo
+                                            - "Hello, world."
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  ssh_pwauth:
+                                    description: |-
+                                      SSHPwdAuth sets whether or not to accept password authentication.
+                                      In order for this config to be applied, SSH may need to be restarted.
+                                      On systemd systems, this restart will only happen if the SSH service has
+                                      already been started. On non-systemd systems, a restart will be attempted
+                                      regardless of the service state.
+                                    type: boolean
+                                  timezone:
+                                    description: Timezone describes the timezone represented
+                                      in /usr/share/zoneinfo.
+                                    type: string
+                                  users:
+                                    description: Users allows adding/configuring one
+                                      or more users on the guest.
+                                    items:
+                                      description: User is a CloudConfig user data
+                                        structure.
+                                      properties:
+                                        create_groups:
+                                          description: |-
+                                            CreateGroups is a flag that may be set to false to disable creation of
+                                            specified user groups.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        expiredate:
+                                          description: ExpireData is the date on which
+                                            the user's account will be disabled.
+                                          type: string
+                                        gecos:
+                                          description: |-
+                                            Gecos is an optional comment about the user, usually a comma-separated
+                                            string of the user's real name and contact information.
+                                          type: string
+                                        groups:
+                                          description: Groups is an optional list
+                                            of groups to add to the user.
+                                          items:
+                                            type: string
+                                          type: array
+                                        hashed_passwd:
+                                          description: |-
+                                            HashedPasswd is a hash of the user's password that will be applied even
+                                            if the specified user already exists.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        homedir:
+                                          description: |-
+                                            Homedir is the optional home directory for the user.
+
+                                            Defaults to "/home/<username>" when Name is not "default".
+                                          type: string
+                                        inactive:
+                                          description: |-
+                                            Inactive optionally represents the number of days until the user is
+                                            disabled.
+                                          format: int32
+                                          type: integer
+                                        lock_passwd:
+                                          description: |-
+                                            LockPasswd disables password login.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        name:
+                                          description: |-
+                                            Name is the user's login name.
+
+                                            Please note this field may be set to the special value of "default" when
+                                            this User is the first element in the Users list from the CloudConfig.
+                                            When set to "default", all other fields from this User must be nil.
+                                          type: string
+                                        no_create_home:
+                                          description: |-
+                                            NoCreateHome prevents the creation of the home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_log_init:
+                                          description: |-
+                                            NoLogInit prevents the initialization of lastlog and faillog for the
+                                            user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_user_group:
+                                          description: |-
+                                            NoUserGroup prevents the creation of the group named after the user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        passwd:
+                                          description: |-
+                                            Passwd is a hash of the user's password that will be applied only to
+                                            a newly created user. To apply a new, hashed password to an existing user
+                                            please use HashedPasswd instead.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        primary_group:
+                                          description: |-
+                                            PrimaryGroup is the primary group for the user.
+
+                                            Defaults to the value of the Name field when it is not "default".
+                                          type: string
+                                        selinux_user:
+                                          description: SELinuxUser is the SELinux
+                                            user for the user's login.
+                                          type: string
+                                        shell:
+                                          description: |-
+                                            Shell is the path to the user's login shell.
+
+                                            Please note the default is to set no shell, which results in a
+                                            system-specific default being used.
+                                          type: string
+                                        snapuser:
+                                          description: |-
+                                            SnapUser specifies an e-mail address to create the user as a Snappy user
+                                            through "snap create-user".
+
+                                            If an Ubuntu SSO account is associated with the address, the username and
+                                            SSH keys will be requested from there.
+                                          type: string
+                                        ssh_authorized_keys:
+                                          description: |-
+                                            SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                            keys file.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_import_id:
+                                          description: |-
+                                            SSHImportID is a list of SSH IDs to import for the user.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_redirect_user:
+                                          description: |-
+                                            SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                            Please note that when specified, all SSH keys from cloud meta-data will
+                                            be configured in a disabled state for this user. Any SSH login as this
+                                            user will timeout with a message to login instead as the default user.
+
+                                            This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        sudo:
+                                          description: |-
+                                            Sudo is a sudo rule to apply to the user.
+
+                                            When omitted, no sudo rules will be applied to the user.
+                                          type: string
+                                        system:
+                                          description: |-
+                                            System is an optional flag that indicates the user should be created as
+                                            a system user with no home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        uid:
+                                          description: |-
+                                            UID is the user's ID.
+
+                                            When omitted the guest will default to the next available number.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  write_files:
+                                    description: WriteFiles allows adding files to
+                                      the guest file system.
+                                    items:
+                                      description: WriteFile is a CloudConfig write_file
+                                        data structure.
+                                      properties:
+                                        append:
+                                          description: |-
+                                            Append specifies whether or not to append the content to an existing file
+                                            if the file specified by Path already exists.
+                                          type: boolean
+                                        content:
+                                          description: |-
+                                            Content is the optional content to write to the provided Path.
+
+                                            When omitted an empty file will be created or existing file will be
+                                            modified.
+
+                                            The value for this field can adhere to two, different formats:
+
+                                            Format 1 -- a string that contains the command and its arguments, ex.
+
+                                                content: Hello, world.
+
+                                            Please note that format 1 supports all of the manners of specifying a
+                                            YAML string.
+
+                                            Format 2 -- a secret reference with the name of the key that contains
+                                                        the content for the file, ex.
+
+                                                content:
+                                                  name: my-bootstrap-secret
+                                                  key: my-file-content
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        defer:
+                                          description: |-
+                                            Defer indicates to defer writing the file until Cloud-Init's "final"
+                                            stage, after users are created and packages are installed.
+                                          type: boolean
+                                        encoding:
+                                          default: text/plain
+                                          description: Encoding is an optional encoding
+                                            type of the content.
+                                          enum:
+                                          - b64
+                                          - base64
+                                          - gz
+                                          - gzip
+                                          - gz+b64
+                                          - gz+base64
+                                          - gzip+b64
+                                          - gzip+base64
+                                          - text/plain
+                                          type: string
+                                        owner:
+                                          default: root:root
+                                          description: Owner is an optional "owner:group"
+                                            to chown the file.
+                                          type: string
+                                        path:
+                                          description: Path is the path of the file
+                                            to which the content is decoded and written.
+                                          type: string
+                                        permissions:
+                                          default: "0644"
+                                          description: |-
+                                            Permissions an optional set of file permissions to set.
+
+                                            Please note the permissions should be specified as an octal string, ex.
+                                            "0###".
+
+                                            When omitted the guest will default this value to "0644".
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - path
+                                    x-kubernetes-list-type: map
+                                type: object
+                              instanceID:
+                                description: |-
+                                  InstanceID is the cloud-init metadata instance ID.
+                                  If omitted, this field defaults to the VM's BiosUUID.
+                                type: string
+                              rawCloudConfig:
+                                description: |-
+                                  RawCloudConfig describes a key in a Secret resource that contains the
+                                  CloudConfig data used to bootstrap the VM.
+
+                                  The CloudConfig data specified by the key may be plain-text,
+                                  base64-encoded, or gzipped and base64-encoded.
+
+                                  Please note this field and CloudConfig are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sshAuthorizedKeys:
+                                description: |-
+                                  SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                                  the guest's default user.
+                                items:
+                                  type: string
+                                type: array
+                              useGlobalNameserversAsDefault:
+                                description: |-
+                                  UseGlobalNameserversAsDefault will use the global nameservers specified in
+                                  the NetworkSpec as the per-interface nameservers when the per-interface
+                                  nameservers is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                              useGlobalSearchDomainsAsDefault:
+                                description: |-
+                                  UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                                  in the NetworkSpec as the per-interface search domains when the per-interface
+                                  search domains is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                            type: object
+                          linuxPrep:
+                            description: |-
+                              LinuxPrep may be used to bootstrap Linux guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or Sysprep bootstrap providers.
+                            properties:
+                              hardwareClockIsUTC:
+                                description: |-
+                                  HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                                  local time.
+                                type: boolean
+                              timeZone:
+                                description: |-
+                                  TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                                  Valid values are based on the tz (timezone) database used by Linux and
+                                  other Unix systems. The values are strings in the form of
+                                  "Area/Location," in which Area is a continent or ocean name, and
+                                  Location is the city, island, or other regional designation.
+
+                                  Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                                  time zones for Linux systems.
+                                type: string
+                            type: object
+                          sysprep:
+                            description: |-
+                              Sysprep may be used to bootstrap Windows guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or LinuxPrep bootstrap providers.
+                            properties:
+                              rawSysprep:
+                                description: |-
+                                  RawSysprep describes a key in a Secret resource that contains an XML
+                                  string of the Sysprep text used to bootstrap the VM.
+
+                                  The data specified by the Secret key may be plain-text, base64-encoded,
+                                  or gzipped and base64-encoded.
+
+                                  Please note this field and Sysprep are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sysprep:
+                                description: |-
+                                  Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                                  This field encloses all the individual keys listed in a sysprep.xml file.
+
+                                  For more detailed information please see
+                                  https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                                  Please note this field and RawSysprep are mutually exclusive.
+                                properties:
+                                  guiRunOnce:
+                                    description: GUIRunOnce is a representation of
+                                      the Sysprep GuiRunOnce key.
+                                    properties:
+                                      commands:
+                                        description: |-
+                                          Commands is a list of commands to run at first user logon, after guest
+                                          customization.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  guiUnattended:
+                                    description: GUIUnattended is a representation
+                                      of the Sysprep GUIUnattended key.
+                                    properties:
+                                      autoLogon:
+                                        description: |-
+                                          AutoLogon determine whether the machine automatically logs on as
+                                          Administrator.
+
+                                          Please note if AutoLogon is true, then Password must be set or guest
+                                          customization will fail.
+                                        type: boolean
+                                      autoLogonCount:
+                                        description: |-
+                                          AutoLogonCount specifies the number of times the machine should
+                                          automatically log on as Administrator.
+
+                                          Generally it should be 1, but if your setup requires a number of reboots,
+                                          you may want to increase it. This number may be determined by the list of
+                                          commands executed by the GuiRunOnce command.
+
+                                          Please note this field must be specified with a non-zero positive integer
+                                          if AutoLogon is true.
+                                        format: int32
+                                        type: integer
+                                      password:
+                                        description: |-
+                                          Password is the new administrator password for the machine.
+
+                                          To specify that the password should be set to blank (that is, no
+                                          password), set the password value to NULL. Because of encryption, "" is
+                                          NOT a valid value.
+
+                                          Please note if the password is set to blank and AutoLogon is true, the
+                                          guest customization will fail.
+
+                                          If the XML file is generated by the VirtualCenter Customization Wizard,
+                                          then the password is encrypted. Otherwise, the client should set the
+                                          plainText attribute to true, so that the customization process does not
+                                          attempt to decrypt the string.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `password`.
+                                        properties:
+                                          key:
+                                            default: password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      timeZone:
+                                        default: 85
+                                        description: |-
+                                          TimeZone is the time zone index for the virtual machine.
+
+                                          Please note that numbers correspond to time zones listed at
+                                          https://bit.ly/3Rzv8oL.
+
+                                          Defaults to UTC.
+                                        format: int32
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - timeZone
+                                    type: object
+                                  identification:
+                                    description: Identification is a representation
+                                      of the Sysprep Identification key.
+                                    properties:
+                                      domainAdmin:
+                                        description: |-
+                                          DomainAdmin is the domain user account used for authentication if the
+                                          virtual machine is joining a domain. The user does not need to be a
+                                          domain administrator, but the account must have the privileges required
+                                          to add computers to the domain.
+                                        type: string
+                                      domainAdminPassword:
+                                        description: |-
+                                          DomainAdminPassword is the password for the domain user account used for
+                                          authentication if the virtual machine is joining a domain.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: domain_admin_password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      domainOU:
+                                        description: |-
+                                          DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                          the OU to which the computer belongs.
+                                        type: string
+                                      joinWorkgroup:
+                                        description: |-
+                                          JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                          this value is supplied, then the fields spec.network.domain,
+                                          spec.bootstrap.sysprep.identification.domainAdmin, and
+                                          spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                        type: string
+                                    type: object
+                                  licenseFilePrintData:
+                                    description: |-
+                                      LicenseFilePrintData is a representation of the Sysprep
+                                      LicenseFilePrintData key.
+
+                                      Please note this is required only for Windows 2000 Server and Windows
+                                      Server 2003.
+                                    properties:
+                                      autoMode:
+                                        description: AutoMode specifies the server
+                                          licensing mode.
+                                        enum:
+                                        - perSeat
+                                        - perServer
+                                        type: string
+                                      autoUsers:
+                                        description: |-
+                                          AutoUsers indicates the number of client licenses purchased for the
+                                          VirtualCenter server being installed.
+
+                                          Please note this value is ignored unless AutoMode is PerServer.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - autoMode
+                                    type: object
+                                  userData:
+                                    description: UserData is a representation of the
+                                      Sysprep UserData key.
+                                    properties:
+                                      fullName:
+                                        description: FullName is the user's full name.
+                                        type: string
+                                      orgName:
+                                        description: OrgName is the name of the user's
+                                          organization.
+                                        type: string
+                                      productID:
+                                        description: |-
+                                          ProductID is a valid serial number.
+
+                                          Please note unless the VirtualMachineImage was installed with a volume
+                                          license key, ProductID must be set or guest customization will fail.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: product_id
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                    required:
+                                    - fullName
+                                    - orgName
+                                    type: object
+                                required:
+                                - userData
+                                type: object
+                            type: object
+                          vAppConfig:
+                            description: |-
+                              VAppConfig may be used to bootstrap guests that rely on vApp properties
+                              (how VMware surfaces OVF properties on guests) to transport data into the
+                              guest.
+
+                              The guest's networking stack may be configured using either vApp
+                              properties or GOSC.
+
+                              Many OVFs define one or more properties that are used by the guest to
+                              bootstrap its networking stack. If the VirtualMachineImage defines one or
+                              more properties like this, then they can be configured to use the network
+                              data provided for this VM at runtime by setting these properties to Go
+                              template strings.
+
+                              It is also possible to use GOSC to bootstrap this VM's network stack by
+                              configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                              Please note the VAppConfig bootstrap provider in conjunction with the
+                              LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                              VM metadata transport to "OvfEnv".
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              bootstrap provider.
+                            properties:
+                              properties:
+                                description: |-
+                                  Properties is a list of vApp/OVF property key/value pairs.
+
+                                  Please note this field and RawProperties are mutually exclusive.
+                                items:
+                                  description: |-
+                                    KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                                    list of key/value pairs where each value could also reference data stored in
+                                    a Secret resource.
+                                  properties:
+                                    key:
+                                      description: Key is the key part of the key/value
+                                        pair.
+                                      type: string
+                                    value:
+                                      description: Value is the optional value part
+                                        of the key/value pair.
+                                      properties:
+                                        from:
+                                          description: |-
+                                            From is specified to reference a value from a Secret resource.
+
+                                            Please note this field is mutually exclusive with the Value field.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        value:
+                                          description: |-
+                                            Value is used to directly specify a value.
+
+                                            Please note this field is mutually exclusive with the From field.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - key
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              rawProperties:
+                                description: |-
+                                  RawProperties is the name of a Secret resource in the same Namespace as
+                                  this VM where each key/value pair from the Secret is used as a vApp
+                                  key/value pair.
+
+                                  Please note this field and Properties are mutually exclusive.
+                                type: string
+                            type: object
+                        type: object
+                      cdrom:
+                        description: |-
+                          Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                          Each CD-ROM device requires a reference to an ISO-type
+                          VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                          Multiple CD-ROM devices using the same backing image, regardless of image
+                          kinds (namespace or cluster scope), are not allowed.
+
+                          CD-ROM devices can be added, updated, or removed when the VM is powered
+                          off. When the VM is powered on, only the connection state of existing
+                          CD-ROM devices can be changed.
+                          CD-ROM devices are attached to the VM in the specified list-order.
+                        items:
+                          description: VirtualMachineCdromSpec describes the desired
+                            state of a CD-ROM device.
+                          properties:
+                            allowGuestControl:
+                              default: true
+                              description: |-
+                                AllowGuestControl describes whether or not a web console connection
+                                may be used to connect/disconnect the CD-ROM device.
+
+                                Defaults to true if omitted.
+                              type: boolean
+                            connected:
+                              default: true
+                              description: |-
+                                Connected describes the desired connection state of the CD-ROM device.
+
+                                When true, the CD-ROM device is added and connected to the VM.
+                                If the device already exists, it is updated to a connected state.
+
+                                When explicitly set to false, the CD-ROM device is added but remains
+                                disconnected from the VM. If the CD-ROM device already exists, it is
+                                updated to a disconnected state.
+
+                                Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                                in the guest OS. Refer to the following KB article for more details:
+                                https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                                Defaults to true if omitted.
+                              type: boolean
+                            image:
+                              description: |-
+                                Image describes the reference to an ISO type VirtualMachineImage or
+                                ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                                If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                                This field is immutable when the VM is powered on.
+
+                                Please note, unlike the spec.imageName field, the value of this
+                                spec.cdrom.image.name MUST be a Kubernetes object name.
+                              properties:
+                                kind:
+                                  description: |-
+                                    Kind describes the type of image, either a namespace-scoped
+                                    VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name refers to the name of a VirtualMachineImage resource in the same
+                                    namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            name:
+                              description: |-
+                                Name consists of at least two lowercase letters or digits of this CD-ROM.
+                                It must be unique among all CD-ROM devices attached to the VM.
+
+                                This field is immutable when the VM is powered on.
+                              pattern: ^[a-z0-9]{2,}$
+                              type: string
+                          required:
+                          - image
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      className:
+                        description: |-
+                          ClassName describes the name of the VirtualMachineClass resource used to
+                          deploy this VM.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM class.
+
+                          If a VM is using a class, a different value in spec.className
+                          leads to the VM being resized.
+                        type: string
+                      crypto:
+                        description: Crypto describes the desired encryption state
+                          of the VirtualMachine.
+                        properties:
+                          encryptionClassName:
+                            description: |-
+                              EncryptionClassName describes the name of the EncryptionClass resource
+                              used to encrypt this VM.
+
+                              Please note, this field is not required to encrypt the VM. If the
+                              underlying platform has a default key provider, the VM may still be fully
+                              or partially encrypted depending on the specified storage and VM classes.
+
+                              If there is a default key provider and an encryption storage class is
+                              selected, the files in the VM's home directory and non-PVC virtual disks
+                              will be encrypted
+
+                              If there is a default key provider and a VM Class with a virtual, trusted
+                              platform module (vTPM) is selected, the files in the VM's home directory,
+                              minus any virtual disks, will be encrypted.
+
+                              If the underlying vSphere platform does not have a default key provider,
+                              then this field is required when specifying an encryption storage class
+                              and/or a VM Class with a vTPM.
+
+                              If this field is set, spec.storageClass must use an encryption-enabled
+                              storage class.
+                            type: string
+                          useDefaultKeyProvider:
+                            default: true
+                            description: |-
+                              UseDefaultKeyProvider describes the desired behavior for when an explicit
+                              EncryptionClass is not provided.
+
+                              When an explicit EncryptionClass is not provided and this value is true:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will be encrypted using the default key provider.
+
+                              - If a VirtualMachine is not encrypted, uses an encryption storage
+                                policy or has a virtual, trusted platform module (vTPM), there is a
+                                default key provider, the VM will be encrypted using the default key
+                                provider.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be rekeyed using the default key provider.
+
+                              When an explicit EncryptionClass is not provided and this value is false:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will fail.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be not be rekeyed.
+
+                                Please note, this could result in a VirtualMachine that cannot be
+                                powered on since it is encrypted using a provider or key that may have
+                                been removed. Without the key, the VM cannot be decrypted and thus
+                                cannot be powered on.
+
+                              Defaults to true if omitted.
+                            type: boolean
+                        type: object
+                      groupName:
+                        description: |-
+                          GroupName indicates the name of the VirtualMachineGroup to which this
+                          VM belongs.
+
+                          VMs that belong to a group do not drive their own placement, rather that
+                          is handled by the group.
+
+                          When this field is set to a valid group that contains this VM as a
+                          member, an owner reference to that group is added to this VM.
+
+                          When this field is deleted or changed, any existing owner reference to
+                          the previous group will be removed from this VM.
+                        type: string
+                      guestID:
+                        description: |-
+                          GuestID describes the desired guest operating system identifier for a VM.
+
+                          The logic that determines the guest ID is as follows:
+
+                          If this field is set, then its value is used.
+                          Otherwise, if the VM is deployed from an OVF template that defines a
+                          guest ID, then that value is used.
+                          The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                          For a complete list of supported values, please refer to
+                          https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                          Please note that some guest ID values may require a minimal hardware
+                          version, which can be set using the `spec.minHardwareVersion` field.
+                          To see the mapping between virtual hardware versions and the product
+                          versions that support a specific guest ID, please refer to
+                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                          Please note that this field is immutable after the VM is powered on.
+                          To change the guest ID after the VM is powered on, the VM must be powered
+                          off and then powered on again with the updated guest ID spec.
+
+                          This field is required when the VM has any CD-ROM devices attached.
+                        type: string
+                      image:
+                        description: |-
+                          Image describes the reference to the VirtualMachineImage or
+                          ClusterVirtualMachineImage resource used to deploy this VM.
+
+                          Please note, unlike the field spec.imageName, the value of
+                          spec.image.name MUST be a Kubernetes object name.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.imageName are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind describes the type of image, either a namespace-scoped
+                              VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                          name:
+                            description: |-
+                              Name refers to the name of a VirtualMachineImage resource in the same
+                              namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      imageName:
+                        description: |-
+                          ImageName describes the name of the image resource used to deploy this
+                          VM.
+
+                          This field may be used to specify the name of a VirtualMachineImage
+                          or ClusterVirtualMachineImage resource. The resolver first checks to see
+                          if there is a VirtualMachineImage with the specified name in the
+                          same namespace as the VM being deployed. If no such resource exists, the
+                          resolver then checks to see if there is a ClusterVirtualMachineImage
+                          resource with the specified name.
+
+                          This field may also be used to specify the display name (vSphere name) of
+                          a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                          display name unambiguously resolves to a distinct VM image (among all
+                          existing VirtualMachineImages in the VM's namespace and all existing
+                          ClusterVirtualMachineImages), then a mutation webhook updates the
+                          spec.image field with the reference to the resolved VM image. If the
+                          display name resolves to multiple or no VM images, then the mutation
+                          webhook denies the request and returns an error.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.image are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        type: string
+                      instanceUUID:
+                        description: |-
+                          InstanceUUID describes the desired Instance UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          This value is only used for the VM Instance UUID,
+                          it is not used within cloudInit.
+                          This identifier is used by VirtualCenter to uniquely identify all
+                          virtual machine instances, including those that may share the same BIOS UUID.
+                        format: uuid
+                        type: string
+                      minHardwareVersion:
+                        description: |-
+                          MinHardwareVersion describes the desired, minimum hardware version.
+
+                          The logic that determines the hardware version is as follows:
+
+                          1. If this field is set, then its value is used.
+                          2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                             non-empty hardware version, then it is used.
+                          3. Finally, if the hardware version is still undetermined, the value is
+                             set to the default hardware version for the Datacenter/Cluster/Host
+                             where the VM is provisioned.
+
+                          This field is never updated to reflect the derived hardware version.
+                          Instead, VirtualMachineStatus.HardwareVersion surfaces
+                          the observed hardware version.
+
+                          Please note, setting this field's value to N ensures a VM's hardware
+                          version is equal to or greater than N. For example, if a VM's observed
+                          hardware version is 10 and this field's value is 13, then the VM will be
+                          upgraded to hardware version 13. However, if the observed hardware
+                          version is 17 and this field's value is 13, no change will occur.
+
+                          Several features are hardware version dependent, for example:
+
+                          * NVMe Controllers                >= 14
+                          * Dynamic Direct Path I/O devices >= 17
+
+                          Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                          hardware versions.
+
+                          It is important to remember that a VM's hardware version may not be
+                          downgraded and upgrading a VM deployed from an image based on an older
+                          hardware version to a more recent one may result in unpredictable
+                          behavior. In other words, please be careful when choosing to upgrade a
+                          VM to a newer hardware version.
+                        format: int32
+                        minimum: 13
+                        type: integer
+                      network:
+                        description: |-
+                          Network describes the desired network configuration for the VM.
+
+                          Please note this value may be omitted entirely and the VM will be
+                          assigned a single, virtual network interface that is connected to the
+                          Namespace's default network.
+                        properties:
+                          disabled:
+                            description: |-
+                              Disabled is a flag that indicates whether or not to disable networking
+                              for this VM.
+
+                              When set to true, the VM is not configured with a default interface nor
+                              any specified from the Interfaces field.
+                            type: boolean
+                          domainName:
+                            description: |-
+                              DomainName describes the value the guest uses as its domain name.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS names:
+
+                                * When joined with the host name, the total length is restricted to 255
+                                  characters or less.
+                                * Individual segments must be 63 characters or less.
+                                * The top-level domain( ex. ".com"), is at least two letters with no
+                                  special characters.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Long, top-level domain names (ex. ".london") are permitted.
+                                * Symbol unicode points, such as emoji, are disallowed in the top-level
+                                  domain.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+
+                              When deploying a guest running Microsoft Windows, this field describes
+                              the domain the computer should join.
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName describes the value the guest uses as its host name. If omitted,
+                              the name of the VM will be used.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS labels:
+
+                                * The total length is restricted to 63 characters or less.
+                                * The total length is restricted to 15 characters or less on Windows
+                                  systems.
+                                * The value may begin with a digit per RFC-1123.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                                  please note that the use of emoji, even where allowed, may not
+                                  compatible with the guest operating system, so it recommended to
+                                  stick with more common characters for this value.
+                                * The value may be a valid IP4 or IP6 address. Please note, the use of
+                                  an IP address for a host name is not compatible with all guest
+                                  operating systems and is discouraged. Additionally, using an IP
+                                  address for the host name is disallowed if spec.network.domainName is
+                                  non-empty.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+                            type: string
+                          interfaces:
+                            description: |-
+                              Interfaces is the list of network interfaces used by this VM.
+
+                              If the Interfaces field is empty and the Disabled field is false, then
+                              a default interface with the name eth0 will be created.
+
+                              The maximum number of network interface allowed is 10 because a vSphere
+                              virtual machine may not have more than 10 virtual ethernet card devices.
+                            items:
+                              description: |-
+                                VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                                network interface.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                                    interface.
+
+                                    Please note this field is only supported if the connected network
+                                    supports manual IP allocation.
+
+                                    Please note IP4 and IP6 addresses must include the network prefix length,
+                                    ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                                    Please note this field may not contain IP4 addresses if DHCP4 is set
+                                    to true or IP6 addresses if DHCP6 is set to true.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 indicates whether or not this interface uses DHCP for IP4
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP4 addresses in the
+                                    Addresses field and the Gateway4 field.
+                                  type: boolean
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 indicates whether or not this interface uses DHCP for IP6
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP6 addresses in the
+                                    Addresses field and the Gateway6 field.
+                                  type: boolean
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the default, IP4 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP4.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 is the primary IP6 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP6.
+                                  type: string
+                                guestDeviceName:
+                                  description: |-
+                                    GuestDeviceName is used to rename the device inside the guest when the
+                                    bootstrap provider is Cloud-Init. Please note it is up to the user to
+                                    ensure the provided device name does not conflict with any other devices
+                                    inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^\w\w+$
+                                  type: string
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the optional MAC address of this interface.
+
+                                    If no MAC address is provided, one will be generated by either the network
+                                    provider or vCenter.
+
+                                    Please note this field is only supported when the Network API Group is
+                                    crd.nsx.vmware.com.
+                                  pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                                  type: string
+                                mtu:
+                                  description: |-
+                                    MTU is the Maximum Transmission Unit size in bytes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  format: int64
+                                  type: integer
+                                name:
+                                  description: |-
+                                    Name describes the unique name of this network interface, used to
+                                    distinguish it from other network interfaces attached to this VM.
+
+                                    When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                                    specified, the device inside the guest will be renamed to this value.
+                                    Please note it is up to the user to ensure the provided name does not
+                                    conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^[a-z0-9]{2,}$
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                                    nameservers.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit and Sysprep.
+
+                                    When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                                    true, if nameservers is not provided, the global nameservers will be used
+                                    instead.
+
+                                    Please note that Linux allows only three nameservers
+                                    (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                network:
+                                  description: |-
+                                    Network is the name of the network resource to which this interface is
+                                    connected.
+
+                                    If no network is provided, then this interface will be connected to the
+                                    Namespace's default network.
+                                  properties:
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion defines the versioned schema of this representation of an object.
+                                        Servers should convert recognized schemas to the latest internal value, and
+                                        may reject unrecognized values.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind is a string value representing the REST resource this object represents.
+                                        Servers may infer this from the endpoint the client submits requests to.
+                                        Cannot be updated.
+                                        In CamelCase.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name refers to a unique resource in the current namespace.
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                routes:
+                                  description: |-
+                                    Routes is a list of optional, static routes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  items:
+                                    description: VirtualMachineNetworkRouteSpec defines
+                                      a static route for a guest.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        minimum: 1
+                                        type: integer
+                                      to:
+                                        description: To is either "default", or an
+                                          IP4 or IP6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IP4 or IP6 address.
+                                        type: string
+                                    required:
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+
+                                    When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                                    or true, if search domains is not provided, the global search domains
+                                    will be used instead.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                              nameservers. These are applied globally.
+
+                              Please note global nameservers are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface nameservers. However, when Cloud-Init
+                              is used and UseGlobalNameserversAsDefault is true, the global
+                              nameservers will be used when the per-interface nameservers is not
+                              provided.
+
+                              Please note that Linux allows only three nameservers
+                              (https://linux.die.net/man/5/resolv.conf).
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of search domains used when resolving IP
+                              addresses with DNS. These are applied globally.
+
+                              Please note global search domains are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface search domains. However, when Cloud-Init
+                              is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                              domains will be used when the per-interface search domains is not provided.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      nextRestartTime:
+                        description: |-
+                          NextRestartTime may be used to restart the VM, in accordance with
+                          RestartMode, by setting the value of this field to "now"
+                          (case-insensitive).
+
+                          A mutating webhook changes this value to the current time (UTC), which
+                          the VM controller then uses to determine the VM should be restarted by
+                          comparing the value to the timestamp of the last time the VM was
+                          restarted.
+
+                          Please note it is not possible to schedule future restarts using this
+                          field. The only value that users may set is the string "now"
+                          (case-insensitive).
+                        type: string
+                      powerOffMode:
+                        default: TrySoft
+                        description: |-
+                          PowerOffMode describes the desired behavior when powering off a VM.
+
+                          There are three, supported power off modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is the equivalent of a physical
+                          system's power cord being ripped from the wall. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                          a graceful shutdown, and if that fails or the VM is not in a powered off
+                          state after five minutes, the VM is halted.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      powerState:
+                        description: |-
+                          PowerState describes the desired power state of a VirtualMachine.
+
+                          Please note this field may be omitted when creating a new VM and will
+                          default to "PoweredOn." However, once the field is set to a non-empty
+                          value, it may no longer be set to an empty value.
+
+                          Additionally, setting this value to "Suspended" is not supported when
+                          creating a new VM. The valid values when creating a new VM are
+                          "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                          since this value defaults to "PoweredOn" for new VMs.
+                        enum:
+                        - PoweredOff
+                        - PoweredOn
+                        - Suspended
+                        type: string
+                      promoteDisksMode:
+                        default: Online
+                        description: |-
+                          PromoteDisksMode describes the mode used to promote a VM's delta disks to
+                          full disks. The available modes are:
+
+                          - Disabled -- Do not promote disks.
+                          - Online   -- Promote disks while the VM is powered on. VMs with
+                                        snapshots do not support online promotion.
+                          - Offline  -- Promote disks while the VM is powered off.
+
+                          Please note, this field is ignored for encrypted VMs since they do not
+                          use delta disks.
+
+                          Defaults to Online.
+                        enum:
+                        - Online
+                        - Offline
+                        - Disabled
+                        type: string
+                      readinessProbe:
+                        description: ReadinessProbe describes a probe used to determine
+                          the VM's ready state.
+                        properties:
+                          guestHeartbeat:
+                            description: GuestHeartbeat specifies an action involving
+                              the guest heartbeat status.
+                            properties:
+                              thresholdStatus:
+                                default: green
+                                description: |-
+                                  ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                                  considered successful.
+                                enum:
+                                - yellow
+                                - green
+                                type: string
+                            type: object
+                          guestInfo:
+                            description: |-
+                              GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                              The elements are evaluated with the logical AND operator, meaning
+                              all expressions must evaluate as true for the probe to succeed.
+
+                              For example, a VM resource's probe definition could be specified as the
+                              following:
+
+                                      guestInfo:
+                                      - key:   ready
+                                        value: true
+
+                              With the above configuration in place, the VM would not be considered
+                              ready until the GuestInfo key "ready" was set to the value "true".
+
+                              From within the guest operating system it is possible to set GuestInfo
+                              key/value pairs using the program "vmware-rpctool," which is included
+                              with VM Tools. For example, the following command will set the key
+                              "guestinfo.ready" to the value "true":
+
+                                      vmware-rpctool "info-set guestinfo.ready true"
+
+                              Once executed, the VM's readiness probe will be signaled and the
+                              VM resource will be marked as ready.
+                            items:
+                              description: |-
+                                GuestInfoAction describes a key from GuestInfo that must match the associated
+                                value expression.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key is the name of the GuestInfo key.
+
+                                    The key is automatically prefixed with "guestinfo." before being
+                                    evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                                    evaluated as "guestinfo.guestinfo.mykey".
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value is a regular expression that is matched against the value of the
+                                    specified key.
+
+                                    An empty value is the equivalent of "match any" or ".*".
+
+                                    All values must adhere to the RE2 regular expression syntax as documented
+                                    at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                                    ignored depending on the implementation of this API. Either way, invalid
+                                    values will not be considered when evaluating the ready state of a VM.
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                          periodSeconds:
+                            description: |-
+                              PeriodSeconds specifics how often (in seconds) to perform the probe.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          tcpSocket:
+                            description: |-
+                              TCPSocket specifies an action involving a TCP port.
+
+                              Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                              This field will be removed in a later API version.
+                            properties:
+                              host:
+                                description: Host is an optional host name to connect
+                                  to. Host defaults to the VM IP.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Port specifies a number or name of the port to access on the VM.
+                                  If the format of port is a number, it must be in the range 1 to 65535.
+                                  If the format of name is a string, it must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          timeoutSeconds:
+                            description: |-
+                              TimeoutSeconds specifies a number of seconds after which the probe times out.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            maximum: 60
+                            minimum: 1
+                            type: integer
+                        type: object
+                      reserved:
+                        description: |-
+                          Reserved describes a set of VM configuration options reserved for system
+                          use.
+
+                          Please note attempts to modify the value of this field by a DevOps user
+                          will result in a validation error.
+                        properties:
+                          resourcePolicyName:
+                            type: string
+                        type: object
+                      restartMode:
+                        default: TrySoft
+                        description: |-
+                          RestartMode describes the desired behavior for restarting a VM when
+                          spec.nextRestartTime is set to "now" (case-insensitive).
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                          interaction inside of the guest. The Soft mode requires the VM's guest to
+                          have VM Tools installed and asks the guest to restart the VM. Its
+                          variant, TrySoft, first attempts a soft restart, and if that fails or
+                          does not complete within five minutes, the VM is hard reset.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      storageClass:
+                        description: |-
+                          StorageClass describes the name of a Kubernetes StorageClass resource
+                          used to configure this VM's storage-related attributes.
+
+                          Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                          for more information on Kubernetes storage classes.
+                        type: string
+                      suspendMode:
+                        default: TrySoft
+                        description: |-
+                          SuspendMode describes the desired behavior when suspending a VM.
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                          disk without any interaction inside of the guest. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully suspend the VM. Its variant, TrySoft, first attempts
+                          a graceful suspend, and if that fails or the VM is not in a put into
+                          standby by the guest after five minutes, the VM is suspended.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      volumes:
+                        description: Volumes describes a list of volumes that can
+                          be mounted to the VM.
+                        items:
+                          description: VirtualMachineVolume represents a named volume
+                            in a VM.
+                          properties:
+                            name:
+                              description: |-
+                                Name represents the volume's name. Must be a DNS_LABEL and unique within
+                                the VM.
+                              type: string
+                            persistentVolumeClaim:
+                              description: |-
+                                PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                                in the same namespace.
+
+                                More information is available at
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                instanceVolumeClaim:
+                                  description: InstanceVolumeClaim is set if the PVC
+                                    is backed by instance storage.
+                                  properties:
+                                    size:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Size is the size of the requested
+                                        instance storage volume.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      description: |-
+                                        StorageClass is the name of the Kubernetes StorageClass that provides
+                                        the backing storage for this instance storage volume.
+                                      type: string
+                                  required:
+                                  - size
+                                  - storageClass
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineReplicaSetStatus represents the observed state of a
+              VirtualMachineReplicaSet resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represents the latest available observations of a
+                  VirtualMachineReplicaSet's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              fullyLabeledReplicas:
+                description: |-
+                  FullyLabeledReplicas is the number of replicas that have labels matching the
+                  labels of the virtual machine template of the VirtualMachineReplicaSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: |-
+                  ObservedGeneration reflects the generation of the most recently observed
+                  VirtualMachineReplicaSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is the number of ready replicas for this VirtualMachineReplicaSet. A
+                  virtual machine is considered ready when it's "Ready" condition is marked as
+                  true.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated virtual machines targeted by this
+        VirtualMachineReplicaSet
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready virtual machines targeted by this VirtualMachineReplicaSet
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Time duration since creation of VirtualMachineReplicaSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineReplicaSet is the schema for the virtualmachinereplicasets
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineReplicaSetSpec is the specification of a VirtualMachineReplicaSet.
+            properties:
+              deletePolicy:
+                description: |-
+                  DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Only supported deletion policy is "Random".
+                enum:
+                - Random
+                type: string
+              replicas:
+                default: 1
+                description: |-
+                  Replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label to query over virtual machines that should match the
+                  replica count. A virtual machine's label keys and values must match in order
+                  to be controlled by this VirtualMachineReplicaSet.
+
+                  It must match the VirtualMachine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  Template is the object that describes the virtual machine that will be
+                  created if insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta contains the desired Labels and Annotations that must be
+                      applied to each replica virtual machine.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: Specification of the desired behavior of each replica
+                      virtual machine.
+                    properties:
+                      advanced:
+                        description: Advanced describes a set of optional, advanced
+                          VM configuration options.
+                        properties:
+                          bootDiskCapacity:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                              from the VirtualMachineImage from which the VM was deployed.
+
+                              Please note it is not advised to change this value while the VM is
+                              running. Also, resizing the VM's boot disk may require actions inside of
+                              the guest to take advantage of the additional capacity. Finally, changing
+                              the size of the VM's boot disk, even increasing it, could adversely
+                              affect the VM.
+
+                              Please note this field is ignored if the VM is deployed from an ISO with
+                              CD-ROM devices attached.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          changeBlockTracking:
+                            description: |-
+                              ChangeBlockTracking is a flag that enables incremental backup support
+                              for this VM, a feature utilized by external backup systems such as
+                              VMware Data Recovery.
+                            type: boolean
+                          defaultVolumeProvisioningMode:
+                            description: |-
+                              DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                              persistent volumes managed by this VM.
+                            enum:
+                            - Thin
+                            - Thick
+                            - ThickEagerZero
+                            type: string
+                        type: object
+                      affinity:
+                        description: Affinity describes the VM's scheduling constraints.
+                        properties:
+                          vmAffinity:
+                            description: VMAffinity describes affinity scheduling
+                              rules related to other VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the affinity expressions specified by this
+                                  field, but it may choose to violate one or more of the expressions.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          vmAntiAffinity:
+                            description: |-
+                              VMAntiAffinity describes anti-affinity scheduling rules related to other
+                              VMs.
+                            properties:
+                              preferredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that should be met, but the VM can still be scheduled if
+                                  the requirement cannot be satisfied. The scheduler will prefer to
+                                  schedule VMs that satisfy the anti-affinity expressions specified by
+                                  this field, but it may choose to violate one or more of the expressions.
+                                  Additionally, it also describes the anti-affinity requirements that
+                                  should be met during run-time, but the VM can still be run if the
+                                  requirements cannot be satisfied.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingPreferredDuringExecution:
+                                description: |-
+                                  RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                                  requirements that must be met or the VM will not be scheduled.
+
+                                  When there are multiple elements, the lists of nodes corresponding to
+                                  each term are intersected, i.e. all terms must be satisfied.
+
+                                  Note: Any update to this field will replace the entire list rather than
+                                  merging with the existing elements.
+                                items:
+                                  description: VMAffinityTerm defines the VM affinity/anti-affinity
+                                    term.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a label query over a set of VMs.
+                                        When omitted, this term matches with no VMs.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey describes where this VM should be co-located (affinity) or not
+                                        co-located (anti-affinity).
+                                        Commonly used values include:
+                                        `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                        `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                        Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                        - When topology key is in the context of a zone, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                        - When topology key is in the context of a host, the only supported verbs are
+                                          PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                          for VM-VM node-level anti-affinity scheduling.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      biosUUID:
+                        description: |-
+                          BiosUUID describes the desired BIOS UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          When the bootstrap provider is Cloud-Init, this value is used as the
+                          default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                        format: uuid
+                        type: string
+                      bootOptions:
+                        description: |-
+                          BootOptions describes the settings that control the boot behavior of the
+                          virtual machine. These settings take effect during the next power-on of the
+                          virtual machine.
+                        properties:
+                          bootDelay:
+                            description: |-
+                              BootDelay is the delay before starting the boot sequence. The boot delay
+                              specifies a time interval between virtual machine power on or restart and
+                              the beginning of the boot sequence.
+                            type: string
+                          bootOrder:
+                            description: |-
+                              BootOrder represents the boot order of the virtual machine. After list is exhausted,
+                              default BIOS boot device algorithm is used for booting. Note that order of the entries
+                              in the list is important: device listed first is used for boot first, if that one
+                              fails second entry is used, and so on. Platform may have some internal limit on the
+                              number of devices it supports. If bootable device is not reached before platform's limit
+                              is hit, boot will fail. At least single entry is supported by all products supporting
+                              boot order settings.
+
+                              The available devices are:
+
+                              - Disk    -- If there are classic and managed disks, the first classic disk is selected.
+                                           If there are only managed disks, the first disk is selected.
+                              - Network -- The first interface listed in spec.network.interfaces.
+                              - CDRom   -- The first bootable CD-ROM device.
+                            items:
+                              description: |-
+                                VirtualMachineBootOptionsBootableDevice represents the type of bootable device
+                                that a VM may be booted from.
+                              enum:
+                              - Disk
+                              - Network
+                              - CDRom
+                              type: string
+                            type: array
+                          bootRetry:
+                            default: Disabled
+                            description: |-
+                              BootRetry specifies whether a virtual machine that fails to boot
+                              will try again. The available values are:
+
+                              - Enabled -- A virtual machine that fails to boot will try again
+                                           after BootRetryDelay time period has expired.
+                              - Disabled -- The virtual machine waits indefinitely for you to
+                                            initiate boot retry.
+                            type: string
+                          bootRetryDelay:
+                            description: |-
+                              BootRetryDelay specifies a time interval between virtual machine boot failure
+                              and the subsequent attempt to boot again. The virtual machine uses this value
+                              only if BootRetry is Enabled.
+                            type: string
+                          efiSecureBoot:
+                            default: Disabled
+                            description: |-
+                              EFISecureBoot specifies whether the virtual machine's firmware will
+                              perform signature checks of any EFI images loaded during startup. If set to
+                              true, signature checks will be performed and the virtual machine's firmware
+                              will refuse to start any images which do not pass those signature checks.
+
+                              Please note, this field will not be honored unless the value of
+                              spec.bootOptions.firmware is "EFI". The available values are:
+
+                              - Enabled -- Signature checks will be performed and the virtual machine's firmware
+                                           will refuse to start any images which do not pass those signature checks.
+                              - Disabled -- No signature checks will be performed.
+                            enum:
+                            - Enabled
+                            - Disabled
+                            type: string
+                          enterBootSetup:
+                            default: Disabled
+                            description: |-
+                              EnterBootSetup specifies whether to automatically enter BIOS/EFI setup the next
+                              time the virtual machine boots. The virtual machine resets this flag to false
+                              so that subsequent boots proceed normally. The available values are:
+
+                              - Enabled -- The virtual machine will automatically enter BIOS/EFI setup the next
+                                           time the virtual machine boots.
+                              - Disabled -- The virtual machine will boot normaally.
+                            enum:
+                            - Enabled
+                            - Disabled
+                            type: string
+                          firmware:
+                            description: |-
+                              Firmware represents the firmware for the virtual machine to use. Any update
+                              to this value after the virtual machine has already been created will be
+                              ignored. Setting will happen in the following manner:
+
+                              1. If this value is specified, it will be used to set the VM firmware. If this
+                                 value is unset, then
+                              2. the virtual machine image will be checked. If that value is set, then it will
+                                 be used to set the VM firmware. If that value is unset, then
+                              3. the virtual machine class will be checked. If that value is set, then it will
+                                 be used to set the VM firmware. If that value is unset, then
+                              4. the VM firmware will be set, by default, to BIOS.
+
+                              The available values of this field are:
+
+                              - BIOS
+                              - EFI
+                            enum:
+                            - BIOS
+                            - EFI
+                            type: string
+                          networkBootProtocol:
+                            default: IP4
+                            description: |-
+                              NetworkBootProtocol is the protocol to attempt during PXE network boot or NetBoot.
+                              The available protocols are:
+
+                              - IP4 -- PXE (or Apple NetBoot) over IPv4. The default.
+                              - IP6 -- PXE over IPv6. Only meaningful for EFI virtual machines.
+                            enum:
+                            - IP4
+                            - IP6
+                            type: string
+                        type: object
+                      bootstrap:
+                        description: |-
+                          Bootstrap describes the desired state of the guest's bootstrap
+                          configuration.
+
+                          If omitted, a default bootstrap method may be selected based on the
+                          guest OS identifier. If Linux, then the LinuxPrep method is used.
+                        properties:
+                          cloudInit:
+                            description: |-
+                              CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                              Windows guests that support Cloudbase-Init.
+
+                              The guest's networking stack is configured by Cloud-Init on Linux guests
+                              and Cloudbase-Init on Windows guests.
+
+                              Please note this bootstrap provider may not be used in conjunction with
+                              the other bootstrap providers.
+                            properties:
+                              cloudConfig:
+                                description: |-
+                                  CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                                  bootstrap the VM.
+
+                                  Please note this field and RawCloudConfig are mutually exclusive.
+                                properties:
+                                  defaultUserEnabled:
+                                    description: |-
+                                      DefaultUserEnabled may be set to true to ensure even if the Users field
+                                      is not empty, the default user is still created on systems that have one
+                                      defined. By default, Cloud-Init ignores the default user if the
+                                      CloudConfig provides one or more non-default users via the Users field.
+                                    type: boolean
+                                  runcmd:
+                                    description: |-
+                                      RunCmd allows running one or more commands on the guest.
+                                      The entries in this list can adhere to two, different formats:
+
+                                      Format 1 -- a string that contains the command and its arguments, ex.
+
+                                          runcmd:
+                                          - "ls -al"
+
+                                      Format 2 -- a list of the command and its arguments, ex.
+
+                                          runcmd:
+                                          - - echo
+                                            - "Hello, world."
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  ssh_pwauth:
+                                    description: |-
+                                      SSHPwdAuth sets whether or not to accept password authentication.
+                                      In order for this config to be applied, SSH may need to be restarted.
+                                      On systemd systems, this restart will only happen if the SSH service has
+                                      already been started. On non-systemd systems, a restart will be attempted
+                                      regardless of the service state.
+                                    type: boolean
+                                  timezone:
+                                    description: Timezone describes the timezone represented
+                                      in /usr/share/zoneinfo.
+                                    type: string
+                                  users:
+                                    description: Users allows adding/configuring one
+                                      or more users on the guest.
+                                    items:
+                                      description: User is a CloudConfig user data
+                                        structure.
+                                      properties:
+                                        create_groups:
+                                          description: |-
+                                            CreateGroups is a flag that may be set to false to disable creation of
+                                            specified user groups.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        expiredate:
+                                          description: ExpireData is the date on which
+                                            the user's account will be disabled.
+                                          type: string
+                                        gecos:
+                                          description: |-
+                                            Gecos is an optional comment about the user, usually a comma-separated
+                                            string of the user's real name and contact information.
+                                          type: string
+                                        groups:
+                                          description: Groups is an optional list
+                                            of groups to add to the user.
+                                          items:
+                                            type: string
+                                          type: array
+                                        hashed_passwd:
+                                          description: |-
+                                            HashedPasswd is a hash of the user's password that will be applied even
+                                            if the specified user already exists.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        homedir:
+                                          description: |-
+                                            Homedir is the optional home directory for the user.
+
+                                            Defaults to "/home/<username>" when Name is not "default".
+                                          type: string
+                                        inactive:
+                                          description: |-
+                                            Inactive optionally represents the number of days until the user is
+                                            disabled.
+                                          format: int32
+                                          type: integer
+                                        lock_passwd:
+                                          description: |-
+                                            LockPasswd disables password login.
+
+                                            Defaults to true when Name is not "default".
+                                          type: boolean
+                                        name:
+                                          description: |-
+                                            Name is the user's login name.
+
+                                            Please note this field may be set to the special value of "default" when
+                                            this User is the first element in the Users list from the CloudConfig.
+                                            When set to "default", all other fields from this User must be nil.
+                                          type: string
+                                        no_create_home:
+                                          description: |-
+                                            NoCreateHome prevents the creation of the home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_log_init:
+                                          description: |-
+                                            NoLogInit prevents the initialization of lastlog and faillog for the
+                                            user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        no_user_group:
+                                          description: |-
+                                            NoUserGroup prevents the creation of the group named after the user.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        passwd:
+                                          description: |-
+                                            Passwd is a hash of the user's password that will be applied only to
+                                            a newly created user. To apply a new, hashed password to an existing user
+                                            please use HashedPasswd instead.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        primary_group:
+                                          description: |-
+                                            PrimaryGroup is the primary group for the user.
+
+                                            Defaults to the value of the Name field when it is not "default".
+                                          type: string
+                                        selinux_user:
+                                          description: SELinuxUser is the SELinux
+                                            user for the user's login.
+                                          type: string
+                                        shell:
+                                          description: |-
+                                            Shell is the path to the user's login shell.
+
+                                            Please note the default is to set no shell, which results in a
+                                            system-specific default being used.
+                                          type: string
+                                        snapuser:
+                                          description: |-
+                                            SnapUser specifies an e-mail address to create the user as a Snappy user
+                                            through "snap create-user".
+
+                                            If an Ubuntu SSO account is associated with the address, the username and
+                                            SSH keys will be requested from there.
+                                          type: string
+                                        ssh_authorized_keys:
+                                          description: |-
+                                            SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                            keys file.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_import_id:
+                                          description: |-
+                                            SSHImportID is a list of SSH IDs to import for the user.
+
+                                            Please note this field may not be combined with SSHRedirectUser.
+                                          items:
+                                            type: string
+                                          type: array
+                                        ssh_redirect_user:
+                                          description: |-
+                                            SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                            Please note that when specified, all SSH keys from cloud meta-data will
+                                            be configured in a disabled state for this user. Any SSH login as this
+                                            user will timeout with a message to login instead as the default user.
+
+                                            This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        sudo:
+                                          description: |-
+                                            Sudo is a sudo rule to apply to the user.
+
+                                            When omitted, no sudo rules will be applied to the user.
+                                          type: string
+                                        system:
+                                          description: |-
+                                            System is an optional flag that indicates the user should be created as
+                                            a system user with no home directory.
+
+                                            Defaults to false when Name is not "default".
+                                          type: boolean
+                                        uid:
+                                          description: |-
+                                            UID is the user's ID.
+
+                                            When omitted the guest will default to the next available number.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  write_files:
+                                    description: WriteFiles allows adding files to
+                                      the guest file system.
+                                    items:
+                                      description: WriteFile is a CloudConfig write_file
+                                        data structure.
+                                      properties:
+                                        append:
+                                          description: |-
+                                            Append specifies whether or not to append the content to an existing file
+                                            if the file specified by Path already exists.
+                                          type: boolean
+                                        content:
+                                          description: |-
+                                            Content is the optional content to write to the provided Path.
+
+                                            When omitted an empty file will be created or existing file will be
+                                            modified.
+
+                                            The value for this field can adhere to two, different formats:
+
+                                            Format 1 -- a string that contains the command and its arguments, ex.
+
+                                                content: Hello, world.
+
+                                            Please note that format 1 supports all of the manners of specifying a
+                                            YAML string.
+
+                                            Format 2 -- a secret reference with the name of the key that contains
+                                                        the content for the file, ex.
+
+                                                content:
+                                                  name: my-bootstrap-secret
+                                                  key: my-file-content
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        defer:
+                                          description: |-
+                                            Defer indicates to defer writing the file until Cloud-Init's "final"
+                                            stage, after users are created and packages are installed.
+                                          type: boolean
+                                        encoding:
+                                          default: text/plain
+                                          description: Encoding is an optional encoding
+                                            type of the content.
+                                          enum:
+                                          - b64
+                                          - base64
+                                          - gz
+                                          - gzip
+                                          - gz+b64
+                                          - gz+base64
+                                          - gzip+b64
+                                          - gzip+base64
+                                          - text/plain
+                                          type: string
+                                        owner:
+                                          default: root:root
+                                          description: Owner is an optional "owner:group"
+                                            to chown the file.
+                                          type: string
+                                        path:
+                                          description: Path is the path of the file
+                                            to which the content is decoded and written.
+                                          type: string
+                                        permissions:
+                                          default: "0644"
+                                          description: |-
+                                            Permissions an optional set of file permissions to set.
+
+                                            Please note the permissions should be specified as an octal string, ex.
+                                            "0###".
+
+                                            When omitted the guest will default this value to "0644".
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - path
+                                    x-kubernetes-list-type: map
+                                type: object
+                              instanceID:
+                                description: |-
+                                  InstanceID is the cloud-init metadata instance ID.
+                                  If omitted, this field defaults to the VM's BiosUUID.
+                                type: string
+                              rawCloudConfig:
+                                description: |-
+                                  RawCloudConfig describes a key in a Secret resource that contains the
+                                  CloudConfig data used to bootstrap the VM.
+
+                                  The CloudConfig data specified by the key may be plain-text,
+                                  base64-encoded, or gzipped and base64-encoded.
+
+                                  Please note this field and CloudConfig are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sshAuthorizedKeys:
+                                description: |-
+                                  SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                                  the guest's default user.
+                                items:
+                                  type: string
+                                type: array
+                              useGlobalNameserversAsDefault:
+                                description: |-
+                                  UseGlobalNameserversAsDefault will use the global nameservers specified in
+                                  the NetworkSpec as the per-interface nameservers when the per-interface
+                                  nameservers is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                              useGlobalSearchDomainsAsDefault:
+                                description: |-
+                                  UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                                  in the NetworkSpec as the per-interface search domains when the per-interface
+                                  search domains is not provided.
+
+                                  Defaults to true if omitted.
+                                type: boolean
+                              waitOnNetwork4:
+                                description: |-
+                                  WaitOnNetwork4 indicates whether the cloud-init datasource should wait
+                                  for an IPv4 address to be available before writing the instance-data.
+
+                                  When set to true, the cloud-init datasource will sleep for a second,
+                                  check network status, and repeat until an IPv4 address is available.
+                                type: boolean
+                              waitOnNetwork6:
+                                description: |-
+                                  WaitOnNetwork6 indicates whether the cloud-init datasource should wait
+                                  for an IPv6 address to be available before writing the instance-data.
+
+                                  When set to true, the cloud-init datasource will sleep for a second,
+                                  check network status, and repeat until an IPv6 address is available.
+                                type: boolean
+                            type: object
+                          linuxPrep:
+                            description: |-
+                              LinuxPrep may be used to bootstrap Linux guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or Sysprep bootstrap providers.
+                            properties:
+                              customizeAtNextPowerOn:
+                                description: |-
+                                  CustomizeAtNextPowerOn describes when customization is performed on the VM.
+
+                                  When set to false, the VM will not be customized at the next power on. When
+                                  set to true, the VM will be customized at the next power on, and after the
+                                  customization this field will be set to false. This allows for when
+                                  customization is done explicitly requested, i.e. so that changes made in the
+                                  VM are not overridden by a later customization.
+
+                                  When not set, the VM will only be customized at every power on when the hash
+                                  of the previous customization specification is different from the current
+                                  specification.
+                                type: boolean
+                              expirePasswordAfterNextLogin:
+                                description: |-
+                                  ExpirePasswordAfterNextLogin indicates whether or not the root account is required to
+                                  change their password after the next login.
+                                type: boolean
+                              hardwareClockIsUTC:
+                                description: |-
+                                  HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                                  local time.
+                                type: boolean
+                              password:
+                                description: |-
+                                  Password is the new root password for the machine.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `password`.
+                                properties:
+                                  key:
+                                    default: password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              scriptText:
+                                description: |-
+                                  ScriptText is the script to run before and after customization.
+
+                                  Please see https://knowledge.broadcom.com/external/article?legacyId=1026614
+                                  for script examples.
+                                properties:
+                                  from:
+                                    description: |-
+                                      From is specified to reference a value from a Secret resource.
+
+                                      Please note this field is mutually exclusive with the Value field.
+                                    properties:
+                                      key:
+                                        description: Key is the key in the secret
+                                          that specifies the requested data.
+                                        type: string
+                                      name:
+                                        description: Name is the name of the secret.
+                                        type: string
+                                    required:
+                                    - key
+                                    - name
+                                    type: object
+                                  value:
+                                    description: |-
+                                      Value is used to directly specify a value.
+
+                                      Please note this field is mutually exclusive with the From field.
+                                    type: string
+                                type: object
+                              timeZone:
+                                description: |-
+                                  TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                                  Valid values are based on the tz (timezone) database used by Linux and
+                                  other Unix systems. The values are strings in the form of
+                                  "Area/Location," in which Area is a continent or ocean name, and
+                                  Location is the city, island, or other regional designation.
+
+                                  Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                                  time zones for Linux systems.
+                                type: string
+                            type: object
+                          sysprep:
+                            description: |-
+                              Sysprep may be used to bootstrap Windows guests.
+
+                              The guest's networking stack is configured by Guest OS Customization
+                              (GOSC).
+
+                              Please note this bootstrap provider may be used in conjunction with the
+                              VAppConfig bootstrap provider when wanting to configure the guest's
+                              network with GOSC but also send vApp/OVF properties into the guest.
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              or LinuxPrep bootstrap providers.
+                            properties:
+                              customizeAtNextPowerOn:
+                                description: |-
+                                  CustomizeAtNextPowerOn describes when customization is performed on the VM.
+
+                                  When set to false, the VM will not be customized at the next power on. When
+                                  set to true, the VM will be customized at the next power on, and after the
+                                  customization this field will be set to false. This allows for when
+                                  customization is done explicitly requested, i.e. so that changes made in the
+                                  VM are not overridden by a later customization.
+
+                                  When not set, the VM will only be customized at every power on when the hash
+                                  of the previous customization specification is different from the current
+                                  specification.
+                                type: boolean
+                              rawSysprep:
+                                description: |-
+                                  RawSysprep describes a key in a Secret resource that contains an XML
+                                  string of the Sysprep text used to bootstrap the VM.
+
+                                  The data specified by the Secret key may be plain-text, base64-encoded,
+                                  or gzipped and base64-encoded.
+
+                                  Please note this field and Sysprep are mutually exclusive.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              sysprep:
+                                description: |-
+                                  Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                                  This field encloses all the individual keys listed in a sysprep.xml file.
+
+                                  For more detailed information please see
+                                  https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                                  Please note this field and RawSysprep are mutually exclusive.
+                                properties:
+                                  expirePasswordAfterNextLogin:
+                                    description: |-
+                                      ExpirePasswordAfterNextLogin indicates whether or not the local Administrators
+                                      group accounts are required to change their password after the next login.
+                                    type: boolean
+                                  guiRunOnce:
+                                    description: GUIRunOnce is a representation of
+                                      the Sysprep GuiRunOnce key.
+                                    properties:
+                                      commands:
+                                        description: |-
+                                          Commands is a list of commands to run at first user logon, after guest
+                                          customization.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  guiUnattended:
+                                    description: GUIUnattended is a representation
+                                      of the Sysprep GUIUnattended key.
+                                    properties:
+                                      autoLogon:
+                                        description: |-
+                                          AutoLogon determine whether the machine automatically logs on as
+                                          Administrator.
+
+                                          Please note if AutoLogon is true, then Password must be set or guest
+                                          customization will fail.
+                                        type: boolean
+                                      autoLogonCount:
+                                        description: |-
+                                          AutoLogonCount specifies the number of times the machine should
+                                          automatically log on as Administrator.
+
+                                          Generally it should be 1, but if your setup requires a number of reboots,
+                                          you may want to increase it. This number may be determined by the list of
+                                          commands executed by the GuiRunOnce command.
+
+                                          Please note this field must be specified with a non-zero positive integer
+                                          if AutoLogon is true.
+                                        format: int32
+                                        type: integer
+                                      password:
+                                        description: |-
+                                          Password is the new administrator password for the machine.
+
+                                          To specify that the password should be set to blank (that is, no
+                                          password), set the password value to NULL. Because of encryption, "" is
+                                          NOT a valid value.
+
+                                          Please note if the password is set to blank and AutoLogon is true, the
+                                          guest customization will fail.
+
+                                          If the XML file is generated by the VirtualCenter Customization Wizard,
+                                          then the password is encrypted. Otherwise, the client should set the
+                                          plainText attribute to true, so that the customization process does not
+                                          attempt to decrypt the string.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `password`.
+                                        properties:
+                                          key:
+                                            default: password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      timeZone:
+                                        default: 85
+                                        description: |-
+                                          TimeZone is the time zone index for the virtual machine.
+
+                                          Please note that numbers correspond to time zones listed at
+                                          https://bit.ly/3Rzv8oL.
+
+                                          Defaults to UTC.
+                                        format: int32
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - timeZone
+                                    type: object
+                                  identification:
+                                    description: Identification is a representation
+                                      of the Sysprep Identification key.
+                                    properties:
+                                      domainAdmin:
+                                        description: |-
+                                          DomainAdmin is the domain user account used for authentication if the
+                                          virtual machine is joining a domain. The user does not need to be a
+                                          domain administrator, but the account must have the privileges required
+                                          to add computers to the domain.
+                                        type: string
+                                      domainAdminPassword:
+                                        description: |-
+                                          DomainAdminPassword is the password for the domain user account used for
+                                          authentication if the virtual machine is joining a domain.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: domain_admin_password
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      domainOU:
+                                        description: |-
+                                          DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                          the OU to which the computer belongs.
+                                        type: string
+                                      joinWorkgroup:
+                                        description: |-
+                                          JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                          this value is supplied, then the fields spec.network.domain,
+                                          spec.bootstrap.sysprep.identification.domainAdmin, and
+                                          spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                        type: string
+                                    type: object
+                                  licenseFilePrintData:
+                                    description: |-
+                                      LicenseFilePrintData is a representation of the Sysprep
+                                      LicenseFilePrintData key.
+
+                                      Please note this is required only for Windows 2000 Server and Windows
+                                      Server 2003.
+                                    properties:
+                                      autoMode:
+                                        description: AutoMode specifies the server
+                                          licensing mode.
+                                        enum:
+                                        - perSeat
+                                        - perServer
+                                        type: string
+                                      autoUsers:
+                                        description: |-
+                                          AutoUsers indicates the number of client licenses purchased for the
+                                          VirtualCenter server being installed.
+
+                                          Please note this value is ignored unless AutoMode is PerServer.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - autoMode
+                                    type: object
+                                  scriptText:
+                                    description: |-
+                                      ScriptText describes the script to run before and after customization. The
+                                      script must be a Windows batch file.
+
+                                      Please see https://knowledge.broadcom.com/external/article?legacyId=1026614
+                                      for script examples.
+                                    properties:
+                                      from:
+                                        description: |-
+                                          From is specified to reference a value from a Secret resource.
+
+                                          Please note this field is mutually exclusive with the Value field.
+                                        properties:
+                                          key:
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                      value:
+                                        description: |-
+                                          Value is used to directly specify a value.
+
+                                          Please note this field is mutually exclusive with the From field.
+                                        type: string
+                                    type: object
+                                  userData:
+                                    description: UserData is a representation of the
+                                      Sysprep UserData key.
+                                    properties:
+                                      fullName:
+                                        description: FullName is the user's full name.
+                                        type: string
+                                      orgName:
+                                        description: OrgName is the name of the user's
+                                          organization.
+                                        type: string
+                                      productID:
+                                        description: |-
+                                          ProductID is a valid serial number.
+
+                                          Please note unless the VirtualMachineImage was installed with a volume
+                                          license key, ProductID must be set or guest customization will fail.
+
+                                          When not explicitly specified, the Key field for the selector defaults to
+                                          `domain_admin_password`.
+                                        properties:
+                                          key:
+                                            default: product_id
+                                            description: Key is the key in the secret
+                                              that specifies the requested data.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the secret.
+                                            type: string
+                                        required:
+                                        - key
+                                        - name
+                                        type: object
+                                    required:
+                                    - fullName
+                                    - orgName
+                                    type: object
+                                required:
+                                - userData
+                                type: object
+                            type: object
+                          vAppConfig:
+                            description: |-
+                              VAppConfig may be used to bootstrap guests that rely on vApp properties
+                              (how VMware surfaces OVF properties on guests) to transport data into the
+                              guest.
+
+                              The guest's networking stack may be configured using either vApp
+                              properties or GOSC.
+
+                              Many OVFs define one or more properties that are used by the guest to
+                              bootstrap its networking stack. If the VirtualMachineImage defines one or
+                              more properties like this, then they can be configured to use the network
+                              data provided for this VM at runtime by setting these properties to Go
+                              template strings.
+
+                              It is also possible to use GOSC to bootstrap this VM's network stack by
+                              configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                              Please note the VAppConfig bootstrap provider in conjunction with the
+                              LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                              VM metadata transport to "OvfEnv".
+
+                              This bootstrap provider may not be used in conjunction with the CloudInit
+                              bootstrap provider.
+                            properties:
+                              properties:
+                                description: |-
+                                  Properties is a list of vApp/OVF property key/value pairs.
+
+                                  Please note this field and RawProperties are mutually exclusive.
+                                items:
+                                  description: |-
+                                    KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                                    list of key/value pairs where each value could also reference data stored in
+                                    a Secret resource.
+                                  properties:
+                                    key:
+                                      description: Key is the key part of the key/value
+                                        pair.
+                                      type: string
+                                    value:
+                                      description: Value is the optional value part
+                                        of the key/value pair.
+                                      properties:
+                                        from:
+                                          description: |-
+                                            From is specified to reference a value from a Secret resource.
+
+                                            Please note this field is mutually exclusive with the Value field.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret
+                                                that specifies the requested data.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                secret.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        value:
+                                          description: |-
+                                            Value is used to directly specify a value.
+
+                                            Please note this field is mutually exclusive with the From field.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - key
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              rawProperties:
+                                description: |-
+                                  RawProperties is the name of a Secret resource in the same Namespace as
+                                  this VM where each key/value pair from the Secret is used as a vApp
+                                  key/value pair.
+
+                                  Please note this field and Properties are mutually exclusive.
+                                type: string
+                            type: object
+                        type: object
+                      class:
+                        description: |-
+                          Class describes the VirtualMachineClassInsance resource that is
+                          referenced by this virtual machine. This can be the
+                          VirtualMachineClassInstance that the virtual machine was
+                          created, or later resized with.
+
+                          The value of spec.class.Name must be the Kubernetes object name
+                          of a valid VirtualMachineClassInstance resource.
+
+                          Please also note, if this field and spec.className are both
+                          non-empty, then they must refer to the same VirtualMachineClass
+                          or an error is returned.
+
+                          If a className is specified, but this field is omitted, VM operator
+                          picks the latest instance for the VM class to create the VM.
+
+                          If a VM class has been modified and thus, the newly available
+                          VirtualMachineClassInstance can be specified in spec.class to
+                          trigger a resize operation.
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an
+                              object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object
+                              represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name refers to a unique resource in the current namespace.
+                              More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        type: object
+                      className:
+                        description: |-
+                          ClassName describes the name of the VirtualMachineClass resource used to
+                          deploy this VM.
+
+                          When creating a virtual machine, if this field is empty and a
+                          VirtualMachineClassInstance is specified in spec.class, then
+                          this field is populated with the VirtualMachineClass object's
+                          name.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.class are both non-empty, then they must refer to the same
+                          VirtualMachineClass or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM class.
+
+                          If a VM is using a class, a different value in spec.className
+                          leads to the VM being resized.
+                        type: string
+                      crypto:
+                        description: Crypto describes the desired encryption state
+                          of the VirtualMachine.
+                        properties:
+                          encryptionClassName:
+                            description: |-
+                              EncryptionClassName describes the name of the EncryptionClass resource
+                              used to encrypt this VM.
+
+                              Please note, this field is not required to encrypt the VM. If the
+                              underlying platform has a default key provider, the VM may still be fully
+                              or partially encrypted depending on the specified storage and VM classes.
+
+                              If there is a default key provider and an encryption storage class is
+                              selected, the files in the VM's home directory and non-PVC virtual disks
+                              will be encrypted
+
+                              If there is a default key provider and a VM Class with a virtual, trusted
+                              platform module (vTPM) is selected, the files in the VM's home directory,
+                              minus any virtual disks, will be encrypted.
+
+                              If the underlying vSphere platform does not have a default key provider,
+                              then this field is required when specifying an encryption storage class
+                              and/or a VM Class with a vTPM.
+
+                              If this field is set, spec.storageClass must use an encryption-enabled
+                              storage class.
+                            type: string
+                          useDefaultKeyProvider:
+                            default: true
+                            description: |-
+                              UseDefaultKeyProvider describes the desired behavior for when an explicit
+                              EncryptionClass is not provided.
+
+                              When an explicit EncryptionClass is not provided and this value is true:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will be encrypted using the default key provider.
+
+                              - If a VirtualMachine is not encrypted, uses an encryption storage
+                                policy or has a virtual, trusted platform module (vTPM), there is a
+                                default key provider, the VM will be encrypted using the default key
+                                provider.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be rekeyed using the default key provider.
+
+                              When an explicit EncryptionClass is not provided and this value is false:
+
+                              - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                                will fail.
+
+                              - If a VirtualMachine is encrypted with a provider other than the default
+                                key provider, the VM will be not be rekeyed.
+
+                                Please note, this could result in a VirtualMachine that cannot be
+                                powered on since it is encrypted using a provider or key that may have
+                                been removed. Without the key, the VM cannot be decrypted and thus
+                                cannot be powered on.
+
+                              Defaults to true if omitted.
+                            type: boolean
+                        type: object
+                      currentSnapshotName:
+                        description: |-
+                          CurrentSnapshotName represents the desired snapshot that the VM
+                          should point to. This field can be specified to revert the VM
+                          to a given snapshot. Once the virtual machine has been
+                          successfully reverted to the desired snapshot, the value of
+                          this field is cleared.
+
+                          The value of this field must be the name of an existing
+                          VirtualMachineSnapshot resource in the same namespace.
+
+                          Reverting a virtual machine to a snapshot rolls back the data
+                          and the configuration of the virtual machine to that of the
+                          specified snapshot. The VirtualMachineSpec of the
+                          VirtualMachine resource is replaced from the one stored with
+                          the snapshot.
+
+                          If the virtual machine is currently powered off, but you revert to
+                          a snapshot that was taken while the VM was powered on, then the
+                          VM will be automatically powered on during the revert.
+                          Additionally, the VirtualMachineSpec will be updated to match
+                          the power state from the snapshot (i.e., powered on). This can
+                          be overridden by specifying the PowerState to PoweredOff in the
+                          VirtualMachineSpec.
+                        type: string
+                      groupName:
+                        description: |-
+                          GroupName indicates the name of the VirtualMachineGroup to which this
+                          VM belongs.
+
+                          VMs that belong to a group do not drive their own placement, rather that
+                          is handled by the group.
+
+                          When this field is set to a valid group that contains this VM as a
+                          member, an owner reference to that group is added to this VM.
+
+                          When this field is deleted or changed, any existing owner reference to
+                          the previous group will be removed from this VM.
+                        type: string
+                      guestID:
+                        description: |-
+                          GuestID describes the desired guest operating system identifier for a VM.
+
+                          The logic that determines the guest ID is as follows:
+
+                          If this field is set, then its value is used.
+                          Otherwise, if the VM is deployed from an OVF template that defines a
+                          guest ID, then that value is used.
+                          The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                          For a complete list of supported values, please refer to
+                          https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                          Please note that some guest ID values may require a minimal hardware
+                          version, which can be set using the `spec.minHardwareVersion` field.
+                          To see the mapping between virtual hardware versions and the product
+                          versions that support a specific guest ID, please refer to
+                          https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                          Please note that this field is immutable after the VM is powered on.
+                          To change the guest ID after the VM is powered on, the VM must be powered
+                          off and then powered on again with the updated guest ID spec.
+
+                          This field is required when the VM has any CD-ROM devices attached.
+                        type: string
+                      hardware:
+                        description: Hardware describes the VM's desired hardware.
+                        properties:
+                          cdrom:
+                            description: |-
+                              Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                              Each CD-ROM device requires a reference to an ISO-type
+                              VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                              Multiple CD-ROM devices using the same backing image, regardless of image
+                              kinds (namespace or cluster scope), are not allowed.
+
+                              CD-ROM devices can be added, updated, or removed when the VM is powered
+                              off. When the VM is powered on, only the connection state of existing
+                              CD-ROM devices can be changed.
+                              CD-ROM devices are attached to the VM in the specified list-order.
+                            items:
+                              description: VirtualMachineCdromSpec describes the desired
+                                state of a CD-ROM device.
+                              properties:
+                                allowGuestControl:
+                                  default: true
+                                  description: |-
+                                    AllowGuestControl describes whether or not a web console connection
+                                    may be used to connect/disconnect the CD-ROM device.
+
+                                    Defaults to true if omitted.
+                                  type: boolean
+                                connected:
+                                  default: true
+                                  description: |-
+                                    Connected describes the desired connection state of the CD-ROM device.
+
+                                    When true, the CD-ROM device is added and connected to the VM.
+                                    If the device already exists, it is updated to a connected state.
+
+                                    When explicitly set to false, the CD-ROM device is added but remains
+                                    disconnected from the VM. If the CD-ROM device already exists, it is
+                                    updated to a disconnected state.
+
+                                    Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                                    in the guest OS. Refer to the following KB article for more details:
+                                    https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                                    Defaults to true if omitted.
+                                  type: boolean
+                                controllerBusNumber:
+                                  description: |-
+                                    ControllerBusNumber describes the bus number of the controller to which
+                                    this CD-ROM should be attached.
+
+                                    The bus number specifies a controller based on the value of the
+                                    controllerType field:
+
+                                      - IDE  -- spec.hardware.ideControllers
+                                      - SATA -- spec.hardware.sataControllers
+
+                                    If this and controllerType are both omitted, the CD-ROM will be attached
+                                    to the  first available IDE controller. If there is no IDE controller
+                                    with an available slot, a new SATA controller will be added as long as
+                                    there are currently three or fewer SATA controllers.
+
+                                    If the specified controller has no available slots, the request will be
+                                    denied.
+                                  format: int32
+                                  type: integer
+                                controllerType:
+                                  allOf:
+                                  - enum:
+                                    - IDE
+                                    - NVME
+                                    - SCSI
+                                    - SATA
+                                  - enum:
+                                    - IDE
+                                    - SATA
+                                  description: |-
+                                    ControllerType describes the type of the controller to which this CD-ROM
+                                    should be attached.
+
+                                    Please keep in mind the number of devices supported by the different
+                                    types of controllers:
+
+                                      - IDE                -- 4 total (2 per controller)
+                                      - SATA               -- 120 total (30 per controller)
+
+                                    Defaults to IDE when controllerBusNumber is also omitted; otherwise the
+                                    default value is determined by the logic outlined in the description of
+                                    the controllerBusNumber field.
+                                  type: string
+                                image:
+                                  description: |-
+                                    Image describes the reference to an ISO type VirtualMachineImage or
+                                    ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                                    If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                                    This field is immutable when the VM is powered on.
+
+                                    Please note, unlike the spec.imageName field, the value of this
+                                    spec.cdrom.image.name MUST be a Kubernetes object name.
+                                  properties:
+                                    kind:
+                                      description: |-
+                                        Kind describes the type of image, either a namespace-scoped
+                                        VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name refers to the name of a VirtualMachineImage resource in the same
+                                        namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name consists of at least two lowercase letters or digits of this CD-ROM.
+                                    It must be unique among all CD-ROM devices attached to the VM.
+
+                                    This field is immutable when the VM is powered on.
+                                  pattern: ^[a-z0-9]{2,}$
+                                  type: string
+                                unitNumber:
+                                  description: |-
+                                    UnitNumber describes the desired unit number for attaching the CD-ROM to
+                                    a storage controller.
+
+                                    When omitted, the next available unit number of the selected controller
+                                    is used.
+
+                                    This value must be unique for the controller referenced by the
+                                    controllerBusNumber and controllerType properties. If the value is
+                                    already used by another device, this CD-ROM will not be attached.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - image
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          ideControllers:
+                            description: |-
+                              IDEControllers describes the desired list of IDE controllers for the VM.
+
+                              Defaults to two IDE controllers, with bus 0 and bus 1.
+                            items:
+                              properties:
+                                busNumber:
+                                  description: BusNumber describes the desired bus
+                                    number of the controller.
+                                  format: int32
+                                  maximum: 1
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - busNumber
+                              type: object
+                            maxItems: 2
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - busNumber
+                            x-kubernetes-list-type: map
+                          nvmeControllers:
+                            description: |-
+                              NVMEControllers describes the desired list of NVME controllers for the
+                              VM.
+                            items:
+                              properties:
+                                busNumber:
+                                  description: BusNumber describes the desired bus
+                                    number of the controller.
+                                  format: int32
+                                  maximum: 3
+                                  minimum: 0
+                                  type: integer
+                                pciSlotNumber:
+                                  description: |-
+                                    PCISlotNumber describes the desired PCI slot number to use for this
+                                    controller.
+
+                                    Please note, most of the time this field should be empty so the system
+                                    can pick an available slot.
+                                  format: int32
+                                  type: integer
+                                sharingMode:
+                                  default: None
+                                  description: |-
+                                    SharingMode describes the sharing mode for the controller.
+
+                                    Defaults to None.
+                                  enum:
+                                  - None
+                                  - Physical
+                                  type: string
+                              required:
+                              - busNumber
+                              type: object
+                            maxItems: 4
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - busNumber
+                            x-kubernetes-list-type: map
+                          sataControllers:
+                            description: |-
+                              SATAControllers describes the desired list of SATA controllers for the
+                              VM.
+
+                              Please note, all SATA controllers are VirtualAHCI.
+                            items:
+                              properties:
+                                busNumber:
+                                  description: BusNumber describes the desired bus
+                                    number of the controller.
+                                  format: int32
+                                  maximum: 3
+                                  minimum: 0
+                                  type: integer
+                                pciSlotNumber:
+                                  description: |-
+                                    PCISlotNumber describes the desired PCI slot number to use for this
+                                    controller.
+
+                                    Please note, most of the time this field should be empty so the system
+                                    can pick an available slot.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - busNumber
+                              type: object
+                            maxItems: 4
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - busNumber
+                            x-kubernetes-list-type: map
+                          scsiControllers:
+                            description: |-
+                              SCSIControllers describes the desired list of SCSI controllers for the
+                              VM.
+                            items:
+                              properties:
+                                busNumber:
+                                  description: BusNumber describes the desired bus
+                                    number of the controller.
+                                  format: int32
+                                  maximum: 3
+                                  minimum: 0
+                                  type: integer
+                                pciSlotNumber:
+                                  description: |-
+                                    PCISlotNumber describes the desired PCI slot number to use for this
+                                    controller.
+
+                                    Please note, most of the time this field should be empty so the system
+                                    can pick an available slot.
+                                  format: int32
+                                  type: integer
+                                sharingMode:
+                                  default: None
+                                  description: |-
+                                    SharingMode describes the sharing mode for the controller.
+
+                                    Defaults to None.
+                                  enum:
+                                  - None
+                                  - Physical
+                                  - Virtual
+                                  type: string
+                                type:
+                                  default: ParaVirtual
+                                  description: |-
+                                    Type describes the desired type of SCSI controller.
+
+                                    Defaults to ParaVirtual.
+                                  enum:
+                                  - ParaVirtual
+                                  - BusLogic
+                                  - LsiLogic
+                                  - LsiLogicSAS
+                                  type: string
+                              required:
+                              - busNumber
+                              type: object
+                            maxItems: 4
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - busNumber
+                            x-kubernetes-list-type: map
+                        type: object
+                      image:
+                        description: |-
+                          Image describes the reference to the VirtualMachineImage or
+                          ClusterVirtualMachineImage resource used to deploy this VM.
+
+                          Please note, unlike the field spec.imageName, the value of
+                          spec.image.name MUST be a Kubernetes object name.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.imageName are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        properties:
+                          kind:
+                            description: |-
+                              Kind describes the type of image, either a namespace-scoped
+                              VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                          name:
+                            description: |-
+                              Name refers to the name of a VirtualMachineImage resource in the same
+                              namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      imageName:
+                        description: |-
+                          ImageName describes the name of the image resource used to deploy this
+                          VM.
+
+                          This field may be used to specify the name of a VirtualMachineImage
+                          or ClusterVirtualMachineImage resource. The resolver first checks to see
+                          if there is a VirtualMachineImage with the specified name in the
+                          same namespace as the VM being deployed. If no such resource exists, the
+                          resolver then checks to see if there is a ClusterVirtualMachineImage
+                          resource with the specified name.
+
+                          This field may also be used to specify the display name (vSphere name) of
+                          a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                          display name unambiguously resolves to a distinct VM image (among all
+                          existing VirtualMachineImages in the VM's namespace and all existing
+                          ClusterVirtualMachineImages), then a mutation webhook updates the
+                          spec.image field with the reference to the resolved VM image. If the
+                          display name resolves to multiple or no VM images, then the mutation
+                          webhook denies the request and returns an error.
+
+                          Please also note, when creating a new VirtualMachine, if this field and
+                          spec.image are both non-empty, then they must refer to the same
+                          resource or an error is returned.
+
+                          Please note, this field *may* be empty if the VM was imported instead of
+                          deployed by VM Operator. An imported VirtualMachine resource references
+                          an existing VM on the underlying platform that was not deployed from a
+                          VM image.
+                        type: string
+                      instanceUUID:
+                        description: |-
+                          InstanceUUID describes the desired Instance UUID for a VM.
+                          If omitted, this field defaults to a random UUID.
+                          This value is only used for the VM Instance UUID,
+                          it is not used within cloudInit.
+                          This identifier is used by VirtualCenter to uniquely identify all
+                          virtual machine instances, including those that may share the same BIOS UUID.
+                        format: uuid
+                        type: string
+                      minHardwareVersion:
+                        description: |-
+                          MinHardwareVersion describes the desired, minimum hardware version.
+
+                          The logic that determines the hardware version is as follows:
+
+                          1. If this field is set, then its value is used.
+                          2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                             non-empty hardware version, then it is used.
+                          3. Finally, if the hardware version is still undetermined, the value is
+                             set to the default hardware version for the Datacenter/Cluster/Host
+                             where the VM is provisioned.
+
+                          This field is never updated to reflect the derived hardware version.
+                          Instead, VirtualMachineStatus.HardwareVersion surfaces
+                          the observed hardware version.
+
+                          Please note, setting this field's value to N ensures a VM's hardware
+                          version is equal to or greater than N. For example, if a VM's observed
+                          hardware version is 10 and this field's value is 13, then the VM will be
+                          upgraded to hardware version 13. However, if the observed hardware
+                          version is 17 and this field's value is 13, no change will occur.
+
+                          Several features are hardware version dependent, for example:
+
+                          * NVMe Controllers                >= 14
+                          * Dynamic Direct Path I/O devices >= 17
+
+                          Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                          hardware versions.
+
+                          It is important to remember that a VM's hardware version may not be
+                          downgraded and upgrading a VM deployed from an image based on an older
+                          hardware version to a more recent one may result in unpredictable
+                          behavior. In other words, please be careful when choosing to upgrade a
+                          VM to a newer hardware version.
+                        format: int32
+                        minimum: 13
+                        type: integer
+                      network:
+                        description: |-
+                          Network describes the desired network configuration for the VM.
+
+                          Please note this value may be omitted entirely and the VM will be
+                          assigned a single, virtual network interface that is connected to the
+                          Namespace's default network.
+                        properties:
+                          disabled:
+                            description: |-
+                              Disabled is a flag that indicates whether or not to disable networking
+                              for this VM.
+
+                              When set to true, the VM is not configured with a default interface nor
+                              any specified from the Interfaces field.
+                            type: boolean
+                          domainName:
+                            description: |-
+                              DomainName describes the value the guest uses as its domain name.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS names:
+
+                                * When joined with the host name, the total length is restricted to 255
+                                  characters or less.
+                                * Individual segments must be 63 characters or less.
+                                * The top-level domain( ex. ".com"), is at least two letters with no
+                                  special characters.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Long, top-level domain names (ex. ".london") are permitted.
+                                * Symbol unicode points, such as emoji, are disallowed in the top-level
+                                  domain.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+
+                              When deploying a guest running Microsoft Windows, this field describes
+                              the domain the computer should join.
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName describes the value the guest uses as its host name. If omitted,
+                              the name of the VM will be used.
+
+                              Please note, this feature is available with the following bootstrap
+                              providers: CloudInit, LinuxPrep, and Sysprep.
+
+                              This field must adhere to the format specified in RFC-1034, Section 3.5
+                              for DNS labels:
+
+                                * The total length is restricted to 63 characters or less.
+                                * The total length is restricted to 15 characters or less on Windows
+                                  systems.
+                                * The value may begin with a digit per RFC-1123.
+                                * Underscores are not allowed.
+                                * Dashes are permitted, but not at the start or end of the value.
+                                * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                                  please note that the use of emoji, even where allowed, may not
+                                  compatible with the guest operating system, so it recommended to
+                                  stick with more common characters for this value.
+                                * The value may be a valid IP4 or IP6 address. Please note, the use of
+                                  an IP address for a host name is not compatible with all guest
+                                  operating systems and is discouraged. Additionally, using an IP
+                                  address for the host name is disallowed if spec.network.domainName is
+                                  non-empty.
+
+                              Please note, the combined values of spec.network.hostName and
+                              spec.network.domainName may not exceed 255 characters in length.
+                            type: string
+                          interfaces:
+                            description: |-
+                              Interfaces is the list of network interfaces used by this VM.
+
+                              If the Interfaces field is empty and the Disabled field is false, then
+                              a default interface with the name eth0 will be created.
+
+                              The maximum number of network interface allowed is 10 because a vSphere
+                              virtual machine may not have more than 10 virtual ethernet card devices.
+                            items:
+                              description: |-
+                                VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                                network interface.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                                    interface.
+
+                                    Please note this field is only supported if the connected network
+                                    supports manual IP allocation.
+
+                                    Please note IP4 and IP6 addresses must include the network prefix length,
+                                    ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                                    Please note this field may not contain IP4 addresses if DHCP4 is set
+                                    to true or IP6 addresses if DHCP6 is set to true.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 indicates whether or not this interface uses DHCP for IP4
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP4 addresses in the
+                                    Addresses field and the Gateway4 field.
+                                  type: boolean
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 indicates whether or not this interface uses DHCP for IP6
+                                    networking.
+
+                                    Please note this field is only supported if the network connection
+                                    supports DHCP.
+
+                                    Please note this field is mutually exclusive with IP6 addresses in the
+                                    Addresses field and the Gateway6 field.
+                                  type: boolean
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the default, IP4 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP4.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 is the primary IP6 gateway for this interface.
+
+                                    If unset, the gateway from the network provider will be used. However,
+                                    if set to "None", the network provider gateway will be ignored.
+
+                                    Please note this field is only supported if the network connection
+                                    supports manual IP allocation.
+
+                                    Please note this field is mutually exclusive with DHCP6.
+                                  type: string
+                                guestDeviceName:
+                                  description: |-
+                                    GuestDeviceName is used to rename the device inside the guest when the
+                                    bootstrap provider is Cloud-Init. Please note it is up to the user to
+                                    ensure the provided device name does not conflict with any other devices
+                                    inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^\w\w+$
+                                  type: string
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the optional MAC address of this interface.
+
+                                    If no MAC address is provided, one will be generated by either the network
+                                    provider or vCenter.
+
+                                    Please note this field is only supported when the Network API Group is
+                                    crd.nsx.vmware.com.
+                                  pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                                  type: string
+                                mtu:
+                                  description: |-
+                                    MTU is the Maximum Transmission Unit size in bytes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  format: int64
+                                  type: integer
+                                name:
+                                  description: |-
+                                    Name describes the unique name of this network interface, used to
+                                    distinguish it from other network interfaces attached to this VM.
+
+                                    When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                                    specified, the device inside the guest will be renamed to this value.
+                                    Please note it is up to the user to ensure the provided name does not
+                                    conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                                  pattern: ^[a-z0-9]{2,}$
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                                    nameservers.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit and Sysprep.
+
+                                    When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                                    true, if nameservers is not provided, the global nameservers will be used
+                                    instead.
+
+                                    Please note that Linux allows only three nameservers
+                                    (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                network:
+                                  description: |-
+                                    Network is the name of the network resource to which this interface is
+                                    connected.
+
+                                    If no network is provided, then this interface will be connected to the
+                                    Namespace's default network.
+                                  properties:
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion defines the versioned schema of this representation of an object.
+                                        Servers should convert recognized schemas to the latest internal value, and
+                                        may reject unrecognized values.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind is a string value representing the REST resource this object represents.
+                                        Servers may infer this from the endpoint the client submits requests to.
+                                        Cannot be updated.
+                                        In CamelCase.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name refers to a unique resource in the current namespace.
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                routes:
+                                  description: |-
+                                    Routes is a list of optional, static routes.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+                                  items:
+                                    description: VirtualMachineNetworkRouteSpec defines
+                                      a static route for a guest.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        minimum: 1
+                                        type: integer
+                                      to:
+                                        description: To is either "default", or an
+                                          IP4 or IP6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IP4 or IP6 address.
+                                        type: string
+                                    required:
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+
+                                    Please note this feature is available only with the following bootstrap
+                                    providers: CloudInit.
+
+                                    When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                                    or true, if search domains is not provided, the global search domains
+                                    will be used instead.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                              nameservers. These are applied globally.
+
+                              Please note global nameservers are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface nameservers. However, when Cloud-Init
+                              is used and UseGlobalNameserversAsDefault is true, the global
+                              nameservers will be used when the per-interface nameservers is not
+                              provided.
+
+                              Please note that Linux allows only three nameservers
+                              (https://linux.die.net/man/5/resolv.conf).
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of search domains used when resolving IP
+                              addresses with DNS. These are applied globally.
+
+                              Please note global search domains are only available with the following
+                              bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                              provider supports per-interface search domains. However, when Cloud-Init
+                              is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                              domains will be used when the per-interface search domains is not provided.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      nextRestartTime:
+                        description: |-
+                          NextRestartTime may be used to restart the VM, in accordance with
+                          RestartMode, by setting the value of this field to "now"
+                          (case-insensitive).
+
+                          A mutating webhook changes this value to the current time (UTC), which
+                          the VM controller then uses to determine the VM should be restarted by
+                          comparing the value to the timestamp of the last time the VM was
+                          restarted.
+
+                          Please note it is not possible to schedule future restarts using this
+                          field. The only value that users may set is the string "now"
+                          (case-insensitive).
+                        type: string
+                      policies:
+                        description: |-
+                          Policies describes a list of policies that should be explicitly applied
+                          to this VM.
+
+                          Please note, not all policies may be applied explicitly to a VM. Please
+                          consult a policy to determine if it may be applied directly. For example,
+                          the ComputePolicy object from the vsphere.policy.vmware.com API group
+                          has a field named spec.type. Only ComputePolicy objects with
+                          type=Optional may be applied explicitly to a VM.
+
+                          Valid policy types are: ComputePolicy.
+                        items:
+                          description: |-
+                            LocalObjectRef describes a reference to another object in the same
+                            namespace as the referrer.
+                          properties:
+                            apiVersion:
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an
+                                object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                              type: string
+                            kind:
+                              description: |-
+                                Kind is a string value representing the REST resource this object
+                                represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name refers to a unique resource in the current namespace.
+                                More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          type: object
+                        type: array
+                      powerOffMode:
+                        default: TrySoft
+                        description: |-
+                          PowerOffMode describes the desired behavior when powering off a VM.
+
+                          There are three, supported power off modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is the equivalent of a physical
+                          system's power cord being ripped from the wall. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                          a graceful shutdown, and if that fails or the VM is not in a powered off
+                          state after five minutes, the VM is halted.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      powerState:
+                        description: |-
+                          PowerState describes the desired power state of a VirtualMachine.
+
+                          Please note this field may be omitted when creating a new VM and will
+                          default to "PoweredOn." However, once the field is set to a non-empty
+                          value, it may no longer be set to an empty value.
+
+                          Additionally, setting this value to "Suspended" is not supported when
+                          creating a new VM. The valid values when creating a new VM are
+                          "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                          since this value defaults to "PoweredOn" for new VMs.
+                        enum:
+                        - PoweredOff
+                        - PoweredOn
+                        - Suspended
+                        type: string
+                      promoteDisksMode:
+                        default: Online
+                        description: |-
+                          PromoteDisksMode describes the mode used to promote a VM's delta disks to
+                          full disks. The available modes are:
+
+                          - Disabled -- Do not promote disks.
+                          - Online   -- Promote disks while the VM is powered on. VMs with
+                                        snapshots do not support online promotion.
+                          - Offline  -- Promote disks while the VM is powered off.
+
+                          Please note, this field is ignored for encrypted VMs since they do not
+                          use delta disks.
+
+                          Defaults to Online.
+                        enum:
+                        - Online
+                        - Offline
+                        - Disabled
+                        type: string
+                      readinessProbe:
+                        description: ReadinessProbe describes a probe used to determine
+                          the VM's ready state.
+                        properties:
+                          guestHeartbeat:
+                            description: GuestHeartbeat specifies an action involving
+                              the guest heartbeat status.
+                            properties:
+                              thresholdStatus:
+                                default: green
+                                description: |-
+                                  ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                                  considered successful.
+                                enum:
+                                - yellow
+                                - green
+                                type: string
+                            type: object
+                          guestInfo:
+                            description: |-
+                              GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                              The elements are evaluated with the logical AND operator, meaning
+                              all expressions must evaluate as true for the probe to succeed.
+
+                              For example, a VM resource's probe definition could be specified as the
+                              following:
+
+                                      guestInfo:
+                                      - key:   ready
+                                        value: true
+
+                              With the above configuration in place, the VM would not be considered
+                              ready until the GuestInfo key "ready" was set to the value "true".
+
+                              From within the guest operating system it is possible to set GuestInfo
+                              key/value pairs using the program "vmware-rpctool," which is included
+                              with VM Tools. For example, the following command will set the key
+                              "guestinfo.ready" to the value "true":
+
+                                      vmware-rpctool "info-set guestinfo.ready true"
+
+                              Once executed, the VM's readiness probe will be signaled and the
+                              VM resource will be marked as ready.
+                            items:
+                              description: |-
+                                GuestInfoAction describes a key from GuestInfo that must match the associated
+                                value expression.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key is the name of the GuestInfo key.
+
+                                    The key is automatically prefixed with "guestinfo." before being
+                                    evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                                    evaluated as "guestinfo.guestinfo.mykey".
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value is a regular expression that is matched against the value of the
+                                    specified key.
+
+                                    An empty value is the equivalent of "match any" or ".*".
+
+                                    All values must adhere to the RE2 regular expression syntax as documented
+                                    at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                                    ignored depending on the implementation of this API. Either way, invalid
+                                    values will not be considered when evaluating the ready state of a VM.
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
+                          periodSeconds:
+                            description: |-
+                              PeriodSeconds specifics how often (in seconds) to perform the probe.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          tcpSocket:
+                            description: |-
+                              TCPSocket specifies an action involving a TCP port.
+
+                              Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                              This field will be removed in a later API version.
+                            properties:
+                              host:
+                                description: Host is an optional host name to connect
+                                  to. Host defaults to the VM IP.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Port specifies a number or name of the port to access on the VM.
+                                  If the format of port is a number, it must be in the range 1 to 65535.
+                                  If the format of name is a string, it must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          timeoutSeconds:
+                            description: |-
+                              TimeoutSeconds specifies a number of seconds after which the probe times out.
+                              Defaults to 10 seconds. Minimum value is 1.
+                            format: int32
+                            maximum: 60
+                            minimum: 1
+                            type: integer
+                        type: object
+                      reserved:
+                        description: |-
+                          Reserved describes a set of VM configuration options reserved for system
+                          use.
+
+                          Please note attempts to modify the value of this field by a DevOps user
+                          will result in a validation error.
+                        properties:
+                          resourcePolicyName:
+                            type: string
+                        type: object
+                      restartMode:
+                        default: TrySoft
+                        description: |-
+                          RestartMode describes the desired behavior for restarting a VM when
+                          spec.nextRestartTime is set to "now" (case-insensitive).
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                          interaction inside of the guest. The Soft mode requires the VM's guest to
+                          have VM Tools installed and asks the guest to restart the VM. Its
+                          variant, TrySoft, first attempts a soft restart, and if that fails or
+                          does not complete within five minutes, the VM is hard reset.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      storageClass:
+                        description: |-
+                          StorageClass describes the name of a Kubernetes StorageClass resource
+                          used to configure this VM's storage-related attributes.
+
+                          Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                          for more information on Kubernetes storage classes.
+                        type: string
+                      suspendMode:
+                        default: TrySoft
+                        description: |-
+                          SuspendMode describes the desired behavior when suspending a VM.
+
+                          There are three, supported suspend modes: Hard, Soft, and
+                          TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                          disk without any interaction inside of the guest. The Soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully suspend the VM. Its variant, TrySoft, first attempts
+                          a graceful suspend, and if that fails or the VM is not in a put into
+                          standby by the guest after five minutes, the VM is suspended.
+
+                          If omitted, the mode defaults to TrySoft.
+                        enum:
+                        - Hard
+                        - Soft
+                        - TrySoft
+                        type: string
+                      volumes:
+                        description: Volumes describes a list of volumes that can
+                          be mounted to the VM.
+                        items:
+                          description: VirtualMachineVolume represents a named volume
+                            in a VM.
+                          properties:
+                            name:
+                              description: |-
+                                Name represents the volume's name. Must be a DNS_LABEL and unique within
+                                the VM.
+                              type: string
+                            persistentVolumeClaim:
+                              description: |-
+                                PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                                in the same namespace.
+
+                                More information is available at
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                              properties:
+                                applicationType:
+                                  description: |-
+                                    ApplicationType describes the type of application for which this volume
+                                    is intended to be used.
+
+                                      - OracleRAC      -- The volume is configured with
+                                                          diskMode=IndependentPersistent and
+                                                          sharingMode=MultiWriter and attached to the first
+                                                          SCSI controller with an available slot and
+                                                          sharingMode=None. If no such controller exists,
+                                                          a new ParaVirtual SCSI controller will be created
+                                                          with sharingMode=None long as there are currently
+                                                          three or fewer SCSI controllers.
+                                      - MicrosoftWSFC  -- The volume is configured with
+                                                          diskMode=IndependentPersistent and attached to a
+                                                          SCSI controller with sharingMode=Physical.
+                                                          If no such controller exists, a new ParaVirtual
+                                                          SCSI controller will be created with
+                                                          sharingMode=Physical as long as there are currently
+                                                          three or fewer SCSI controllers.
+                                  enum:
+                                  - OracleRAC
+                                  - MicrosoftWSFC
+                                  type: string
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                controllerBusNumber:
+                                  description: |-
+                                    ControllerBusNumber describes the bus number of the controller to which
+                                    this volume should be attached.
+
+                                    The bus number specifies a controller based on the value of the
+                                    controllerType field:
+
+                                      - IDE  -- spec.hardware.ideControllers
+                                      - NVME -- spec.hardware.nvmeControllers
+                                      - SATA -- spec.hardware.sataControllers
+                                      - SCSI -- spec.hardware.scsiControllers
+
+                                    If this and controllerType are both omitted, the volume will be attached
+                                    to the first available SCSI controller. If there is no SCSI controller
+                                    with an available slot, a new ParaVirtual SCSI controller will be added
+                                    as long as there are currently three or fewer SCSI controllers.
+
+                                    If the specified controller has no available slots, the request will be
+                                    denied.
+                                  format: int32
+                                  type: integer
+                                controllerType:
+                                  default: SCSI
+                                  description: |-
+                                    ControllerType describes the type of the controller to which this volume
+                                    should be attached.
+
+                                    Please keep in mind the number of volumes supported by the different
+                                    types of controllers:
+
+                                      - IDE                -- 4 total (2 per controller)
+                                      - NVME               -- 256 total (64 per controller)
+                                      - SATA               -- 120 total (30 per controller)
+                                      - SCSI (ParaVirtual) -- 252 total (63 per controller)
+                                      - SCSI (BusLogic)    -- 60 total (15 per controller)
+                                      - SCSI (LsiLogic)    -- 60 total (15 per controller)
+                                      - SCSI (LsiLogicSAS) -- 60 total (15 per controller)
+
+                                    Please note, the number of supported volumes per SCSI controller may seem
+                                    off, but remember that a SCSI controller occupies a slot on its own bus.
+                                    Thus even though a ParaVirtual SCSI controller supports 64 targets and
+                                    the other types of SCSI controllers support 16 targets, one of the
+                                    targets is occupied by the controller itself.
+
+                                    Defaults to SCSI when controllerBusNumber is also omitted; otherwise the
+                                    default value is determined by the logic outlined in the description of
+                                    the controllerBusNumber field.
+                                  enum:
+                                  - IDE
+                                  - NVME
+                                  - SCSI
+                                  - SATA
+                                  type: string
+                                diskMode:
+                                  default: Persistent
+                                  description: |-
+                                    DiskMode describes the desired mode to use when attaching the volume.
+
+                                    Please note, volumes attached as IndependentNonPersistent or
+                                    IndependentPersistent are not included in a VM's snapshots or backups.
+
+                                    Also, any data written to volumes attached as IndependentNonPersistent or
+                                    NonPersistent will be discarded when the VM is powered off.
+
+                                    Defaults to Persistent.
+                                  enum:
+                                  - IndependentNonPersistent
+                                  - IndependentPersistent
+                                  - NonPersistent
+                                  - Persistent
+                                  - Dependent
+                                  type: string
+                                instanceVolumeClaim:
+                                  description: InstanceVolumeClaim is set if the PVC
+                                    is backed by instance storage.
+                                  properties:
+                                    size:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Size is the size of the requested
+                                        instance storage volume.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      description: |-
+                                        StorageClass is the name of the Kubernetes StorageClass that provides
+                                        the backing storage for this instance storage volume.
+                                      type: string
+                                  required:
+                                  - size
+                                  - storageClass
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                                sharingMode:
+                                  default: None
+                                  description: |-
+                                    SharingMode describes the volume's desired sharing mode.
+
+                                    When applicationType=OracleRAC, the field defaults to MultiWriter.
+                                    Otherwise, defaults to None.
+                                  enum:
+                                  - MultiWriter
+                                  - None
+                                  type: string
+                                unitNumber:
+                                  description: |-
+                                    UnitNumber describes the desired unit number for attaching the volume to
+                                    a storage controller.
+
+                                    When omitted, the next available unit number of the selected controller
+                                    is used.
+
+                                    This value must be unique for the controller referenced by the
+                                    controllerBusNumber and controllerType properties. If the value is
+                                    already used by another device, this volume will not be attached.
+
+                                    Please note the value 7 is invalid if controllerType=SCSI as 7 is the
+                                    unit number of the SCSI controller on its own bus.
+                                  format: int32
+                                  type: integer
+                                unmanagedVolumeClaim:
+                                  description: |-
+                                    UnmanagedVolumeClaim is set if the PVC is backed by an existing,
+                                    unmanaged volume.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name describes the name of the unmanaged volume.
+
+                                        For volumes from an image, the name is from the image's
+                                        status.disks[].name field.
+
+                                        For volumes from the VM, the name is from the VM's
+                                        status.volumes[].name field.
+
+                                        Please note, specifying the name of an existing, managed volume is not
+                                        supported and will be ignored.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        Type describes the source of the unmanaged volume.
+
+                                        - FromImage - The source is a disk from the VM image.
+                                        - FromVM    - The source is an unmanaged volume on the current VM.
+                                      enum:
+                                      - FromImage
+                                      - FromVM
+                                      type: string
+                                    uuid:
+                                      description: |-
+                                        UUID describes the UUID of the unmanaged volume.
+
+                                        For volumes from an image, the value is mutated in on create operations.
+
+                                        For volumes from the VM, this field may be omitted as its value is
+                                        already stored in the name field.
+                                      type: string
+                                  required:
+                                  - name
+                                  - type
+                                  type: object
+                              required:
+                              - claimName
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineReplicaSetStatus represents the observed state of a
+              VirtualMachineReplicaSet resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represents the latest available observations of a
+                  VirtualMachineReplicaSet's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              fullyLabeledReplicas:
+                description: |-
+                  FullyLabeledReplicas is the number of replicas that have labels matching the
+                  labels of the virtual machine template of the VirtualMachineReplicaSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: |-
+                  ObservedGeneration reflects the generation of the most recently observed
+                  VirtualMachineReplicaSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is the number of ready replicas for this VirtualMachineReplicaSet. A
+                  virtual machine is considered ready when it's "Ready" condition is marked as
+                  true.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachines.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -35,6 +35,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -104,14 +105,12 @@ spec:
                   ImageName describes the name of the image resource used to deploy this
                   VM.
 
-
                   This field may be used to specify the name of a VirtualMachineImage
                   or ClusterVirtualMachineImage resource. The resolver first checks to see
-                  if there is a VirtualMachineImage with the specified name. If no
-                  such resource exists, the resolver then checks to see if there is a
-                  ClusterVirtualMachineImage resource with the specified name in the same
-                  Namespace as the VM being deployed.
-
+                  if there is a VirtualMachineImage with the specified name in the
+                  same namespace as the VM being deployed. If no such resource exists, the
+                  resolver then checks to see if there is a ClusterVirtualMachineImage
+                  resource with the specified name.
 
                   This field may also be used to specify the display name (vSphere name) of
                   a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
@@ -127,7 +126,6 @@ spec:
                   MinHardwareVersion specifies the desired minimum hardware version
                   for this VM.
 
-
                   Usually the VM's hardware version is derived from:
                   1. the VirtualMachineClass used to deploy the VM provided by the ClassName field
                   2. the datacenter/cluster/host default hardware version
@@ -135,11 +133,9 @@ spec:
                   is at least set to the specified value. To enforce this, it will override
                   the value from the VirtualMachineClass.
 
-
                   This field is never updated to reflect the derived hardware version.
                   Instead, VirtualMachineStatus.HardwareVersion surfaces
                   the observed hardware version.
-
 
                   Please note, setting this field's value to N ensures a VM's hardware
                   version is equal to or greater than N. For example, if a VM's observed
@@ -147,17 +143,13 @@ spec:
                   upgraded to hardware version 13. However, if the observed hardware
                   version is 17 and this field's value is 13, no change will occur.
 
-
                   Several features are hardware version dependent, for example:
-
 
                   * NVMe Controllers                >= 14
                   * Dynamic Direct Path I/O devices >= 17
 
-
                   Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
                   hardware versions.
-
 
                   It is important to remember that a VM's hardware version may not be
                   downgraded and upgrading a VM deployed from an image based on an older
@@ -172,7 +164,6 @@ spec:
                   NetworkInterfaces describes a list of VirtualMachineNetworkInterfaces to be configured on the VirtualMachine instance.
                   Each of these VirtualMachineNetworkInterfaces describes external network integration configurations that are to be
                   used by the VirtualMachine controller when integrating the VirtualMachine into one or more external networks.
-
 
                   The maximum number of network interface allowed is 10 because of the limit built into vSphere.
                 items:
@@ -232,12 +223,10 @@ spec:
                   RestartMode, by setting the value of this field to "now"
                   (case-insensitive).
 
-
                   A mutating webhook changes this value to the current time (UTC), which
                   the VM controller then uses to determine the VM should be restarted by
                   comparing the value to the timestamp of the last time the VM was
                   restarted.
-
 
                   Please note it is not possible to schedule future restarts using this
                   field. The only value that users may set is the string "now"
@@ -256,7 +245,8 @@ spec:
                     port:
                       type: integer
                     protocol:
-                      default: TCP
+                      description: Protocol defines network protocols supported for
+                        things like container ports.
                       type: string
                   required:
                   - ip
@@ -270,7 +260,6 @@ spec:
                 description: |-
                   PowerOffMode describes the desired behavior when powering off a VM.
 
-
                   There are three, supported power off modes: hard, soft, and
                   trySoft. The first mode, hard, is the equivalent of a physical
                   system's power cord being ripped from the wall. The soft mode
@@ -278,7 +267,6 @@ spec:
                   gracefully shutdown the VM. Its variant, trySoft, first attempts
                   a graceful shutdown, and if that fails or the VM is not in a powered off
                   state after five minutes, the VM is halted.
-
 
                   If omitted, the mode defaults to hard.
                 enum:
@@ -290,11 +278,9 @@ spec:
                 description: |-
                   PowerState describes the desired power state of a VirtualMachine.
 
-
                   Please note this field may be omitted when creating a new VM and will
                   default to "poweredOn." However, once the field is set to a non-empty
                   value, it may no longer be set to an empty value.
-
 
                   Additionally, setting this value to "suspended" is not supported when
                   creating a new VM. The valid values when creating a new VM are
@@ -335,7 +321,6 @@ spec:
                     description: |-
                       TCPSocket specifies an action involving a TCP port.
 
-
                       Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
                       This field will be removed in a later API version.
                     properties:
@@ -375,14 +360,12 @@ spec:
                   RestartMode describes the desired behavior for restarting a VM when
                   spec.nextRestartTime is set to "now" (case-insensitive).
 
-
                   There are three, supported suspend modes: hard, soft, and
                   trySoft. The first mode, hard, is where vSphere resets the VM without any
                   interaction inside of the guest. The soft mode requires the VM's guest to
                   have VM Tools installed and asks the guest to restart the VM. Its
                   variant, trySoft, first attempts a soft restart, and if that fails or
                   does not complete within five minutes, the VM is hard reset.
-
 
                   If omitted, the mode defaults to hard.
                 enum:
@@ -400,7 +383,6 @@ spec:
                 description: |-
                   SuspendMode describes the desired behavior when suspending a VM.
 
-
                   There are three, supported suspend modes: hard, soft, and
                   trySoft. The first mode, hard, is where vSphere suspends the VM to
                   disk without any interaction inside of the guest. The soft mode
@@ -408,7 +390,6 @@ spec:
                   gracefully suspend the VM. Its variant, trySoft, first attempts
                   a graceful suspend, and if that fails or the VM is not in a put into
                   standby by the guest after five minutes, the VM is suspended.
-
 
                   If omitted, the mode defaults to hard.
                 enum:
@@ -467,10 +448,8 @@ spec:
                         in the same namespace. The PersistentVolumeClaim must match one of the
                         following:
 
-
                           * A volume provisioned (either statically or dynamically) by the
                             cluster's CSI provider.
-
 
                           * An instance volume with a lifecycle coupled to the VM.
                       properties:
@@ -589,6 +568,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to disambiguate is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -598,7 +578,6 @@ spec:
                   HardwareVersion describes the VirtualMachine resource's observed
                   hardware version.
 
-
                   Please refer to VirtualMachineSpec.MinHardwareVersion for more
                   information on the topic of a VM's hardware version.
                 format: int32
@@ -606,6 +585,15 @@ spec:
               host:
                 description: Host describes the hostname or IP address of the infrastructure
                   host that the VirtualMachine is executing on.
+                type: string
+              hostName:
+                description: |-
+                  HostName describes the observed hostname reported by the VirtualMachine's
+                  guest operating system.
+
+                  Please note, this value is only reported if VMware Tools is installed in
+                  the guest, and the value may or may not be a fully qualified domain name
+                  (FQDN), it simply depends on what is reported by the guest.
                 type: string
               instanceUUID:
                 description: InstanceUUID describes the unique instance UUID provided
@@ -764,7 +752,6 @@ spec:
                       BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
                       from the VirtualMachineImage from which the VM was deployed.
 
-
                       Please note it is not advised to change this value while the VM is
                       running. Also, resizing the VM's boot disk may require actions inside of
                       the guest to take advantage of the additional capacity. Finally, changing
@@ -788,11 +775,366 @@ spec:
                     - ThickEagerZero
                     type: string
                 type: object
+              affinity:
+                description: Affinity describes the VM's scheduling constraints.
+                properties:
+                  vmAffinity:
+                    description: VMAffinity describes affinity scheduling rules related
+                      to other VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the affinity expressions specified by this
+                          field, but it may choose to violate one or more of the expressions.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  vmAntiAffinity:
+                    description: |-
+                      VMAntiAffinity describes anti-affinity scheduling rules related to other
+                      VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the anti-affinity expressions specified by
+                          this field, but it may choose to violate one or more of the expressions.
+                          Additionally, it also describes the anti-affinity requirements that
+                          should be met during run-time, but the VM can still be run if the
+                          requirements cannot be satisfied.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
               bootstrap:
                 description: |-
                   Bootstrap describes the desired state of the guest's bootstrap
                   configuration.
-
 
                   If omitted, a default bootstrap method may be selected based on the
                   guest OS identifier. If Linux, then the LinuxPrep method is used.
@@ -802,10 +1144,8 @@ spec:
                       CloudInit may be used to bootstrap Linux guests with Cloud-Init or
                       Windows guests that support Cloudbase-Init.
 
-
                       The guest's networking stack is configured by Cloud-Init on Linux guests
                       and Cloudbase-Init on Windows guests.
-
 
                       Please note this bootstrap provider may not be used in conjunction with
                       the other bootstrap providers.
@@ -814,7 +1154,6 @@ spec:
                         description: |-
                           CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
                           bootstrap the VM.
-
 
                           Please note this field and RawCloudConfig are mutually exclusive.
                         properties:
@@ -830,16 +1169,12 @@ spec:
                               RunCmd allows running one or more commands on the guest.
                               The entries in this list can adhere to two, different formats:
 
-
                               Format 1 -- a string that contains the command and its arguments, ex.
-
 
                                   runcmd:
                                   - "ls -al"
 
-
                               Format 2 -- a list of the command and its arguments, ex.
-
 
                                   runcmd:
                                   - - echo
@@ -867,7 +1202,6 @@ spec:
                                   description: |-
                                     CreateGroups is a flag that may be set to false to disable creation of
                                     specified user groups.
-
 
                                     Defaults to true when Name is not "default".
                                   type: boolean
@@ -906,7 +1240,6 @@ spec:
                                   description: |-
                                     Homedir is the optional home directory for the user.
 
-
                                     Defaults to "/home/<username>" when Name is not "default".
                                   type: string
                                 inactive:
@@ -919,13 +1252,11 @@ spec:
                                   description: |-
                                     LockPasswd disables password login.
 
-
                                     Defaults to true when Name is not "default".
                                   type: boolean
                                 name:
                                   description: |-
                                     Name is the user's login name.
-
 
                                     Please note this field may be set to the special value of "default" when
                                     this User is the first element in the Users list from the CloudConfig.
@@ -935,7 +1266,6 @@ spec:
                                   description: |-
                                     NoCreateHome prevents the creation of the home directory.
 
-
                                     Defaults to false when Name is not "default".
                                   type: boolean
                                 no_log_init:
@@ -943,13 +1273,11 @@ spec:
                                     NoLogInit prevents the initialization of lastlog and faillog for the
                                     user.
 
-
                                     Defaults to false when Name is not "default".
                                   type: boolean
                                 no_user_group:
                                   description: |-
                                     NoUserGroup prevents the creation of the group named after the user.
-
 
                                     Defaults to false when Name is not "default".
                                   type: boolean
@@ -974,7 +1302,6 @@ spec:
                                   description: |-
                                     PrimaryGroup is the primary group for the user.
 
-
                                     Defaults to the value of the Name field when it is not "default".
                                   type: string
                                 selinux_user:
@@ -985,7 +1312,6 @@ spec:
                                   description: |-
                                     Shell is the path to the user's login shell.
 
-
                                     Please note the default is to set no shell, which results in a
                                     system-specific default being used.
                                   type: string
@@ -993,7 +1319,6 @@ spec:
                                   description: |-
                                     SnapUser specifies an e-mail address to create the user as a Snappy user
                                     through "snap create-user".
-
 
                                     If an Ubuntu SSO account is associated with the address, the username and
                                     SSH keys will be requested from there.
@@ -1003,7 +1328,6 @@ spec:
                                     SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
                                     keys file.
 
-
                                     Please note this field may not be combined with SSHRedirectUser.
                                   items:
                                     type: string
@@ -1011,7 +1335,6 @@ spec:
                                 ssh_import_id:
                                   description: |-
                                     SSHImportID is a list of SSH IDs to import for the user.
-
 
                                     Please note this field may not be combined with SSHRedirectUser.
                                   items:
@@ -1021,21 +1344,17 @@ spec:
                                   description: |-
                                     SSHRedirectUser may be set to true to disable SSH logins for this user.
 
-
                                     Please note that when specified, all SSH keys from cloud meta-data will
                                     be configured in a disabled state for this user. Any SSH login as this
                                     user will timeout with a message to login instead as the default user.
 
-
                                     This field may not be combined with SSHAuthorizedKeys or SSHImportID.
-
 
                                     Defaults to false when Name is not "default".
                                   type: boolean
                                 sudo:
                                   description: |-
                                     Sudo is a sudo rule to apply to the user.
-
 
                                     When omitted, no sudo rules will be applied to the user.
                                   type: string
@@ -1044,13 +1363,11 @@ spec:
                                     System is an optional flag that indicates the user should be created as
                                     a system user with no home directory.
 
-
                                     Defaults to false when Name is not "default".
                                   type: boolean
                                 uid:
                                   description: |-
                                     UID is the user's ID.
-
 
                                     When omitted the guest will default to the next available number.
                                   format: int64
@@ -1078,27 +1395,20 @@ spec:
                                   description: |-
                                     Content is the optional content to write to the provided Path.
 
-
                                     When omitted an empty file will be created or existing file will be
                                     modified.
 
-
                                     The value for this field can adhere to two, different formats:
-
 
                                     Format 1 -- a string that contains the command and its arguments, ex.
 
-
                                         content: Hello, world.
-
 
                                     Please note that format 1 supports all of the manners of specifying a
                                     YAML string.
 
-
                                     Format 2 -- a secret reference with the name of the key that contains
                                                 the content for the file, ex.
-
 
                                         content:
                                           name: my-bootstrap-secret
@@ -1138,10 +1448,8 @@ spec:
                                   description: |-
                                     Permissions an optional set of file permissions to set.
 
-
                                     Please note the permissions should be specified as an octal string, ex.
                                     "0###".
-
 
                                     When omitted the guest will default this value to "0644".
                                   type: string
@@ -1158,10 +1466,8 @@ spec:
                           RawCloudConfig describes a key in a Secret resource that contains the
                           CloudConfig data used to bootstrap the VM.
 
-
                           The CloudConfig data specified by the key may be plain-text,
                           base64-encoded, or gzipped and base64-encoded.
-
 
                           Please note this field and CloudConfig are mutually exclusive.
                         properties:
@@ -1183,20 +1489,33 @@ spec:
                         items:
                           type: string
                         type: array
+                      useGlobalNameserversAsDefault:
+                        description: |-
+                          UseGlobalNameserversAsDefault will use the global nameservers specified in
+                          the NetworkSpec as the per-interface nameservers when the per-interface
+                          nameservers is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                      useGlobalSearchDomainsAsDefault:
+                        description: |-
+                          UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                          in the NetworkSpec as the per-interface search domains when the per-interface
+                          search domains is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
                     type: object
                   linuxPrep:
                     description: |-
                       LinuxPrep may be used to bootstrap Linux guests.
 
-
                       The guest's networking stack is configured by Guest OS Customization
                       (GOSC).
-
 
                       Please note this bootstrap provider may be used in conjunction with the
                       VAppConfig bootstrap provider when wanting to configure the guest's
                       network with GOSC but also send vApp/OVF properties into the guest.
-
 
                       This bootstrap provider may not be used in conjunction with the CloudInit
                       or Sysprep bootstrap providers.
@@ -1210,12 +1529,10 @@ spec:
                         description: |-
                           TimeZone is a case-sensitive timezone, such as Europe/Sofia.
 
-
                           Valid values are based on the tz (timezone) database used by Linux and
                           other Unix systems. The values are strings in the form of
                           "Area/Location," in which Area is a continent or ocean name, and
                           Location is the city, island, or other regional designation.
-
 
                           Please see https://kb.vmware.com/s/article/2145518 for a list of valid
                           time zones for Linux systems.
@@ -1225,15 +1542,12 @@ spec:
                     description: |-
                       Sysprep may be used to bootstrap Windows guests.
 
-
                       The guest's networking stack is configured by Guest OS Customization
                       (GOSC).
-
 
                       Please note this bootstrap provider may be used in conjunction with the
                       VAppConfig bootstrap provider when wanting to configure the guest's
                       network with GOSC but also send vApp/OVF properties into the guest.
-
 
                       This bootstrap provider may not be used in conjunction with the CloudInit
                       or LinuxPrep bootstrap providers.
@@ -1243,10 +1557,8 @@ spec:
                           RawSysprep describes a key in a Secret resource that contains an XML
                           string of the Sysprep text used to bootstrap the VM.
 
-
                           The data specified by the Secret key may be plain-text, base64-encoded,
                           or gzipped and base64-encoded.
-
 
                           Please note this field and Sysprep are mutually exclusive.
                         properties:
@@ -1265,13 +1577,10 @@ spec:
                         description: |-
                           Sysprep is an object representation of a Windows sysprep.xml answer file.
 
-
                           This field encloses all the individual keys listed in a sysprep.xml file.
-
 
                           For more detailed information please see
                           https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
-
 
                           Please note this field and RawSysprep are mutually exclusive.
                         properties:
@@ -1296,7 +1605,6 @@ spec:
                                   AutoLogon determine whether the machine automatically logs on as
                                   Administrator.
 
-
                                   Please note if AutoLogon is true, then Password must be set or guest
                                   customization will fail.
                                 type: boolean
@@ -1305,11 +1613,9 @@ spec:
                                   AutoLogonCount specifies the number of times the machine should
                                   automatically log on as Administrator.
 
-
                                   Generally it should be 1, but if your setup requires a number of reboots,
                                   you may want to increase it. This number may be determined by the list of
                                   commands executed by the GuiRunOnce command.
-
 
                                   Please note this field must be specified with a non-zero positive integer if AutoLogon is true.
                                 format: int32
@@ -1318,21 +1624,17 @@ spec:
                                 description: |-
                                   Password is the new administrator password for the machine.
 
-
                                   To specify that the password should be set to blank (that is, no
                                   password), set the password value to NULL. Because of encryption, "" is
                                   NOT a valid value.
 
-
                                   Please note if the password is set to blank and AutoLogon is true, the
                                   guest customization will fail.
-
 
                                   If the XML file is generated by the VirtualCenter Customization Wizard,
                                   then the password is encrypted. Otherwise, the client should set the
                                   plainText attribute to true, so that the customization process does not
                                   attempt to decrypt the string.
-
 
                                   When not explicitly specified, the Key field for the selector defaults to
                                   `password`.
@@ -1352,7 +1654,6 @@ spec:
                               timeZone:
                                 description: |-
                                   TimeZone is the time zone index for the virtual machine.
-
 
                                   Please note that numbers correspond to time zones listed at
                                   https://bit.ly/3Rzv8oL.
@@ -1375,7 +1676,6 @@ spec:
                                   DomainAdminPassword is the password for the domain user account used for
                                   authentication if the virtual machine is joining a domain.
 
-
                                   When not explicitly specified, the Key field for the selector defaults to
                                   `domain_admin_password`.
                                 properties:
@@ -1391,6 +1691,11 @@ spec:
                                 - key
                                 - name
                                 type: object
+                              domainOU:
+                                description: |-
+                                  DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                  the OU to which the computer belongs.
+                                type: string
                               joinDomain:
                                 description: |-
                                   JoinDomain is the domain that the virtual machine should join. If this
@@ -1409,7 +1714,6 @@ spec:
                               LicenseFilePrintData is a representation of the Sysprep
                               LicenseFilePrintData key.
 
-
                               Please note this is required only for Windows 2000 Server and Windows
                               Server 2003.
                             properties:
@@ -1424,7 +1728,6 @@ spec:
                                 description: |-
                                   AutoUsers indicates the number of client licenses purchased for the
                                   VirtualCenter server being installed.
-
 
                                   Please note this value is ignored unless AutoMode is PerServer.
                                 format: int32
@@ -1446,10 +1749,8 @@ spec:
                                 description: |-
                                   ProductID is a valid serial number.
 
-
                                   Please note unless the VirtualMachineImage was installed with a volume
                                   license key, ProductID must be set or guest customization will fail.
-
 
                                   When not explicitly specified, the Key field for the selector defaults to
                                   `domain_admin_password`.
@@ -1480,10 +1781,8 @@ spec:
                       (how VMware surfaces OVF properties on guests) to transport data into the
                       guest.
 
-
                       The guest's networking stack may be configured using either vApp
                       properties or GOSC.
-
 
                       Many OVFs define one or more properties that are used by the guest to
                       bootstrap its networking stack. If the VirtualMachineImage defines one or
@@ -1491,15 +1790,12 @@ spec:
                       data provided for this VM at runtime by setting these properties to Go
                       template strings.
 
-
                       It is also possible to use GOSC to bootstrap this VM's network stack by
                       configuring either the LinuxPrep or Sysprep bootstrap providers.
-
 
                       Please note the VAppConfig bootstrap provider in conjunction with the
                       LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
                       VM metadata transport to "OvfEnv".
-
 
                       This bootstrap provider may not be used in conjunction with the CloudInit
                       bootstrap provider.
@@ -1507,7 +1803,6 @@ spec:
                       properties:
                         description: |-
                           Properties is a list of vApp/OVF property key/value pairs.
-
 
                           Please note this field and RawProperties are mutually exclusive.
                         items:
@@ -1527,7 +1822,6 @@ spec:
                                   description: |-
                                     From is specified to reference a value from a Secret resource.
 
-
                                     Please note this field is mutually exclusive with the Value field.
                                   properties:
                                     key:
@@ -1545,7 +1839,6 @@ spec:
                                   description: |-
                                     Value is used to directly specify a value.
 
-
                                     Please note this field is mutually exclusive with the From field.
                                   type: string
                               type: object
@@ -1562,7 +1855,6 @@ spec:
                           this VM where each key/value pair from the Secret is used as a vApp
                           key/value pair.
 
-
                           Please note this field and Properties are mutually exclusive.
                         type: string
                     type: object
@@ -1572,19 +1864,94 @@ spec:
                   ClassName describes the name of the VirtualMachineClass resource used to
                   deploy this VM.
                 type: string
+              crypto:
+                description: Crypto describes the desired encryption state of the
+                  VirtualMachine.
+                properties:
+                  encryptionClassName:
+                    description: |-
+                      EncryptionClassName describes the name of the EncryptionClass resource
+                      used to encrypt this VM.
+
+                      Please note, this field is not required to encrypt the VM. If the
+                      underlying platform has a default key provider, the VM may still be fully
+                      or partially encrypted depending on the specified storage and VM classes.
+
+                      If there is a default key provider and an encryption storage class is
+                      selected, the files in the VM's home directory and non-PVC virtual disks
+                      will be encrypted
+
+                      If there is a default key provider and a VM Class with a virtual, trusted
+                      platform module (vTPM) is selected, the files in the VM's home directory,
+                      minus any virtual disks, will be encrypted.
+
+                      If the underlying vSphere platform does not have a default key provider,
+                      then this field is required when specifying an encryption storage class
+                      and/or a VM Class with a vTPM.
+
+                      If this field is set, spec.storageClass must use an encryption-enabled
+                      storage class.
+                    type: string
+                  useDefaultKeyProvider:
+                    default: true
+                    description: |-
+                      UseDefaultKeyProvider describes the desired behavior for when an explicit
+                      EncryptionClass is not provided.
+
+                      When an explicit EncryptionClass is not provided and this value is true:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will be encrypted using the default key provider.
+
+                      - If a VirtualMachine is not encrypted, uses an encryption storage
+                        policy or has a virtual, trusted platform module (vTPM), there is a
+                        default key provider, the VM will be encrypted using the default key
+                        provider.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be rekeyed using the default key provider.
+
+                      When an explicit EncryptionClass is not provided and this value is false:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will fail.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be not be rekeyed.
+
+                        Please note, this could result in a VirtualMachine that cannot be
+                        powered on since it is encrypted using a provider or key that may have
+                        been removed. Without the key, the VM cannot be decrypted and thus
+                        cannot be powered on.
+
+                      Defaults to true if omitted.
+                    type: boolean
+                type: object
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
               imageName:
                 description: |-
                   ImageName describes the name of the image resource used to deploy this
                   VM.
 
-
                   This field may be used to specify the name of a VirtualMachineImage
                   or ClusterVirtualMachineImage resource. The resolver first checks to see
-                  if there is a VirtualMachineImage with the specified name. If no
-                  such resource exists, the resolver then checks to see if there is a
-                  ClusterVirtualMachineImage resource with the specified name in the same
-                  Namespace as the VM being deployed.
-
+                  if there is a VirtualMachineImage with the specified name in the
+                  same namespace as the VM being deployed. If no such resource exists, the
+                  resolver then checks to see if there is a ClusterVirtualMachineImage
+                  resource with the specified name.
 
                   This field may also be used to specify the display name (vSphere name) of
                   a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
@@ -1599,9 +1966,7 @@ spec:
                 description: |-
                   MinHardwareVersion describes the desired, minimum hardware version.
 
-
                   The logic that determines the hardware version is as follows:
-
 
                   1. If this field is set, then its value is used.
                   2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
@@ -1610,11 +1975,9 @@ spec:
                      set to the default hardware version for the Datacenter/Cluster/Host
                      where the VM is provisioned.
 
-
                   This field is never updated to reflect the derived hardware version.
                   Instead, VirtualMachineStatus.HardwareVersion surfaces
                   the observed hardware version.
-
 
                   Please note, setting this field's value to N ensures a VM's hardware
                   version is equal to or greater than N. For example, if a VM's observed
@@ -1622,17 +1985,13 @@ spec:
                   upgraded to hardware version 13. However, if the observed hardware
                   version is 17 and this field's value is 13, no change will occur.
 
-
                   Several features are hardware version dependent, for example:
-
 
                   * NVMe Controllers                >= 14
                   * Dynamic Direct Path I/O devices >= 17
 
-
                   Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
                   hardware versions.
-
 
                   It is important to remember that a VM's hardware version may not be
                   downgraded and upgrading a VM deployed from an image based on an older
@@ -1646,7 +2005,6 @@ spec:
                 description: |-
                   Network describes the desired network configuration for the VM.
 
-
                   Please note this value may be omitted entirely and the VM will be
                   assigned a single, virtual network interface that is connected to the
                   Namespace's default network.
@@ -1656,7 +2014,6 @@ spec:
                       Disabled is a flag that indicates whether or not to disable networking
                       for this VM.
 
-
                       When set to true, the VM is not configured with a default interface nor
                       any specified from the Interfaces field.
                     type: boolean
@@ -1665,10 +2022,8 @@ spec:
                       HostName is the value the guest uses as its host name.
                       If omitted then the name of the VM will be used.
 
-
                       Please note this feature is available only with the following bootstrap
                       providers: CloudInit, LinuxPrep, and Sysprep (except for RawSysprep).
-
 
                       When the bootstrap provider is Sysprep (except for RawSysprep) this is
                       used as the Computer Name.
@@ -1677,10 +2032,8 @@ spec:
                     description: |-
                       Interfaces is the list of network interfaces used by this VM.
 
-
                       If the Interfaces field is empty and the Disabled field is false, then
                       a default interface with the name eth0 will be created.
-
 
                       The maximum number of network interface allowed is 10 because of the limit
                       built into vSphere.
@@ -1694,21 +2047,14 @@ spec:
                             Addresses is an optional list of IP4 or IP6 addresses to assign to this
                             interface.
 
-
                             Please note this field is only supported if the connected network
                             supports manual IP allocation.
-
 
                             Please note IP4 and IP6 addresses must include the network prefix length,
                             ex. 192.168.0.10/24 or 2001:db8:101::a/64.
 
-
                             Please note this field may not contain IP4 addresses if DHCP4 is set
                             to true or IP6 addresses if DHCP6 is set to true.
-
-
-                            Please note if the Interfaces field is non-empty then this field is
-                            ignored and should be specified on the elements in the Interfaces list.
                           items:
                             type: string
                           type: array
@@ -1717,10 +2063,8 @@ spec:
                             DHCP4 indicates whether or not this interface uses DHCP for IP4
                             networking.
 
-
                             Please note this field is only supported if the network connection
                             supports DHCP.
-
 
                             Please note this field is mutually exclusive with IP4 addresses in the
                             Addresses field and the Gateway4 field.
@@ -1730,10 +2074,8 @@ spec:
                             DHCP6 indicates whether or not this interface uses DHCP for IP6
                             networking.
 
-
                             Please note this field is only supported if the network connection
                             supports DHCP.
-
 
                             Please note this field is mutually exclusive with IP6 addresses in the
                             Addresses field and the Gateway6 field.
@@ -1742,19 +2084,11 @@ spec:
                           description: |-
                             Gateway4 is the default, IP4 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
 
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP4 address, then this field
-                            is required.
-
-
-                            Please note the IP address must include the network prefix length, ex.
-                            192.168.0.1/24.
-
 
                             Please note this field is mutually exclusive with DHCP4.
                           type: string
@@ -1762,19 +2096,11 @@ spec:
                           description: |-
                             Gateway6 is the primary IP6 gateway for this interface.
 
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
 
                             Please note this field is only supported if the network connection
                             supports manual IP allocation.
-
-
-                            If the network connection supports manual IP allocation and the
-                            Addresses field includes at least one IP6 address, then this field
-                            is required.
-
-
-                            Please note the IP address must include the network prefix length, ex.
-                            2001:db8:101::1/64.
-
 
                             Please note this field is mutually exclusive with DHCP6.
                           type: string
@@ -1786,10 +2112,20 @@ spec:
                             inside the guest, ex. dvd, cdrom, sda, etc.
                           pattern: ^\w\w+$
                           type: string
+                        macAddr:
+                          description: |-
+                            MACAddr is the optional MAC address of this interface.
+
+                            If no MAC address is provided, one will be generated by either the network
+                            provider or vCenter.
+
+                            Please note this field is only supported when the Network API Group is
+                            crd.nsx.vmware.com.
+                          pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                          type: string
                         mtu:
                           description: |-
                             MTU is the Maximum Transmission Unit size in bytes.
-
 
                             Please note this feature is available only with the following bootstrap
                             providers: CloudInit.
@@ -1799,7 +2135,6 @@ spec:
                           description: |-
                             Name describes the unique name of this network interface, used to
                             distinguish it from other network interfaces attached to this VM.
-
 
                             When the bootstrap provider is Cloud-Init and GuestDeviceName is not
                             specified, the device inside the guest will be renamed to this value.
@@ -1812,10 +2147,12 @@ spec:
                             Nameservers is a list of IP4 and/or IP6 addresses used as DNS
                             nameservers.
 
-
                             Please note this feature is available only with the following bootstrap
                             providers: CloudInit and Sysprep.
 
+                            When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                            true, if nameservers is not provided, the global nameservers will be used
+                            instead.
 
                             Please note that Linux allows only three nameservers
                             (https://linux.die.net/man/5/resolv.conf).
@@ -1826,7 +2163,6 @@ spec:
                           description: |-
                             Network is the name of the network resource to which this interface is
                             connected.
-
 
                             If no network is provided, then this interface will be connected to the
                             Namespace's default network.
@@ -1858,7 +2194,6 @@ spec:
                           description: |-
                             Routes is a list of optional, static routes.
 
-
                             Please note this feature is available only with the following bootstrap
                             providers: CloudInit.
                           items:
@@ -1869,15 +2204,16 @@ spec:
                                 description: Metric is the weight/priority of the
                                   route.
                                 format: int32
+                                minimum: 1
                                 type: integer
                               to:
-                                description: To is an IP4 or IP6 address.
+                                description: To is either "default", or an IP4 or
+                                  IP6 address.
                                 type: string
                               via:
                                 description: Via is an IP4 or IP6 address.
                                 type: string
                             required:
-                            - metric
                             - to
                             - via
                             type: object
@@ -1887,9 +2223,12 @@ spec:
                             SearchDomains is a list of search domains used when resolving IP
                             addresses with DNS.
 
-
                             Please note this feature is available only with the following bootstrap
                             providers: CloudInit.
+
+                            When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                            or true, if search domains is not provided, the global search domains
+                            will be used instead.
                           items:
                             type: string
                           type: array
@@ -1906,11 +2245,12 @@ spec:
                       Nameservers is a list of IP4 and/or IP6 addresses used as DNS
                       nameservers. These are applied globally.
 
-
                       Please note global nameservers are only available with the following
                       bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
-                      provider supports per-interface nameservers.
-
+                      provider supports per-interface nameservers. However, when Cloud-Init
+                      is used and UseGlobalNameserversAsDefault is true, the global
+                      nameservers will be used when the per-interface nameservers is not
+                      provided.
 
                       Please note that Linux allows only three nameservers
                       (https://linux.die.net/man/5/resolv.conf).
@@ -1922,10 +2262,11 @@ spec:
                       SearchDomains is a list of search domains used when resolving IP
                       addresses with DNS. These are applied globally.
 
-
                       Please note global search domains are only available with the following
                       bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
-                      provider supports per-interface search domains.
+                      provider supports per-interface search domains. However, when Cloud-Init
+                      is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                      domains will be used when the per-interface search domains is not provided.
                     items:
                       type: string
                     type: array
@@ -1936,12 +2277,10 @@ spec:
                   RestartMode, by setting the value of this field to "now"
                   (case-insensitive).
 
-
                   A mutating webhook changes this value to the current time (UTC), which
                   the VM controller then uses to determine the VM should be restarted by
                   comparing the value to the timestamp of the last time the VM was
                   restarted.
-
 
                   Please note it is not possible to schedule future restarts using this
                   field. The only value that users may set is the string "now"
@@ -1952,7 +2291,6 @@ spec:
                 description: |-
                   PowerOffMode describes the desired behavior when powering off a VM.
 
-
                   There are three, supported power off modes: Hard, Soft, and
                   TrySoft. The first mode, Hard, is the equivalent of a physical
                   system's power cord being ripped from the wall. The Soft mode
@@ -1960,7 +2298,6 @@ spec:
                   gracefully shutdown the VM. Its variant, TrySoft, first attempts
                   a graceful shutdown, and if that fails or the VM is not in a powered off
                   state after five minutes, the VM is halted.
-
 
                   If omitted, the mode defaults to TrySoft.
                 enum:
@@ -1972,11 +2309,9 @@ spec:
                 description: |-
                   PowerState describes the desired power state of a VirtualMachine.
 
-
                   Please note this field may be omitted when creating a new VM and will
                   default to "PoweredOn." However, once the field is set to a non-empty
                   value, it may no longer be set to an empty value.
-
 
                   Additionally, setting this value to "Suspended" is not supported when
                   creating a new VM. The valid values when creating a new VM are
@@ -2009,32 +2344,25 @@ spec:
                     description: |-
                       GuestInfo specifies an action involving key/value pairs from GuestInfo.
 
-
                       The elements are evaluated with the logical AND operator, meaning
                       all expressions must evaluate as true for the probe to succeed.
 
-
                       For example, a VM resource's probe definition could be specified as the
                       following:
-
 
                               guestInfo:
                               - key:   ready
                                 value: true
 
-
                       With the above configuration in place, the VM would not be considered
                       ready until the GuestInfo key "ready" was set to the value "true".
-
 
                       From within the guest operating system it is possible to set GuestInfo
                       key/value pairs using the program "vmware-rpctool," which is included
                       with VM Tools. For example, the following command will set the key
                       "guestinfo.ready" to the value "true":
 
-
                               vmware-rpctool "info-set guestinfo.ready true"
-
 
                       Once executed, the VM's readiness probe will be signaled and the
                       VM resource will be marked as ready.
@@ -2047,7 +2375,6 @@ spec:
                           description: |-
                             Key is the name of the GuestInfo key.
 
-
                             The key is automatically prefixed with "guestinfo." before being
                             evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
                             evaluated as "guestinfo.guestinfo.mykey".
@@ -2057,9 +2384,7 @@ spec:
                             Value is a regular expression that is matched against the value of the
                             specified key.
 
-
                             An empty value is the equivalent of "match any" or ".*".
-
 
                             All values must adhere to the RE2 regular expression syntax as documented
                             at https://golang.org/s/re2syntax. Invalid values may be rejected or
@@ -2080,7 +2405,6 @@ spec:
                   tcpSocket:
                     description: |-
                       TCPSocket specifies an action involving a TCP port.
-
 
                       Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
                       This field will be removed in a later API version.
@@ -2115,7 +2439,6 @@ spec:
                   Reserved describes a set of VM configuration options reserved for system
                   use.
 
-
                   Please note attempts to modify the value of this field by a DevOps user
                   will result in a validation error.
                 properties:
@@ -2132,14 +2455,12 @@ spec:
                   RestartMode describes the desired behavior for restarting a VM when
                   spec.nextRestartTime is set to "now" (case-insensitive).
 
-
                   There are three, supported suspend modes: Hard, Soft, and
                   TrySoft. The first mode, Hard, is where vSphere resets the VM without any
                   interaction inside of the guest. The Soft mode requires the VM's guest to
                   have VM Tools installed and asks the guest to restart the VM. Its
                   variant, TrySoft, first attempts a soft restart, and if that fails or
                   does not complete within five minutes, the VM is hard reset.
-
 
                   If omitted, the mode defaults to TrySoft.
                 enum:
@@ -2152,7 +2473,6 @@ spec:
                   StorageClass describes the name of a Kubernetes StorageClass resource
                   used to configure this VM's storage-related attributes.
 
-
                   Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
                   for more information on Kubernetes storage classes.
                 type: string
@@ -2161,7 +2481,6 @@ spec:
                 description: |-
                   SuspendMode describes the desired behavior when suspending a VM.
 
-
                   There are three, supported suspend modes: Hard, Soft, and
                   TrySoft. The first mode, Hard, is where vSphere suspends the VM to
                   disk without any interaction inside of the guest. The Soft mode
@@ -2169,7 +2488,6 @@ spec:
                   gracefully suspend the VM. Its variant, TrySoft, first attempts
                   a graceful suspend, and if that fails or the VM is not in a put into
                   standby by the guest after five minutes, the VM is suspended.
-
 
                   If omitted, the mode defaults to TrySoft.
                 enum:
@@ -2193,7 +2511,6 @@ spec:
                       description: |-
                         PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
                         in the same namespace.
-
 
                         More information is available at
                         https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
@@ -2286,16 +2603,8 @@ spec:
               conditions:
                 description: Conditions describes the observed conditions of the VirtualMachine.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2336,12 +2645,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2357,7 +2661,6 @@ spec:
                 description: |-
                   HardwareVersion describes the VirtualMachine resource's observed
                   hardware version.
-
 
                   Please refer to VirtualMachineSpec.MinHardwareVersion for more
                   information on the topic of a VM's hardware version.
@@ -2418,7 +2721,6 @@ spec:
                       such as an interface's IP address obtained from IPAM, or global DNS
                       settings.
 
-
                       Please note this information does *not* represent the *observed* network
                       state of the VM, but is intended for situations where someone boots a VM
                       with no appropriate bootstrap engine and needs to know the network config
@@ -2437,10 +2739,8 @@ spec:
                             description: |-
                               Nameservers is a list of the IP addresses for the DNS servers to use.
 
-
                               IP4 addresses are specified using dotted decimal notation. For example,
                               "192.0.2.1".
-
 
                               IP6 addresses are 128-bit addresses represented as eight fields of up to
                               four hexadecimal digits. A colon separates each field (:). For example,
@@ -2479,10 +2779,8 @@ spec:
                                   description: |-
                                     Nameservers is a list of the IP addresses for the DNS servers to use.
 
-
                                     IP4 addresses are specified using dotted decimal notation. For example,
                                     "192.0.2.1".
-
 
                                     IP6 addresses are 128-bit addresses represented as eight fields of up to
                                     four hexadecimal digits. A colon separates each field (:). For example,
@@ -2539,14 +2837,12 @@ spec:
                                   description: |-
                                     Gateway4 describes the interface's configured, default, IP4 gateway.
 
-
                                     Please note the IP address include the network prefix length, ex.
                                     192.168.0.1/24.
                                   type: string
                                 gateway6:
                                   description: |-
                                     Gateway6 describes the interface's configured, default, IP6 gateway.
-
 
                                     Please note the IP address includes the network prefix length, ex.
                                     2001:db8:101::1/64.
@@ -2557,7 +2853,6 @@ spec:
                                 Name describes the corresponding network interface with the same name
                                 in the VM's desired network interface list.
 
-
                                 Please note this name is not necessarily related to the name of the
                                 device as it is surfaced inside of the guest.
                               type: string
@@ -2566,6 +2861,15 @@ spec:
                           type: object
                         type: array
                     type: object
+                  hostName:
+                    description: |-
+                      HostName describes the observed hostname reported by the VirtualMachine's
+                      guest operating system.
+
+                      Please note, this value is only reported if VMware Tools is installed in
+                      the guest, and the value may or may not be a fully qualified domain name
+                      (FQDN), it simply depends on what is reported by the guest.
+                    type: string
                   interfaces:
                     description: Interfaces describes the status of the VM's network
                       interfaces.
@@ -2603,10 +2907,8 @@ spec:
                               description: |-
                                 Nameservers is a list of the IP addresses for the DNS servers to use.
 
-
                                 IP4 addresses are specified using dotted decimal notation. For example,
                                 "192.0.2.1".
-
 
                                 IP6 addresses are 128-bit addresses represented as eight fields of up to
                                 four hexadecimal digits. A colon separates each field (:). For example,
@@ -2640,10 +2942,8 @@ spec:
                                     description: |-
                                       Address is an IP4 or IP6 address and their network prefix length.
 
-
                                       An IP4 address is specified using dotted decimal notation. For example,
                                       "192.0.2.1".
-
 
                                       IP6 addresses are 128-bit addresses represented as eight fields of up to
                                       four hexadecimal digits. A colon separates each field (:). For example,
@@ -2687,10 +2987,8 @@ spec:
                                 AutoConfigurationEnabled describes whether or not ICMPv6 router
                                 solicitation requests are enabled or disabled from a given interface.
 
-
                                 These requests acquire an IP6 address and default gateway route from
                                 zero-to-many routers on the connected network.
-
 
                                 If not set then ICMPv6 is not available on this VM.
                               type: boolean
@@ -2706,7 +3004,6 @@ spec:
                                     config:
                                       description: |-
                                         Config describes platform-dependent settings for the DHCP client.
-
 
                                         The key part is a unique number while the value part is the platform
                                         specific configuration command. For example on Linux and BSD systems
@@ -2747,7 +3044,6 @@ spec:
                                     config:
                                       description: |-
                                         Config describes platform-dependent settings for the DHCP client.
-
 
                                         The key part is a unique number while the value part is the platform
                                         specific configuration command. For example on Linux and BSD systems
@@ -2793,7 +3089,6 @@ spec:
                             in the VM's desired network interface list. If unset, then there is no
                             corresponding entry for this interface.
 
-
                             Please note this name is not necessarily related to the name of the
                             device as it is surfaced inside of the guest.
                           type: string
@@ -2819,7 +3114,6 @@ spec:
                                 config:
                                   description: |-
                                     Config describes platform-dependent settings for the DHCP client.
-
 
                                     The key part is a unique number while the value part is the platform
                                     specific configuration command. For example on Linux and BSD systems
@@ -2860,7 +3154,6 @@ spec:
                                 config:
                                   description: |-
                                     Config describes platform-dependent settings for the DHCP client.
-
 
                                     The key part is a unique number while the value part is the platform
                                     specific configuration command. For example on Linux and BSD systems
@@ -2918,10 +3211,8 @@ spec:
                               description: |-
                                 Nameservers is a list of the IP addresses for the DNS servers to use.
 
-
                                 IP4 addresses are specified using dotted decimal notation. For example,
                                 "192.0.2.1".
-
 
                                 IP6 addresses are 128-bit addresses represented as eight fields of up to
                                 four hexadecimal digits. A colon separates each field (:). For example,
@@ -2965,10 +3256,8 @@ spec:
                                 description: |-
                                   NetworkAddress is the IP4 or IP6 address of the destination network.
 
-
                                   Addresses include the network's prefix length, ex. 192.168.0.0/24 or
                                   2001:DB8:101::230:6eff:fe04:d9ff::/64.
-
 
                                   IP6 addresses are 128-bit addresses represented as eight fields of up to
                                   four hexadecimal digits. A colon separates each field (:). For example,
@@ -2985,7 +3274,6 @@ spec:
                           description: |-
                             KernelConfig describes the observed state of the VM's kernel IP
                             configuration settings.
-
 
                             The key part contains a unique number while the value part contains the
                             'key=value' as provided by the underlying provider. For example, on
@@ -3017,12 +3305,10 @@ spec:
                     description: |-
                       PrimaryIP4 describes the VM's primary IP4 address.
 
-
                       If the bootstrap provider is CloudInit then this value is set to the
                       value of the VM's "guestinfo.local-ipv4" property. Please see
                       https://bit.ly/3NJB534 for more information on how this value is
                       calculated.
-
 
                       If the bootstrap provider is anything else then this field is set to the
                       value of the infrastructure VM's "guest.ipAddress" field. Please see
@@ -3032,12 +3318,10 @@ spec:
                     description: |-
                       PrimaryIP6 describes the VM's primary IP6 address.
 
-
                       If the bootstrap provider is CloudInit then this value is set to the
                       value of the VM's "guestinfo.local-ipv6" property. Please see
                       https://bit.ly/3NJB534 for more information on how this value is
                       calculated.
-
 
                       If the bootstrap provider is anything else then this field is set to the
                       value of the infrastructure VM's "guest.ipAddress" field. Please see
@@ -3096,6 +3380,10141 @@ spec:
                   Zone describes the availability zone where the VirtualMachine has been
                   scheduled.
 
+                  Please note this field may be empty when the cluster is not zone-aware.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.powerState
+      name: Power-State
+      type: string
+    - jsonPath: .spec.className
+      name: Class
+      priority: 1
+      type: string
+    - jsonPath: .spec.image.name
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.network.primaryIP4
+      name: Primary-IP4
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachine is the schema for the virtualmachines API and represents the
+          desired state and observed status of a virtualmachines resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine.
+            properties:
+              advanced:
+                description: Advanced describes a set of optional, advanced VM configuration
+                  options.
+                properties:
+                  bootDiskCapacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                      from the VirtualMachineImage from which the VM was deployed.
+
+                      Please note it is not advised to change this value while the VM is
+                      running. Also, resizing the VM's boot disk may require actions inside of
+                      the guest to take advantage of the additional capacity. Finally, changing
+                      the size of the VM's boot disk, even increasing it, could adversely
+                      affect the VM.
+
+                      Please note this field is ignored if the VM is deployed from an ISO with
+                      CD-ROM devices attached.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  changeBlockTracking:
+                    description: |-
+                      ChangeBlockTracking is a flag that enables incremental backup support
+                      for this VM, a feature utilized by external backup systems such as
+                      VMware Data Recovery.
+                    type: boolean
+                  defaultVolumeProvisioningMode:
+                    description: |-
+                      DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                      persistent volumes managed by this VM.
+                    enum:
+                    - Thin
+                    - Thick
+                    - ThickEagerZero
+                    type: string
+                type: object
+              affinity:
+                description: Affinity describes the VM's scheduling constraints.
+                properties:
+                  vmAffinity:
+                    description: VMAffinity describes affinity scheduling rules related
+                      to other VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the affinity expressions specified by this
+                          field, but it may choose to violate one or more of the expressions.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  vmAntiAffinity:
+                    description: |-
+                      VMAntiAffinity describes anti-affinity scheduling rules related to other
+                      VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the anti-affinity expressions specified by
+                          this field, but it may choose to violate one or more of the expressions.
+                          Additionally, it also describes the anti-affinity requirements that
+                          should be met during run-time, but the VM can still be run if the
+                          requirements cannot be satisfied.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              biosUUID:
+                description: |-
+                  BiosUUID describes the desired BIOS UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  When the bootstrap provider is Cloud-Init, this value is used as the
+                  default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                format: uuid
+                type: string
+              bootstrap:
+                description: |-
+                  Bootstrap describes the desired state of the guest's bootstrap
+                  configuration.
+
+                  If omitted, a default bootstrap method may be selected based on the
+                  guest OS identifier. If Linux, then the LinuxPrep method is used.
+                properties:
+                  cloudInit:
+                    description: |-
+                      CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                      Windows guests that support Cloudbase-Init.
+
+                      The guest's networking stack is configured by Cloud-Init on Linux guests
+                      and Cloudbase-Init on Windows guests.
+
+                      Please note this bootstrap provider may not be used in conjunction with
+                      the other bootstrap providers.
+                    properties:
+                      cloudConfig:
+                        description: |-
+                          CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                          bootstrap the VM.
+
+                          Please note this field and RawCloudConfig are mutually exclusive.
+                        properties:
+                          defaultUserEnabled:
+                            description: |-
+                              DefaultUserEnabled may be set to true to ensure even if the Users field
+                              is not empty, the default user is still created on systems that have one
+                              defined. By default, Cloud-Init ignores the default user if the
+                              CloudConfig provides one or more non-default users via the Users field.
+                            type: boolean
+                          runcmd:
+                            description: |-
+                              RunCmd allows running one or more commands on the guest.
+                              The entries in this list can adhere to two, different formats:
+
+                              Format 1 -- a string that contains the command and its arguments, ex.
+
+                                  runcmd:
+                                  - "ls -al"
+
+                              Format 2 -- a list of the command and its arguments, ex.
+
+                                  runcmd:
+                                  - - echo
+                                    - "Hello, world."
+                            x-kubernetes-preserve-unknown-fields: true
+                          ssh_pwauth:
+                            description: |-
+                              SSHPwdAuth sets whether or not to accept password authentication.
+                              In order for this config to be applied, SSH may need to be restarted.
+                              On systemd systems, this restart will only happen if the SSH service has
+                              already been started. On non-systemd systems, a restart will be attempted
+                              regardless of the service state.
+                            type: boolean
+                          timezone:
+                            description: Timezone describes the timezone represented
+                              in /usr/share/zoneinfo.
+                            type: string
+                          users:
+                            description: Users allows adding/configuring one or more
+                              users on the guest.
+                            items:
+                              description: User is a CloudConfig user data structure.
+                              properties:
+                                create_groups:
+                                  description: |-
+                                    CreateGroups is a flag that may be set to false to disable creation of
+                                    specified user groups.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                expiredate:
+                                  description: ExpireData is the date on which the
+                                    user's account will be disabled.
+                                  type: string
+                                gecos:
+                                  description: |-
+                                    Gecos is an optional comment about the user, usually a comma-separated
+                                    string of the user's real name and contact information.
+                                  type: string
+                                groups:
+                                  description: Groups is an optional list of groups
+                                    to add to the user.
+                                  items:
+                                    type: string
+                                  type: array
+                                hashed_passwd:
+                                  description: |-
+                                    HashedPasswd is a hash of the user's password that will be applied even
+                                    if the specified user already exists.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                homedir:
+                                  description: |-
+                                    Homedir is the optional home directory for the user.
+
+                                    Defaults to "/home/<username>" when Name is not "default".
+                                  type: string
+                                inactive:
+                                  description: |-
+                                    Inactive optionally represents the number of days until the user is
+                                    disabled.
+                                  format: int32
+                                  type: integer
+                                lock_passwd:
+                                  description: |-
+                                    LockPasswd disables password login.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                name:
+                                  description: |-
+                                    Name is the user's login name.
+
+                                    Please note this field may be set to the special value of "default" when
+                                    this User is the first element in the Users list from the CloudConfig.
+                                    When set to "default", all other fields from this User must be nil.
+                                  type: string
+                                no_create_home:
+                                  description: |-
+                                    NoCreateHome prevents the creation of the home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_log_init:
+                                  description: |-
+                                    NoLogInit prevents the initialization of lastlog and faillog for the
+                                    user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_user_group:
+                                  description: |-
+                                    NoUserGroup prevents the creation of the group named after the user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                passwd:
+                                  description: |-
+                                    Passwd is a hash of the user's password that will be applied only to
+                                    a newly created user. To apply a new, hashed password to an existing user
+                                    please use HashedPasswd instead.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                primary_group:
+                                  description: |-
+                                    PrimaryGroup is the primary group for the user.
+
+                                    Defaults to the value of the Name field when it is not "default".
+                                  type: string
+                                selinux_user:
+                                  description: SELinuxUser is the SELinux user for
+                                    the user's login.
+                                  type: string
+                                shell:
+                                  description: |-
+                                    Shell is the path to the user's login shell.
+
+                                    Please note the default is to set no shell, which results in a
+                                    system-specific default being used.
+                                  type: string
+                                snapuser:
+                                  description: |-
+                                    SnapUser specifies an e-mail address to create the user as a Snappy user
+                                    through "snap create-user".
+
+                                    If an Ubuntu SSO account is associated with the address, the username and
+                                    SSH keys will be requested from there.
+                                  type: string
+                                ssh_authorized_keys:
+                                  description: |-
+                                    SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                    keys file.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_import_id:
+                                  description: |-
+                                    SSHImportID is a list of SSH IDs to import for the user.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_redirect_user:
+                                  description: |-
+                                    SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                    Please note that when specified, all SSH keys from cloud meta-data will
+                                    be configured in a disabled state for this user. Any SSH login as this
+                                    user will timeout with a message to login instead as the default user.
+
+                                    This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                sudo:
+                                  description: |-
+                                    Sudo is a sudo rule to apply to the user.
+
+                                    When omitted, no sudo rules will be applied to the user.
+                                  type: string
+                                system:
+                                  description: |-
+                                    System is an optional flag that indicates the user should be created as
+                                    a system user with no home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                uid:
+                                  description: |-
+                                    UID is the user's ID.
+
+                                    When omitted the guest will default to the next available number.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          write_files:
+                            description: WriteFiles allows adding files to the guest
+                              file system.
+                            items:
+                              description: WriteFile is a CloudConfig write_file data
+                                structure.
+                              properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether or not to append the content to an existing file
+                                    if the file specified by Path already exists.
+                                  type: boolean
+                                content:
+                                  description: |-
+                                    Content is the optional content to write to the provided Path.
+
+                                    When omitted an empty file will be created or existing file will be
+                                    modified.
+
+                                    The value for this field can adhere to two, different formats:
+
+                                    Format 1 -- a string that contains the command and its arguments, ex.
+
+                                        content: Hello, world.
+
+                                    Please note that format 1 supports all of the manners of specifying a
+                                    YAML string.
+
+                                    Format 2 -- a secret reference with the name of the key that contains
+                                                the content for the file, ex.
+
+                                        content:
+                                          name: my-bootstrap-secret
+                                          key: my-file-content
+                                  x-kubernetes-preserve-unknown-fields: true
+                                defer:
+                                  description: |-
+                                    Defer indicates to defer writing the file until Cloud-Init's "final"
+                                    stage, after users are created and packages are installed.
+                                  type: boolean
+                                encoding:
+                                  default: text/plain
+                                  description: Encoding is an optional encoding type
+                                    of the content.
+                                  enum:
+                                  - b64
+                                  - base64
+                                  - gz
+                                  - gzip
+                                  - gz+b64
+                                  - gz+base64
+                                  - gzip+b64
+                                  - gzip+base64
+                                  - text/plain
+                                  type: string
+                                owner:
+                                  default: root:root
+                                  description: Owner is an optional "owner:group"
+                                    to chown the file.
+                                  type: string
+                                path:
+                                  description: Path is the path of the file to which
+                                    the content is decoded and written.
+                                  type: string
+                                permissions:
+                                  default: "0644"
+                                  description: |-
+                                    Permissions an optional set of file permissions to set.
+
+                                    Please note the permissions should be specified as an octal string, ex.
+                                    "0###".
+
+                                    When omitted the guest will default this value to "0644".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - path
+                            x-kubernetes-list-type: map
+                        type: object
+                      instanceID:
+                        description: |-
+                          InstanceID is the cloud-init metadata instance ID.
+                          If omitted, this field defaults to the VM's BiosUUID.
+                        type: string
+                      rawCloudConfig:
+                        description: |-
+                          RawCloudConfig describes a key in a Secret resource that contains the
+                          CloudConfig data used to bootstrap the VM.
+
+                          The CloudConfig data specified by the key may be plain-text,
+                          base64-encoded, or gzipped and base64-encoded.
+
+                          Please note this field and CloudConfig are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                          the guest's default user.
+                        items:
+                          type: string
+                        type: array
+                      useGlobalNameserversAsDefault:
+                        description: |-
+                          UseGlobalNameserversAsDefault will use the global nameservers specified in
+                          the NetworkSpec as the per-interface nameservers when the per-interface
+                          nameservers is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                      useGlobalSearchDomainsAsDefault:
+                        description: |-
+                          UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                          in the NetworkSpec as the per-interface search domains when the per-interface
+                          search domains is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                    type: object
+                  linuxPrep:
+                    description: |-
+                      LinuxPrep may be used to bootstrap Linux guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or Sysprep bootstrap providers.
+                    properties:
+                      hardwareClockIsUTC:
+                        description: |-
+                          HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                          local time.
+                        type: boolean
+                      timeZone:
+                        description: |-
+                          TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                          Valid values are based on the tz (timezone) database used by Linux and
+                          other Unix systems. The values are strings in the form of
+                          "Area/Location," in which Area is a continent or ocean name, and
+                          Location is the city, island, or other regional designation.
+
+                          Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                          time zones for Linux systems.
+                        type: string
+                    type: object
+                  sysprep:
+                    description: |-
+                      Sysprep may be used to bootstrap Windows guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or LinuxPrep bootstrap providers.
+                    properties:
+                      rawSysprep:
+                        description: |-
+                          RawSysprep describes a key in a Secret resource that contains an XML
+                          string of the Sysprep text used to bootstrap the VM.
+
+                          The data specified by the Secret key may be plain-text, base64-encoded,
+                          or gzipped and base64-encoded.
+
+                          Please note this field and Sysprep are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sysprep:
+                        description: |-
+                          Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                          This field encloses all the individual keys listed in a sysprep.xml file.
+
+                          For more detailed information please see
+                          https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                          Please note this field and RawSysprep are mutually exclusive.
+                        properties:
+                          guiRunOnce:
+                            description: GUIRunOnce is a representation of the Sysprep
+                              GuiRunOnce key.
+                            properties:
+                              commands:
+                                description: |-
+                                  Commands is a list of commands to run at first user logon, after guest
+                                  customization.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          guiUnattended:
+                            description: GUIUnattended is a representation of the
+                              Sysprep GUIUnattended key.
+                            properties:
+                              autoLogon:
+                                description: |-
+                                  AutoLogon determine whether the machine automatically logs on as
+                                  Administrator.
+
+                                  Please note if AutoLogon is true, then Password must be set or guest
+                                  customization will fail.
+                                type: boolean
+                              autoLogonCount:
+                                description: |-
+                                  AutoLogonCount specifies the number of times the machine should
+                                  automatically log on as Administrator.
+
+                                  Generally it should be 1, but if your setup requires a number of reboots,
+                                  you may want to increase it. This number may be determined by the list of
+                                  commands executed by the GuiRunOnce command.
+
+                                  Please note this field must be specified with a non-zero positive integer
+                                  if AutoLogon is true.
+                                format: int32
+                                type: integer
+                              password:
+                                description: |-
+                                  Password is the new administrator password for the machine.
+
+                                  To specify that the password should be set to blank (that is, no
+                                  password), set the password value to NULL. Because of encryption, "" is
+                                  NOT a valid value.
+
+                                  Please note if the password is set to blank and AutoLogon is true, the
+                                  guest customization will fail.
+
+                                  If the XML file is generated by the VirtualCenter Customization Wizard,
+                                  then the password is encrypted. Otherwise, the client should set the
+                                  plainText attribute to true, so that the customization process does not
+                                  attempt to decrypt the string.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `password`.
+                                properties:
+                                  key:
+                                    default: password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              timeZone:
+                                default: 85
+                                description: |-
+                                  TimeZone is the time zone index for the virtual machine.
+
+                                  Please note that numbers correspond to time zones listed at
+                                  https://bit.ly/3Rzv8oL.
+
+                                  Defaults to UTC.
+                                format: int32
+                                minimum: 0
+                                type: integer
+                            required:
+                            - timeZone
+                            type: object
+                          identification:
+                            description: Identification is a representation of the
+                              Sysprep Identification key.
+                            properties:
+                              domainAdmin:
+                                description: |-
+                                  DomainAdmin is the domain user account used for authentication if the
+                                  virtual machine is joining a domain. The user does not need to be a
+                                  domain administrator, but the account must have the privileges required
+                                  to add computers to the domain.
+                                type: string
+                              domainAdminPassword:
+                                description: |-
+                                  DomainAdminPassword is the password for the domain user account used for
+                                  authentication if the virtual machine is joining a domain.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: domain_admin_password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              domainOU:
+                                description: |-
+                                  DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                  the OU to which the computer belongs.
+                                type: string
+                              joinWorkgroup:
+                                description: |-
+                                  JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                  this value is supplied, then the fields spec.network.domain,
+                                  spec.bootstrap.sysprep.identification.domainAdmin, and
+                                  spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                type: string
+                            type: object
+                          licenseFilePrintData:
+                            description: |-
+                              LicenseFilePrintData is a representation of the Sysprep
+                              LicenseFilePrintData key.
+
+                              Please note this is required only for Windows 2000 Server and Windows
+                              Server 2003.
+                            properties:
+                              autoMode:
+                                description: AutoMode specifies the server licensing
+                                  mode.
+                                enum:
+                                - perSeat
+                                - perServer
+                                type: string
+                              autoUsers:
+                                description: |-
+                                  AutoUsers indicates the number of client licenses purchased for the
+                                  VirtualCenter server being installed.
+
+                                  Please note this value is ignored unless AutoMode is PerServer.
+                                format: int32
+                                type: integer
+                            required:
+                            - autoMode
+                            type: object
+                          userData:
+                            description: UserData is a representation of the Sysprep
+                              UserData key.
+                            properties:
+                              fullName:
+                                description: FullName is the user's full name.
+                                type: string
+                              orgName:
+                                description: OrgName is the name of the user's organization.
+                                type: string
+                              productID:
+                                description: |-
+                                  ProductID is a valid serial number.
+
+                                  Please note unless the VirtualMachineImage was installed with a volume
+                                  license key, ProductID must be set or guest customization will fail.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: product_id
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - fullName
+                            - orgName
+                            type: object
+                        required:
+                        - userData
+                        type: object
+                    type: object
+                  vAppConfig:
+                    description: |-
+                      VAppConfig may be used to bootstrap guests that rely on vApp properties
+                      (how VMware surfaces OVF properties on guests) to transport data into the
+                      guest.
+
+                      The guest's networking stack may be configured using either vApp
+                      properties or GOSC.
+
+                      Many OVFs define one or more properties that are used by the guest to
+                      bootstrap its networking stack. If the VirtualMachineImage defines one or
+                      more properties like this, then they can be configured to use the network
+                      data provided for this VM at runtime by setting these properties to Go
+                      template strings.
+
+                      It is also possible to use GOSC to bootstrap this VM's network stack by
+                      configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                      Please note the VAppConfig bootstrap provider in conjunction with the
+                      LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                      VM metadata transport to "OvfEnv".
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      bootstrap provider.
+                    properties:
+                      properties:
+                        description: |-
+                          Properties is a list of vApp/OVF property key/value pairs.
+
+                          Please note this field and RawProperties are mutually exclusive.
+                        items:
+                          description: |-
+                            KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                            list of key/value pairs where each value could also reference data stored in
+                            a Secret resource.
+                          properties:
+                            key:
+                              description: Key is the key part of the key/value pair.
+                              type: string
+                            value:
+                              description: Value is the optional value part of the
+                                key/value pair.
+                              properties:
+                                from:
+                                  description: |-
+                                    From is specified to reference a value from a Secret resource.
+
+                                    Please note this field is mutually exclusive with the Value field.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                value:
+                                  description: |-
+                                    Value is used to directly specify a value.
+
+                                    Please note this field is mutually exclusive with the From field.
+                                  type: string
+                              type: object
+                          required:
+                          - key
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      rawProperties:
+                        description: |-
+                          RawProperties is the name of a Secret resource in the same Namespace as
+                          this VM where each key/value pair from the Secret is used as a vApp
+                          key/value pair.
+
+                          Please note this field and Properties are mutually exclusive.
+                        type: string
+                    type: object
+                type: object
+              cdrom:
+                description: |-
+                  Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                  Each CD-ROM device requires a reference to an ISO-type
+                  VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                  Multiple CD-ROM devices using the same backing image, regardless of image
+                  kinds (namespace or cluster scope), are not allowed.
+
+                  CD-ROM devices can be added, updated, or removed when the VM is powered
+                  off. When the VM is powered on, only the connection state of existing
+                  CD-ROM devices can be changed.
+                  CD-ROM devices are attached to the VM in the specified list-order.
+                items:
+                  description: VirtualMachineCdromSpec describes the desired state
+                    of a CD-ROM device.
+                  properties:
+                    allowGuestControl:
+                      default: true
+                      description: |-
+                        AllowGuestControl describes whether or not a web console connection
+                        may be used to connect/disconnect the CD-ROM device.
+
+                        Defaults to true if omitted.
+                      type: boolean
+                    connected:
+                      default: true
+                      description: |-
+                        Connected describes the desired connection state of the CD-ROM device.
+
+                        When true, the CD-ROM device is added and connected to the VM.
+                        If the device already exists, it is updated to a connected state.
+
+                        When explicitly set to false, the CD-ROM device is added but remains
+                        disconnected from the VM. If the CD-ROM device already exists, it is
+                        updated to a disconnected state.
+
+                        Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                        in the guest OS. Refer to the following KB article for more details:
+                        https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                        Defaults to true if omitted.
+                      type: boolean
+                    image:
+                      description: |-
+                        Image describes the reference to an ISO type VirtualMachineImage or
+                        ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                        If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                        This field is immutable when the VM is powered on.
+
+                        Please note, unlike the spec.imageName field, the value of this
+                        spec.cdrom.image.name MUST be a Kubernetes object name.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind describes the type of image, either a namespace-scoped
+                            VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                          type: string
+                        name:
+                          description: |-
+                            Name refers to the name of a VirtualMachineImage resource in the same
+                            namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    name:
+                      description: |-
+                        Name consists of at least two lowercase letters or digits of this CD-ROM.
+                        It must be unique among all CD-ROM devices attached to the VM.
+
+                        This field is immutable when the VM is powered on.
+                      pattern: ^[a-z0-9]{2,}$
+                      type: string
+                  required:
+                  - image
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              className:
+                description: |-
+                  ClassName describes the name of the VirtualMachineClass resource used to
+                  deploy this VM.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM class.
+                type: string
+              crypto:
+                description: Crypto describes the desired encryption state of the
+                  VirtualMachine.
+                properties:
+                  encryptionClassName:
+                    description: |-
+                      EncryptionClassName describes the name of the EncryptionClass resource
+                      used to encrypt this VM.
+
+                      Please note, this field is not required to encrypt the VM. If the
+                      underlying platform has a default key provider, the VM may still be fully
+                      or partially encrypted depending on the specified storage and VM classes.
+
+                      If there is a default key provider and an encryption storage class is
+                      selected, the files in the VM's home directory and non-PVC virtual disks
+                      will be encrypted
+
+                      If there is a default key provider and a VM Class with a virtual, trusted
+                      platform module (vTPM) is selected, the files in the VM's home directory,
+                      minus any virtual disks, will be encrypted.
+
+                      If the underlying vSphere platform does not have a default key provider,
+                      then this field is required when specifying an encryption storage class
+                      and/or a VM Class with a vTPM.
+
+                      If this field is set, spec.storageClass must use an encryption-enabled
+                      storage class.
+                    type: string
+                  useDefaultKeyProvider:
+                    default: true
+                    description: |-
+                      UseDefaultKeyProvider describes the desired behavior for when an explicit
+                      EncryptionClass is not provided.
+
+                      When an explicit EncryptionClass is not provided and this value is true:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will be encrypted using the default key provider.
+
+                      - If a VirtualMachine is not encrypted, uses an encryption storage
+                        policy or has a virtual, trusted platform module (vTPM), there is a
+                        default key provider, the VM will be encrypted using the default key
+                        provider.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be rekeyed using the default key provider.
+
+                      When an explicit EncryptionClass is not provided and this value is false:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will fail.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be not be rekeyed.
+
+                        Please note, this could result in a VirtualMachine that cannot be
+                        powered on since it is encrypted using a provider or key that may have
+                        been removed. Without the key, the VM cannot be decrypted and thus
+                        cannot be powered on.
+
+                      Defaults to true if omitted.
+                    type: boolean
+                type: object
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
+              guestID:
+                description: |-
+                  GuestID describes the desired guest operating system identifier for a VM.
+
+                  The logic that determines the guest ID is as follows:
+
+                  If this field is set, then its value is used.
+                  Otherwise, if the VM is deployed from an OVF template that defines a
+                  guest ID, then that value is used.
+                  The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                  For a complete list of supported values, please refer to
+                  https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                  Please note that some guest ID values may require a minimal hardware
+                  version, which can be set using the `spec.minHardwareVersion` field.
+                  To see the mapping between virtual hardware versions and the product
+                  versions that support a specific guest ID, please refer to
+                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                  Please note that this field is immutable after the VM is powered on.
+                  To change the guest ID after the VM is powered on, the VM must be powered
+                  off and then powered on again with the updated guest ID spec.
+
+                  This field is required when the VM has any CD-ROM devices attached.
+                type: string
+              image:
+                description: |-
+                  Image describes the reference to the VirtualMachineImage or
+                  ClusterVirtualMachineImage resource used to deploy this VM.
+
+                  Please note, unlike the field spec.imageName, the value of
+                  spec.image.name MUST be a Kubernetes object name.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.imageName are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                properties:
+                  kind:
+                    description: |-
+                      Kind describes the type of image, either a namespace-scoped
+                      VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to the name of a VirtualMachineImage resource in the same
+                      namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageName:
+                description: |-
+                  ImageName describes the name of the image resource used to deploy this
+                  VM.
+
+                  This field may be used to specify the name of a VirtualMachineImage
+                  or ClusterVirtualMachineImage resource. The resolver first checks to see
+                  if there is a VirtualMachineImage with the specified name in the
+                  same namespace as the VM being deployed. If no such resource exists, the
+                  resolver then checks to see if there is a ClusterVirtualMachineImage
+                  resource with the specified name.
+
+                  This field may also be used to specify the display name (vSphere name) of
+                  a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                  display name unambiguously resolves to a distinct VM image (among all
+                  existing VirtualMachineImages in the VM's namespace and all existing
+                  ClusterVirtualMachineImages), then a mutation webhook updates the
+                  spec.image field with the reference to the resolved VM image. If the
+                  display name resolves to multiple or no VM images, then the mutation
+                  webhook denies the request and returns an error.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.image are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                type: string
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the desired Instance UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  This value is only used for the VM Instance UUID,
+                  it is not used within cloudInit.
+                  This identifier is used by VirtualCenter to uniquely identify all
+                  virtual machine instances, including those that may share the same BIOS UUID.
+                format: uuid
+                type: string
+              minHardwareVersion:
+                description: |-
+                  MinHardwareVersion describes the desired, minimum hardware version.
+
+                  The logic that determines the hardware version is as follows:
+
+                  1. If this field is set, then its value is used.
+                  2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                     non-empty hardware version, then it is used.
+                  3. Finally, if the hardware version is still undetermined, the value is
+                     set to the default hardware version for the Datacenter/Cluster/Host
+                     where the VM is provisioned.
+
+                  This field is never updated to reflect the derived hardware version.
+                  Instead, VirtualMachineStatus.HardwareVersion surfaces
+                  the observed hardware version.
+
+                  Please note, setting this field's value to N ensures a VM's hardware
+                  version is equal to or greater than N. For example, if a VM's observed
+                  hardware version is 10 and this field's value is 13, then the VM will be
+                  upgraded to hardware version 13. However, if the observed hardware
+                  version is 17 and this field's value is 13, no change will occur.
+
+                  Several features are hardware version dependent, for example:
+
+                  * NVMe Controllers                >= 14
+                  * Dynamic Direct Path I/O devices >= 17
+
+                  Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                  hardware versions.
+
+                  It is important to remember that a VM's hardware version may not be
+                  downgraded and upgrading a VM deployed from an image based on an older
+                  hardware version to a more recent one may result in unpredictable
+                  behavior. In other words, please be careful when choosing to upgrade a
+                  VM to a newer hardware version.
+                format: int32
+                minimum: 13
+                type: integer
+              network:
+                description: |-
+                  Network describes the desired network configuration for the VM.
+
+                  Please note this value may be omitted entirely and the VM will be
+                  assigned a single, virtual network interface that is connected to the
+                  Namespace's default network.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled is a flag that indicates whether or not to disable networking
+                      for this VM.
+
+                      When set to true, the VM is not configured with a default interface nor
+                      any specified from the Interfaces field.
+                    type: boolean
+                  domainName:
+                    description: |-
+                      DomainName describes the value the guest uses as its domain name.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS names:
+
+                        * When joined with the host name, the total length is restricted to 255
+                          characters or less.
+                        * Individual segments must be 63 characters or less.
+                        * The top-level domain( ex. ".com"), is at least two letters with no
+                          special characters.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Long, top-level domain names (ex. ".london") are permitted.
+                        * Symbol unicode points, such as emoji, are disallowed in the top-level
+                          domain.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+
+                      When deploying a guest running Microsoft Windows, this field describes
+                      the domain the computer should join.
+                    type: string
+                  hostName:
+                    description: |-
+                      HostName describes the value the guest uses as its host name. If omitted,
+                      the name of the VM will be used.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS labels:
+
+                        * The total length is restricted to 63 characters or less.
+                        * The total length is restricted to 15 characters or less on Windows
+                          systems.
+                        * The value may begin with a digit per RFC-1123.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                          please note that the use of emoji, even where allowed, may not
+                          compatible with the guest operating system, so it recommended to
+                          stick with more common characters for this value.
+                        * The value may be a valid IP4 or IP6 address. Please note, the use of
+                          an IP address for a host name is not compatible with all guest
+                          operating systems and is discouraged. Additionally, using an IP
+                          address for the host name is disallowed if spec.network.domainName is
+                          non-empty.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+                    type: string
+                  interfaces:
+                    description: |-
+                      Interfaces is the list of network interfaces used by this VM.
+
+                      If the Interfaces field is empty and the Disabled field is false, then
+                      a default interface with the name eth0 will be created.
+
+                      The maximum number of network interface allowed is 10 because a vSphere
+                      virtual machine may not have more than 10 virtual ethernet card devices.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                        network interface.
+                      properties:
+                        addresses:
+                          description: |-
+                            Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                            interface.
+
+                            Please note this field is only supported if the connected network
+                            supports manual IP allocation.
+
+                            Please note IP4 and IP6 addresses must include the network prefix length,
+                            ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                            Please note this field may not contain IP4 addresses if DHCP4 is set
+                            to true or IP6 addresses if DHCP6 is set to true.
+                          items:
+                            type: string
+                          type: array
+                        dhcp4:
+                          description: |-
+                            DHCP4 indicates whether or not this interface uses DHCP for IP4
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP4 addresses in the
+                            Addresses field and the Gateway4 field.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 indicates whether or not this interface uses DHCP for IP6
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP6 addresses in the
+                            Addresses field and the Gateway6 field.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the default, IP4 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP4.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway6 is the primary IP6 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP6.
+                          type: string
+                        guestDeviceName:
+                          description: |-
+                            GuestDeviceName is used to rename the device inside the guest when the
+                            bootstrap provider is Cloud-Init. Please note it is up to the user to
+                            ensure the provided device name does not conflict with any other devices
+                            inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^\w\w+$
+                          type: string
+                        macAddr:
+                          description: |-
+                            MACAddr is the optional MAC address of this interface.
+
+                            If no MAC address is provided, one will be generated by either the network
+                            provider or vCenter.
+
+                            Please note this field is only supported when the Network API Group is
+                            crd.nsx.vmware.com.
+                          pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                          type: string
+                        mtu:
+                          description: |-
+                            MTU is the Maximum Transmission Unit size in bytes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          format: int64
+                          type: integer
+                        name:
+                          description: |-
+                            Name describes the unique name of this network interface, used to
+                            distinguish it from other network interfaces attached to this VM.
+
+                            When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                            specified, the device inside the guest will be renamed to this value.
+                            Please note it is up to the user to ensure the provided name does not
+                            conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^[a-z0-9]{2,}$
+                          type: string
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                            nameservers.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit and Sysprep.
+
+                            When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                            true, if nameservers is not provided, the global nameservers will be used
+                            instead.
+
+                            Please note that Linux allows only three nameservers
+                            (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        network:
+                          description: |-
+                            Network is the name of the network resource to which this interface is
+                            connected.
+
+                            If no network is provided, then this interface will be connected to the
+                            Namespace's default network.
+                          properties:
+                            apiVersion:
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                              type: string
+                            kind:
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name refers to a unique resource in the current namespace.
+                                More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        routes:
+                          description: |-
+                            Routes is a list of optional, static routes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          items:
+                            description: VirtualMachineNetworkRouteSpec defines a
+                              static route for a guest.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              to:
+                                description: To is either "default", or an IP4 or
+                                  IP6 address.
+                                type: string
+                              via:
+                                description: Via is an IP4 or IP6 address.
+                                type: string
+                            required:
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+
+                            When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                            or true, if search domains is not provided, the global search domains
+                            will be used instead.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nameservers:
+                    description: |-
+                      Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                      nameservers. These are applied globally.
+
+                      Please note global nameservers are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface nameservers. However, when Cloud-Init
+                      is used and UseGlobalNameserversAsDefault is true, the global
+                      nameservers will be used when the per-interface nameservers is not
+                      provided.
+
+                      Please note that Linux allows only three nameservers
+                      (https://linux.die.net/man/5/resolv.conf).
+                    items:
+                      type: string
+                    type: array
+                  searchDomains:
+                    description: |-
+                      SearchDomains is a list of search domains used when resolving IP
+                      addresses with DNS. These are applied globally.
+
+                      Please note global search domains are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface search domains. However, when Cloud-Init
+                      is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                      domains will be used when the per-interface search domains is not provided.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nextRestartTime:
+                description: |-
+                  NextRestartTime may be used to restart the VM, in accordance with
+                  RestartMode, by setting the value of this field to "now"
+                  (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM controller then uses to determine the VM should be restarted by
+                  comparing the value to the timestamp of the last time the VM was
+                  restarted.
+
+                  Please note it is not possible to schedule future restarts using this
+                  field. The only value that users may set is the string "now"
+                  (case-insensitive).
+                type: string
+              powerOffMode:
+                default: TrySoft
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM.
+
+                  There are three, supported power off modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                  a graceful shutdown, and if that fails or the VM is not in a powered off
+                  state after five minutes, the VM is halted.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachine.
+
+                  Please note this field may be omitted when creating a new VM and will
+                  default to "PoweredOn." However, once the field is set to a non-empty
+                  value, it may no longer be set to an empty value.
+
+                  Additionally, setting this value to "Suspended" is not supported when
+                  creating a new VM. The valid values when creating a new VM are
+                  "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                  since this value defaults to "PoweredOn" for new VMs.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              readinessProbe:
+                description: ReadinessProbe describes a probe used to determine the
+                  VM's ready state.
+                properties:
+                  guestHeartbeat:
+                    description: GuestHeartbeat specifies an action involving the
+                      guest heartbeat status.
+                    properties:
+                      thresholdStatus:
+                        default: green
+                        description: |-
+                          ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                          considered successful.
+                        enum:
+                        - yellow
+                        - green
+                        type: string
+                    type: object
+                  guestInfo:
+                    description: |-
+                      GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                      The elements are evaluated with the logical AND operator, meaning
+                      all expressions must evaluate as true for the probe to succeed.
+
+                      For example, a VM resource's probe definition could be specified as the
+                      following:
+
+                              guestInfo:
+                              - key:   ready
+                                value: true
+
+                      With the above configuration in place, the VM would not be considered
+                      ready until the GuestInfo key "ready" was set to the value "true".
+
+                      From within the guest operating system it is possible to set GuestInfo
+                      key/value pairs using the program "vmware-rpctool," which is included
+                      with VM Tools. For example, the following command will set the key
+                      "guestinfo.ready" to the value "true":
+
+                              vmware-rpctool "info-set guestinfo.ready true"
+
+                      Once executed, the VM's readiness probe will be signaled and the
+                      VM resource will be marked as ready.
+                    items:
+                      description: |-
+                        GuestInfoAction describes a key from GuestInfo that must match the associated
+                        value expression.
+                      properties:
+                        key:
+                          description: |-
+                            Key is the name of the GuestInfo key.
+
+                            The key is automatically prefixed with "guestinfo." before being
+                            evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                            evaluated as "guestinfo.guestinfo.mykey".
+                          type: string
+                        value:
+                          description: |-
+                            Value is a regular expression that is matched against the value of the
+                            specified key.
+
+                            An empty value is the equivalent of "match any" or ".*".
+
+                            All values must adhere to the RE2 regular expression syntax as documented
+                            at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                            ignored depending on the implementation of this API. Either way, invalid
+                            values will not be considered when evaluating the ready state of a VM.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  periodSeconds:
+                    description: |-
+                      PeriodSeconds specifics how often (in seconds) to perform the probe.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tcpSocket:
+                    description: |-
+                      TCPSocket specifies an action involving a TCP port.
+
+                      Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                      This field will be removed in a later API version.
+                    properties:
+                      host:
+                        description: Host is an optional host name to connect to.
+                          Host defaults to the VM IP.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Port specifies a number or name of the port to access on the VM.
+                          If the format of port is a number, it must be in the range 1 to 65535.
+                          If the format of name is a string, it must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies a number of seconds after which the probe times out.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
+                type: object
+              reserved:
+                description: |-
+                  Reserved describes a set of VM configuration options reserved for system
+                  use.
+
+                  Please note attempts to modify the value of this field by a DevOps user
+                  will result in a validation error.
+                properties:
+                  resourcePolicyName:
+                    type: string
+                type: object
+              restartMode:
+                default: TrySoft
+                description: |-
+                  RestartMode describes the desired behavior for restarting a VM when
+                  spec.nextRestartTime is set to "now" (case-insensitive).
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                  interaction inside of the guest. The Soft mode requires the VM's guest to
+                  have VM Tools installed and asks the guest to restart the VM. Its
+                  variant, TrySoft, first attempts a soft restart, and if that fails or
+                  does not complete within five minutes, the VM is hard reset.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              storageClass:
+                description: |-
+                  StorageClass describes the name of a Kubernetes StorageClass resource
+                  used to configure this VM's storage-related attributes.
+
+                  Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                  for more information on Kubernetes storage classes.
+                type: string
+              suspendMode:
+                default: TrySoft
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM.
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                  disk without any interaction inside of the guest. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully suspend the VM. Its variant, TrySoft, first attempts
+                  a graceful suspend, and if that fails or the VM is not in a put into
+                  standby by the guest after five minutes, the VM is suspended.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              volumes:
+                description: Volumes describes a list of volumes that can be mounted
+                  to the VM.
+                items:
+                  description: VirtualMachineVolume represents a named volume in a
+                    VM.
+                  properties:
+                    name:
+                      description: |-
+                        Name represents the volume's name. Must be a DNS_LABEL and unique within
+                        the VM.
+                      type: string
+                    persistentVolumeClaim:
+                      description: |-
+                        PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                        in the same namespace.
+
+                        More information is available at
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        instanceVolumeClaim:
+                          description: InstanceVolumeClaim is set if the PVC is backed
+                            by instance storage.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Size is the size of the requested instance
+                                storage volume.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageClass:
+                              description: |-
+                                StorageClass is the name of the Kubernetes StorageClass that provides
+                                the backing storage for this instance storage volume.
+                              type: string
+                          required:
+                          - size
+                          - storageClass
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: VirtualMachineStatus defines the observed state of a VirtualMachine
+              instance.
+            properties:
+              biosUUID:
+                description: |-
+                  BiosUUID describes a unique identifier provided by the underlying
+                  infrastructure provider that is exposed to the Guest OS BIOS as a unique
+                  hardware identifier.
+                type: string
+              changeBlockTracking:
+                description: |-
+                  ChangeBlockTracking describes whether or not change block tracking is
+                  enabled for the VirtualMachine.
+                type: boolean
+              class:
+                description: |-
+                  Class is a reference to the VirtualMachineClass resource used to deploy
+                  this VM.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachine.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              crypto:
+                description: |-
+                  Crypto describes the observed state of the VirtualMachine's encryption
+                  configuration.
+                properties:
+                  encrypted:
+                    description: |-
+                      Encrypted describes the observed state of the VirtualMachine's
+                      encryption. There may be two values in this list:
+
+                      - Config -- This refers to all of the files related to a VM except any
+                                  virtual disks.
+                      - Disks  -- This refers to at least one of the VM's attached disks. To
+                                  determine the encryption state of the individual disks,
+                                  please refer to status.volumes[].crypto.
+                    items:
+                      type: string
+                    type: array
+                  keyID:
+                    description: |-
+                      KeyID describes the key ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                  providerID:
+                    description: |-
+                      ProviderID describes the provider ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                type: object
+              hardwareVersion:
+                description: |-
+                  HardwareVersion describes the VirtualMachine resource's observed
+                  hardware version.
+
+                  Please refer to VirtualMachineSpec.MinHardwareVersion for more
+                  information on the topic of a VM's hardware version.
+                format: int32
+                type: integer
+              host:
+                description: |-
+                  Host describes the hostname or IP address of the infrastructure host
+                  where the VM is executed.
+                type: string
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the unique instance UUID provided by the
+                  underlying infrastructure provider, such as vSphere.
+                type: string
+              lastRestartTime:
+                description: LastRestartTime describes the last time the VM was restarted.
+                format: date-time
+                type: string
+              network:
+                description: |-
+                  Network describes the observed state of the VM's network configuration.
+                  Please note much of the network status information is only available if
+                  the guest has VM Tools installed.
+                properties:
+                  config:
+                    description: |-
+                      Config describes the resolved, configured network settings for the VM,
+                      such as an interface's IP address obtained from IPAM, or global DNS
+                      settings.
+
+                      Please note this information does *not* represent the *observed* network
+                      state of the VM, but is intended for situations where someone boots a VM
+                      with no appropriate bootstrap engine and needs to know the network config
+                      valid for the deployed VM.
+                    properties:
+                      dns:
+                        description: DNS describes the configured state of client-side
+                          DNS.
+                        properties:
+                          domainName:
+                            description: |-
+                              DomainName is the domain name portion of the DNS name. For example,
+                              the "domain.local" part of "my-vm.domain.local".
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName is the host name portion of the DNS name. For example,
+                              the "my-vm" part of "my-vm.domain.local".
+                            type: string
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                              IP4 addresses are specified using dotted decimal notation. For example,
+                              "192.0.2.1".
+
+                              IP6 addresses are 128-bit addresses represented as eight fields of up to
+                              four hexadecimal digits. A colon separates each field (:). For example,
+                              2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                              symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                              once in an address as described in RFC 2373.
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of domains in which to search for hosts, in the
+                              order of preference.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      interfaces:
+                        description: Interfaces describes the configured state of
+                          the network interfaces.
+                        items:
+                          description: |-
+                            VirtualMachineNetworkConfigInterfaceStatus describes the configured state of
+                            network interface.
+                          properties:
+                            dns:
+                              description: DNS describes the interface's configured
+                                DNS information.
+                              properties:
+                                domainName:
+                                  description: |-
+                                    DomainName is the domain name portion of the DNS name. For example,
+                                    the "domain.local" part of "my-vm.domain.local".
+                                  type: string
+                                hostName:
+                                  description: |-
+                                    HostName is the host name portion of the DNS name. For example,
+                                    the "my-vm" part of "my-vm.domain.local".
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                    IP4 addresses are specified using dotted decimal notation. For example,
+                                    "192.0.2.1".
+
+                                    IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                    four hexadecimal digits. A colon separates each field (:). For example,
+                                    2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                    symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                    once in an address as described in RFC 2373.
+                                  items:
+                                    type: string
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of domains in which to search for hosts, in the
+                                    order of preference.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            ip:
+                              description: IP describes the interface's configured
+                                IP information.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses describes configured IP addresses for this interface.
+                                    Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                    2001:DB8:101::230:6eff:fe04:d9ff::/64.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp:
+                                  description: DHCP describes the interface's configured
+                                    DHCP options.
+                                  properties:
+                                    ip4:
+                                      description: IP4 describes the configured state
+                                        of the IP4 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                    ip6:
+                                      description: IP6 describes the configured state
+                                        of the IP6 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                gateway4:
+                                  description: |-
+                                    Gateway4 describes the interface's configured, default, IP4 gateway.
+
+                                    Please note the IP address include the network prefix length, ex.
+                                    192.168.0.1/24.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 describes the interface's configured, default, IP6 gateway.
+
+                                    Please note the IP address includes the network prefix length, ex.
+                                    2001:db8:101::1/64.
+                                  type: string
+                              type: object
+                            name:
+                              description: |-
+                                Name describes the corresponding network interface with the same name
+                                in the VM's desired network interface list.
+
+                                Please note this name is not necessarily related to the name of the
+                                device as it is surfaced inside of the guest.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  hostName:
+                    description: |-
+                      HostName describes the observed hostname reported by the VirtualMachine's
+                      guest operating system.
+
+                      Please note, this value is only reported if VMware Tools is installed in
+                      the guest, and the value may or may not be a fully qualified domain name
+                      (FQDN), it simply depends on what is reported by the guest.
+                    type: string
+                  interfaces:
+                    description: Interfaces describes the status of the VM's network
+                      interfaces.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceStatus describes the observed state of a
+                        VM's network interface.
+                      properties:
+                        deviceKey:
+                          description: |-
+                            DeviceKey describes the unique hardware device key of this network
+                            interface.
+                          format: int32
+                          type: integer
+                        dns:
+                          description: DNS describes the observed state of the interface's
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ip:
+                          description: IP describes the observed state of the interface's
+                            IP configuration.
+                          properties:
+                            addresses:
+                              description: Addresses describes observed IP addresses
+                                for this interface.
+                              items:
+                                description: |-
+                                  VirtualMachineNetworkInterfaceIPAddrStatus describes information about a
+                                  specific IP address.
+                                properties:
+                                  address:
+                                    description: |-
+                                      Address is an IP4 or IP6 address and their network prefix length.
+
+                                      An IP4 address is specified using dotted decimal notation. For example,
+                                      "192.0.2.1".
+
+                                      IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                      four hexadecimal digits. A colon separates each field (:). For example,
+                                      2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                      symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                      once in an address as described in RFC 2373.
+                                    type: string
+                                  lifetime:
+                                    description: Lifetime describes when this address
+                                      will expire.
+                                    format: date-time
+                                    type: string
+                                  origin:
+                                    description: Origin describes how this address
+                                      was configured.
+                                    enum:
+                                    - dhcp
+                                    - linklayer
+                                    - manual
+                                    - other
+                                    - random
+                                    type: string
+                                  state:
+                                    description: State describes the state of this
+                                      IP address.
+                                    enum:
+                                    - deprecated
+                                    - duplicate
+                                    - inaccessible
+                                    - invalid
+                                    - preferred
+                                    - tentative
+                                    - unknown
+                                    type: string
+                                type: object
+                              type: array
+                            autoConfigurationEnabled:
+                              description: |-
+                                AutoConfigurationEnabled describes whether or not ICMPv6 router
+                                solicitation requests are enabled or disabled from a given interface.
+
+                                These requests acquire an IP6 address and default gateway route from
+                                zero-to-many routers on the connected network.
+
+                                If not set then ICMPv6 is not available on this VM.
+                              type: boolean
+                            dhcp:
+                              description: |-
+                                DHCP describes the VM's observed, client-side, interface-specific DHCP
+                                options.
+                              properties:
+                                ip4:
+                                  description: IP4 describes the observed state of
+                                    the IP4 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                                ip6:
+                                  description: IP6 describes the observed state of
+                                    the IP6 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                              type: object
+                            macAddr:
+                              description: MACAddr describes the observed MAC address
+                                for this interface.
+                              type: string
+                          type: object
+                        name:
+                          description: |-
+                            Name describes the corresponding network interface with the same name
+                            in the VM's desired network interface list. If unset, then there is no
+                            corresponding entry for this interface.
+
+                            Please note this name is not necessarily related to the name of the
+                            device as it is surfaced inside of the guest.
+                          type: string
+                      type: object
+                    type: array
+                  ipStacks:
+                    description: |-
+                      IPStacks describes information about the guest's configured IP networking
+                      stacks.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkIPStackStatus describes the observed state of a
+                        VM's IP stack.
+                      properties:
+                        dhcp:
+                          description: DHCP describes the VM's observed, client-side,
+                            system-wide DHCP options.
+                          properties:
+                            ip4:
+                              description: IP4 describes the observed state of the
+                                IP4 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                            ip6:
+                              description: IP6 describes the observed state of the
+                                IP6 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                          type: object
+                        dns:
+                          description: DNS describes the VM's observed, client-side
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ipRoutes:
+                          description: IPRoutes contain the VM's routing tables for
+                            all address families.
+                          items:
+                            description: |-
+                              VirtualMachineNetworkIPRouteStatus describes the observed state of a
+                              guest network's IP routes.
+                            properties:
+                              gateway:
+                                description: Gateway describes where to send the packets
+                                  to next.
+                                properties:
+                                  address:
+                                    description: Address is the IP4 or IP6 address
+                                      of the gateway.
+                                    type: string
+                                  device:
+                                    description: |-
+                                      Device is the name of the device in the guest for which this gateway
+                                      applies.
+                                    type: string
+                                type: object
+                              networkAddress:
+                                description: |-
+                                  NetworkAddress is the IP4 or IP6 address of the destination network.
+
+                                  Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                  2001:DB8:101::230:6eff:fe04:d9ff::/64.
+
+                                  IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                  four hexadecimal digits. A colon separates each field (:). For example,
+                                  2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of symbol
+                                  '::' to represent multiple 16-bit groups of contiguous 0's only once in
+                                  an address as described in RFC 2373.
+                                type: string
+                            type: object
+                          type: array
+                        kernelConfig:
+                          description: |-
+                            KernelConfig describes the observed state of the VM's kernel IP
+                            configuration settings.
+
+                            The key part contains a unique number while the value part contains the
+                            'key=value' as provided by the underlying provider. For example, on
+                            Linux and/or BSD, the systcl -a output would be reported as:
+                            key='5', value='net.ipv4.tcp_keepalive_time = 7200'.
+                          items:
+                            description: |-
+                              KeyValuePair is useful when wanting to realize a map as a list of key/value
+                              pairs.
+                            properties:
+                              key:
+                                description: Key is the key part of the key/value
+                                  pair.
+                                type: string
+                              value:
+                                description: Value is the optional value part of the
+                                  key/value pair.
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
+                      type: object
+                    type: array
+                  primaryIP4:
+                    description: |-
+                      PrimaryIP4 describes the VM's primary IP4 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv4" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                  primaryIP6:
+                    description: |-
+                      PrimaryIP6 describes the VM's primary IP6 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv6" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                type: object
+              powerState:
+                description: PowerState describes the observed power state of the
+                  VirtualMachine.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              storage:
+                description: Storage describes the observed state of the VirtualMachine's
+                  storage.
+                properties:
+                  usage:
+                    description: Usage describes the observed amount of storage used
+                      by a VirtualMachine.
+                    properties:
+                      disks:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Disks describes the total storage space used by a VirtualMachine's
+                          non-PVC disks.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      other:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Other describes the total storage space used by the VirtualMachine's
+                          non disk files, ex. the configuration file, swap space, logs, snapshots,
+                          etc.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      total:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Total describes the total storage space used by a VirtualMachine that
+                          counts against the Namespace's storage quota.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              uniqueID:
+                description: |-
+                  UniqueID describes a unique identifier that is provided by the underlying
+                  infrastructure provider, such as vSphere.
+                type: string
+              volumes:
+                description: |-
+                  Volumes describes the observed state of the volumes that are intended to
+                  be attached to the VirtualMachine.
+                items:
+                  description: |-
+                    VirtualMachineVolumeStatus defines the observed state of a
+                    VirtualMachineVolume instance.
+                  properties:
+                    attached:
+                      description: |-
+                        Attached represents whether a volume has been successfully attached to
+                        the VirtualMachine or not.
+                      type: boolean
+                    crypto:
+                      description: Crypto describes the volume's encryption status.
+                      properties:
+                        keyID:
+                          description: |-
+                            KeyID describes the key ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                        providerID:
+                          description: |-
+                            ProviderID describes the provider ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                      type: object
+                    diskUUID:
+                      description: |-
+                        DiskUUID represents the underlying virtual disk UUID and is present when
+                        attachment succeeds.
+                      type: string
+                    error:
+                      description: |-
+                        Error represents the last error seen when attaching or detaching a
+                        volume.  Error will be empty if attachment succeeds.
+                      type: string
+                    limit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Limit describes the storage limit for the volume.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the name of the attached volume.
+                      type: string
+                    type:
+                      default: Managed
+                      description: Type is the type of the attached volume.
+                      enum:
+                      - Classic
+                      - Managed
+                      type: string
+                    used:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Used describes the observed, non-shared size of the volume on disk.
+                        For example, if this is a linked-clone's boot volume, this value
+                        represents the space consumed by the linked clone, not the parent.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - type
+                x-kubernetes-list-type: map
+              zone:
+                description: |-
+                  Zone describes the availability zone where the VirtualMachine has been
+                  scheduled.
+
+                  Please note this field may be empty when the cluster is not zone-aware.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.powerState
+      name: Power-State
+      type: string
+    - jsonPath: .spec.className
+      name: Class
+      priority: 1
+      type: string
+    - jsonPath: .spec.image.name
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.network.primaryIP4
+      name: Primary-IP4
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachine is the schema for the virtualmachines API and represents the
+          desired state and observed status of a virtualmachines resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine.
+            properties:
+              advanced:
+                description: Advanced describes a set of optional, advanced VM configuration
+                  options.
+                properties:
+                  bootDiskCapacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                      from the VirtualMachineImage from which the VM was deployed.
+
+                      Please note it is not advised to change this value while the VM is
+                      running. Also, resizing the VM's boot disk may require actions inside of
+                      the guest to take advantage of the additional capacity. Finally, changing
+                      the size of the VM's boot disk, even increasing it, could adversely
+                      affect the VM.
+
+                      Please note this field is ignored if the VM is deployed from an ISO with
+                      CD-ROM devices attached.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  changeBlockTracking:
+                    description: |-
+                      ChangeBlockTracking is a flag that enables incremental backup support
+                      for this VM, a feature utilized by external backup systems such as
+                      VMware Data Recovery.
+                    type: boolean
+                  defaultVolumeProvisioningMode:
+                    description: |-
+                      DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                      persistent volumes managed by this VM.
+                    enum:
+                    - Thin
+                    - Thick
+                    - ThickEagerZero
+                    type: string
+                type: object
+              affinity:
+                description: Affinity describes the VM's scheduling constraints.
+                properties:
+                  vmAffinity:
+                    description: VMAffinity describes affinity scheduling rules related
+                      to other VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the affinity expressions specified by this
+                          field, but it may choose to violate one or more of the expressions.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  vmAntiAffinity:
+                    description: |-
+                      VMAntiAffinity describes anti-affinity scheduling rules related to other
+                      VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the anti-affinity expressions specified by
+                          this field, but it may choose to violate one or more of the expressions.
+                          Additionally, it also describes the anti-affinity requirements that
+                          should be met during run-time, but the VM can still be run if the
+                          requirements cannot be satisfied.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              biosUUID:
+                description: |-
+                  BiosUUID describes the desired BIOS UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  When the bootstrap provider is Cloud-Init, this value is used as the
+                  default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                format: uuid
+                type: string
+              bootstrap:
+                description: |-
+                  Bootstrap describes the desired state of the guest's bootstrap
+                  configuration.
+
+                  If omitted, a default bootstrap method may be selected based on the
+                  guest OS identifier. If Linux, then the LinuxPrep method is used.
+                properties:
+                  cloudInit:
+                    description: |-
+                      CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                      Windows guests that support Cloudbase-Init.
+
+                      The guest's networking stack is configured by Cloud-Init on Linux guests
+                      and Cloudbase-Init on Windows guests.
+
+                      Please note this bootstrap provider may not be used in conjunction with
+                      the other bootstrap providers.
+                    properties:
+                      cloudConfig:
+                        description: |-
+                          CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                          bootstrap the VM.
+
+                          Please note this field and RawCloudConfig are mutually exclusive.
+                        properties:
+                          defaultUserEnabled:
+                            description: |-
+                              DefaultUserEnabled may be set to true to ensure even if the Users field
+                              is not empty, the default user is still created on systems that have one
+                              defined. By default, Cloud-Init ignores the default user if the
+                              CloudConfig provides one or more non-default users via the Users field.
+                            type: boolean
+                          runcmd:
+                            description: |-
+                              RunCmd allows running one or more commands on the guest.
+                              The entries in this list can adhere to two, different formats:
+
+                              Format 1 -- a string that contains the command and its arguments, ex.
+
+                                  runcmd:
+                                  - "ls -al"
+
+                              Format 2 -- a list of the command and its arguments, ex.
+
+                                  runcmd:
+                                  - - echo
+                                    - "Hello, world."
+                            x-kubernetes-preserve-unknown-fields: true
+                          ssh_pwauth:
+                            description: |-
+                              SSHPwdAuth sets whether or not to accept password authentication.
+                              In order for this config to be applied, SSH may need to be restarted.
+                              On systemd systems, this restart will only happen if the SSH service has
+                              already been started. On non-systemd systems, a restart will be attempted
+                              regardless of the service state.
+                            type: boolean
+                          timezone:
+                            description: Timezone describes the timezone represented
+                              in /usr/share/zoneinfo.
+                            type: string
+                          users:
+                            description: Users allows adding/configuring one or more
+                              users on the guest.
+                            items:
+                              description: User is a CloudConfig user data structure.
+                              properties:
+                                create_groups:
+                                  description: |-
+                                    CreateGroups is a flag that may be set to false to disable creation of
+                                    specified user groups.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                expiredate:
+                                  description: ExpireData is the date on which the
+                                    user's account will be disabled.
+                                  type: string
+                                gecos:
+                                  description: |-
+                                    Gecos is an optional comment about the user, usually a comma-separated
+                                    string of the user's real name and contact information.
+                                  type: string
+                                groups:
+                                  description: Groups is an optional list of groups
+                                    to add to the user.
+                                  items:
+                                    type: string
+                                  type: array
+                                hashed_passwd:
+                                  description: |-
+                                    HashedPasswd is a hash of the user's password that will be applied even
+                                    if the specified user already exists.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                homedir:
+                                  description: |-
+                                    Homedir is the optional home directory for the user.
+
+                                    Defaults to "/home/<username>" when Name is not "default".
+                                  type: string
+                                inactive:
+                                  description: |-
+                                    Inactive optionally represents the number of days until the user is
+                                    disabled.
+                                  format: int32
+                                  type: integer
+                                lock_passwd:
+                                  description: |-
+                                    LockPasswd disables password login.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                name:
+                                  description: |-
+                                    Name is the user's login name.
+
+                                    Please note this field may be set to the special value of "default" when
+                                    this User is the first element in the Users list from the CloudConfig.
+                                    When set to "default", all other fields from this User must be nil.
+                                  type: string
+                                no_create_home:
+                                  description: |-
+                                    NoCreateHome prevents the creation of the home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_log_init:
+                                  description: |-
+                                    NoLogInit prevents the initialization of lastlog and faillog for the
+                                    user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_user_group:
+                                  description: |-
+                                    NoUserGroup prevents the creation of the group named after the user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                passwd:
+                                  description: |-
+                                    Passwd is a hash of the user's password that will be applied only to
+                                    a newly created user. To apply a new, hashed password to an existing user
+                                    please use HashedPasswd instead.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                primary_group:
+                                  description: |-
+                                    PrimaryGroup is the primary group for the user.
+
+                                    Defaults to the value of the Name field when it is not "default".
+                                  type: string
+                                selinux_user:
+                                  description: SELinuxUser is the SELinux user for
+                                    the user's login.
+                                  type: string
+                                shell:
+                                  description: |-
+                                    Shell is the path to the user's login shell.
+
+                                    Please note the default is to set no shell, which results in a
+                                    system-specific default being used.
+                                  type: string
+                                snapuser:
+                                  description: |-
+                                    SnapUser specifies an e-mail address to create the user as a Snappy user
+                                    through "snap create-user".
+
+                                    If an Ubuntu SSO account is associated with the address, the username and
+                                    SSH keys will be requested from there.
+                                  type: string
+                                ssh_authorized_keys:
+                                  description: |-
+                                    SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                    keys file.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_import_id:
+                                  description: |-
+                                    SSHImportID is a list of SSH IDs to import for the user.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_redirect_user:
+                                  description: |-
+                                    SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                    Please note that when specified, all SSH keys from cloud meta-data will
+                                    be configured in a disabled state for this user. Any SSH login as this
+                                    user will timeout with a message to login instead as the default user.
+
+                                    This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                sudo:
+                                  description: |-
+                                    Sudo is a sudo rule to apply to the user.
+
+                                    When omitted, no sudo rules will be applied to the user.
+                                  type: string
+                                system:
+                                  description: |-
+                                    System is an optional flag that indicates the user should be created as
+                                    a system user with no home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                uid:
+                                  description: |-
+                                    UID is the user's ID.
+
+                                    When omitted the guest will default to the next available number.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          write_files:
+                            description: WriteFiles allows adding files to the guest
+                              file system.
+                            items:
+                              description: WriteFile is a CloudConfig write_file data
+                                structure.
+                              properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether or not to append the content to an existing file
+                                    if the file specified by Path already exists.
+                                  type: boolean
+                                content:
+                                  description: |-
+                                    Content is the optional content to write to the provided Path.
+
+                                    When omitted an empty file will be created or existing file will be
+                                    modified.
+
+                                    The value for this field can adhere to two, different formats:
+
+                                    Format 1 -- a string that contains the command and its arguments, ex.
+
+                                        content: Hello, world.
+
+                                    Please note that format 1 supports all of the manners of specifying a
+                                    YAML string.
+
+                                    Format 2 -- a secret reference with the name of the key that contains
+                                                the content for the file, ex.
+
+                                        content:
+                                          name: my-bootstrap-secret
+                                          key: my-file-content
+                                  x-kubernetes-preserve-unknown-fields: true
+                                defer:
+                                  description: |-
+                                    Defer indicates to defer writing the file until Cloud-Init's "final"
+                                    stage, after users are created and packages are installed.
+                                  type: boolean
+                                encoding:
+                                  default: text/plain
+                                  description: Encoding is an optional encoding type
+                                    of the content.
+                                  enum:
+                                  - b64
+                                  - base64
+                                  - gz
+                                  - gzip
+                                  - gz+b64
+                                  - gz+base64
+                                  - gzip+b64
+                                  - gzip+base64
+                                  - text/plain
+                                  type: string
+                                owner:
+                                  default: root:root
+                                  description: Owner is an optional "owner:group"
+                                    to chown the file.
+                                  type: string
+                                path:
+                                  description: Path is the path of the file to which
+                                    the content is decoded and written.
+                                  type: string
+                                permissions:
+                                  default: "0644"
+                                  description: |-
+                                    Permissions an optional set of file permissions to set.
+
+                                    Please note the permissions should be specified as an octal string, ex.
+                                    "0###".
+
+                                    When omitted the guest will default this value to "0644".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - path
+                            x-kubernetes-list-type: map
+                        type: object
+                      instanceID:
+                        description: |-
+                          InstanceID is the cloud-init metadata instance ID.
+                          If omitted, this field defaults to the VM's BiosUUID.
+                        type: string
+                      rawCloudConfig:
+                        description: |-
+                          RawCloudConfig describes a key in a Secret resource that contains the
+                          CloudConfig data used to bootstrap the VM.
+
+                          The CloudConfig data specified by the key may be plain-text,
+                          base64-encoded, or gzipped and base64-encoded.
+
+                          Please note this field and CloudConfig are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                          the guest's default user.
+                        items:
+                          type: string
+                        type: array
+                      useGlobalNameserversAsDefault:
+                        description: |-
+                          UseGlobalNameserversAsDefault will use the global nameservers specified in
+                          the NetworkSpec as the per-interface nameservers when the per-interface
+                          nameservers is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                      useGlobalSearchDomainsAsDefault:
+                        description: |-
+                          UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                          in the NetworkSpec as the per-interface search domains when the per-interface
+                          search domains is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                    type: object
+                  linuxPrep:
+                    description: |-
+                      LinuxPrep may be used to bootstrap Linux guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or Sysprep bootstrap providers.
+                    properties:
+                      hardwareClockIsUTC:
+                        description: |-
+                          HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                          local time.
+                        type: boolean
+                      timeZone:
+                        description: |-
+                          TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                          Valid values are based on the tz (timezone) database used by Linux and
+                          other Unix systems. The values are strings in the form of
+                          "Area/Location," in which Area is a continent or ocean name, and
+                          Location is the city, island, or other regional designation.
+
+                          Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                          time zones for Linux systems.
+                        type: string
+                    type: object
+                  sysprep:
+                    description: |-
+                      Sysprep may be used to bootstrap Windows guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or LinuxPrep bootstrap providers.
+                    properties:
+                      rawSysprep:
+                        description: |-
+                          RawSysprep describes a key in a Secret resource that contains an XML
+                          string of the Sysprep text used to bootstrap the VM.
+
+                          The data specified by the Secret key may be plain-text, base64-encoded,
+                          or gzipped and base64-encoded.
+
+                          Please note this field and Sysprep are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sysprep:
+                        description: |-
+                          Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                          This field encloses all the individual keys listed in a sysprep.xml file.
+
+                          For more detailed information please see
+                          https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                          Please note this field and RawSysprep are mutually exclusive.
+                        properties:
+                          guiRunOnce:
+                            description: GUIRunOnce is a representation of the Sysprep
+                              GuiRunOnce key.
+                            properties:
+                              commands:
+                                description: |-
+                                  Commands is a list of commands to run at first user logon, after guest
+                                  customization.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          guiUnattended:
+                            description: GUIUnattended is a representation of the
+                              Sysprep GUIUnattended key.
+                            properties:
+                              autoLogon:
+                                description: |-
+                                  AutoLogon determine whether the machine automatically logs on as
+                                  Administrator.
+
+                                  Please note if AutoLogon is true, then Password must be set or guest
+                                  customization will fail.
+                                type: boolean
+                              autoLogonCount:
+                                description: |-
+                                  AutoLogonCount specifies the number of times the machine should
+                                  automatically log on as Administrator.
+
+                                  Generally it should be 1, but if your setup requires a number of reboots,
+                                  you may want to increase it. This number may be determined by the list of
+                                  commands executed by the GuiRunOnce command.
+
+                                  Please note this field must be specified with a non-zero positive integer
+                                  if AutoLogon is true.
+                                format: int32
+                                type: integer
+                              password:
+                                description: |-
+                                  Password is the new administrator password for the machine.
+
+                                  To specify that the password should be set to blank (that is, no
+                                  password), set the password value to NULL. Because of encryption, "" is
+                                  NOT a valid value.
+
+                                  Please note if the password is set to blank and AutoLogon is true, the
+                                  guest customization will fail.
+
+                                  If the XML file is generated by the VirtualCenter Customization Wizard,
+                                  then the password is encrypted. Otherwise, the client should set the
+                                  plainText attribute to true, so that the customization process does not
+                                  attempt to decrypt the string.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `password`.
+                                properties:
+                                  key:
+                                    default: password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              timeZone:
+                                default: 85
+                                description: |-
+                                  TimeZone is the time zone index for the virtual machine.
+
+                                  Please note that numbers correspond to time zones listed at
+                                  https://bit.ly/3Rzv8oL.
+
+                                  Defaults to UTC.
+                                format: int32
+                                minimum: 0
+                                type: integer
+                            required:
+                            - timeZone
+                            type: object
+                          identification:
+                            description: Identification is a representation of the
+                              Sysprep Identification key.
+                            properties:
+                              domainAdmin:
+                                description: |-
+                                  DomainAdmin is the domain user account used for authentication if the
+                                  virtual machine is joining a domain. The user does not need to be a
+                                  domain administrator, but the account must have the privileges required
+                                  to add computers to the domain.
+                                type: string
+                              domainAdminPassword:
+                                description: |-
+                                  DomainAdminPassword is the password for the domain user account used for
+                                  authentication if the virtual machine is joining a domain.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: domain_admin_password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              domainOU:
+                                description: |-
+                                  DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                  the OU to which the computer belongs.
+                                type: string
+                              joinWorkgroup:
+                                description: |-
+                                  JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                  this value is supplied, then the fields spec.network.domain,
+                                  spec.bootstrap.sysprep.identification.domainAdmin, and
+                                  spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                type: string
+                            type: object
+                          licenseFilePrintData:
+                            description: |-
+                              LicenseFilePrintData is a representation of the Sysprep
+                              LicenseFilePrintData key.
+
+                              Please note this is required only for Windows 2000 Server and Windows
+                              Server 2003.
+                            properties:
+                              autoMode:
+                                description: AutoMode specifies the server licensing
+                                  mode.
+                                enum:
+                                - perSeat
+                                - perServer
+                                type: string
+                              autoUsers:
+                                description: |-
+                                  AutoUsers indicates the number of client licenses purchased for the
+                                  VirtualCenter server being installed.
+
+                                  Please note this value is ignored unless AutoMode is PerServer.
+                                format: int32
+                                type: integer
+                            required:
+                            - autoMode
+                            type: object
+                          userData:
+                            description: UserData is a representation of the Sysprep
+                              UserData key.
+                            properties:
+                              fullName:
+                                description: FullName is the user's full name.
+                                type: string
+                              orgName:
+                                description: OrgName is the name of the user's organization.
+                                type: string
+                              productID:
+                                description: |-
+                                  ProductID is a valid serial number.
+
+                                  Please note unless the VirtualMachineImage was installed with a volume
+                                  license key, ProductID must be set or guest customization will fail.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: product_id
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - fullName
+                            - orgName
+                            type: object
+                        required:
+                        - userData
+                        type: object
+                    type: object
+                  vAppConfig:
+                    description: |-
+                      VAppConfig may be used to bootstrap guests that rely on vApp properties
+                      (how VMware surfaces OVF properties on guests) to transport data into the
+                      guest.
+
+                      The guest's networking stack may be configured using either vApp
+                      properties or GOSC.
+
+                      Many OVFs define one or more properties that are used by the guest to
+                      bootstrap its networking stack. If the VirtualMachineImage defines one or
+                      more properties like this, then they can be configured to use the network
+                      data provided for this VM at runtime by setting these properties to Go
+                      template strings.
+
+                      It is also possible to use GOSC to bootstrap this VM's network stack by
+                      configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                      Please note the VAppConfig bootstrap provider in conjunction with the
+                      LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                      VM metadata transport to "OvfEnv".
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      bootstrap provider.
+                    properties:
+                      properties:
+                        description: |-
+                          Properties is a list of vApp/OVF property key/value pairs.
+
+                          Please note this field and RawProperties are mutually exclusive.
+                        items:
+                          description: |-
+                            KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                            list of key/value pairs where each value could also reference data stored in
+                            a Secret resource.
+                          properties:
+                            key:
+                              description: Key is the key part of the key/value pair.
+                              type: string
+                            value:
+                              description: Value is the optional value part of the
+                                key/value pair.
+                              properties:
+                                from:
+                                  description: |-
+                                    From is specified to reference a value from a Secret resource.
+
+                                    Please note this field is mutually exclusive with the Value field.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                value:
+                                  description: |-
+                                    Value is used to directly specify a value.
+
+                                    Please note this field is mutually exclusive with the From field.
+                                  type: string
+                              type: object
+                          required:
+                          - key
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      rawProperties:
+                        description: |-
+                          RawProperties is the name of a Secret resource in the same Namespace as
+                          this VM where each key/value pair from the Secret is used as a vApp
+                          key/value pair.
+
+                          Please note this field and Properties are mutually exclusive.
+                        type: string
+                    type: object
+                type: object
+              cdrom:
+                description: |-
+                  Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                  Each CD-ROM device requires a reference to an ISO-type
+                  VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                  Multiple CD-ROM devices using the same backing image, regardless of image
+                  kinds (namespace or cluster scope), are not allowed.
+
+                  CD-ROM devices can be added, updated, or removed when the VM is powered
+                  off. When the VM is powered on, only the connection state of existing
+                  CD-ROM devices can be changed.
+                  CD-ROM devices are attached to the VM in the specified list-order.
+                items:
+                  description: VirtualMachineCdromSpec describes the desired state
+                    of a CD-ROM device.
+                  properties:
+                    allowGuestControl:
+                      default: true
+                      description: |-
+                        AllowGuestControl describes whether or not a web console connection
+                        may be used to connect/disconnect the CD-ROM device.
+
+                        Defaults to true if omitted.
+                      type: boolean
+                    connected:
+                      default: true
+                      description: |-
+                        Connected describes the desired connection state of the CD-ROM device.
+
+                        When true, the CD-ROM device is added and connected to the VM.
+                        If the device already exists, it is updated to a connected state.
+
+                        When explicitly set to false, the CD-ROM device is added but remains
+                        disconnected from the VM. If the CD-ROM device already exists, it is
+                        updated to a disconnected state.
+
+                        Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                        in the guest OS. Refer to the following KB article for more details:
+                        https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                        Defaults to true if omitted.
+                      type: boolean
+                    image:
+                      description: |-
+                        Image describes the reference to an ISO type VirtualMachineImage or
+                        ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                        If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                        This field is immutable when the VM is powered on.
+
+                        Please note, unlike the spec.imageName field, the value of this
+                        spec.cdrom.image.name MUST be a Kubernetes object name.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind describes the type of image, either a namespace-scoped
+                            VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                          type: string
+                        name:
+                          description: |-
+                            Name refers to the name of a VirtualMachineImage resource in the same
+                            namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    name:
+                      description: |-
+                        Name consists of at least two lowercase letters or digits of this CD-ROM.
+                        It must be unique among all CD-ROM devices attached to the VM.
+
+                        This field is immutable when the VM is powered on.
+                      pattern: ^[a-z0-9]{2,}$
+                      type: string
+                  required:
+                  - image
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              className:
+                description: |-
+                  ClassName describes the name of the VirtualMachineClass resource used to
+                  deploy this VM.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM class.
+
+                  If a VM is using a class, a different value in spec.className
+                  leads to the VM being resized.
+                type: string
+              crypto:
+                description: Crypto describes the desired encryption state of the
+                  VirtualMachine.
+                properties:
+                  encryptionClassName:
+                    description: |-
+                      EncryptionClassName describes the name of the EncryptionClass resource
+                      used to encrypt this VM.
+
+                      Please note, this field is not required to encrypt the VM. If the
+                      underlying platform has a default key provider, the VM may still be fully
+                      or partially encrypted depending on the specified storage and VM classes.
+
+                      If there is a default key provider and an encryption storage class is
+                      selected, the files in the VM's home directory and non-PVC virtual disks
+                      will be encrypted
+
+                      If there is a default key provider and a VM Class with a virtual, trusted
+                      platform module (vTPM) is selected, the files in the VM's home directory,
+                      minus any virtual disks, will be encrypted.
+
+                      If the underlying vSphere platform does not have a default key provider,
+                      then this field is required when specifying an encryption storage class
+                      and/or a VM Class with a vTPM.
+
+                      If this field is set, spec.storageClass must use an encryption-enabled
+                      storage class.
+                    type: string
+                  useDefaultKeyProvider:
+                    default: true
+                    description: |-
+                      UseDefaultKeyProvider describes the desired behavior for when an explicit
+                      EncryptionClass is not provided.
+
+                      When an explicit EncryptionClass is not provided and this value is true:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will be encrypted using the default key provider.
+
+                      - If a VirtualMachine is not encrypted, uses an encryption storage
+                        policy or has a virtual, trusted platform module (vTPM), there is a
+                        default key provider, the VM will be encrypted using the default key
+                        provider.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be rekeyed using the default key provider.
+
+                      When an explicit EncryptionClass is not provided and this value is false:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will fail.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be not be rekeyed.
+
+                        Please note, this could result in a VirtualMachine that cannot be
+                        powered on since it is encrypted using a provider or key that may have
+                        been removed. Without the key, the VM cannot be decrypted and thus
+                        cannot be powered on.
+
+                      Defaults to true if omitted.
+                    type: boolean
+                type: object
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
+              guestID:
+                description: |-
+                  GuestID describes the desired guest operating system identifier for a VM.
+
+                  The logic that determines the guest ID is as follows:
+
+                  If this field is set, then its value is used.
+                  Otherwise, if the VM is deployed from an OVF template that defines a
+                  guest ID, then that value is used.
+                  The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                  For a complete list of supported values, please refer to
+                  https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                  Please note that some guest ID values may require a minimal hardware
+                  version, which can be set using the `spec.minHardwareVersion` field.
+                  To see the mapping between virtual hardware versions and the product
+                  versions that support a specific guest ID, please refer to
+                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                  Please note that this field is immutable after the VM is powered on.
+                  To change the guest ID after the VM is powered on, the VM must be powered
+                  off and then powered on again with the updated guest ID spec.
+
+                  This field is required when the VM has any CD-ROM devices attached.
+                type: string
+              image:
+                description: |-
+                  Image describes the reference to the VirtualMachineImage or
+                  ClusterVirtualMachineImage resource used to deploy this VM.
+
+                  Please note, unlike the field spec.imageName, the value of
+                  spec.image.name MUST be a Kubernetes object name.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.imageName are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                properties:
+                  kind:
+                    description: |-
+                      Kind describes the type of image, either a namespace-scoped
+                      VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to the name of a VirtualMachineImage resource in the same
+                      namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageName:
+                description: |-
+                  ImageName describes the name of the image resource used to deploy this
+                  VM.
+
+                  This field may be used to specify the name of a VirtualMachineImage
+                  or ClusterVirtualMachineImage resource. The resolver first checks to see
+                  if there is a VirtualMachineImage with the specified name in the
+                  same namespace as the VM being deployed. If no such resource exists, the
+                  resolver then checks to see if there is a ClusterVirtualMachineImage
+                  resource with the specified name.
+
+                  This field may also be used to specify the display name (vSphere name) of
+                  a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                  display name unambiguously resolves to a distinct VM image (among all
+                  existing VirtualMachineImages in the VM's namespace and all existing
+                  ClusterVirtualMachineImages), then a mutation webhook updates the
+                  spec.image field with the reference to the resolved VM image. If the
+                  display name resolves to multiple or no VM images, then the mutation
+                  webhook denies the request and returns an error.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.image are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                type: string
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the desired Instance UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  This value is only used for the VM Instance UUID,
+                  it is not used within cloudInit.
+                  This identifier is used by VirtualCenter to uniquely identify all
+                  virtual machine instances, including those that may share the same BIOS UUID.
+                format: uuid
+                type: string
+              minHardwareVersion:
+                description: |-
+                  MinHardwareVersion describes the desired, minimum hardware version.
+
+                  The logic that determines the hardware version is as follows:
+
+                  1. If this field is set, then its value is used.
+                  2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                     non-empty hardware version, then it is used.
+                  3. Finally, if the hardware version is still undetermined, the value is
+                     set to the default hardware version for the Datacenter/Cluster/Host
+                     where the VM is provisioned.
+
+                  This field is never updated to reflect the derived hardware version.
+                  Instead, VirtualMachineStatus.HardwareVersion surfaces
+                  the observed hardware version.
+
+                  Please note, setting this field's value to N ensures a VM's hardware
+                  version is equal to or greater than N. For example, if a VM's observed
+                  hardware version is 10 and this field's value is 13, then the VM will be
+                  upgraded to hardware version 13. However, if the observed hardware
+                  version is 17 and this field's value is 13, no change will occur.
+
+                  Several features are hardware version dependent, for example:
+
+                  * NVMe Controllers                >= 14
+                  * Dynamic Direct Path I/O devices >= 17
+
+                  Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                  hardware versions.
+
+                  It is important to remember that a VM's hardware version may not be
+                  downgraded and upgrading a VM deployed from an image based on an older
+                  hardware version to a more recent one may result in unpredictable
+                  behavior. In other words, please be careful when choosing to upgrade a
+                  VM to a newer hardware version.
+                format: int32
+                minimum: 13
+                type: integer
+              network:
+                description: |-
+                  Network describes the desired network configuration for the VM.
+
+                  Please note this value may be omitted entirely and the VM will be
+                  assigned a single, virtual network interface that is connected to the
+                  Namespace's default network.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled is a flag that indicates whether or not to disable networking
+                      for this VM.
+
+                      When set to true, the VM is not configured with a default interface nor
+                      any specified from the Interfaces field.
+                    type: boolean
+                  domainName:
+                    description: |-
+                      DomainName describes the value the guest uses as its domain name.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS names:
+
+                        * When joined with the host name, the total length is restricted to 255
+                          characters or less.
+                        * Individual segments must be 63 characters or less.
+                        * The top-level domain( ex. ".com"), is at least two letters with no
+                          special characters.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Long, top-level domain names (ex. ".london") are permitted.
+                        * Symbol unicode points, such as emoji, are disallowed in the top-level
+                          domain.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+
+                      When deploying a guest running Microsoft Windows, this field describes
+                      the domain the computer should join.
+                    type: string
+                  hostName:
+                    description: |-
+                      HostName describes the value the guest uses as its host name. If omitted,
+                      the name of the VM will be used.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS labels:
+
+                        * The total length is restricted to 63 characters or less.
+                        * The total length is restricted to 15 characters or less on Windows
+                          systems.
+                        * The value may begin with a digit per RFC-1123.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                          please note that the use of emoji, even where allowed, may not
+                          compatible with the guest operating system, so it recommended to
+                          stick with more common characters for this value.
+                        * The value may be a valid IP4 or IP6 address. Please note, the use of
+                          an IP address for a host name is not compatible with all guest
+                          operating systems and is discouraged. Additionally, using an IP
+                          address for the host name is disallowed if spec.network.domainName is
+                          non-empty.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+                    type: string
+                  interfaces:
+                    description: |-
+                      Interfaces is the list of network interfaces used by this VM.
+
+                      If the Interfaces field is empty and the Disabled field is false, then
+                      a default interface with the name eth0 will be created.
+
+                      The maximum number of network interface allowed is 10 because a vSphere
+                      virtual machine may not have more than 10 virtual ethernet card devices.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                        network interface.
+                      properties:
+                        addresses:
+                          description: |-
+                            Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                            interface.
+
+                            Please note this field is only supported if the connected network
+                            supports manual IP allocation.
+
+                            Please note IP4 and IP6 addresses must include the network prefix length,
+                            ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                            Please note this field may not contain IP4 addresses if DHCP4 is set
+                            to true or IP6 addresses if DHCP6 is set to true.
+                          items:
+                            type: string
+                          type: array
+                        dhcp4:
+                          description: |-
+                            DHCP4 indicates whether or not this interface uses DHCP for IP4
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP4 addresses in the
+                            Addresses field and the Gateway4 field.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 indicates whether or not this interface uses DHCP for IP6
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP6 addresses in the
+                            Addresses field and the Gateway6 field.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the default, IP4 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP4.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway6 is the primary IP6 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP6.
+                          type: string
+                        guestDeviceName:
+                          description: |-
+                            GuestDeviceName is used to rename the device inside the guest when the
+                            bootstrap provider is Cloud-Init. Please note it is up to the user to
+                            ensure the provided device name does not conflict with any other devices
+                            inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^\w\w+$
+                          type: string
+                        macAddr:
+                          description: |-
+                            MACAddr is the optional MAC address of this interface.
+
+                            If no MAC address is provided, one will be generated by either the network
+                            provider or vCenter.
+
+                            Please note this field is only supported when the Network API Group is
+                            crd.nsx.vmware.com.
+                          pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                          type: string
+                        mtu:
+                          description: |-
+                            MTU is the Maximum Transmission Unit size in bytes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          format: int64
+                          type: integer
+                        name:
+                          description: |-
+                            Name describes the unique name of this network interface, used to
+                            distinguish it from other network interfaces attached to this VM.
+
+                            When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                            specified, the device inside the guest will be renamed to this value.
+                            Please note it is up to the user to ensure the provided name does not
+                            conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^[a-z0-9]{2,}$
+                          type: string
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                            nameservers.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit and Sysprep.
+
+                            When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                            true, if nameservers is not provided, the global nameservers will be used
+                            instead.
+
+                            Please note that Linux allows only three nameservers
+                            (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        network:
+                          description: |-
+                            Network is the name of the network resource to which this interface is
+                            connected.
+
+                            If no network is provided, then this interface will be connected to the
+                            Namespace's default network.
+                          properties:
+                            apiVersion:
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                              type: string
+                            kind:
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name refers to a unique resource in the current namespace.
+                                More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        routes:
+                          description: |-
+                            Routes is a list of optional, static routes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          items:
+                            description: VirtualMachineNetworkRouteSpec defines a
+                              static route for a guest.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              to:
+                                description: To is either "default", or an IP4 or
+                                  IP6 address.
+                                type: string
+                              via:
+                                description: Via is an IP4 or IP6 address.
+                                type: string
+                            required:
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+
+                            When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                            or true, if search domains is not provided, the global search domains
+                            will be used instead.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nameservers:
+                    description: |-
+                      Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                      nameservers. These are applied globally.
+
+                      Please note global nameservers are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface nameservers. However, when Cloud-Init
+                      is used and UseGlobalNameserversAsDefault is true, the global
+                      nameservers will be used when the per-interface nameservers is not
+                      provided.
+
+                      Please note that Linux allows only three nameservers
+                      (https://linux.die.net/man/5/resolv.conf).
+                    items:
+                      type: string
+                    type: array
+                  searchDomains:
+                    description: |-
+                      SearchDomains is a list of search domains used when resolving IP
+                      addresses with DNS. These are applied globally.
+
+                      Please note global search domains are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface search domains. However, when Cloud-Init
+                      is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                      domains will be used when the per-interface search domains is not provided.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nextRestartTime:
+                description: |-
+                  NextRestartTime may be used to restart the VM, in accordance with
+                  RestartMode, by setting the value of this field to "now"
+                  (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM controller then uses to determine the VM should be restarted by
+                  comparing the value to the timestamp of the last time the VM was
+                  restarted.
+
+                  Please note it is not possible to schedule future restarts using this
+                  field. The only value that users may set is the string "now"
+                  (case-insensitive).
+                type: string
+              powerOffMode:
+                default: TrySoft
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM.
+
+                  There are three, supported power off modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                  a graceful shutdown, and if that fails or the VM is not in a powered off
+                  state after five minutes, the VM is halted.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachine.
+
+                  Please note this field may be omitted when creating a new VM and will
+                  default to "PoweredOn." However, once the field is set to a non-empty
+                  value, it may no longer be set to an empty value.
+
+                  Additionally, setting this value to "Suspended" is not supported when
+                  creating a new VM. The valid values when creating a new VM are
+                  "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                  since this value defaults to "PoweredOn" for new VMs.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              promoteDisksMode:
+                default: Online
+                description: |-
+                  PromoteDisksMode describes the mode used to promote a VM's delta disks to
+                  full disks. The available modes are:
+
+                  - Disabled -- Do not promote disks.
+                  - Online   -- Promote disks while the VM is powered on. VMs with
+                                snapshots do not support online promotion.
+                  - Offline  -- Promote disks while the VM is powered off.
+
+                  Please note, this field is ignored for encrypted VMs since they do not
+                  use delta disks.
+
+                  Defaults to Online.
+                enum:
+                - Online
+                - Offline
+                - Disabled
+                type: string
+              readinessProbe:
+                description: ReadinessProbe describes a probe used to determine the
+                  VM's ready state.
+                properties:
+                  guestHeartbeat:
+                    description: GuestHeartbeat specifies an action involving the
+                      guest heartbeat status.
+                    properties:
+                      thresholdStatus:
+                        default: green
+                        description: |-
+                          ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                          considered successful.
+                        enum:
+                        - yellow
+                        - green
+                        type: string
+                    type: object
+                  guestInfo:
+                    description: |-
+                      GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                      The elements are evaluated with the logical AND operator, meaning
+                      all expressions must evaluate as true for the probe to succeed.
+
+                      For example, a VM resource's probe definition could be specified as the
+                      following:
+
+                              guestInfo:
+                              - key:   ready
+                                value: true
+
+                      With the above configuration in place, the VM would not be considered
+                      ready until the GuestInfo key "ready" was set to the value "true".
+
+                      From within the guest operating system it is possible to set GuestInfo
+                      key/value pairs using the program "vmware-rpctool," which is included
+                      with VM Tools. For example, the following command will set the key
+                      "guestinfo.ready" to the value "true":
+
+                              vmware-rpctool "info-set guestinfo.ready true"
+
+                      Once executed, the VM's readiness probe will be signaled and the
+                      VM resource will be marked as ready.
+                    items:
+                      description: |-
+                        GuestInfoAction describes a key from GuestInfo that must match the associated
+                        value expression.
+                      properties:
+                        key:
+                          description: |-
+                            Key is the name of the GuestInfo key.
+
+                            The key is automatically prefixed with "guestinfo." before being
+                            evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                            evaluated as "guestinfo.guestinfo.mykey".
+                          type: string
+                        value:
+                          description: |-
+                            Value is a regular expression that is matched against the value of the
+                            specified key.
+
+                            An empty value is the equivalent of "match any" or ".*".
+
+                            All values must adhere to the RE2 regular expression syntax as documented
+                            at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                            ignored depending on the implementation of this API. Either way, invalid
+                            values will not be considered when evaluating the ready state of a VM.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  periodSeconds:
+                    description: |-
+                      PeriodSeconds specifics how often (in seconds) to perform the probe.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tcpSocket:
+                    description: |-
+                      TCPSocket specifies an action involving a TCP port.
+
+                      Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                      This field will be removed in a later API version.
+                    properties:
+                      host:
+                        description: Host is an optional host name to connect to.
+                          Host defaults to the VM IP.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Port specifies a number or name of the port to access on the VM.
+                          If the format of port is a number, it must be in the range 1 to 65535.
+                          If the format of name is a string, it must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies a number of seconds after which the probe times out.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
+                type: object
+              reserved:
+                description: |-
+                  Reserved describes a set of VM configuration options reserved for system
+                  use.
+
+                  Please note attempts to modify the value of this field by a DevOps user
+                  will result in a validation error.
+                properties:
+                  resourcePolicyName:
+                    type: string
+                type: object
+              restartMode:
+                default: TrySoft
+                description: |-
+                  RestartMode describes the desired behavior for restarting a VM when
+                  spec.nextRestartTime is set to "now" (case-insensitive).
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                  interaction inside of the guest. The Soft mode requires the VM's guest to
+                  have VM Tools installed and asks the guest to restart the VM. Its
+                  variant, TrySoft, first attempts a soft restart, and if that fails or
+                  does not complete within five minutes, the VM is hard reset.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              storageClass:
+                description: |-
+                  StorageClass describes the name of a Kubernetes StorageClass resource
+                  used to configure this VM's storage-related attributes.
+
+                  Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                  for more information on Kubernetes storage classes.
+                type: string
+              suspendMode:
+                default: TrySoft
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM.
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                  disk without any interaction inside of the guest. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully suspend the VM. Its variant, TrySoft, first attempts
+                  a graceful suspend, and if that fails or the VM is not in a put into
+                  standby by the guest after five minutes, the VM is suspended.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              volumes:
+                description: Volumes describes a list of volumes that can be mounted
+                  to the VM.
+                items:
+                  description: VirtualMachineVolume represents a named volume in a
+                    VM.
+                  properties:
+                    name:
+                      description: |-
+                        Name represents the volume's name. Must be a DNS_LABEL and unique within
+                        the VM.
+                      type: string
+                    persistentVolumeClaim:
+                      description: |-
+                        PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                        in the same namespace.
+
+                        More information is available at
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        instanceVolumeClaim:
+                          description: InstanceVolumeClaim is set if the PVC is backed
+                            by instance storage.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Size is the size of the requested instance
+                                storage volume.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageClass:
+                              description: |-
+                                StorageClass is the name of the Kubernetes StorageClass that provides
+                                the backing storage for this instance storage volume.
+                              type: string
+                          required:
+                          - size
+                          - storageClass
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: VirtualMachineStatus defines the observed state of a VirtualMachine
+              instance.
+            properties:
+              biosUUID:
+                description: |-
+                  BiosUUID describes a unique identifier provided by the underlying
+                  infrastructure provider that is exposed to the Guest OS BIOS as a unique
+                  hardware identifier.
+                type: string
+              changeBlockTracking:
+                description: |-
+                  ChangeBlockTracking describes whether or not change block tracking is
+                  enabled for the VirtualMachine.
+                type: boolean
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachine.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              crypto:
+                description: |-
+                  Crypto describes the observed state of the VirtualMachine's encryption
+                  configuration.
+                properties:
+                  encrypted:
+                    description: |-
+                      Encrypted describes the observed state of the VirtualMachine's
+                      encryption. There may be two values in this list:
+
+                      - Config -- This refers to all of the files related to a VM except any
+                                  virtual disks.
+                      - Disks  -- This refers to at least one of the VM's attached disks. To
+                                  determine the encryption state of the individual disks,
+                                  please refer to status.volumes[].crypto.
+                    items:
+                      type: string
+                    type: array
+                  keyID:
+                    description: |-
+                      KeyID describes the key ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                  providerID:
+                    description: |-
+                      ProviderID describes the provider ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                type: object
+              hardwareVersion:
+                description: |-
+                  HardwareVersion describes the VirtualMachine resource's observed
+                  hardware version.
+
+                  Please refer to VirtualMachineSpec.MinHardwareVersion for more
+                  information on the topic of a VM's hardware version.
+                format: int32
+                type: integer
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the unique instance UUID provided by the
+                  underlying infrastructure provider, such as vSphere.
+                type: string
+              lastRestartTime:
+                description: LastRestartTime describes the last time the VM was restarted.
+                format: date-time
+                type: string
+              network:
+                description: |-
+                  Network describes the observed state of the VM's network configuration.
+                  Please note much of the network status information is only available if
+                  the guest has VM Tools installed.
+                properties:
+                  config:
+                    description: |-
+                      Config describes the resolved, configured network settings for the VM,
+                      such as an interface's IP address obtained from IPAM, or global DNS
+                      settings.
+
+                      Please note this information does *not* represent the *observed* network
+                      state of the VM, but is intended for situations where someone boots a VM
+                      with no appropriate bootstrap engine and needs to know the network config
+                      valid for the deployed VM.
+                    properties:
+                      dns:
+                        description: DNS describes the configured state of client-side
+                          DNS.
+                        properties:
+                          domainName:
+                            description: |-
+                              DomainName is the domain name portion of the DNS name. For example,
+                              the "domain.local" part of "my-vm.domain.local".
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName is the host name portion of the DNS name. For example,
+                              the "my-vm" part of "my-vm.domain.local".
+                            type: string
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                              IP4 addresses are specified using dotted decimal notation. For example,
+                              "192.0.2.1".
+
+                              IP6 addresses are 128-bit addresses represented as eight fields of up to
+                              four hexadecimal digits. A colon separates each field (:). For example,
+                              2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                              symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                              once in an address as described in RFC 2373.
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of domains in which to search for hosts, in the
+                              order of preference.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      interfaces:
+                        description: Interfaces describes the configured state of
+                          the network interfaces.
+                        items:
+                          description: |-
+                            VirtualMachineNetworkConfigInterfaceStatus describes the configured state of
+                            network interface.
+                          properties:
+                            dns:
+                              description: DNS describes the interface's configured
+                                DNS information.
+                              properties:
+                                domainName:
+                                  description: |-
+                                    DomainName is the domain name portion of the DNS name. For example,
+                                    the "domain.local" part of "my-vm.domain.local".
+                                  type: string
+                                hostName:
+                                  description: |-
+                                    HostName is the host name portion of the DNS name. For example,
+                                    the "my-vm" part of "my-vm.domain.local".
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                    IP4 addresses are specified using dotted decimal notation. For example,
+                                    "192.0.2.1".
+
+                                    IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                    four hexadecimal digits. A colon separates each field (:). For example,
+                                    2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                    symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                    once in an address as described in RFC 2373.
+                                  items:
+                                    type: string
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of domains in which to search for hosts, in the
+                                    order of preference.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            ip:
+                              description: IP describes the interface's configured
+                                IP information.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses describes configured IP addresses for this interface.
+                                    Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                    2001:DB8:101::230:6eff:fe04:d9ff::/64.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp:
+                                  description: DHCP describes the interface's configured
+                                    DHCP options.
+                                  properties:
+                                    ip4:
+                                      description: IP4 describes the configured state
+                                        of the IP4 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                    ip6:
+                                      description: IP6 describes the configured state
+                                        of the IP6 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                gateway4:
+                                  description: |-
+                                    Gateway4 describes the interface's configured, default, IP4 gateway.
+
+                                    Please note the IP address include the network prefix length, ex.
+                                    192.168.0.1/24.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 describes the interface's configured, default, IP6 gateway.
+
+                                    Please note the IP address includes the network prefix length, ex.
+                                    2001:db8:101::1/64.
+                                  type: string
+                              type: object
+                            name:
+                              description: |-
+                                Name describes the corresponding network interface with the same name
+                                in the VM's desired network interface list.
+
+                                Please note this name is not necessarily related to the name of the
+                                device as it is surfaced inside of the guest.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  hostName:
+                    description: |-
+                      HostName describes the observed hostname reported by the VirtualMachine's
+                      guest operating system.
+
+                      Please note, this value is only reported if VMware Tools is installed in
+                      the guest, and the value may or may not be a fully qualified domain name
+                      (FQDN), it simply depends on what is reported by the guest.
+                    type: string
+                  interfaces:
+                    description: Interfaces describes the status of the VM's network
+                      interfaces.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceStatus describes the observed state of a
+                        VM's network interface.
+                      properties:
+                        deviceKey:
+                          description: |-
+                            DeviceKey describes the unique hardware device key of this network
+                            interface.
+                          format: int32
+                          type: integer
+                        dns:
+                          description: DNS describes the observed state of the interface's
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ip:
+                          description: IP describes the observed state of the interface's
+                            IP configuration.
+                          properties:
+                            addresses:
+                              description: Addresses describes observed IP addresses
+                                for this interface.
+                              items:
+                                description: |-
+                                  VirtualMachineNetworkInterfaceIPAddrStatus describes information about a
+                                  specific IP address.
+                                properties:
+                                  address:
+                                    description: |-
+                                      Address is an IP4 or IP6 address and their network prefix length.
+
+                                      An IP4 address is specified using dotted decimal notation. For example,
+                                      "192.0.2.1".
+
+                                      IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                      four hexadecimal digits. A colon separates each field (:). For example,
+                                      2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                      symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                      once in an address as described in RFC 2373.
+                                    type: string
+                                  lifetime:
+                                    description: Lifetime describes when this address
+                                      will expire.
+                                    format: date-time
+                                    type: string
+                                  origin:
+                                    description: Origin describes how this address
+                                      was configured.
+                                    enum:
+                                    - dhcp
+                                    - linklayer
+                                    - manual
+                                    - other
+                                    - random
+                                    type: string
+                                  state:
+                                    description: State describes the state of this
+                                      IP address.
+                                    enum:
+                                    - deprecated
+                                    - duplicate
+                                    - inaccessible
+                                    - invalid
+                                    - preferred
+                                    - tentative
+                                    - unknown
+                                    type: string
+                                type: object
+                              type: array
+                            autoConfigurationEnabled:
+                              description: |-
+                                AutoConfigurationEnabled describes whether or not ICMPv6 router
+                                solicitation requests are enabled or disabled from a given interface.
+
+                                These requests acquire an IP6 address and default gateway route from
+                                zero-to-many routers on the connected network.
+
+                                If not set then ICMPv6 is not available on this VM.
+                              type: boolean
+                            dhcp:
+                              description: |-
+                                DHCP describes the VM's observed, client-side, interface-specific DHCP
+                                options.
+                              properties:
+                                ip4:
+                                  description: IP4 describes the observed state of
+                                    the IP4 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                                ip6:
+                                  description: IP6 describes the observed state of
+                                    the IP6 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                              type: object
+                            macAddr:
+                              description: MACAddr describes the observed MAC address
+                                for this interface.
+                              type: string
+                          type: object
+                        name:
+                          description: |-
+                            Name describes the corresponding network interface with the same name
+                            in the VM's desired network interface list. If unset, then there is no
+                            corresponding entry for this interface.
+
+                            Please note this name is not necessarily related to the name of the
+                            device as it is surfaced inside of the guest.
+                          type: string
+                      type: object
+                    type: array
+                  ipStacks:
+                    description: |-
+                      IPStacks describes information about the guest's configured IP networking
+                      stacks.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkIPStackStatus describes the observed state of a
+                        VM's IP stack.
+                      properties:
+                        dhcp:
+                          description: DHCP describes the VM's observed, client-side,
+                            system-wide DHCP options.
+                          properties:
+                            ip4:
+                              description: IP4 describes the observed state of the
+                                IP4 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                            ip6:
+                              description: IP6 describes the observed state of the
+                                IP6 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                          type: object
+                        dns:
+                          description: DNS describes the VM's observed, client-side
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ipRoutes:
+                          description: IPRoutes contain the VM's routing tables for
+                            all address families.
+                          items:
+                            description: |-
+                              VirtualMachineNetworkIPRouteStatus describes the observed state of a
+                              guest network's IP routes.
+                            properties:
+                              gateway:
+                                description: Gateway describes where to send the packets
+                                  to next.
+                                properties:
+                                  address:
+                                    description: Address is the IP4 or IP6 address
+                                      of the gateway.
+                                    type: string
+                                  device:
+                                    description: |-
+                                      Device is the name of the device in the guest for which this gateway
+                                      applies.
+                                    type: string
+                                type: object
+                              networkAddress:
+                                description: |-
+                                  NetworkAddress is the IP4 or IP6 address of the destination network.
+
+                                  Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                  2001:DB8:101::230:6eff:fe04:d9ff::/64.
+
+                                  IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                  four hexadecimal digits. A colon separates each field (:). For example,
+                                  2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of symbol
+                                  '::' to represent multiple 16-bit groups of contiguous 0's only once in
+                                  an address as described in RFC 2373.
+                                type: string
+                            type: object
+                          type: array
+                        kernelConfig:
+                          description: |-
+                            KernelConfig describes the observed state of the VM's kernel IP
+                            configuration settings.
+
+                            The key part contains a unique number while the value part contains the
+                            'key=value' as provided by the underlying provider. For example, on
+                            Linux and/or BSD, the systcl -a output would be reported as:
+                            key='5', value='net.ipv4.tcp_keepalive_time = 7200'.
+                          items:
+                            description: |-
+                              KeyValuePair is useful when wanting to realize a map as a list of key/value
+                              pairs.
+                            properties:
+                              key:
+                                description: Key is the key part of the key/value
+                                  pair.
+                                type: string
+                              value:
+                                description: Value is the optional value part of the
+                                  key/value pair.
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
+                      type: object
+                    type: array
+                  primaryIP4:
+                    description: |-
+                      PrimaryIP4 describes the VM's primary IP4 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv4" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                  primaryIP6:
+                    description: |-
+                      PrimaryIP6 describes the VM's primary IP6 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv6" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                type: object
+              nodeName:
+                description: |-
+                  NodeName describes the observed name of the node where the VirtualMachine
+                  is scheduled.
+                type: string
+              powerState:
+                description: PowerState describes the observed power state of the
+                  VirtualMachine.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              storage:
+                description: Storage describes the observed state of the VirtualMachine's
+                  storage.
+                properties:
+                  requested:
+                    description: |-
+                      Requested describes the observed amount of storage requested by a
+                      VirtualMachine.
+                    properties:
+                      disks:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Disks describes the total storage space requested by a VirtualMachine's
+                          non-PVC disks.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  total:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Total describes the total storage space used by a VirtualMachine that
+                      counts against the Namespace's storage quota.
+                      This value is a sum of requested.disks and used.other.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  usage:
+                    description: Used describes the observed amount of storage used
+                      by a VirtualMachine.
+                    properties:
+                      disks:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Disks describes the total storage space used by a VirtualMachine's
+                          non-PVC disks. This does not include the any child / delta disks
+                          created for snapshots.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      other:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Other describes the total storage space used by the VirtualMachine's
+                          non-disk files, ex. the configuration file, swap space, logs, etc.
+                          This does not include the non-disk files created for snapshots,
+                          ex. snapshot data, list, and memory files.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              uniqueID:
+                description: |-
+                  UniqueID describes a unique identifier that is provided by the underlying
+                  infrastructure provider, such as vSphere.
+                type: string
+              volumes:
+                description: |-
+                  Volumes describes the observed state of the volumes that are intended to
+                  be attached to the VirtualMachine.
+                items:
+                  description: |-
+                    VirtualMachineVolumeStatus defines the observed state of a
+                    VirtualMachineVolume instance.
+                  properties:
+                    attached:
+                      description: |-
+                        Attached represents whether a volume has been successfully attached to
+                        the VirtualMachine or not.
+                      type: boolean
+                    crypto:
+                      description: Crypto describes the volume's encryption status.
+                      properties:
+                        keyID:
+                          description: |-
+                            KeyID describes the key ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                        providerID:
+                          description: |-
+                            ProviderID describes the provider ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                      type: object
+                    diskUUID:
+                      description: |-
+                        DiskUUID represents the underlying virtual disk UUID and is present when
+                        attachment succeeds.
+                      type: string
+                    error:
+                      description: |-
+                        Error represents the last error seen when attaching or detaching a
+                        volume.  Error will be empty if attachment succeeds.
+                      type: string
+                    limit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Limit describes the maximum, requested capacity
+                        of the volume.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the name of the attached volume.
+                      type: string
+                    requested:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Requested describes the minimum, requested capacity of the volume.
+
+                        Please note, this value is used when calculating a VM's impact to a
+                        namespace's storage quota.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type:
+                      default: Managed
+                      description: Type is the type of the attached volume.
+                      enum:
+                      - Classic
+                      - Managed
+                      type: string
+                    used:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Used describes the observed, non-shared size of the volume on disk.
+
+                        For example, if this is a linked-clone's boot volume, this value
+                        represents the space consumed by the linked clone, not the parent.
+
+                        Another example is when a volume is thin-provisioned. The volume's
+                        capacity may be 20Gi, but the actual usage on disk may only be a few
+                        hundred mebibytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - type
+                x-kubernetes-list-type: map
+              zone:
+                description: |-
+                  Zone describes the availability zone where the VirtualMachine has been
+                  scheduled.
+
+                  Please note this field may be empty when the cluster is not zone-aware.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.powerState
+      name: Power-State
+      type: string
+    - jsonPath: .spec.className
+      name: Class
+      priority: 1
+      type: string
+    - jsonPath: .spec.image.name
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .status.network.primaryIP4
+      name: Primary-IP4
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachine is the schema for the virtualmachines API and represents the
+          desired state and observed status of a virtualmachines resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec defines the desired state of a VirtualMachine.
+            properties:
+              advanced:
+                description: Advanced describes a set of optional, advanced VM configuration
+                  options.
+                properties:
+                  bootDiskCapacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      BootDiskCapacity is the capacity of the VM's boot disk -- the first disk
+                      from the VirtualMachineImage from which the VM was deployed.
+
+                      Please note it is not advised to change this value while the VM is
+                      running. Also, resizing the VM's boot disk may require actions inside of
+                      the guest to take advantage of the additional capacity. Finally, changing
+                      the size of the VM's boot disk, even increasing it, could adversely
+                      affect the VM.
+
+                      Please note this field is ignored if the VM is deployed from an ISO with
+                      CD-ROM devices attached.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  changeBlockTracking:
+                    description: |-
+                      ChangeBlockTracking is a flag that enables incremental backup support
+                      for this VM, a feature utilized by external backup systems such as
+                      VMware Data Recovery.
+                    type: boolean
+                  defaultVolumeProvisioningMode:
+                    description: |-
+                      DefaultVolumeProvisioningMode specifies the default provisioning mode for
+                      persistent volumes managed by this VM.
+                    enum:
+                    - Thin
+                    - Thick
+                    - ThickEagerZero
+                    type: string
+                type: object
+              affinity:
+                description: Affinity describes the VM's scheduling constraints.
+                properties:
+                  vmAffinity:
+                    description: VMAffinity describes affinity scheduling rules related
+                      to other VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the affinity expressions specified by this
+                          field, but it may choose to violate one or more of the expressions.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  vmAntiAffinity:
+                    description: |-
+                      VMAntiAffinity describes anti-affinity scheduling rules related to other
+                      VMs.
+                    properties:
+                      preferredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          PreferredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that should be met, but the VM can still be scheduled if
+                          the requirement cannot be satisfied. The scheduler will prefer to
+                          schedule VMs that satisfy the anti-affinity expressions specified by
+                          this field, but it may choose to violate one or more of the expressions.
+                          Additionally, it also describes the anti-affinity requirements that
+                          should be met during run-time, but the VM can still be run if the
+                          requirements cannot be satisfied.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingPreferredDuringExecution:
+                        description: |-
+                          RequiredDuringSchedulingPreferredDuringExecution describes anti-affinity
+                          requirements that must be met or the VM will not be scheduled.
+
+                          When there are multiple elements, the lists of nodes corresponding to
+                          each term are intersected, i.e. all terms must be satisfied.
+
+                          Note: Any update to this field will replace the entire list rather than
+                          merging with the existing elements.
+                        items:
+                          description: VMAffinityTerm defines the VM affinity/anti-affinity
+                            term.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a label query over a set of VMs.
+                                When omitted, this term matches with no VMs.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            topologyKey:
+                              description: |-
+                                TopologyKey describes where this VM should be co-located (affinity) or not
+                                co-located (anti-affinity).
+                                Commonly used values include:
+                                `kubernetes.io/hostname` -- The rule is executed in the context of a node/host.
+                                `topology.kubernetes.io/zone` -- This rule is executed in the context of a zone.
+
+                                Please note, The following rules apply when specifying the topology key in the context of a zone/host.
+
+                                - When topology key is in the context of a zone, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution.
+                                - When topology key is in the context of a host, the only supported verbs are
+                                  PreferredDuringSchedulingPreferredDuringExecution and RequiredDuringSchedulingPreferredDuringExecution
+                                  for VM-VM node-level anti-affinity scheduling.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              biosUUID:
+                description: |-
+                  BiosUUID describes the desired BIOS UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  When the bootstrap provider is Cloud-Init, this value is used as the
+                  default value for spec.bootstrap.cloudInit.instanceID if it is omitted.
+                format: uuid
+                type: string
+              bootOptions:
+                description: |-
+                  BootOptions describes the settings that control the boot behavior of the
+                  virtual machine. These settings take effect during the next power-on of the
+                  virtual machine.
+                properties:
+                  bootDelay:
+                    description: |-
+                      BootDelay is the delay before starting the boot sequence. The boot delay
+                      specifies a time interval between virtual machine power on or restart and
+                      the beginning of the boot sequence.
+                    type: string
+                  bootOrder:
+                    description: |-
+                      BootOrder represents the boot order of the virtual machine. After list is exhausted,
+                      default BIOS boot device algorithm is used for booting. Note that order of the entries
+                      in the list is important: device listed first is used for boot first, if that one
+                      fails second entry is used, and so on. Platform may have some internal limit on the
+                      number of devices it supports. If bootable device is not reached before platform's limit
+                      is hit, boot will fail. At least single entry is supported by all products supporting
+                      boot order settings.
+
+                      The available devices are:
+
+                      - Disk    -- If there are classic and managed disks, the first classic disk is selected.
+                                   If there are only managed disks, the first disk is selected.
+                      - Network -- The first interface listed in spec.network.interfaces.
+                      - CDRom   -- The first bootable CD-ROM device.
+                    items:
+                      description: |-
+                        VirtualMachineBootOptionsBootableDevice represents the type of bootable device
+                        that a VM may be booted from.
+                      enum:
+                      - Disk
+                      - Network
+                      - CDRom
+                      type: string
+                    type: array
+                  bootRetry:
+                    default: Disabled
+                    description: |-
+                      BootRetry specifies whether a virtual machine that fails to boot
+                      will try again. The available values are:
+
+                      - Enabled -- A virtual machine that fails to boot will try again
+                                   after BootRetryDelay time period has expired.
+                      - Disabled -- The virtual machine waits indefinitely for you to
+                                    initiate boot retry.
+                    type: string
+                  bootRetryDelay:
+                    description: |-
+                      BootRetryDelay specifies a time interval between virtual machine boot failure
+                      and the subsequent attempt to boot again. The virtual machine uses this value
+                      only if BootRetry is Enabled.
+                    type: string
+                  efiSecureBoot:
+                    default: Disabled
+                    description: |-
+                      EFISecureBoot specifies whether the virtual machine's firmware will
+                      perform signature checks of any EFI images loaded during startup. If set to
+                      true, signature checks will be performed and the virtual machine's firmware
+                      will refuse to start any images which do not pass those signature checks.
+
+                      Please note, this field will not be honored unless the value of
+                      spec.bootOptions.firmware is "EFI". The available values are:
+
+                      - Enabled -- Signature checks will be performed and the virtual machine's firmware
+                                   will refuse to start any images which do not pass those signature checks.
+                      - Disabled -- No signature checks will be performed.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  enterBootSetup:
+                    default: Disabled
+                    description: |-
+                      EnterBootSetup specifies whether to automatically enter BIOS/EFI setup the next
+                      time the virtual machine boots. The virtual machine resets this flag to false
+                      so that subsequent boots proceed normally. The available values are:
+
+                      - Enabled -- The virtual machine will automatically enter BIOS/EFI setup the next
+                                   time the virtual machine boots.
+                      - Disabled -- The virtual machine will boot normaally.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  firmware:
+                    description: |-
+                      Firmware represents the firmware for the virtual machine to use. Any update
+                      to this value after the virtual machine has already been created will be
+                      ignored. Setting will happen in the following manner:
+
+                      1. If this value is specified, it will be used to set the VM firmware. If this
+                         value is unset, then
+                      2. the virtual machine image will be checked. If that value is set, then it will
+                         be used to set the VM firmware. If that value is unset, then
+                      3. the virtual machine class will be checked. If that value is set, then it will
+                         be used to set the VM firmware. If that value is unset, then
+                      4. the VM firmware will be set, by default, to BIOS.
+
+                      The available values of this field are:
+
+                      - BIOS
+                      - EFI
+                    enum:
+                    - BIOS
+                    - EFI
+                    type: string
+                  networkBootProtocol:
+                    default: IP4
+                    description: |-
+                      NetworkBootProtocol is the protocol to attempt during PXE network boot or NetBoot.
+                      The available protocols are:
+
+                      - IP4 -- PXE (or Apple NetBoot) over IPv4. The default.
+                      - IP6 -- PXE over IPv6. Only meaningful for EFI virtual machines.
+                    enum:
+                    - IP4
+                    - IP6
+                    type: string
+                type: object
+              bootstrap:
+                description: |-
+                  Bootstrap describes the desired state of the guest's bootstrap
+                  configuration.
+
+                  If omitted, a default bootstrap method may be selected based on the
+                  guest OS identifier. If Linux, then the LinuxPrep method is used.
+                properties:
+                  cloudInit:
+                    description: |-
+                      CloudInit may be used to bootstrap Linux guests with Cloud-Init or
+                      Windows guests that support Cloudbase-Init.
+
+                      The guest's networking stack is configured by Cloud-Init on Linux guests
+                      and Cloudbase-Init on Windows guests.
+
+                      Please note this bootstrap provider may not be used in conjunction with
+                      the other bootstrap providers.
+                    properties:
+                      cloudConfig:
+                        description: |-
+                          CloudConfig describes a subset of a Cloud-Init CloudConfig, used to
+                          bootstrap the VM.
+
+                          Please note this field and RawCloudConfig are mutually exclusive.
+                        properties:
+                          defaultUserEnabled:
+                            description: |-
+                              DefaultUserEnabled may be set to true to ensure even if the Users field
+                              is not empty, the default user is still created on systems that have one
+                              defined. By default, Cloud-Init ignores the default user if the
+                              CloudConfig provides one or more non-default users via the Users field.
+                            type: boolean
+                          runcmd:
+                            description: |-
+                              RunCmd allows running one or more commands on the guest.
+                              The entries in this list can adhere to two, different formats:
+
+                              Format 1 -- a string that contains the command and its arguments, ex.
+
+                                  runcmd:
+                                  - "ls -al"
+
+                              Format 2 -- a list of the command and its arguments, ex.
+
+                                  runcmd:
+                                  - - echo
+                                    - "Hello, world."
+                            x-kubernetes-preserve-unknown-fields: true
+                          ssh_pwauth:
+                            description: |-
+                              SSHPwdAuth sets whether or not to accept password authentication.
+                              In order for this config to be applied, SSH may need to be restarted.
+                              On systemd systems, this restart will only happen if the SSH service has
+                              already been started. On non-systemd systems, a restart will be attempted
+                              regardless of the service state.
+                            type: boolean
+                          timezone:
+                            description: Timezone describes the timezone represented
+                              in /usr/share/zoneinfo.
+                            type: string
+                          users:
+                            description: Users allows adding/configuring one or more
+                              users on the guest.
+                            items:
+                              description: User is a CloudConfig user data structure.
+                              properties:
+                                create_groups:
+                                  description: |-
+                                    CreateGroups is a flag that may be set to false to disable creation of
+                                    specified user groups.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                expiredate:
+                                  description: ExpireData is the date on which the
+                                    user's account will be disabled.
+                                  type: string
+                                gecos:
+                                  description: |-
+                                    Gecos is an optional comment about the user, usually a comma-separated
+                                    string of the user's real name and contact information.
+                                  type: string
+                                groups:
+                                  description: Groups is an optional list of groups
+                                    to add to the user.
+                                  items:
+                                    type: string
+                                  type: array
+                                hashed_passwd:
+                                  description: |-
+                                    HashedPasswd is a hash of the user's password that will be applied even
+                                    if the specified user already exists.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                homedir:
+                                  description: |-
+                                    Homedir is the optional home directory for the user.
+
+                                    Defaults to "/home/<username>" when Name is not "default".
+                                  type: string
+                                inactive:
+                                  description: |-
+                                    Inactive optionally represents the number of days until the user is
+                                    disabled.
+                                  format: int32
+                                  type: integer
+                                lock_passwd:
+                                  description: |-
+                                    LockPasswd disables password login.
+
+                                    Defaults to true when Name is not "default".
+                                  type: boolean
+                                name:
+                                  description: |-
+                                    Name is the user's login name.
+
+                                    Please note this field may be set to the special value of "default" when
+                                    this User is the first element in the Users list from the CloudConfig.
+                                    When set to "default", all other fields from this User must be nil.
+                                  type: string
+                                no_create_home:
+                                  description: |-
+                                    NoCreateHome prevents the creation of the home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_log_init:
+                                  description: |-
+                                    NoLogInit prevents the initialization of lastlog and faillog for the
+                                    user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                no_user_group:
+                                  description: |-
+                                    NoUserGroup prevents the creation of the group named after the user.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                passwd:
+                                  description: |-
+                                    Passwd is a hash of the user's password that will be applied only to
+                                    a newly created user. To apply a new, hashed password to an existing user
+                                    please use HashedPasswd instead.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                primary_group:
+                                  description: |-
+                                    PrimaryGroup is the primary group for the user.
+
+                                    Defaults to the value of the Name field when it is not "default".
+                                  type: string
+                                selinux_user:
+                                  description: SELinuxUser is the SELinux user for
+                                    the user's login.
+                                  type: string
+                                shell:
+                                  description: |-
+                                    Shell is the path to the user's login shell.
+
+                                    Please note the default is to set no shell, which results in a
+                                    system-specific default being used.
+                                  type: string
+                                snapuser:
+                                  description: |-
+                                    SnapUser specifies an e-mail address to create the user as a Snappy user
+                                    through "snap create-user".
+
+                                    If an Ubuntu SSO account is associated with the address, the username and
+                                    SSH keys will be requested from there.
+                                  type: string
+                                ssh_authorized_keys:
+                                  description: |-
+                                    SSHAuthorizedKeys is a list of SSH keys to add to the user's authorized
+                                    keys file.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_import_id:
+                                  description: |-
+                                    SSHImportID is a list of SSH IDs to import for the user.
+
+                                    Please note this field may not be combined with SSHRedirectUser.
+                                  items:
+                                    type: string
+                                  type: array
+                                ssh_redirect_user:
+                                  description: |-
+                                    SSHRedirectUser may be set to true to disable SSH logins for this user.
+
+                                    Please note that when specified, all SSH keys from cloud meta-data will
+                                    be configured in a disabled state for this user. Any SSH login as this
+                                    user will timeout with a message to login instead as the default user.
+
+                                    This field may not be combined with SSHAuthorizedKeys or SSHImportID.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                sudo:
+                                  description: |-
+                                    Sudo is a sudo rule to apply to the user.
+
+                                    When omitted, no sudo rules will be applied to the user.
+                                  type: string
+                                system:
+                                  description: |-
+                                    System is an optional flag that indicates the user should be created as
+                                    a system user with no home directory.
+
+                                    Defaults to false when Name is not "default".
+                                  type: boolean
+                                uid:
+                                  description: |-
+                                    UID is the user's ID.
+
+                                    When omitted the guest will default to the next available number.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          write_files:
+                            description: WriteFiles allows adding files to the guest
+                              file system.
+                            items:
+                              description: WriteFile is a CloudConfig write_file data
+                                structure.
+                              properties:
+                                append:
+                                  description: |-
+                                    Append specifies whether or not to append the content to an existing file
+                                    if the file specified by Path already exists.
+                                  type: boolean
+                                content:
+                                  description: |-
+                                    Content is the optional content to write to the provided Path.
+
+                                    When omitted an empty file will be created or existing file will be
+                                    modified.
+
+                                    The value for this field can adhere to two, different formats:
+
+                                    Format 1 -- a string that contains the command and its arguments, ex.
+
+                                        content: Hello, world.
+
+                                    Please note that format 1 supports all of the manners of specifying a
+                                    YAML string.
+
+                                    Format 2 -- a secret reference with the name of the key that contains
+                                                the content for the file, ex.
+
+                                        content:
+                                          name: my-bootstrap-secret
+                                          key: my-file-content
+                                  x-kubernetes-preserve-unknown-fields: true
+                                defer:
+                                  description: |-
+                                    Defer indicates to defer writing the file until Cloud-Init's "final"
+                                    stage, after users are created and packages are installed.
+                                  type: boolean
+                                encoding:
+                                  default: text/plain
+                                  description: Encoding is an optional encoding type
+                                    of the content.
+                                  enum:
+                                  - b64
+                                  - base64
+                                  - gz
+                                  - gzip
+                                  - gz+b64
+                                  - gz+base64
+                                  - gzip+b64
+                                  - gzip+base64
+                                  - text/plain
+                                  type: string
+                                owner:
+                                  default: root:root
+                                  description: Owner is an optional "owner:group"
+                                    to chown the file.
+                                  type: string
+                                path:
+                                  description: Path is the path of the file to which
+                                    the content is decoded and written.
+                                  type: string
+                                permissions:
+                                  default: "0644"
+                                  description: |-
+                                    Permissions an optional set of file permissions to set.
+
+                                    Please note the permissions should be specified as an octal string, ex.
+                                    "0###".
+
+                                    When omitted the guest will default this value to "0644".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - path
+                            x-kubernetes-list-type: map
+                        type: object
+                      instanceID:
+                        description: |-
+                          InstanceID is the cloud-init metadata instance ID.
+                          If omitted, this field defaults to the VM's BiosUUID.
+                        type: string
+                      rawCloudConfig:
+                        description: |-
+                          RawCloudConfig describes a key in a Secret resource that contains the
+                          CloudConfig data used to bootstrap the VM.
+
+                          The CloudConfig data specified by the key may be plain-text,
+                          base64-encoded, or gzipped and base64-encoded.
+
+                          Please note this field and CloudConfig are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public keys that CloudInit will apply to
+                          the guest's default user.
+                        items:
+                          type: string
+                        type: array
+                      useGlobalNameserversAsDefault:
+                        description: |-
+                          UseGlobalNameserversAsDefault will use the global nameservers specified in
+                          the NetworkSpec as the per-interface nameservers when the per-interface
+                          nameservers is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                      useGlobalSearchDomainsAsDefault:
+                        description: |-
+                          UseGlobalSearchDomainsAsDefault will use the global search domains specified
+                          in the NetworkSpec as the per-interface search domains when the per-interface
+                          search domains is not provided.
+
+                          Defaults to true if omitted.
+                        type: boolean
+                      waitOnNetwork4:
+                        description: |-
+                          WaitOnNetwork4 indicates whether the cloud-init datasource should wait
+                          for an IPv4 address to be available before writing the instance-data.
+
+                          When set to true, the cloud-init datasource will sleep for a second,
+                          check network status, and repeat until an IPv4 address is available.
+                        type: boolean
+                      waitOnNetwork6:
+                        description: |-
+                          WaitOnNetwork6 indicates whether the cloud-init datasource should wait
+                          for an IPv6 address to be available before writing the instance-data.
+
+                          When set to true, the cloud-init datasource will sleep for a second,
+                          check network status, and repeat until an IPv6 address is available.
+                        type: boolean
+                    type: object
+                  linuxPrep:
+                    description: |-
+                      LinuxPrep may be used to bootstrap Linux guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or Sysprep bootstrap providers.
+                    properties:
+                      customizeAtNextPowerOn:
+                        description: |-
+                          CustomizeAtNextPowerOn describes when customization is performed on the VM.
+
+                          When set to false, the VM will not be customized at the next power on. When
+                          set to true, the VM will be customized at the next power on, and after the
+                          customization this field will be set to false. This allows for when
+                          customization is done explicitly requested, i.e. so that changes made in the
+                          VM are not overridden by a later customization.
+
+                          When not set, the VM will only be customized at every power on when the hash
+                          of the previous customization specification is different from the current
+                          specification.
+                        type: boolean
+                      expirePasswordAfterNextLogin:
+                        description: |-
+                          ExpirePasswordAfterNextLogin indicates whether or not the root account is required to
+                          change their password after the next login.
+                        type: boolean
+                      hardwareClockIsUTC:
+                        description: |-
+                          HardwareClockIsUTC specifies whether the hardware clock is in UTC or
+                          local time.
+                        type: boolean
+                      password:
+                        description: |-
+                          Password is the new root password for the machine.
+
+                          When not explicitly specified, the Key field for the selector defaults to
+                          `password`.
+                        properties:
+                          key:
+                            default: password
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      scriptText:
+                        description: |-
+                          ScriptText is the script to run before and after customization.
+
+                          Please see https://knowledge.broadcom.com/external/article?legacyId=1026614
+                          for script examples.
+                        properties:
+                          from:
+                            description: |-
+                              From is specified to reference a value from a Secret resource.
+
+                              Please note this field is mutually exclusive with the Value field.
+                            properties:
+                              key:
+                                description: Key is the key in the secret that specifies
+                                  the requested data.
+                                type: string
+                              name:
+                                description: Name is the name of the secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          value:
+                            description: |-
+                              Value is used to directly specify a value.
+
+                              Please note this field is mutually exclusive with the From field.
+                            type: string
+                        type: object
+                      timeZone:
+                        description: |-
+                          TimeZone is a case-sensitive timezone, such as Europe/Sofia.
+
+                          Valid values are based on the tz (timezone) database used by Linux and
+                          other Unix systems. The values are strings in the form of
+                          "Area/Location," in which Area is a continent or ocean name, and
+                          Location is the city, island, or other regional designation.
+
+                          Please see https://kb.vmware.com/s/article/2145518 for a list of valid
+                          time zones for Linux systems.
+                        type: string
+                    type: object
+                  sysprep:
+                    description: |-
+                      Sysprep may be used to bootstrap Windows guests.
+
+                      The guest's networking stack is configured by Guest OS Customization
+                      (GOSC).
+
+                      Please note this bootstrap provider may be used in conjunction with the
+                      VAppConfig bootstrap provider when wanting to configure the guest's
+                      network with GOSC but also send vApp/OVF properties into the guest.
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      or LinuxPrep bootstrap providers.
+                    properties:
+                      customizeAtNextPowerOn:
+                        description: |-
+                          CustomizeAtNextPowerOn describes when customization is performed on the VM.
+
+                          When set to false, the VM will not be customized at the next power on. When
+                          set to true, the VM will be customized at the next power on, and after the
+                          customization this field will be set to false. This allows for when
+                          customization is done explicitly requested, i.e. so that changes made in the
+                          VM are not overridden by a later customization.
+
+                          When not set, the VM will only be customized at every power on when the hash
+                          of the previous customization specification is different from the current
+                          specification.
+                        type: boolean
+                      rawSysprep:
+                        description: |-
+                          RawSysprep describes a key in a Secret resource that contains an XML
+                          string of the Sysprep text used to bootstrap the VM.
+
+                          The data specified by the Secret key may be plain-text, base64-encoded,
+                          or gzipped and base64-encoded.
+
+                          Please note this field and Sysprep are mutually exclusive.
+                        properties:
+                          key:
+                            description: Key is the key in the secret that specifies
+                              the requested data.
+                            type: string
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sysprep:
+                        description: |-
+                          Sysprep is an object representation of a Windows sysprep.xml answer file.
+
+                          This field encloses all the individual keys listed in a sysprep.xml file.
+
+                          For more detailed information please see
+                          https://technet.microsoft.com/en-us/library/cc771830(v=ws.10).aspx.
+
+                          Please note this field and RawSysprep are mutually exclusive.
+                        properties:
+                          expirePasswordAfterNextLogin:
+                            description: |-
+                              ExpirePasswordAfterNextLogin indicates whether or not the local Administrators
+                              group accounts are required to change their password after the next login.
+                            type: boolean
+                          guiRunOnce:
+                            description: GUIRunOnce is a representation of the Sysprep
+                              GuiRunOnce key.
+                            properties:
+                              commands:
+                                description: |-
+                                  Commands is a list of commands to run at first user logon, after guest
+                                  customization.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          guiUnattended:
+                            description: GUIUnattended is a representation of the
+                              Sysprep GUIUnattended key.
+                            properties:
+                              autoLogon:
+                                description: |-
+                                  AutoLogon determine whether the machine automatically logs on as
+                                  Administrator.
+
+                                  Please note if AutoLogon is true, then Password must be set or guest
+                                  customization will fail.
+                                type: boolean
+                              autoLogonCount:
+                                description: |-
+                                  AutoLogonCount specifies the number of times the machine should
+                                  automatically log on as Administrator.
+
+                                  Generally it should be 1, but if your setup requires a number of reboots,
+                                  you may want to increase it. This number may be determined by the list of
+                                  commands executed by the GuiRunOnce command.
+
+                                  Please note this field must be specified with a non-zero positive integer
+                                  if AutoLogon is true.
+                                format: int32
+                                type: integer
+                              password:
+                                description: |-
+                                  Password is the new administrator password for the machine.
+
+                                  To specify that the password should be set to blank (that is, no
+                                  password), set the password value to NULL. Because of encryption, "" is
+                                  NOT a valid value.
+
+                                  Please note if the password is set to blank and AutoLogon is true, the
+                                  guest customization will fail.
+
+                                  If the XML file is generated by the VirtualCenter Customization Wizard,
+                                  then the password is encrypted. Otherwise, the client should set the
+                                  plainText attribute to true, so that the customization process does not
+                                  attempt to decrypt the string.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `password`.
+                                properties:
+                                  key:
+                                    default: password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              timeZone:
+                                default: 85
+                                description: |-
+                                  TimeZone is the time zone index for the virtual machine.
+
+                                  Please note that numbers correspond to time zones listed at
+                                  https://bit.ly/3Rzv8oL.
+
+                                  Defaults to UTC.
+                                format: int32
+                                minimum: 0
+                                type: integer
+                            required:
+                            - timeZone
+                            type: object
+                          identification:
+                            description: Identification is a representation of the
+                              Sysprep Identification key.
+                            properties:
+                              domainAdmin:
+                                description: |-
+                                  DomainAdmin is the domain user account used for authentication if the
+                                  virtual machine is joining a domain. The user does not need to be a
+                                  domain administrator, but the account must have the privileges required
+                                  to add computers to the domain.
+                                type: string
+                              domainAdminPassword:
+                                description: |-
+                                  DomainAdminPassword is the password for the domain user account used for
+                                  authentication if the virtual machine is joining a domain.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: domain_admin_password
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              domainOU:
+                                description: |-
+                                  DomainOU is the MachineObjectOU which specifies the full LDAP path name of
+                                  the OU to which the computer belongs.
+                                type: string
+                              joinWorkgroup:
+                                description: |-
+                                  JoinWorkgroup is the workgroup that the virtual machine should join. If
+                                  this value is supplied, then the fields spec.network.domain,
+                                  spec.bootstrap.sysprep.identification.domainAdmin, and
+                                  spec.bootstrap.sysprep.identification.domainAdminPassword must be empty.
+                                type: string
+                            type: object
+                          licenseFilePrintData:
+                            description: |-
+                              LicenseFilePrintData is a representation of the Sysprep
+                              LicenseFilePrintData key.
+
+                              Please note this is required only for Windows 2000 Server and Windows
+                              Server 2003.
+                            properties:
+                              autoMode:
+                                description: AutoMode specifies the server licensing
+                                  mode.
+                                enum:
+                                - perSeat
+                                - perServer
+                                type: string
+                              autoUsers:
+                                description: |-
+                                  AutoUsers indicates the number of client licenses purchased for the
+                                  VirtualCenter server being installed.
+
+                                  Please note this value is ignored unless AutoMode is PerServer.
+                                format: int32
+                                type: integer
+                            required:
+                            - autoMode
+                            type: object
+                          scriptText:
+                            description: |-
+                              ScriptText describes the script to run before and after customization. The
+                              script must be a Windows batch file.
+
+                              Please see https://knowledge.broadcom.com/external/article?legacyId=1026614
+                              for script examples.
+                            properties:
+                              from:
+                                description: |-
+                                  From is specified to reference a value from a Secret resource.
+
+                                  Please note this field is mutually exclusive with the Value field.
+                                properties:
+                                  key:
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                              value:
+                                description: |-
+                                  Value is used to directly specify a value.
+
+                                  Please note this field is mutually exclusive with the From field.
+                                type: string
+                            type: object
+                          userData:
+                            description: UserData is a representation of the Sysprep
+                              UserData key.
+                            properties:
+                              fullName:
+                                description: FullName is the user's full name.
+                                type: string
+                              orgName:
+                                description: OrgName is the name of the user's organization.
+                                type: string
+                              productID:
+                                description: |-
+                                  ProductID is a valid serial number.
+
+                                  Please note unless the VirtualMachineImage was installed with a volume
+                                  license key, ProductID must be set or guest customization will fail.
+
+                                  When not explicitly specified, the Key field for the selector defaults to
+                                  `domain_admin_password`.
+                                properties:
+                                  key:
+                                    default: product_id
+                                    description: Key is the key in the secret that
+                                      specifies the requested data.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - fullName
+                            - orgName
+                            type: object
+                        required:
+                        - userData
+                        type: object
+                    type: object
+                  vAppConfig:
+                    description: |-
+                      VAppConfig may be used to bootstrap guests that rely on vApp properties
+                      (how VMware surfaces OVF properties on guests) to transport data into the
+                      guest.
+
+                      The guest's networking stack may be configured using either vApp
+                      properties or GOSC.
+
+                      Many OVFs define one or more properties that are used by the guest to
+                      bootstrap its networking stack. If the VirtualMachineImage defines one or
+                      more properties like this, then they can be configured to use the network
+                      data provided for this VM at runtime by setting these properties to Go
+                      template strings.
+
+                      It is also possible to use GOSC to bootstrap this VM's network stack by
+                      configuring either the LinuxPrep or Sysprep bootstrap providers.
+
+                      Please note the VAppConfig bootstrap provider in conjunction with the
+                      LinuxPrep bootstrap provider is the equivalent of setting the v1alpha1
+                      VM metadata transport to "OvfEnv".
+
+                      This bootstrap provider may not be used in conjunction with the CloudInit
+                      bootstrap provider.
+                    properties:
+                      properties:
+                        description: |-
+                          Properties is a list of vApp/OVF property key/value pairs.
+
+                          Please note this field and RawProperties are mutually exclusive.
+                        items:
+                          description: |-
+                            KeyValueOrSecretKeySelectorPair is useful when wanting to realize a map as a
+                            list of key/value pairs where each value could also reference data stored in
+                            a Secret resource.
+                          properties:
+                            key:
+                              description: Key is the key part of the key/value pair.
+                              type: string
+                            value:
+                              description: Value is the optional value part of the
+                                key/value pair.
+                              properties:
+                                from:
+                                  description: |-
+                                    From is specified to reference a value from a Secret resource.
+
+                                    Please note this field is mutually exclusive with the Value field.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret that
+                                        specifies the requested data.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                value:
+                                  description: |-
+                                    Value is used to directly specify a value.
+
+                                    Please note this field is mutually exclusive with the From field.
+                                  type: string
+                              type: object
+                          required:
+                          - key
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      rawProperties:
+                        description: |-
+                          RawProperties is the name of a Secret resource in the same Namespace as
+                          this VM where each key/value pair from the Secret is used as a vApp
+                          key/value pair.
+
+                          Please note this field and Properties are mutually exclusive.
+                        type: string
+                    type: object
+                type: object
+              class:
+                description: |-
+                  Class describes the VirtualMachineClassInsance resource that is
+                  referenced by this virtual machine. This can be the
+                  VirtualMachineClassInstance that the virtual machine was
+                  created, or later resized with.
+
+                  The value of spec.class.Name must be the Kubernetes object name
+                  of a valid VirtualMachineClassInstance resource.
+
+                  Please also note, if this field and spec.className are both
+                  non-empty, then they must refer to the same VirtualMachineClass
+                  or an error is returned.
+
+                  If a className is specified, but this field is omitted, VM operator
+                  picks the latest instance for the VM class to create the VM.
+
+                  If a VM class has been modified and thus, the newly available
+                  VirtualMachineClassInstance can be specified in spec.class to
+                  trigger a resize operation.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              className:
+                description: |-
+                  ClassName describes the name of the VirtualMachineClass resource used to
+                  deploy this VM.
+
+                  When creating a virtual machine, if this field is empty and a
+                  VirtualMachineClassInstance is specified in spec.class, then
+                  this field is populated with the VirtualMachineClass object's
+                  name.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.class are both non-empty, then they must refer to the same
+                  VirtualMachineClass or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM class.
+
+                  If a VM is using a class, a different value in spec.className
+                  leads to the VM being resized.
+                type: string
+              crypto:
+                description: Crypto describes the desired encryption state of the
+                  VirtualMachine.
+                properties:
+                  encryptionClassName:
+                    description: |-
+                      EncryptionClassName describes the name of the EncryptionClass resource
+                      used to encrypt this VM.
+
+                      Please note, this field is not required to encrypt the VM. If the
+                      underlying platform has a default key provider, the VM may still be fully
+                      or partially encrypted depending on the specified storage and VM classes.
+
+                      If there is a default key provider and an encryption storage class is
+                      selected, the files in the VM's home directory and non-PVC virtual disks
+                      will be encrypted
+
+                      If there is a default key provider and a VM Class with a virtual, trusted
+                      platform module (vTPM) is selected, the files in the VM's home directory,
+                      minus any virtual disks, will be encrypted.
+
+                      If the underlying vSphere platform does not have a default key provider,
+                      then this field is required when specifying an encryption storage class
+                      and/or a VM Class with a vTPM.
+
+                      If this field is set, spec.storageClass must use an encryption-enabled
+                      storage class.
+                    type: string
+                  useDefaultKeyProvider:
+                    default: true
+                    description: |-
+                      UseDefaultKeyProvider describes the desired behavior for when an explicit
+                      EncryptionClass is not provided.
+
+                      When an explicit EncryptionClass is not provided and this value is true:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will be encrypted using the default key provider.
+
+                      - If a VirtualMachine is not encrypted, uses an encryption storage
+                        policy or has a virtual, trusted platform module (vTPM), there is a
+                        default key provider, the VM will be encrypted using the default key
+                        provider.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be rekeyed using the default key provider.
+
+                      When an explicit EncryptionClass is not provided and this value is false:
+
+                      - Deploying a VirtualMachine with an encryption storage policy or vTPM
+                        will fail.
+
+                      - If a VirtualMachine is encrypted with a provider other than the default
+                        key provider, the VM will be not be rekeyed.
+
+                        Please note, this could result in a VirtualMachine that cannot be
+                        powered on since it is encrypted using a provider or key that may have
+                        been removed. Without the key, the VM cannot be decrypted and thus
+                        cannot be powered on.
+
+                      Defaults to true if omitted.
+                    type: boolean
+                type: object
+              currentSnapshotName:
+                description: |-
+                  CurrentSnapshotName represents the desired snapshot that the VM
+                  should point to. This field can be specified to revert the VM
+                  to a given snapshot. Once the virtual machine has been
+                  successfully reverted to the desired snapshot, the value of
+                  this field is cleared.
+
+                  The value of this field must be the name of an existing
+                  VirtualMachineSnapshot resource in the same namespace.
+
+                  Reverting a virtual machine to a snapshot rolls back the data
+                  and the configuration of the virtual machine to that of the
+                  specified snapshot. The VirtualMachineSpec of the
+                  VirtualMachine resource is replaced from the one stored with
+                  the snapshot.
+
+                  If the virtual machine is currently powered off, but you revert to
+                  a snapshot that was taken while the VM was powered on, then the
+                  VM will be automatically powered on during the revert.
+                  Additionally, the VirtualMachineSpec will be updated to match
+                  the power state from the snapshot (i.e., powered on). This can
+                  be overridden by specifying the PowerState to PoweredOff in the
+                  VirtualMachineSpec.
+                type: string
+              groupName:
+                description: |-
+                  GroupName indicates the name of the VirtualMachineGroup to which this
+                  VM belongs.
+
+                  VMs that belong to a group do not drive their own placement, rather that
+                  is handled by the group.
+
+                  When this field is set to a valid group that contains this VM as a
+                  member, an owner reference to that group is added to this VM.
+
+                  When this field is deleted or changed, any existing owner reference to
+                  the previous group will be removed from this VM.
+                type: string
+              guestID:
+                description: |-
+                  GuestID describes the desired guest operating system identifier for a VM.
+
+                  The logic that determines the guest ID is as follows:
+
+                  If this field is set, then its value is used.
+                  Otherwise, if the VM is deployed from an OVF template that defines a
+                  guest ID, then that value is used.
+                  The guest ID from VirtualMachineClass used to deploy the VM is ignored.
+
+                  For a complete list of supported values, please refer to
+                  https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html.
+
+                  Please note that some guest ID values may require a minimal hardware
+                  version, which can be set using the `spec.minHardwareVersion` field.
+                  To see the mapping between virtual hardware versions and the product
+                  versions that support a specific guest ID, please refer to
+                  https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html.
+
+                  Please note that this field is immutable after the VM is powered on.
+                  To change the guest ID after the VM is powered on, the VM must be powered
+                  off and then powered on again with the updated guest ID spec.
+
+                  This field is required when the VM has any CD-ROM devices attached.
+                type: string
+              hardware:
+                description: Hardware describes the VM's desired hardware.
+                properties:
+                  cdrom:
+                    description: |-
+                      Cdrom describes the desired state of the VM's CD-ROM devices.
+
+                      Each CD-ROM device requires a reference to an ISO-type
+                      VirtualMachineImage or ClusterVirtualMachineImage resource as backing.
+
+                      Multiple CD-ROM devices using the same backing image, regardless of image
+                      kinds (namespace or cluster scope), are not allowed.
+
+                      CD-ROM devices can be added, updated, or removed when the VM is powered
+                      off. When the VM is powered on, only the connection state of existing
+                      CD-ROM devices can be changed.
+                      CD-ROM devices are attached to the VM in the specified list-order.
+                    items:
+                      description: VirtualMachineCdromSpec describes the desired state
+                        of a CD-ROM device.
+                      properties:
+                        allowGuestControl:
+                          default: true
+                          description: |-
+                            AllowGuestControl describes whether or not a web console connection
+                            may be used to connect/disconnect the CD-ROM device.
+
+                            Defaults to true if omitted.
+                          type: boolean
+                        connected:
+                          default: true
+                          description: |-
+                            Connected describes the desired connection state of the CD-ROM device.
+
+                            When true, the CD-ROM device is added and connected to the VM.
+                            If the device already exists, it is updated to a connected state.
+
+                            When explicitly set to false, the CD-ROM device is added but remains
+                            disconnected from the VM. If the CD-ROM device already exists, it is
+                            updated to a disconnected state.
+
+                            Note: Before disconnecting a CD-ROM, the device may need to be unmounted
+                            in the guest OS. Refer to the following KB article for more details:
+                            https://knowledge.broadcom.com/external/article?legacyId=2144053
+
+                            Defaults to true if omitted.
+                          type: boolean
+                        controllerBusNumber:
+                          description: |-
+                            ControllerBusNumber describes the bus number of the controller to which
+                            this CD-ROM should be attached.
+
+                            The bus number specifies a controller based on the value of the
+                            controllerType field:
+
+                              - IDE  -- spec.hardware.ideControllers
+                              - SATA -- spec.hardware.sataControllers
+
+                            If this and controllerType are both omitted, the CD-ROM will be attached
+                            to the  first available IDE controller. If there is no IDE controller
+                            with an available slot, a new SATA controller will be added as long as
+                            there are currently three or fewer SATA controllers.
+
+                            If the specified controller has no available slots, the request will be
+                            denied.
+                          format: int32
+                          type: integer
+                        controllerType:
+                          allOf:
+                          - enum:
+                            - IDE
+                            - NVME
+                            - SCSI
+                            - SATA
+                          - enum:
+                            - IDE
+                            - SATA
+                          description: |-
+                            ControllerType describes the type of the controller to which this CD-ROM
+                            should be attached.
+
+                            Please keep in mind the number of devices supported by the different
+                            types of controllers:
+
+                              - IDE                -- 4 total (2 per controller)
+                              - SATA               -- 120 total (30 per controller)
+
+                            Defaults to IDE when controllerBusNumber is also omitted; otherwise the
+                            default value is determined by the logic outlined in the description of
+                            the controllerBusNumber field.
+                          type: string
+                        image:
+                          description: |-
+                            Image describes the reference to an ISO type VirtualMachineImage or
+                            ClusterVirtualMachineImage resource used as the backing for the CD-ROM.
+                            If the image kind is omitted, it defaults to VirtualMachineImage.
+
+                            This field is immutable when the VM is powered on.
+
+                            Please note, unlike the spec.imageName field, the value of this
+                            spec.cdrom.image.name MUST be a Kubernetes object name.
+                          properties:
+                            kind:
+                              description: |-
+                                Kind describes the type of image, either a namespace-scoped
+                                VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                              type: string
+                            name:
+                              description: |-
+                                Name refers to the name of a VirtualMachineImage resource in the same
+                                namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        name:
+                          description: |-
+                            Name consists of at least two lowercase letters or digits of this CD-ROM.
+                            It must be unique among all CD-ROM devices attached to the VM.
+
+                            This field is immutable when the VM is powered on.
+                          pattern: ^[a-z0-9]{2,}$
+                          type: string
+                        unitNumber:
+                          description: |-
+                            UnitNumber describes the desired unit number for attaching the CD-ROM to
+                            a storage controller.
+
+                            When omitted, the next available unit number of the selected controller
+                            is used.
+
+                            This value must be unique for the controller referenced by the
+                            controllerBusNumber and controllerType properties. If the value is
+                            already used by another device, this CD-ROM will not be attached.
+                          format: int32
+                          type: integer
+                      required:
+                      - image
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  ideControllers:
+                    description: |-
+                      IDEControllers describes the desired list of IDE controllers for the VM.
+
+                      Defaults to two IDE controllers, with bus 0 and bus 1.
+                    items:
+                      properties:
+                        busNumber:
+                          description: BusNumber describes the desired bus number
+                            of the controller.
+                          format: int32
+                          maximum: 1
+                          minimum: 0
+                          type: integer
+                      required:
+                      - busNumber
+                      type: object
+                    maxItems: 2
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - busNumber
+                    x-kubernetes-list-type: map
+                  nvmeControllers:
+                    description: |-
+                      NVMEControllers describes the desired list of NVME controllers for the
+                      VM.
+                    items:
+                      properties:
+                        busNumber:
+                          description: BusNumber describes the desired bus number
+                            of the controller.
+                          format: int32
+                          maximum: 3
+                          minimum: 0
+                          type: integer
+                        pciSlotNumber:
+                          description: |-
+                            PCISlotNumber describes the desired PCI slot number to use for this
+                            controller.
+
+                            Please note, most of the time this field should be empty so the system
+                            can pick an available slot.
+                          format: int32
+                          type: integer
+                        sharingMode:
+                          default: None
+                          description: |-
+                            SharingMode describes the sharing mode for the controller.
+
+                            Defaults to None.
+                          enum:
+                          - None
+                          - Physical
+                          type: string
+                      required:
+                      - busNumber
+                      type: object
+                    maxItems: 4
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - busNumber
+                    x-kubernetes-list-type: map
+                  sataControllers:
+                    description: |-
+                      SATAControllers describes the desired list of SATA controllers for the
+                      VM.
+
+                      Please note, all SATA controllers are VirtualAHCI.
+                    items:
+                      properties:
+                        busNumber:
+                          description: BusNumber describes the desired bus number
+                            of the controller.
+                          format: int32
+                          maximum: 3
+                          minimum: 0
+                          type: integer
+                        pciSlotNumber:
+                          description: |-
+                            PCISlotNumber describes the desired PCI slot number to use for this
+                            controller.
+
+                            Please note, most of the time this field should be empty so the system
+                            can pick an available slot.
+                          format: int32
+                          type: integer
+                      required:
+                      - busNumber
+                      type: object
+                    maxItems: 4
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - busNumber
+                    x-kubernetes-list-type: map
+                  scsiControllers:
+                    description: |-
+                      SCSIControllers describes the desired list of SCSI controllers for the
+                      VM.
+                    items:
+                      properties:
+                        busNumber:
+                          description: BusNumber describes the desired bus number
+                            of the controller.
+                          format: int32
+                          maximum: 3
+                          minimum: 0
+                          type: integer
+                        pciSlotNumber:
+                          description: |-
+                            PCISlotNumber describes the desired PCI slot number to use for this
+                            controller.
+
+                            Please note, most of the time this field should be empty so the system
+                            can pick an available slot.
+                          format: int32
+                          type: integer
+                        sharingMode:
+                          default: None
+                          description: |-
+                            SharingMode describes the sharing mode for the controller.
+
+                            Defaults to None.
+                          enum:
+                          - None
+                          - Physical
+                          - Virtual
+                          type: string
+                        type:
+                          default: ParaVirtual
+                          description: |-
+                            Type describes the desired type of SCSI controller.
+
+                            Defaults to ParaVirtual.
+                          enum:
+                          - ParaVirtual
+                          - BusLogic
+                          - LsiLogic
+                          - LsiLogicSAS
+                          type: string
+                      required:
+                      - busNumber
+                      type: object
+                    maxItems: 4
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - busNumber
+                    x-kubernetes-list-type: map
+                type: object
+              image:
+                description: |-
+                  Image describes the reference to the VirtualMachineImage or
+                  ClusterVirtualMachineImage resource used to deploy this VM.
+
+                  Please note, unlike the field spec.imageName, the value of
+                  spec.image.name MUST be a Kubernetes object name.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.imageName are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                properties:
+                  kind:
+                    description: |-
+                      Kind describes the type of image, either a namespace-scoped
+                      VirtualMachineImage or cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to the name of a VirtualMachineImage resource in the same
+                      namespace as this VM or a cluster-scoped ClusterVirtualMachineImage.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageName:
+                description: |-
+                  ImageName describes the name of the image resource used to deploy this
+                  VM.
+
+                  This field may be used to specify the name of a VirtualMachineImage
+                  or ClusterVirtualMachineImage resource. The resolver first checks to see
+                  if there is a VirtualMachineImage with the specified name in the
+                  same namespace as the VM being deployed. If no such resource exists, the
+                  resolver then checks to see if there is a ClusterVirtualMachineImage
+                  resource with the specified name.
+
+                  This field may also be used to specify the display name (vSphere name) of
+                  a VirtualMachineImage or ClusterVirtualMachineImage resource. If the
+                  display name unambiguously resolves to a distinct VM image (among all
+                  existing VirtualMachineImages in the VM's namespace and all existing
+                  ClusterVirtualMachineImages), then a mutation webhook updates the
+                  spec.image field with the reference to the resolved VM image. If the
+                  display name resolves to multiple or no VM images, then the mutation
+                  webhook denies the request and returns an error.
+
+                  Please also note, when creating a new VirtualMachine, if this field and
+                  spec.image are both non-empty, then they must refer to the same
+                  resource or an error is returned.
+
+                  Please note, this field *may* be empty if the VM was imported instead of
+                  deployed by VM Operator. An imported VirtualMachine resource references
+                  an existing VM on the underlying platform that was not deployed from a
+                  VM image.
+                type: string
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the desired Instance UUID for a VM.
+                  If omitted, this field defaults to a random UUID.
+                  This value is only used for the VM Instance UUID,
+                  it is not used within cloudInit.
+                  This identifier is used by VirtualCenter to uniquely identify all
+                  virtual machine instances, including those that may share the same BIOS UUID.
+                format: uuid
+                type: string
+              minHardwareVersion:
+                description: |-
+                  MinHardwareVersion describes the desired, minimum hardware version.
+
+                  The logic that determines the hardware version is as follows:
+
+                  1. If this field is set, then its value is used.
+                  2. Otherwise, if the VirtualMachineClass used to deploy the VM contains a
+                     non-empty hardware version, then it is used.
+                  3. Finally, if the hardware version is still undetermined, the value is
+                     set to the default hardware version for the Datacenter/Cluster/Host
+                     where the VM is provisioned.
+
+                  This field is never updated to reflect the derived hardware version.
+                  Instead, VirtualMachineStatus.HardwareVersion surfaces
+                  the observed hardware version.
+
+                  Please note, setting this field's value to N ensures a VM's hardware
+                  version is equal to or greater than N. For example, if a VM's observed
+                  hardware version is 10 and this field's value is 13, then the VM will be
+                  upgraded to hardware version 13. However, if the observed hardware
+                  version is 17 and this field's value is 13, no change will occur.
+
+                  Several features are hardware version dependent, for example:
+
+                  * NVMe Controllers                >= 14
+                  * Dynamic Direct Path I/O devices >= 17
+
+                  Please refer to https://kb.vmware.com/s/article/1003746 for a list of VM
+                  hardware versions.
+
+                  It is important to remember that a VM's hardware version may not be
+                  downgraded and upgrading a VM deployed from an image based on an older
+                  hardware version to a more recent one may result in unpredictable
+                  behavior. In other words, please be careful when choosing to upgrade a
+                  VM to a newer hardware version.
+                format: int32
+                minimum: 13
+                type: integer
+              network:
+                description: |-
+                  Network describes the desired network configuration for the VM.
+
+                  Please note this value may be omitted entirely and the VM will be
+                  assigned a single, virtual network interface that is connected to the
+                  Namespace's default network.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled is a flag that indicates whether or not to disable networking
+                      for this VM.
+
+                      When set to true, the VM is not configured with a default interface nor
+                      any specified from the Interfaces field.
+                    type: boolean
+                  domainName:
+                    description: |-
+                      DomainName describes the value the guest uses as its domain name.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS names:
+
+                        * When joined with the host name, the total length is restricted to 255
+                          characters or less.
+                        * Individual segments must be 63 characters or less.
+                        * The top-level domain( ex. ".com"), is at least two letters with no
+                          special characters.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Long, top-level domain names (ex. ".london") are permitted.
+                        * Symbol unicode points, such as emoji, are disallowed in the top-level
+                          domain.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+
+                      When deploying a guest running Microsoft Windows, this field describes
+                      the domain the computer should join.
+                    type: string
+                  hostName:
+                    description: |-
+                      HostName describes the value the guest uses as its host name. If omitted,
+                      the name of the VM will be used.
+
+                      Please note, this feature is available with the following bootstrap
+                      providers: CloudInit, LinuxPrep, and Sysprep.
+
+                      This field must adhere to the format specified in RFC-1034, Section 3.5
+                      for DNS labels:
+
+                        * The total length is restricted to 63 characters or less.
+                        * The total length is restricted to 15 characters or less on Windows
+                          systems.
+                        * The value may begin with a digit per RFC-1123.
+                        * Underscores are not allowed.
+                        * Dashes are permitted, but not at the start or end of the value.
+                        * Symbol unicode points, such as emoji, are permitted, ex. ✓. However,
+                          please note that the use of emoji, even where allowed, may not
+                          compatible with the guest operating system, so it recommended to
+                          stick with more common characters for this value.
+                        * The value may be a valid IP4 or IP6 address. Please note, the use of
+                          an IP address for a host name is not compatible with all guest
+                          operating systems and is discouraged. Additionally, using an IP
+                          address for the host name is disallowed if spec.network.domainName is
+                          non-empty.
+
+                      Please note, the combined values of spec.network.hostName and
+                      spec.network.domainName may not exceed 255 characters in length.
+                    type: string
+                  interfaces:
+                    description: |-
+                      Interfaces is the list of network interfaces used by this VM.
+
+                      If the Interfaces field is empty and the Disabled field is false, then
+                      a default interface with the name eth0 will be created.
+
+                      The maximum number of network interface allowed is 10 because a vSphere
+                      virtual machine may not have more than 10 virtual ethernet card devices.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceSpec describes the desired state of a VM's
+                        network interface.
+                      properties:
+                        addresses:
+                          description: |-
+                            Addresses is an optional list of IP4 or IP6 addresses to assign to this
+                            interface.
+
+                            Please note this field is only supported if the connected network
+                            supports manual IP allocation.
+
+                            Please note IP4 and IP6 addresses must include the network prefix length,
+                            ex. 192.168.0.10/24 or 2001:db8:101::a/64.
+
+                            Please note this field may not contain IP4 addresses if DHCP4 is set
+                            to true or IP6 addresses if DHCP6 is set to true.
+                          items:
+                            type: string
+                          type: array
+                        dhcp4:
+                          description: |-
+                            DHCP4 indicates whether or not this interface uses DHCP for IP4
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP4 addresses in the
+                            Addresses field and the Gateway4 field.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 indicates whether or not this interface uses DHCP for IP6
+                            networking.
+
+                            Please note this field is only supported if the network connection
+                            supports DHCP.
+
+                            Please note this field is mutually exclusive with IP6 addresses in the
+                            Addresses field and the Gateway6 field.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the default, IP4 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP4.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway6 is the primary IP6 gateway for this interface.
+
+                            If unset, the gateway from the network provider will be used. However,
+                            if set to "None", the network provider gateway will be ignored.
+
+                            Please note this field is only supported if the network connection
+                            supports manual IP allocation.
+
+                            Please note this field is mutually exclusive with DHCP6.
+                          type: string
+                        guestDeviceName:
+                          description: |-
+                            GuestDeviceName is used to rename the device inside the guest when the
+                            bootstrap provider is Cloud-Init. Please note it is up to the user to
+                            ensure the provided device name does not conflict with any other devices
+                            inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^\w\w+$
+                          type: string
+                        macAddr:
+                          description: |-
+                            MACAddr is the optional MAC address of this interface.
+
+                            If no MAC address is provided, one will be generated by either the network
+                            provider or vCenter.
+
+                            Please note this field is only supported when the Network API Group is
+                            crd.nsx.vmware.com.
+                          pattern: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+                          type: string
+                        mtu:
+                          description: |-
+                            MTU is the Maximum Transmission Unit size in bytes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          format: int64
+                          type: integer
+                        name:
+                          description: |-
+                            Name describes the unique name of this network interface, used to
+                            distinguish it from other network interfaces attached to this VM.
+
+                            When the bootstrap provider is Cloud-Init and GuestDeviceName is not
+                            specified, the device inside the guest will be renamed to this value.
+                            Please note it is up to the user to ensure the provided name does not
+                            conflict with any other devices inside the guest, ex. dvd, cdrom, sda, etc.
+                          pattern: ^[a-z0-9]{2,}$
+                          type: string
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                            nameservers.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit and Sysprep.
+
+                            When using CloudInit and UseGlobalNameserversAsDefault is either unset or
+                            true, if nameservers is not provided, the global nameservers will be used
+                            instead.
+
+                            Please note that Linux allows only three nameservers
+                            (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        network:
+                          description: |-
+                            Network is the name of the network resource to which this interface is
+                            connected.
+
+                            If no network is provided, then this interface will be connected to the
+                            Namespace's default network.
+                          properties:
+                            apiVersion:
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                              type: string
+                            kind:
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name refers to a unique resource in the current namespace.
+                                More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        routes:
+                          description: |-
+                            Routes is a list of optional, static routes.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+                          items:
+                            description: VirtualMachineNetworkRouteSpec defines a
+                              static route for a guest.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              to:
+                                description: To is either "default", or an IP4 or
+                                  IP6 address.
+                                type: string
+                              via:
+                                description: Via is an IP4 or IP6 address.
+                                type: string
+                            required:
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+
+                            Please note this feature is available only with the following bootstrap
+                            providers: CloudInit.
+
+                            When using CloudInit and UseGlobalSearchDomainsAsDefault is either unset
+                            or true, if search domains is not provided, the global search domains
+                            will be used instead.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nameservers:
+                    description: |-
+                      Nameservers is a list of IP4 and/or IP6 addresses used as DNS
+                      nameservers. These are applied globally.
+
+                      Please note global nameservers are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface nameservers. However, when Cloud-Init
+                      is used and UseGlobalNameserversAsDefault is true, the global
+                      nameservers will be used when the per-interface nameservers is not
+                      provided.
+
+                      Please note that Linux allows only three nameservers
+                      (https://linux.die.net/man/5/resolv.conf).
+                    items:
+                      type: string
+                    type: array
+                  searchDomains:
+                    description: |-
+                      SearchDomains is a list of search domains used when resolving IP
+                      addresses with DNS. These are applied globally.
+
+                      Please note global search domains are only available with the following
+                      bootstrap providers: LinuxPrep and Sysprep. The Cloud-Init bootstrap
+                      provider supports per-interface search domains. However, when Cloud-Init
+                      is used and UseGlobalSearchDomainsAsDefault is true, the global search
+                      domains will be used when the per-interface search domains is not provided.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nextRestartTime:
+                description: |-
+                  NextRestartTime may be used to restart the VM, in accordance with
+                  RestartMode, by setting the value of this field to "now"
+                  (case-insensitive).
+
+                  A mutating webhook changes this value to the current time (UTC), which
+                  the VM controller then uses to determine the VM should be restarted by
+                  comparing the value to the timestamp of the last time the VM was
+                  restarted.
+
+                  Please note it is not possible to schedule future restarts using this
+                  field. The only value that users may set is the string "now"
+                  (case-insensitive).
+                type: string
+              policies:
+                description: |-
+                  Policies describes a list of policies that should be explicitly applied
+                  to this VM.
+
+                  Please note, not all policies may be applied explicitly to a VM. Please
+                  consult a policy to determine if it may be applied directly. For example,
+                  the ComputePolicy object from the vsphere.policy.vmware.com API group
+                  has a field named spec.type. Only ComputePolicy objects with
+                  type=Optional may be applied explicitly to a VM.
+
+                  Valid policy types are: ComputePolicy.
+                items:
+                  description: |-
+                    LocalObjectRef describes a reference to another object in the same
+                    namespace as the referrer.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an
+                        object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object
+                        represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name refers to a unique resource in the current namespace.
+                        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+              powerOffMode:
+                default: TrySoft
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM.
+
+                  There are three, supported power off modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully shutdown the VM. Its variant, TrySoft, first attempts
+                  a graceful shutdown, and if that fails or the VM is not in a powered off
+                  state after five minutes, the VM is halted.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              powerState:
+                description: |-
+                  PowerState describes the desired power state of a VirtualMachine.
+
+                  Please note this field may be omitted when creating a new VM and will
+                  default to "PoweredOn." However, once the field is set to a non-empty
+                  value, it may no longer be set to an empty value.
+
+                  Additionally, setting this value to "Suspended" is not supported when
+                  creating a new VM. The valid values when creating a new VM are
+                  "PoweredOn" and "PoweredOff." An empty value is also allowed on create
+                  since this value defaults to "PoweredOn" for new VMs.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              promoteDisksMode:
+                default: Online
+                description: |-
+                  PromoteDisksMode describes the mode used to promote a VM's delta disks to
+                  full disks. The available modes are:
+
+                  - Disabled -- Do not promote disks.
+                  - Online   -- Promote disks while the VM is powered on. VMs with
+                                snapshots do not support online promotion.
+                  - Offline  -- Promote disks while the VM is powered off.
+
+                  Please note, this field is ignored for encrypted VMs since they do not
+                  use delta disks.
+
+                  Defaults to Online.
+                enum:
+                - Online
+                - Offline
+                - Disabled
+                type: string
+              readinessProbe:
+                description: ReadinessProbe describes a probe used to determine the
+                  VM's ready state.
+                properties:
+                  guestHeartbeat:
+                    description: GuestHeartbeat specifies an action involving the
+                      guest heartbeat status.
+                    properties:
+                      thresholdStatus:
+                        default: green
+                        description: |-
+                          ThresholdStatus is the value that the guest heartbeat status must be at or above to be
+                          considered successful.
+                        enum:
+                        - yellow
+                        - green
+                        type: string
+                    type: object
+                  guestInfo:
+                    description: |-
+                      GuestInfo specifies an action involving key/value pairs from GuestInfo.
+
+                      The elements are evaluated with the logical AND operator, meaning
+                      all expressions must evaluate as true for the probe to succeed.
+
+                      For example, a VM resource's probe definition could be specified as the
+                      following:
+
+                              guestInfo:
+                              - key:   ready
+                                value: true
+
+                      With the above configuration in place, the VM would not be considered
+                      ready until the GuestInfo key "ready" was set to the value "true".
+
+                      From within the guest operating system it is possible to set GuestInfo
+                      key/value pairs using the program "vmware-rpctool," which is included
+                      with VM Tools. For example, the following command will set the key
+                      "guestinfo.ready" to the value "true":
+
+                              vmware-rpctool "info-set guestinfo.ready true"
+
+                      Once executed, the VM's readiness probe will be signaled and the
+                      VM resource will be marked as ready.
+                    items:
+                      description: |-
+                        GuestInfoAction describes a key from GuestInfo that must match the associated
+                        value expression.
+                      properties:
+                        key:
+                          description: |-
+                            Key is the name of the GuestInfo key.
+
+                            The key is automatically prefixed with "guestinfo." before being
+                            evaluated. Thus if the key "guestinfo.mykey" is provided, it will be
+                            evaluated as "guestinfo.guestinfo.mykey".
+                          type: string
+                        value:
+                          description: |-
+                            Value is a regular expression that is matched against the value of the
+                            specified key.
+
+                            An empty value is the equivalent of "match any" or ".*".
+
+                            All values must adhere to the RE2 regular expression syntax as documented
+                            at https://golang.org/s/re2syntax. Invalid values may be rejected or
+                            ignored depending on the implementation of this API. Either way, invalid
+                            values will not be considered when evaluating the ready state of a VM.
+                          type: string
+                      required:
+                      - key
+                      type: object
+                    type: array
+                  periodSeconds:
+                    description: |-
+                      PeriodSeconds specifics how often (in seconds) to perform the probe.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tcpSocket:
+                    description: |-
+                      TCPSocket specifies an action involving a TCP port.
+
+                      Deprecated: The TCPSocket action requires network connectivity that is not supported in all environments.
+                      This field will be removed in a later API version.
+                    properties:
+                      host:
+                        description: Host is an optional host name to connect to.
+                          Host defaults to the VM IP.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Port specifies a number or name of the port to access on the VM.
+                          If the format of port is a number, it must be in the range 1 to 65535.
+                          If the format of name is a string, it must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies a number of seconds after which the probe times out.
+                      Defaults to 10 seconds. Minimum value is 1.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
+                type: object
+              reserved:
+                description: |-
+                  Reserved describes a set of VM configuration options reserved for system
+                  use.
+
+                  Please note attempts to modify the value of this field by a DevOps user
+                  will result in a validation error.
+                properties:
+                  resourcePolicyName:
+                    type: string
+                type: object
+              restartMode:
+                default: TrySoft
+                description: |-
+                  RestartMode describes the desired behavior for restarting a VM when
+                  spec.nextRestartTime is set to "now" (case-insensitive).
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere resets the VM without any
+                  interaction inside of the guest. The Soft mode requires the VM's guest to
+                  have VM Tools installed and asks the guest to restart the VM. Its
+                  variant, TrySoft, first attempts a soft restart, and if that fails or
+                  does not complete within five minutes, the VM is hard reset.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              storageClass:
+                description: |-
+                  StorageClass describes the name of a Kubernetes StorageClass resource
+                  used to configure this VM's storage-related attributes.
+
+                  Please see https://kubernetes.io/docs/concepts/storage/storage-classes/
+                  for more information on Kubernetes storage classes.
+                type: string
+              suspendMode:
+                default: TrySoft
+                description: |-
+                  SuspendMode describes the desired behavior when suspending a VM.
+
+                  There are three, supported suspend modes: Hard, Soft, and
+                  TrySoft. The first mode, Hard, is where vSphere suspends the VM to
+                  disk without any interaction inside of the guest. The Soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully suspend the VM. Its variant, TrySoft, first attempts
+                  a graceful suspend, and if that fails or the VM is not in a put into
+                  standby by the guest after five minutes, the VM is suspended.
+
+                  If omitted, the mode defaults to TrySoft.
+                enum:
+                - Hard
+                - Soft
+                - TrySoft
+                type: string
+              volumes:
+                description: Volumes describes a list of volumes that can be mounted
+                  to the VM.
+                items:
+                  description: VirtualMachineVolume represents a named volume in a
+                    VM.
+                  properties:
+                    name:
+                      description: |-
+                        Name represents the volume's name. Must be a DNS_LABEL and unique within
+                        the VM.
+                      type: string
+                    persistentVolumeClaim:
+                      description: |-
+                        PersistentVolumeClaim represents a reference to a PersistentVolumeClaim
+                        in the same namespace.
+
+                        More information is available at
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims.
+                      properties:
+                        applicationType:
+                          description: |-
+                            ApplicationType describes the type of application for which this volume
+                            is intended to be used.
+
+                              - OracleRAC      -- The volume is configured with
+                                                  diskMode=IndependentPersistent and
+                                                  sharingMode=MultiWriter and attached to the first
+                                                  SCSI controller with an available slot and
+                                                  sharingMode=None. If no such controller exists,
+                                                  a new ParaVirtual SCSI controller will be created
+                                                  with sharingMode=None long as there are currently
+                                                  three or fewer SCSI controllers.
+                              - MicrosoftWSFC  -- The volume is configured with
+                                                  diskMode=IndependentPersistent and attached to a
+                                                  SCSI controller with sharingMode=Physical.
+                                                  If no such controller exists, a new ParaVirtual
+                                                  SCSI controller will be created with
+                                                  sharingMode=Physical as long as there are currently
+                                                  three or fewer SCSI controllers.
+                          enum:
+                          - OracleRAC
+                          - MicrosoftWSFC
+                          type: string
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        controllerBusNumber:
+                          description: |-
+                            ControllerBusNumber describes the bus number of the controller to which
+                            this volume should be attached.
+
+                            The bus number specifies a controller based on the value of the
+                            controllerType field:
+
+                              - IDE  -- spec.hardware.ideControllers
+                              - NVME -- spec.hardware.nvmeControllers
+                              - SATA -- spec.hardware.sataControllers
+                              - SCSI -- spec.hardware.scsiControllers
+
+                            If this and controllerType are both omitted, the volume will be attached
+                            to the first available SCSI controller. If there is no SCSI controller
+                            with an available slot, a new ParaVirtual SCSI controller will be added
+                            as long as there are currently three or fewer SCSI controllers.
+
+                            If the specified controller has no available slots, the request will be
+                            denied.
+                          format: int32
+                          type: integer
+                        controllerType:
+                          default: SCSI
+                          description: |-
+                            ControllerType describes the type of the controller to which this volume
+                            should be attached.
+
+                            Please keep in mind the number of volumes supported by the different
+                            types of controllers:
+
+                              - IDE                -- 4 total (2 per controller)
+                              - NVME               -- 256 total (64 per controller)
+                              - SATA               -- 120 total (30 per controller)
+                              - SCSI (ParaVirtual) -- 252 total (63 per controller)
+                              - SCSI (BusLogic)    -- 60 total (15 per controller)
+                              - SCSI (LsiLogic)    -- 60 total (15 per controller)
+                              - SCSI (LsiLogicSAS) -- 60 total (15 per controller)
+
+                            Please note, the number of supported volumes per SCSI controller may seem
+                            off, but remember that a SCSI controller occupies a slot on its own bus.
+                            Thus even though a ParaVirtual SCSI controller supports 64 targets and
+                            the other types of SCSI controllers support 16 targets, one of the
+                            targets is occupied by the controller itself.
+
+                            Defaults to SCSI when controllerBusNumber is also omitted; otherwise the
+                            default value is determined by the logic outlined in the description of
+                            the controllerBusNumber field.
+                          enum:
+                          - IDE
+                          - NVME
+                          - SCSI
+                          - SATA
+                          type: string
+                        diskMode:
+                          default: Persistent
+                          description: |-
+                            DiskMode describes the desired mode to use when attaching the volume.
+
+                            Please note, volumes attached as IndependentNonPersistent or
+                            IndependentPersistent are not included in a VM's snapshots or backups.
+
+                            Also, any data written to volumes attached as IndependentNonPersistent or
+                            NonPersistent will be discarded when the VM is powered off.
+
+                            Defaults to Persistent.
+                          enum:
+                          - IndependentNonPersistent
+                          - IndependentPersistent
+                          - NonPersistent
+                          - Persistent
+                          - Dependent
+                          type: string
+                        instanceVolumeClaim:
+                          description: InstanceVolumeClaim is set if the PVC is backed
+                            by instance storage.
+                          properties:
+                            size:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Size is the size of the requested instance
+                                storage volume.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            storageClass:
+                              description: |-
+                                StorageClass is the name of the Kubernetes StorageClass that provides
+                                the backing storage for this instance storage volume.
+                              type: string
+                          required:
+                          - size
+                          - storageClass
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                        sharingMode:
+                          default: None
+                          description: |-
+                            SharingMode describes the volume's desired sharing mode.
+
+                            When applicationType=OracleRAC, the field defaults to MultiWriter.
+                            Otherwise, defaults to None.
+                          enum:
+                          - MultiWriter
+                          - None
+                          type: string
+                        unitNumber:
+                          description: |-
+                            UnitNumber describes the desired unit number for attaching the volume to
+                            a storage controller.
+
+                            When omitted, the next available unit number of the selected controller
+                            is used.
+
+                            This value must be unique for the controller referenced by the
+                            controllerBusNumber and controllerType properties. If the value is
+                            already used by another device, this volume will not be attached.
+
+                            Please note the value 7 is invalid if controllerType=SCSI as 7 is the
+                            unit number of the SCSI controller on its own bus.
+                          format: int32
+                          type: integer
+                        unmanagedVolumeClaim:
+                          description: |-
+                            UnmanagedVolumeClaim is set if the PVC is backed by an existing,
+                            unmanaged volume.
+                          properties:
+                            name:
+                              description: |-
+                                Name describes the name of the unmanaged volume.
+
+                                For volumes from an image, the name is from the image's
+                                status.disks[].name field.
+
+                                For volumes from the VM, the name is from the VM's
+                                status.volumes[].name field.
+
+                                Please note, specifying the name of an existing, managed volume is not
+                                supported and will be ignored.
+                              type: string
+                            type:
+                              description: |-
+                                Type describes the source of the unmanaged volume.
+
+                                - FromImage - The source is a disk from the VM image.
+                                - FromVM    - The source is an unmanaged volume on the current VM.
+                              enum:
+                              - FromImage
+                              - FromVM
+                              type: string
+                            uuid:
+                              description: |-
+                                UUID describes the UUID of the unmanaged volume.
+
+                                For volumes from an image, the value is mutated in on create operations.
+
+                                For volumes from the VM, this field may be omitted as its value is
+                                already stored in the name field.
+                              type: string
+                          required:
+                          - name
+                          - type
+                          type: object
+                      required:
+                      - claimName
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: VirtualMachineStatus defines the observed state of a VirtualMachine
+              instance.
+            properties:
+              biosUUID:
+                description: |-
+                  BiosUUID describes a unique identifier provided by the underlying
+                  infrastructure provider that is exposed to the Guest OS BIOS as a unique
+                  hardware identifier.
+                type: string
+              changeBlockTracking:
+                description: |-
+                  ChangeBlockTracking describes whether or not change block tracking is
+                  enabled for the VirtualMachine.
+                type: boolean
+              class:
+                description: |-
+                  Class is a reference to the VirtualMachineClass resource used to deploy
+                  this VM.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object
+                      represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachine.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              crypto:
+                description: |-
+                  Crypto describes the observed state of the VirtualMachine's encryption
+                  configuration.
+                properties:
+                  encrypted:
+                    description: |-
+                      Encrypted describes the observed state of the VirtualMachine's
+                      encryption. There may be two values in this list:
+
+                      - Config -- This refers to all of the files related to a VM except any
+                                  virtual disks.
+                      - Disks  -- This refers to at least one of the VM's attached disks. To
+                                  determine the encryption state of the individual disks,
+                                  please refer to status.volumes[].crypto.
+                    items:
+                      type: string
+                    type: array
+                  hasVTPM:
+                    description: HasVTPM indicates whether or not the VM has a vTPM.
+                    type: boolean
+                  keyID:
+                    description: |-
+                      KeyID describes the key ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                  providerID:
+                    description: |-
+                      ProviderID describes the provider ID used to encrypt the VirtualMachine.
+                      Please note, this field will be empty if the VirtualMachine is not
+                      encrypted.
+                    type: string
+                type: object
+              currentSnapshot:
+                description: |-
+                  CurrentSnapshot describes the observed working snapshot of the VirtualMachine.
+                  This field contains the name of the current snapshot.
+                properties:
+                  name:
+                    description: |-
+                      Name is the name of the snapshot resource.  This field is only set
+                      for managed snapshots.
+                    type: string
+                  type:
+                    default: Managed
+                    description: |-
+                      Type describes the type of the snapshot reference.
+
+                      Possible values are: Managed, Unmanaged
+                    enum:
+                    - Managed
+                    - Unmanaged
+                    type: string
+                required:
+                - name
+                - type
+                type: object
+              guest:
+                description: Guest describes the observed state of the VM's guest.
+                properties:
+                  guestFullName:
+                    description: GuestFullName describes the full name of the observed
+                      operating system.
+                    type: string
+                  guestID:
+                    description: GuestID describes the ID of the observed operating
+                      system.
+                    type: string
+                type: object
+              hardware:
+                description: Hardware describes the observed state of the VM's hardware.
+                properties:
+                  controllers:
+                    description: |-
+                      Controllers describes the observed list of virtual controllers for the
+                      VM.
+                    items:
+                      properties:
+                        busNumber:
+                          description: BusNumber describes the observed bus number
+                            of the controller.
+                          format: int32
+                          type: integer
+                        deviceKey:
+                          description: DeviceKey describes the observed device key
+                            of the controller.
+                          format: int32
+                          type: integer
+                        devices:
+                          description: Devices describes the observed devices connected
+                            to the controller.
+                          items:
+                            properties:
+                              name:
+                                description: Name describes the name of the virtual
+                                  device.
+                                type: string
+                              type:
+                                description: Type describes the type of the virtual
+                                  device.
+                                enum:
+                                - CDROM
+                                - Disk
+                                type: string
+                              unitNumber:
+                                description: UnitNumber describes the observed unit
+                                  number of the device.
+                                format: int32
+                                type: integer
+                            required:
+                            - name
+                            - type
+                            - unitNumber
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          - type
+                          x-kubernetes-list-type: map
+                        type:
+                          description: Type describes the observed type of the controller.
+                          enum:
+                          - IDE
+                          - NVME
+                          - SCSI
+                          - SATA
+                          type: string
+                      required:
+                      - busNumber
+                      - deviceKey
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - busNumber
+                    - type
+                    x-kubernetes-list-type: map
+                  cpu:
+                    description: CPU describes the observed CPU allocation of the
+                      VM.
+                    properties:
+                      reservation:
+                        description: Reservation describes the observed CPU reservation
+                          in MHz.
+                        format: int64
+                        type: integer
+                      total:
+                        description: Total describes the observed number of processors.
+                        format: int32
+                        type: integer
+                    type: object
+                  memory:
+                    description: Memory describes the observed memory allocation of
+                      the VM.
+                    properties:
+                      reservation:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Reservation describes the observed memory reservation.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      total:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Total describes the observed amount of configured
+                          memory.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  vGPUs:
+                    description: VGPUs describes the observed vGPUs used by this VM.
+                    items:
+                      properties:
+                        migrationType:
+                          description: MigrationType describes the vGPU's observed
+                            vMotion support.
+                          type: string
+                        profile:
+                          description: |-
+                            Profile describes the observed profile used by the vGPU.
+
+                            Please note, this is only applicable to Nvidia vGPUs.
+                          type: string
+                        type:
+                          description: Type describes the observed type of the vGPU.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              hardwareVersion:
+                description: |-
+                  HardwareVersion describes the VirtualMachine resource's observed
+                  hardware version.
+
+                  Please refer to VirtualMachineSpec.MinHardwareVersion for more
+                  information on the topic of a VM's hardware version.
+                format: int32
+                type: integer
+              instanceUUID:
+                description: |-
+                  InstanceUUID describes the unique instance UUID provided by the
+                  underlying infrastructure provider, such as vSphere.
+                type: string
+              lastRestartTime:
+                description: LastRestartTime describes the last time the VM was restarted.
+                format: date-time
+                type: string
+              network:
+                description: |-
+                  Network describes the observed state of the VM's network configuration.
+                  Please note much of the network status information is only available if
+                  the guest has VM Tools installed.
+                properties:
+                  config:
+                    description: |-
+                      Config describes the resolved, configured network settings for the VM,
+                      such as an interface's IP address obtained from IPAM, or global DNS
+                      settings.
+
+                      Please note this information does *not* represent the *observed* network
+                      state of the VM, but is intended for situations where someone boots a VM
+                      with no appropriate bootstrap engine and needs to know the network config
+                      valid for the deployed VM.
+                    properties:
+                      dns:
+                        description: DNS describes the configured state of client-side
+                          DNS.
+                        properties:
+                          domainName:
+                            description: |-
+                              DomainName is the domain name portion of the DNS name. For example,
+                              the "domain.local" part of "my-vm.domain.local".
+                            type: string
+                          hostName:
+                            description: |-
+                              HostName is the host name portion of the DNS name. For example,
+                              the "my-vm" part of "my-vm.domain.local".
+                            type: string
+                          nameservers:
+                            description: |-
+                              Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                              IP4 addresses are specified using dotted decimal notation. For example,
+                              "192.0.2.1".
+
+                              IP6 addresses are 128-bit addresses represented as eight fields of up to
+                              four hexadecimal digits. A colon separates each field (:). For example,
+                              2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                              symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                              once in an address as described in RFC 2373.
+                            items:
+                              type: string
+                            type: array
+                          searchDomains:
+                            description: |-
+                              SearchDomains is a list of domains in which to search for hosts, in the
+                              order of preference.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      interfaces:
+                        description: Interfaces describes the configured state of
+                          the network interfaces.
+                        items:
+                          description: |-
+                            VirtualMachineNetworkConfigInterfaceStatus describes the configured state of
+                            network interface.
+                          properties:
+                            dns:
+                              description: DNS describes the interface's configured
+                                DNS information.
+                              properties:
+                                domainName:
+                                  description: |-
+                                    DomainName is the domain name portion of the DNS name. For example,
+                                    the "domain.local" part of "my-vm.domain.local".
+                                  type: string
+                                hostName:
+                                  description: |-
+                                    HostName is the host name portion of the DNS name. For example,
+                                    the "my-vm" part of "my-vm.domain.local".
+                                  type: string
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                    IP4 addresses are specified using dotted decimal notation. For example,
+                                    "192.0.2.1".
+
+                                    IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                    four hexadecimal digits. A colon separates each field (:). For example,
+                                    2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                    symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                    once in an address as described in RFC 2373.
+                                  items:
+                                    type: string
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of domains in which to search for hosts, in the
+                                    order of preference.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            ip:
+                              description: IP describes the interface's configured
+                                IP information.
+                              properties:
+                                addresses:
+                                  description: |-
+                                    Addresses describes configured IP addresses for this interface.
+                                    Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                    2001:DB8:101::230:6eff:fe04:d9ff::/64.
+                                  items:
+                                    type: string
+                                  type: array
+                                dhcp:
+                                  description: DHCP describes the interface's configured
+                                    DHCP options.
+                                  properties:
+                                    ip4:
+                                      description: IP4 describes the configured state
+                                        of the IP4 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                    ip6:
+                                      description: IP6 describes the configured state
+                                        of the IP6 DHCP settings.
+                                      properties:
+                                        enabled:
+                                          description: Enabled describes whether DHCP
+                                            is enabled.
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                gateway4:
+                                  description: |-
+                                    Gateway4 describes the interface's configured, default, IP4 gateway.
+
+                                    Please note the IP address include the network prefix length, ex.
+                                    192.168.0.1/24.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway6 describes the interface's configured, default, IP6 gateway.
+
+                                    Please note the IP address includes the network prefix length, ex.
+                                    2001:db8:101::1/64.
+                                  type: string
+                              type: object
+                            name:
+                              description: |-
+                                Name describes the corresponding network interface with the same name
+                                in the VM's desired network interface list.
+
+                                Please note this name is not necessarily related to the name of the
+                                device as it is surfaced inside of the guest.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  hostName:
+                    description: |-
+                      HostName describes the observed hostname reported by the VirtualMachine's
+                      guest operating system.
+
+                      Please note, this value is only reported if VMware Tools is installed in
+                      the guest, and the value may or may not be a fully qualified domain name
+                      (FQDN), it simply depends on what is reported by the guest.
+                    type: string
+                  interfaces:
+                    description: Interfaces describes the status of the VM's network
+                      interfaces.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkInterfaceStatus describes the observed state of a
+                        VM's network interface.
+                      properties:
+                        deviceKey:
+                          description: |-
+                            DeviceKey describes the unique hardware device key of this network
+                            interface.
+                          format: int32
+                          type: integer
+                        dns:
+                          description: DNS describes the observed state of the interface's
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ip:
+                          description: IP describes the observed state of the interface's
+                            IP configuration.
+                          properties:
+                            addresses:
+                              description: Addresses describes observed IP addresses
+                                for this interface.
+                              items:
+                                description: |-
+                                  VirtualMachineNetworkInterfaceIPAddrStatus describes information about a
+                                  specific IP address.
+                                properties:
+                                  address:
+                                    description: |-
+                                      Address is an IP4 or IP6 address and their network prefix length.
+
+                                      An IP4 address is specified using dotted decimal notation. For example,
+                                      "192.0.2.1".
+
+                                      IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                      four hexadecimal digits. A colon separates each field (:). For example,
+                                      2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                      symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                      once in an address as described in RFC 2373.
+                                    type: string
+                                  lifetime:
+                                    description: Lifetime describes when this address
+                                      will expire.
+                                    format: date-time
+                                    type: string
+                                  origin:
+                                    description: Origin describes how this address
+                                      was configured.
+                                    enum:
+                                    - dhcp
+                                    - linklayer
+                                    - manual
+                                    - other
+                                    - random
+                                    type: string
+                                  state:
+                                    description: State describes the state of this
+                                      IP address.
+                                    enum:
+                                    - deprecated
+                                    - duplicate
+                                    - inaccessible
+                                    - invalid
+                                    - preferred
+                                    - tentative
+                                    - unknown
+                                    type: string
+                                type: object
+                              type: array
+                            autoConfigurationEnabled:
+                              description: |-
+                                AutoConfigurationEnabled describes whether or not ICMPv6 router
+                                solicitation requests are enabled or disabled from a given interface.
+
+                                These requests acquire an IP6 address and default gateway route from
+                                zero-to-many routers on the connected network.
+
+                                If not set then ICMPv6 is not available on this VM.
+                              type: boolean
+                            dhcp:
+                              description: |-
+                                DHCP describes the VM's observed, client-side, interface-specific DHCP
+                                options.
+                              properties:
+                                ip4:
+                                  description: IP4 describes the observed state of
+                                    the IP4 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                                ip6:
+                                  description: IP6 describes the observed state of
+                                    the IP6 DHCP client settings.
+                                  properties:
+                                    config:
+                                      description: |-
+                                        Config describes platform-dependent settings for the DHCP client.
+
+                                        The key part is a unique number while the value part is the platform
+                                        specific configuration command. For example on Linux and BSD systems
+                                        using the file dhclient.conf output would be reported at system scope:
+                                        key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                        reported per interface would be:
+                                        key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                        key='2', value='require subnet-mask, domain-name-servers;'.
+                                      items:
+                                        description: |-
+                                          KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                          pairs.
+                                        properties:
+                                          key:
+                                            description: Key is the key part of the
+                                              key/value pair.
+                                            type: string
+                                          value:
+                                            description: Value is the optional value
+                                              part of the key/value pair.
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    enabled:
+                                      description: Enabled reports the status of the
+                                        DHCP client services.
+                                      type: boolean
+                                  type: object
+                              type: object
+                            macAddr:
+                              description: MACAddr describes the observed MAC address
+                                for this interface.
+                              type: string
+                          type: object
+                        name:
+                          description: |-
+                            Name describes the corresponding network interface with the same name
+                            in the VM's desired network interface list. If unset, then there is no
+                            corresponding entry for this interface.
+
+                            Please note this name is not necessarily related to the name of the
+                            device as it is surfaced inside of the guest.
+                          type: string
+                      type: object
+                    type: array
+                  ipStacks:
+                    description: |-
+                      IPStacks describes information about the guest's configured IP networking
+                      stacks.
+                    items:
+                      description: |-
+                        VirtualMachineNetworkIPStackStatus describes the observed state of a
+                        VM's IP stack.
+                      properties:
+                        dhcp:
+                          description: DHCP describes the VM's observed, client-side,
+                            system-wide DHCP options.
+                          properties:
+                            ip4:
+                              description: IP4 describes the observed state of the
+                                IP4 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                            ip6:
+                              description: IP6 describes the observed state of the
+                                IP6 DHCP client settings.
+                              properties:
+                                config:
+                                  description: |-
+                                    Config describes platform-dependent settings for the DHCP client.
+
+                                    The key part is a unique number while the value part is the platform
+                                    specific configuration command. For example on Linux and BSD systems
+                                    using the file dhclient.conf output would be reported at system scope:
+                                    key='1', value='timeout 60;' key='2', value='reboot 10;'. The output
+                                    reported per interface would be:
+                                    key='1', value='prepend domain-name-servers 192.0.2.1;'
+                                    key='2', value='require subnet-mask, domain-name-servers;'.
+                                  items:
+                                    description: |-
+                                      KeyValuePair is useful when wanting to realize a map as a list of key/value
+                                      pairs.
+                                    properties:
+                                      key:
+                                        description: Key is the key part of the key/value
+                                          pair.
+                                        type: string
+                                      value:
+                                        description: Value is the optional value part
+                                          of the key/value pair.
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                enabled:
+                                  description: Enabled reports the status of the DHCP
+                                    client services.
+                                  type: boolean
+                              type: object
+                          type: object
+                        dns:
+                          description: DNS describes the VM's observed, client-side
+                            DNS configuration.
+                          properties:
+                            dhcp:
+                              description: |-
+                                DHCP indicates whether or not dynamic host control protocol (DHCP) was
+                                used to configure DNS configuration.
+                              type: boolean
+                            domainName:
+                              description: |-
+                                DomainName is the domain name portion of the DNS name. For example,
+                                the "domain.local" part of "my-vm.domain.local".
+                              type: string
+                            hostName:
+                              description: |-
+                                HostName is the host name portion of the DNS name. For example,
+                                the "my-vm" part of "my-vm.domain.local".
+                              type: string
+                            nameservers:
+                              description: |-
+                                Nameservers is a list of the IP addresses for the DNS servers to use.
+
+                                IP4 addresses are specified using dotted decimal notation. For example,
+                                "192.0.2.1".
+
+                                IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                four hexadecimal digits. A colon separates each field (:). For example,
+                                2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of the
+                                symbol '::' to represent multiple 16-bit groups of contiguous 0's only
+                                once in an address as described in RFC 2373.
+                              items:
+                                type: string
+                              type: array
+                            searchDomains:
+                              description: |-
+                                SearchDomains is a list of domains in which to search for hosts, in the
+                                order of preference.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ipRoutes:
+                          description: IPRoutes contain the VM's routing tables for
+                            all address families.
+                          items:
+                            description: |-
+                              VirtualMachineNetworkIPRouteStatus describes the observed state of a
+                              guest network's IP routes.
+                            properties:
+                              gateway:
+                                description: Gateway describes where to send the packets
+                                  to next.
+                                properties:
+                                  address:
+                                    description: Address is the IP4 or IP6 address
+                                      of the gateway.
+                                    type: string
+                                  device:
+                                    description: |-
+                                      Device is the name of the device in the guest for which this gateway
+                                      applies.
+                                    type: string
+                                type: object
+                              networkAddress:
+                                description: |-
+                                  NetworkAddress is the IP4 or IP6 address of the destination network.
+
+                                  Addresses include the network's prefix length, ex. 192.168.0.0/24 or
+                                  2001:DB8:101::230:6eff:fe04:d9ff::/64.
+
+                                  IP6 addresses are 128-bit addresses represented as eight fields of up to
+                                  four hexadecimal digits. A colon separates each field (:). For example,
+                                  2001:DB8:101::230:6eff:fe04:d9ff. The address can also consist of symbol
+                                  '::' to represent multiple 16-bit groups of contiguous 0's only once in
+                                  an address as described in RFC 2373.
+                                type: string
+                            type: object
+                          type: array
+                        kernelConfig:
+                          description: |-
+                            KernelConfig describes the observed state of the VM's kernel IP
+                            configuration settings.
+
+                            The key part contains a unique number while the value part contains the
+                            'key=value' as provided by the underlying provider. For example, on
+                            Linux and/or BSD, the systcl -a output would be reported as:
+                            key='5', value='net.ipv4.tcp_keepalive_time = 7200'.
+                          items:
+                            description: |-
+                              KeyValuePair is useful when wanting to realize a map as a list of key/value
+                              pairs.
+                            properties:
+                              key:
+                                description: Key is the key part of the key/value
+                                  pair.
+                                type: string
+                              value:
+                                description: Value is the optional value part of the
+                                  key/value pair.
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - key
+                          x-kubernetes-list-type: map
+                      type: object
+                    type: array
+                  primaryIP4:
+                    description: |-
+                      PrimaryIP4 describes the VM's primary IP4 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv4" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                  primaryIP6:
+                    description: |-
+                      PrimaryIP6 describes the VM's primary IP6 address.
+
+                      If the bootstrap provider is CloudInit then this value is set to the
+                      value of the VM's "guestinfo.local-ipv6" property. Please see
+                      https://bit.ly/3NJB534 for more information on how this value is
+                      calculated.
+
+                      If the bootstrap provider is anything else then this field is set to the
+                      value of the infrastructure VM's "guest.ipAddress" field. Please see
+                      https://bit.ly/3Au0jM4 for more information.
+                    type: string
+                type: object
+              nodeName:
+                description: |-
+                  NodeName describes the observed name of the node where the VirtualMachine
+                  is scheduled.
+                type: string
+              policies:
+                description: Policies describes the observed policies applied to this
+                  VM.
+                items:
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an
+                        object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    generation:
+                      description: |-
+                        Generation describes the observed generation of the policy applied to
+                        this VM.
+                      format: int64
+                      type: integer
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object
+                        represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name refers to a unique resource in the current namespace.
+                        More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                      type: string
+                  required:
+                  - apiVersion
+                  - generation
+                  - kind
+                  - name
+                  type: object
+                type: array
+              powerState:
+                description: PowerState describes the observed power state of the
+                  VirtualMachine.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              rootSnapshots:
+                description: |-
+                  RootSnapshots represents the observed list of root snapshots of
+                  a VM. Since each snapshot includes the list of its child
+                  snapshots, these root snapshot references can effectively be
+                  used to construct the entire snapshot chain of a virtual
+                  machine.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the snapshot resource.  This field is only set
+                        for managed snapshots.
+                      type: string
+                    type:
+                      default: Managed
+                      description: |-
+                        Type describes the type of the snapshot reference.
+
+                        Possible values are: Managed, Unmanaged
+                      enum:
+                      - Managed
+                      - Unmanaged
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              storage:
+                description: Storage describes the observed state of the VirtualMachine's
+                  storage.
+                properties:
+                  requested:
+                    description: |-
+                      Requested describes the observed amount of storage requested by a
+                      VirtualMachine.
+                    properties:
+                      disks:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Disks describes the total storage space requested by a VirtualMachine's
+                          disks.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  total:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Total describes the total storage space used by a VirtualMachine that
+                      counts against the Namespace's storage quota.
+                      This value is a sum of requested.disks + used.other.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  usage:
+                    description: Used describes the observed amount of storage used
+                      by a VirtualMachine.
+                    properties:
+                      disks:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Disks describes the total storage space used by a VirtualMachine's
+                          disks.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      other:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Other describes the total storage space used by the VirtualMachine's
+                          non disk files, ex. the configuration file, swap space, logs, etc.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      snapshots:
+                        description: |-
+                          Snapshots describes the total storage space used by a VirtualMachine's
+                          snapshots.
+                        properties:
+                          vm:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              VM describes the total storage space used by the VirtualMachine's
+                              VirtualMachineSnapshot, including the space for snapshot's metadata,
+                              memory file, delta disks, etc.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          volume:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Volume describes the total storage space used by the VirtualMachine's
+                              VolumeSnapshot, including the space for first class disk(FCD)'s
+                              delta disks.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              uniqueID:
+                description: |-
+                  UniqueID describes a unique identifier that is provided by the underlying
+                  infrastructure provider, such as vSphere.
+                type: string
+              volumes:
+                description: |-
+                  Volumes describes the observed state of the volumes that are intended to
+                  be attached to the VirtualMachine.
+                items:
+                  description: |-
+                    VirtualMachineVolumeStatus defines the observed state of a
+                    VirtualMachineVolume instance.
+                  properties:
+                    attached:
+                      description: |-
+                        Attached represents whether a volume has been successfully attached to
+                        the VirtualMachine or not.
+                      type: boolean
+                    controllerBusNumber:
+                      description: ControllerBusNumber describes volume's observed
+                        controller's bus number.
+                      format: int32
+                      type: integer
+                    controllerType:
+                      description: ControllerType describes volume's observed controller's
+                        type.
+                      enum:
+                      - IDE
+                      - NVME
+                      - SCSI
+                      - SATA
+                      type: string
+                    crypto:
+                      description: Crypto describes the volume's encryption status.
+                      properties:
+                        keyID:
+                          description: |-
+                            KeyID describes the key ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                        providerID:
+                          description: |-
+                            ProviderID describes the provider ID used to encrypt the volume.
+                            Please note, this field will be empty if the volume is not
+                            encrypted.
+                          type: string
+                      type: object
+                    diskMode:
+                      description: DiskMode describes the volume's observed disk mode.
+                      enum:
+                      - IndependentNonPersistent
+                      - IndependentPersistent
+                      - NonPersistent
+                      - Persistent
+                      - Dependent
+                      type: string
+                    diskUUID:
+                      description: |-
+                        DiskUUID represents the underlying virtual disk UUID and is present when
+                        attachment succeeds.
+                      type: string
+                    error:
+                      description: |-
+                        Error represents the last error seen when attaching or detaching a
+                        volume.  Error will be empty if attachment succeeds.
+                      type: string
+                    limit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Limit describes the maximum, requested capacity
+                        of the volume.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the name of the attached volume.
+                      type: string
+                    requested:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Requested describes the minimum, requested capacity of the volume.
+
+                        Please note, this value is used when calculating a VM's impact to a
+                        namespace's storage quota.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    sharingMode:
+                      description: SharingMode describes the volume's observed sharing
+                        mode.
+                      enum:
+                      - MultiWriter
+                      - None
+                      type: string
+                    type:
+                      default: Managed
+                      description: Type is the type of the attached volume.
+                      enum:
+                      - Classic
+                      - Managed
+                      type: string
+                    used:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Used describes the observed, non-shared size of the volume on disk.
+
+                        For example, if this is a linked-clone's boot volume, this value
+                        represents the space consumed by the linked clone, not the parent.
+
+                        Another example is when a volume is thin-provisioned. The volume's
+                        capacity may be 20Gi, but the actual usage on disk may only be a few
+                        hundred mebibytes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - type
+                x-kubernetes-list-type: map
+              zone:
+                description: |-
+                  Zone describes the availability zone where the VirtualMachine has been
+                  scheduled.
 
                   Please note this field may be empty when the cluster is not zone-aware.
                 type: string

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachineservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachineservices.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -23,6 +23,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -241,6 +242,519 @@ spec:
                 description: |-
                   Only applies to VirtualMachineService Type: LoadBalancer
                   LoadBalancer will get created with the IP specified in this field.
+                  This feature depends on whether the underlying load balancer provider
+                  supports specifying the loadBalancerIP when a load balancer is created.
+                  This field will be ignored if the provider does not support the feature.
+                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                  Using it is non-portable and it may not support dual-stack.
+                  Users are encouraged to use implementation-specific annotations when available.
+                type: string
+              loadBalancerSourceRanges:
+                description: |-
+                  LoadBalancerSourceRanges is an array of IP addresses in the format of
+                  CIDRs, for example: 103.21.244.0/22 and 10.0.0.0/24.
+                  If specified and supported by the load balancer provider, this will
+                  restrict ingress traffic to the specified client IPs. This field will be
+                  ignored if the provider does not support the feature.
+                items:
+                  type: string
+                type: array
+              ports:
+                description: |-
+                  Ports specifies a list of VirtualMachineServicePort to expose with this
+                  VirtualMachineService. Each of these ports will be an accessible network
+                  entry point to access this service by.
+                items:
+                  description: |-
+                    VirtualMachineServicePort describes the specification of a service port to
+                    be exposed by a VirtualMachineService. This VirtualMachineServicePort
+                    specification includes attributes that define the external and internal
+                    representation of the service port.
+                  properties:
+                    name:
+                      description: |-
+                        Name describes the name to be used to identify this
+                        VirtualMachineServicePort.
+                      type: string
+                    port:
+                      description: Port describes the external port that will be exposed
+                        by the service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol describes the Layer 4 transport protocol for this port.
+                        Supports "TCP", "UDP", and "SCTP".
+                      type: string
+                    targetPort:
+                      description: |-
+                        TargetPort describes the internal port open on a VirtualMachine that
+                        should be mapped to the external Port.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  - targetPort
+                  type: object
+                type: array
+              selector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Selector specifies a map of key-value pairs, also known as a Label
+                  Selector, that is used to match this VirtualMachineService with the set
+                  of VirtualMachines that should back this VirtualMachineService.
+                type: object
+              type:
+                description: |-
+                  Type specifies a desired VirtualMachineServiceType for this
+                  VirtualMachineService. Supported types are ClusterIP, LoadBalancer,
+                  ExternalName.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: |-
+              VirtualMachineServiceStatus defines the observed state of
+              VirtualMachineService.
+            properties:
+              loadBalancer:
+                description: |-
+                  LoadBalancer contains the current status of the load balancer,
+                  if one is present.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress addresses for the load balancer.
+                      Traffic intended for the service should be sent to any of these ingress
+                      points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                        IP or Hostname may both be set in this structure. It is up to the consumer to
+                        determine which field should be used when accessing this LoadBalancer.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load balancer ingress points that are specified by a
+                            DNS address.
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load balancer ingress points that are specified by an IP
+                            address.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineService is the Schema for the virtualmachineservices
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
+            properties:
+              clusterIp:
+                description: |-
+                  ClusterIP is the IP address of the service and is usually assigned
+                  randomly by the master. If an address is specified manually and is not in
+                  use by others, it will be allocated to the service; otherwise, creation
+                  of the service will fail. This field can not be changed through updates.
+                  Valid values are "None", empty string (""), or a valid IP address. "None"
+                  can be specified for headless services when proxying is not required.
+                  Only applies to types ClusterIP and LoadBalancer.
+                  Ignored if type is ExternalName.
+                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                type: string
+              externalName:
+                description: |-
+                  ExternalName is the external reference that kubedns or equivalent will
+                  return as a CNAME record for this service. No proxying will be involved.
+                  Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                  and requires Type to be ExternalName.
+                type: string
+              loadBalancerIP:
+                description: |-
+                  LoadBalancer will get created with the IP specified in this field.
+                  Only applies to VirtualMachineService Type: LoadBalancer
+                  This feature depends on whether the underlying load balancer provider
+                  supports specifying the loadBalancerIP when a load balancer is created.
+                  This field will be ignored if the provider does not support the feature.
+                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                  Using it is non-portable and it may not support dual-stack.
+                  Users are encouraged to use implementation-specific annotations when available.
+                type: string
+              loadBalancerSourceRanges:
+                description: |-
+                  LoadBalancerSourceRanges is an array of IP addresses in the format of
+                  CIDRs, for example: 103.21.244.0/22 and 10.0.0.0/24.
+                  If specified and supported by the load balancer provider, this will
+                  restrict ingress traffic to the specified client IPs. This field will be
+                  ignored if the provider does not support the feature.
+                items:
+                  type: string
+                type: array
+              ports:
+                description: |-
+                  Ports specifies a list of VirtualMachineServicePort to expose with this
+                  VirtualMachineService. Each of these ports will be an accessible network
+                  entry point to access this service by.
+                items:
+                  description: |-
+                    VirtualMachineServicePort describes the specification of a service port to
+                    be exposed by a VirtualMachineService. This VirtualMachineServicePort
+                    specification includes attributes that define the external and internal
+                    representation of the service port.
+                  properties:
+                    name:
+                      description: |-
+                        Name describes the name to be used to identify this
+                        VirtualMachineServicePort.
+                      type: string
+                    port:
+                      description: Port describes the external port that will be exposed
+                        by the service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol describes the Layer 4 transport protocol for this port.
+                        Supports "TCP", "UDP", and "SCTP".
+                      type: string
+                    targetPort:
+                      description: |-
+                        TargetPort describes the internal port open on a VirtualMachine that
+                        should be mapped to the external Port.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  - targetPort
+                  type: object
+                type: array
+              selector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Selector specifies a map of key-value pairs, also known as a Label
+                  Selector, that is used to match this VirtualMachineService with the set
+                  of VirtualMachines that should back this VirtualMachineService.
+                type: object
+              type:
+                description: |-
+                  Type specifies a desired VirtualMachineServiceType for this
+                  VirtualMachineService. Supported types are ClusterIP, LoadBalancer,
+                  ExternalName.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: |-
+              VirtualMachineServiceStatus defines the observed state of
+              VirtualMachineService.
+            properties:
+              loadBalancer:
+                description: |-
+                  LoadBalancer contains the current status of the load balancer,
+                  if one is present.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress addresses for the load balancer.
+                      Traffic intended for the service should be sent to any of these ingress
+                      points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                        IP or Hostname may both be set in this structure. It is up to the consumer to
+                        determine which field should be used when accessing this LoadBalancer.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load balancer ingress points that are specified by a
+                            DNS address.
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load balancer ingress points that are specified by an IP
+                            address.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineService is the Schema for the virtualmachineservices
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
+            properties:
+              clusterIp:
+                description: |-
+                  ClusterIP is the IP address of the service and is usually assigned
+                  randomly by the master. If an address is specified manually and is not in
+                  use by others, it will be allocated to the service; otherwise, creation
+                  of the service will fail. This field can not be changed through updates.
+                  Valid values are "None", empty string (""), or a valid IP address. "None"
+                  can be specified for headless services when proxying is not required.
+                  Only applies to types ClusterIP and LoadBalancer.
+                  Ignored if type is ExternalName.
+                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                type: string
+              externalName:
+                description: |-
+                  ExternalName is the external reference that kubedns or equivalent will
+                  return as a CNAME record for this service. No proxying will be involved.
+                  Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                  and requires Type to be ExternalName.
+                type: string
+              loadBalancerIP:
+                description: |-
+                  LoadBalancer will get created with the IP specified in this field.
+                  Only applies to VirtualMachineService Type: LoadBalancer
+                  This feature depends on whether the underlying load balancer provider
+                  supports specifying the loadBalancerIP when a load balancer is created.
+                  This field will be ignored if the provider does not support the feature.
+                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                  Using it is non-portable and it may not support dual-stack.
+                  Users are encouraged to use implementation-specific annotations when available.
+                type: string
+              loadBalancerSourceRanges:
+                description: |-
+                  LoadBalancerSourceRanges is an array of IP addresses in the format of
+                  CIDRs, for example: 103.21.244.0/22 and 10.0.0.0/24.
+                  If specified and supported by the load balancer provider, this will
+                  restrict ingress traffic to the specified client IPs. This field will be
+                  ignored if the provider does not support the feature.
+                items:
+                  type: string
+                type: array
+              ports:
+                description: |-
+                  Ports specifies a list of VirtualMachineServicePort to expose with this
+                  VirtualMachineService. Each of these ports will be an accessible network
+                  entry point to access this service by.
+                items:
+                  description: |-
+                    VirtualMachineServicePort describes the specification of a service port to
+                    be exposed by a VirtualMachineService. This VirtualMachineServicePort
+                    specification includes attributes that define the external and internal
+                    representation of the service port.
+                  properties:
+                    name:
+                      description: |-
+                        Name describes the name to be used to identify this
+                        VirtualMachineServicePort.
+                      type: string
+                    port:
+                      description: Port describes the external port that will be exposed
+                        by the service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol describes the Layer 4 transport protocol for this port.
+                        Supports "TCP", "UDP", and "SCTP".
+                      type: string
+                    targetPort:
+                      description: |-
+                        TargetPort describes the internal port open on a VirtualMachine that
+                        should be mapped to the external Port.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  - targetPort
+                  type: object
+                type: array
+              selector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Selector specifies a map of key-value pairs, also known as a Label
+                  Selector, that is used to match this VirtualMachineService with the set
+                  of VirtualMachines that should back this VirtualMachineService.
+                type: object
+              type:
+                description: |-
+                  Type specifies a desired VirtualMachineServiceType for this
+                  VirtualMachineService. Supported types are ClusterIP, LoadBalancer,
+                  ExternalName.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: |-
+              VirtualMachineServiceStatus defines the observed state of
+              VirtualMachineService.
+            properties:
+              loadBalancer:
+                description: |-
+                  LoadBalancer contains the current status of the load balancer,
+                  if one is present.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress addresses for the load balancer.
+                      Traffic intended for the service should be sent to any of these ingress
+                      points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                        IP or Hostname may both be set in this structure. It is up to the consumer to
+                        determine which field should be used when accessing this LoadBalancer.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load balancer ingress points that are specified by a
+                            DNS address.
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load balancer ingress points that are specified by an IP
+                            address.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineService is the Schema for the virtualmachineservices
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineServiceSpec defines the desired state of VirtualMachineService.
+            properties:
+              clusterIp:
+                description: |-
+                  ClusterIP is the IP address of the service and is usually assigned
+                  randomly by the master. If an address is specified manually and is not in
+                  use by others, it will be allocated to the service; otherwise, creation
+                  of the service will fail. This field can not be changed through updates.
+                  Valid values are "None", empty string (""), or a valid IP address. "None"
+                  can be specified for headless services when proxying is not required.
+                  Only applies to types ClusterIP and LoadBalancer.
+                  Ignored if type is ExternalName.
+                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                type: string
+              externalName:
+                description: |-
+                  ExternalName is the external reference that kubedns or equivalent will
+                  return as a CNAME record for this service. No proxying will be involved.
+                  Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                  and requires Type to be ExternalName.
+                type: string
+              loadBalancerIP:
+                description: |-
+                  LoadBalancer will get created with the IP specified in this field.
+                  Only applies to VirtualMachineService Type: LoadBalancer
                   This feature depends on whether the underlying load balancer provider
                   supports specifying the loadBalancerIP when a load balancer is created.
                   This field will be ignored if the provider does not support the feature.

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachinesetresourcepolicies.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -14,7 +14,8 @@ spec:
     singular: virtualmachinesetresourcepolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
@@ -124,6 +125,18 @@ spec:
                   - moduleUUID
                   type: object
                 type: array
+              resourcePools:
+                items:
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
+                  type: object
+                type: array
             type: object
         type: object
     served: true
@@ -230,6 +243,390 @@ spec:
                   - clusterMoID
                   - groupName
                   - moduleUUID
+                  type: object
+                type: array
+              resourcePools:
+                items:
+                  description: |-
+                    ResourcePoolStatus describes the observed state of a vSphere child
+                    resource pool created for the Spec.ResourcePool.Name.
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineSetResourcePolicySpec defines the desired state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clusterModuleGroups:
+                items:
+                  type: string
+                type: array
+              folder:
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePoolSpec defines a Logical Grouping of workloads that share resource
+                  policies.
+                properties:
+                  limits:
+                    description: Limits describes the limit to resources available
+                      to the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  name:
+                    description: Name describes the name of the ResourcePool grouping.
+                    type: string
+                  reservations:
+                    description: |-
+                      Reservations describes the guaranteed resources reserved for the
+                      ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineSetResourcePolicyStatus defines the observed state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clustermodules:
+                items:
+                  description: |-
+                    VSphereClusterModuleStatus describes the observed state of a vSphere
+                    cluster module.
+                  properties:
+                    clusterMoID:
+                      type: string
+                    groupName:
+                      type: string
+                    moduleUUID:
+                      type: string
+                  required:
+                  - clusterMoID
+                  - groupName
+                  - moduleUUID
+                  type: object
+                type: array
+              resourcePools:
+                items:
+                  description: |-
+                    ResourcePoolStatus describes the observed state of a vSphere child
+                    resource pool created for the Spec.ResourcePool.Name.
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineSetResourcePolicySpec defines the desired state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clusterModuleGroups:
+                items:
+                  type: string
+                type: array
+              folder:
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePoolSpec defines a Logical Grouping of workloads that share resource
+                  policies.
+                properties:
+                  limits:
+                    description: Limits describes the limit to resources available
+                      to the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  name:
+                    description: Name describes the name of the ResourcePool grouping.
+                    type: string
+                  reservations:
+                    description: |-
+                      Reservations describes the guaranteed resources reserved for the
+                      ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineSetResourcePolicyStatus defines the observed state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clustermodules:
+                items:
+                  description: |-
+                    VSphereClusterModuleStatus describes the observed state of a vSphere
+                    cluster module.
+                  properties:
+                    clusterMoID:
+                      type: string
+                    groupName:
+                      type: string
+                    moduleUUID:
+                      type: string
+                  required:
+                  - clusterMoID
+                  - groupName
+                  - moduleUUID
+                  type: object
+                type: array
+              resourcePools:
+                items:
+                  description: |-
+                    ResourcePoolStatus describes the observed state of a vSphere child
+                    resource pool created for the Spec.ResourcePool.Name.
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSetResourcePolicy is the Schema for the virtualmachinesetresourcepolicies
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineSetResourcePolicySpec defines the desired state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clusterModuleGroups:
+                items:
+                  type: string
+                type: array
+              folder:
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePoolSpec defines a Logical Grouping of workloads that share resource
+                  policies.
+                properties:
+                  limits:
+                    description: Limits describes the limit to resources available
+                      to the ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  name:
+                    description: Name describes the name of the ResourcePool grouping.
+                    type: string
+                  reservations:
+                    description: |-
+                      Reservations describes the guaranteed resources reserved for the
+                      ResourcePool.
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              VirtualMachineSetResourcePolicyStatus defines the observed state of
+              VirtualMachineSetResourcePolicy.
+            properties:
+              clustermodules:
+                items:
+                  description: |-
+                    VSphereClusterModuleStatus describes the observed state of a vSphere
+                    cluster module.
+                  properties:
+                    clusterMoID:
+                      type: string
+                    groupName:
+                      type: string
+                    moduleUUID:
+                      type: string
+                  required:
+                  - clusterMoID
+                  - groupName
+                  - moduleUUID
+                  type: object
+                type: array
+              resourcePools:
+                items:
+                  description: |-
+                    ResourcePoolStatus describes the observed state of a vSphere child
+                    resource pool created for the Spec.ResourcePool.Name.
+                  properties:
+                    childResourcePoolMoID:
+                      type: string
+                    clusterMoID:
+                      type: string
+                  required:
+                  - childResourcePoolMoID
+                  - clusterMoID
                   type: object
                 type: array
             type: object

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesnapshots.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinesnapshots.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: virtualmachinesnapshots.vmoperator.vmware.com
+spec:
+  group: vmoperator.vmware.com
+  names:
+    kind: VirtualMachineSnapshot
+    listKind: VirtualMachineSnapshotList
+    plural: virtualmachinesnapshots
+    shortNames:
+    - vmsnapshot
+    singular: virtualmachinesnapshot
+  scope: Namespaced
+  versions:
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineSnapshot is the schema for the virtualmachinesnapshot
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSnapshotSpec defines the desired state of VirtualMachineSnapshot.
+            properties:
+              description:
+                description: Description represents a description of the snapshot.
+                type: string
+              memory:
+                description: |-
+                  Memory represents whether the snapshot includes the VM's
+                  memory. If true, a dump of the internal state of the virtual
+                  machine (a memory dump) is included in the snapshot. Memory
+                  snapshots consume time and resources and thus, take longer to
+                  create.
+                  The virtual machine must support this capability.
+                  When set to false, the power state of the snapshot is set to
+                  false.
+                  For a VM in suspended state, memory is always included
+                  in the snashot.
+                type: boolean
+              quiesce:
+                description: |-
+                  Quiesce represents the spec used for granular control over
+                  quiesce details. If quiesceSpec is set and the virtual machine
+                  is powered on when the snapshot is taken, VMware Tools is used
+                  to quiesce the file system in the virtual machine. This assures
+                  that a disk snapshot represents a consistent state of the guest
+                  file systems. If the virtual machine is powered off or VMware
+                  Tools are not available, the quiesce spec is ignored.
+                properties:
+                  timeout:
+                    description: |-
+                      Timeout represents the maximum time in minutes for snapshot
+                      operation to be performed on the virtual machine. The timeout
+                      can not be less than 5 minutes or more than 240 minutes.
+                    type: string
+                type: object
+              vmName:
+                description: |-
+                  VMName represents the name of the virtual machine for which the
+                  snapshot is requested.
+                type: string
+            type: object
+          status:
+            description: VirtualMachineSnapshotStatus defines the observed state of
+              VirtualMachineSnapshot.
+            properties:
+              children:
+                description: |-
+                  Children represents the snapshots for which this snapshot is
+                  the parent.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the snapshot resource.  This field is only set
+                        for managed snapshots.
+                      type: string
+                    type:
+                      default: Managed
+                      description: |-
+                        Type describes the type of the snapshot reference.
+
+                        Possible values are: Managed, Unmanaged
+                      enum:
+                      - Managed
+                      - Unmanaged
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions describes the observed conditions of the VirtualMachine.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              powerState:
+                description: |-
+                  PowerState represents the observed power state of the virtual
+                  machine when the snapshot was taken.
+                enum:
+                - PoweredOff
+                - PoweredOn
+                - Suspended
+                type: string
+              quiesced:
+                description: |-
+                  Quiesced represents whether or not the snapshot was created
+                  with the quiesce option to ensure a snapshot with a consistent
+                  state of the guest file system.
+                type: boolean
+              storage:
+                description: |-
+                  Storage describes the observed amount of storage used by a
+                  VirtualMachineSnapshot, including the space for FCDs.
+                properties:
+                  requested:
+                    description: |-
+                      Requested describes the observed amount of storage requested by a
+                      VirtualMachineSnapshot. It's a list of requested storage for each
+                      storage class.
+                      Since a snapshot can have multiple PVCs, it can point to multiple storage
+                      classes.
+                    items:
+                      description: |-
+                        VirtualMachineSnapshotStorageStatusRequested describes the observed amount of
+                        storage requested by a VirtualMachineSnapshot for a storage class.
+                      properties:
+                        storageClass:
+                          description: StorageClass is the name of the storage class.
+                          type: string
+                        total:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Total describes the total storage space requested by a
+                            VirtualMachineSnapshot for the storage class.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - storageClass
+                      - total
+                      type: object
+                    type: array
+                  used:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Used describes the observed amount of storage used by a
+                      VirtualMachineSnapshot, except the space for FCDs.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              uniqueID:
+                description: |-
+                  UniqueID describes a unique identifier provider by the backing
+                  infrastructure (e.g., vSphere) that can be used to distinguish
+                  this snapshot from other snapshots of this virtual machine.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: virtualmachinewebconsolerequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -71,20 +71,16 @@ spec:
                   ProxyAddr describes the host address and optional port used to access
                   the VM's web console.
 
-
                   The value could be a DNS entry, IPv4, or IPv6 address, followed by an
                   optional port. For example, valid values include:
-
 
                       DNS
                           * host.com
                           * host.com:6443
 
-
                       IPv4
                           * 1.2.3.4
                           * 1.2.3.4:6443
-
 
                       IPv6
                           * 1234:1234:1234:1234:1234:1234:1234:1234
@@ -93,6 +89,272 @@ spec:
                           * 1234:1234:1234::::1234:1234
                           * [1234:1234:1234::::1234:1234]:6443
 
+                  In other words, the field may be set to any value that is parsable
+                  by Go's https://pkg.go.dev/net#ResolveIPAddr and
+                  https://pkg.go.dev/net#ParseIP functions.
+                type: string
+              response:
+                description: Response will be the authenticated ticket corresponding
+                  to this web console request.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineWebConsoleRequest allows the creation of a one-time, web
+          console connection to a VM.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineWebConsoleRequestSpec describes the desired state for a web
+              console request to a VM.
+            properties:
+              name:
+                description: |-
+                  Name is the name of a VM in the same Namespace as this web console
+                  request.
+                type: string
+              publicKey:
+                description: PublicKey is used to encrypt the status.response. This
+                  is expected to be a RSA OAEP public key in X.509 PEM format.
+                type: string
+            required:
+            - name
+            - publicKey
+            type: object
+          status:
+            description: |-
+              VirtualMachineWebConsoleRequestStatus describes the observed state of the
+              request.
+            properties:
+              expiryTime:
+                description: ExpiryTime is the time at which access via this request
+                  will expire.
+                format: date-time
+                type: string
+              proxyAddr:
+                description: |-
+                  ProxyAddr describes the host address and optional port used to access
+                  the VM's web console.
+
+                  The value could be a DNS entry, IPv4, or IPv6 address, followed by an
+                  optional port. For example, valid values include:
+
+                      DNS
+                          * host.com
+                          * host.com:6443
+
+                      IPv4
+                          * 1.2.3.4
+                          * 1.2.3.4:6443
+
+                      IPv6
+                          * 1234:1234:1234:1234:1234:1234:1234:1234
+                          * [1234:1234:1234:1234:1234:1234:1234:1234]:6443
+                          * 1234:1234:1234:0000:0000:0000:1234:1234
+                          * 1234:1234:1234::::1234:1234
+                          * [1234:1234:1234::::1234:1234]:6443
+
+                  In other words, the field may be set to any value that is parsable
+                  by Go's https://pkg.go.dev/net#ResolveIPAddr and
+                  https://pkg.go.dev/net#ParseIP functions.
+                type: string
+              response:
+                description: Response will be the authenticated ticket corresponding
+                  to this web console request.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineWebConsoleRequest allows the creation of a one-time, web
+          console connection to a VM.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineWebConsoleRequestSpec describes the desired state for a web
+              console request to a VM.
+            properties:
+              name:
+                description: |-
+                  Name is the name of a VM in the same Namespace as this web console
+                  request.
+                type: string
+              publicKey:
+                description: PublicKey is used to encrypt the status.response. This
+                  is expected to be a RSA OAEP public key in X.509 PEM format.
+                type: string
+            required:
+            - name
+            - publicKey
+            type: object
+          status:
+            description: |-
+              VirtualMachineWebConsoleRequestStatus describes the observed state of the
+              request.
+            properties:
+              expiryTime:
+                description: ExpiryTime is the time at which access via this request
+                  will expire.
+                format: date-time
+                type: string
+              proxyAddr:
+                description: |-
+                  ProxyAddr describes the host address and optional port used to access
+                  the VM's web console.
+
+                  The value could be a DNS entry, IPv4, or IPv6 address, followed by an
+                  optional port. For example, valid values include:
+
+                      DNS
+                          * host.com
+                          * host.com:6443
+
+                      IPv4
+                          * 1.2.3.4
+                          * 1.2.3.4:6443
+
+                      IPv6
+                          * 1234:1234:1234:1234:1234:1234:1234:1234
+                          * [1234:1234:1234:1234:1234:1234:1234:1234]:6443
+                          * 1234:1234:1234:0000:0000:0000:1234:1234
+                          * 1234:1234:1234::::1234:1234
+                          * [1234:1234:1234::::1234:1234]:6443
+
+                  In other words, the field may be set to any value that is parsable
+                  by Go's https://pkg.go.dev/net#ResolveIPAddr and
+                  https://pkg.go.dev/net#ParseIP functions.
+                type: string
+              response:
+                description: Response will be the authenticated ticket corresponding
+                  to this web console request.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha5
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VirtualMachineWebConsoleRequest allows the creation of a one-time, web
+          console connection to a VM.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              VirtualMachineWebConsoleRequestSpec describes the desired state for a web
+              console request to a VM.
+            properties:
+              name:
+                description: |-
+                  Name is the name of a VM in the same Namespace as this web console
+                  request.
+                type: string
+              publicKey:
+                description: PublicKey is used to encrypt the status.response. This
+                  is expected to be a RSA OAEP public key in X.509 PEM format.
+                type: string
+            required:
+            - name
+            - publicKey
+            type: object
+          status:
+            description: |-
+              VirtualMachineWebConsoleRequestStatus describes the observed state of the
+              request.
+            properties:
+              expiryTime:
+                description: ExpiryTime is the time at which access via this request
+                  will expire.
+                format: date-time
+                type: string
+              proxyAddr:
+                description: |-
+                  ProxyAddr describes the host address and optional port used to access
+                  the VM's web console.
+
+                  The value could be a DNS entry, IPv4, or IPv6 address, followed by an
+                  optional port. For example, valid values include:
+
+                      DNS
+                          * host.com
+                          * host.com:6443
+
+                      IPv4
+                          * 1.2.3.4
+                          * 1.2.3.4:6443
+
+                      IPv6
+                          * 1234:1234:1234:1234:1234:1234:1234:1234
+                          * [1234:1234:1234:1234:1234:1234:1234:1234]:6443
+                          * 1234:1234:1234:0000:0000:0000:1234:1234
+                          * 1234:1234:1234::::1234:1234
+                          * [1234:1234:1234::::1234:1234]:6443
 
                   In other words, the field may be set to any value that is parsable
                   by Go's https://pkg.go.dev/net#ResolveIPAddr and

--- a/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
+++ b/config/deployments/integration-tests/crds/vmoperator.vmware.com_webconsolerequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: webconsolerequests.vmoperator.vmware.com
 spec:
   group: vmoperator.vmware.com
@@ -14,7 +14,10 @@ spec:
     singular: webconsolerequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: This API has been deprecated and is unsupported in future
+      versions
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: WebConsoleRequest allows the creation of a one-time web console
@@ -69,16 +72,13 @@ spec:
                   The value could be a DNS entry, IPv4, or IPv6 address, followed by an
                   optional port. For example, valid values include:
 
-
                       DNS
                           * host.com
                           * host.com:6443
 
-
                       IPv4
                           * 1.2.3.4
                           * 1.2.3.4:6443
-
 
                       IPv6
                           * 1234:1234:1234:1234:1234:1234:1234:1234
@@ -86,7 +86,6 @@ spec:
                           * 1234:1234:1234:0000:0000:0000:1234:1234
                           * 1234:1234:1234::::1234:1234
                           * [1234:1234:1234::::1234:1234]:6443
-
 
                   In other words, the field may be set to any value that is parsable
                   by Go's https://pkg.go.dev/net#ResolveIPAddr and

--- a/config/deployments/integration-tests/kustomization.yaml
+++ b/config/deployments/integration-tests/kustomization.yaml
@@ -8,10 +8,16 @@ resources:
 - ./crds/vmoperator.vmware.com_contentsources.yaml
 - ./crds/vmoperator.vmware.com_virtualmachineclassbindings.yaml
 - ./crds/vmoperator.vmware.com_virtualmachineclasses.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineclassinstances.yaml
+- ./crds/vmoperator.vmware.com_virtualmachinegrouppublishrequests.yaml
+- ./crds/vmoperator.vmware.com_virtualmachinegroups.yaml
+- ./crds/vmoperator.vmware.com_virtualmachineimagecaches.yaml
 - ./crds/vmoperator.vmware.com_virtualmachineimages.yaml
 - ./crds/vmoperator.vmware.com_virtualmachinepublishrequests.yaml
+- ./crds/vmoperator.vmware.com_virtualmachinereplicasets.yaml
 - ./crds/vmoperator.vmware.com_virtualmachines.yaml
 - ./crds/vmoperator.vmware.com_virtualmachineservices.yaml
 - ./crds/vmoperator.vmware.com_virtualmachinesetresourcepolicies.yaml
+- ./crds/vmoperator.vmware.com_virtualmachinesnapshots.yaml
 - ./crds/vmoperator.vmware.com_virtualmachinewebconsolerequests.yaml
 - ./crds/vmoperator.vmware.com_webconsolerequests.yaml

--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -75,7 +75,7 @@ func setup(ctx context.Context) (*helpers.TestEnvironment, clustercache.ClusterC
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmoprvhub.AddToScheme(scheme.Scheme))
-	utilruntime.Must(vmoprv1alpha2.AddToScheme(scheme.Scheme))
+	utilruntime.Must(vmoprv1alpha5.AddToScheme(scheme.Scheme))
 	utilruntime.Must(topologyv1.AddToScheme(scheme.Scheme))
 
 	testEnv := helpers.NewTestEnvironment(ctx)

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -26,7 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -494,7 +494,7 @@ var _ = Describe("Reconciliation tests", func() {
 			By("Expect a ResourcePolicy to exist")
 			rpKey := client.ObjectKey{Namespace: infraCluster.GetNamespace(), Name: infraCluster.GetName()}
 			// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-			resourcePolicy := &vmoprv1alpha2.VirtualMachineSetResourcePolicy{}
+			resourcePolicy := &vmoprv1alpha5.VirtualMachineSetResourcePolicy{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, rpKey, resourcePolicy)
 			}, time.Second*30).Should(Succeed())
@@ -663,7 +663,7 @@ var _ = Describe("Reconciliation tests", func() {
 
 			By("Expect the VM to have been successfully created")
 			// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-			newVM := &vmoprv1alpha2.VirtualMachine{}
+			newVM := &vmoprv1alpha5.VirtualMachine{}
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, machineKey, newVM)).Should(Succeed())
 			}, time.Second*10).Should(Succeed())
@@ -675,9 +675,9 @@ var _ = Describe("Reconciliation tests", func() {
 					return err
 				}
 				// These two lines must be initialized as requirements of having valid Status
-				newVM.Status.Volumes = []vmoprv1alpha2.VirtualMachineVolumeStatus{}
+				newVM.Status.Volumes = []vmoprv1alpha5.VirtualMachineVolumeStatus{}
 				newVM.Status.Conditions = append(newVM.Status.Conditions, metav1.Condition{
-					Type:               vmoprv1alpha2.VirtualMachineConditionCreated,
+					Type:               vmoprv1alpha5.VirtualMachineConditionCreated,
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
 					Reason:             string(metav1.ConditionTrue),
@@ -694,7 +694,7 @@ var _ = Describe("Reconciliation tests", func() {
 				if err != nil {
 					return err
 				}
-				newVM.Status.PowerState = vmoprv1alpha2.VirtualMachinePowerStateOn
+				newVM.Status.PowerState = vmoprv1alpha5.VirtualMachinePowerStateOn
 				return k8sClient.Status().Update(ctx, newVM)
 			}, time.Second*30).Should(Succeed())
 
@@ -708,11 +708,11 @@ var _ = Describe("Reconciliation tests", func() {
 					return err
 				}
 				if newVM.Status.Network == nil {
-					newVM.Status.Network = &vmoprv1alpha2.VirtualMachineNetworkStatus{}
+					newVM.Status.Network = &vmoprv1alpha5.VirtualMachineNetworkStatus{}
 				}
 				newVM.Status.Network.PrimaryIP4 = "1.2.3.4"
 				newVM.Status.BiosUUID = "test-bios-uuid"
-				newVM.Status.Host = "some-esxi-host"
+				newVM.Status.NodeName = "some-esxi-host"
 				return k8sClient.Status().Update(ctx, newVM)
 			}, time.Second*30).Should(Succeed())
 

--- a/controllers/vmware/virtualmachinegroup_reconciler_test.go
+++ b/controllers/vmware/virtualmachinegroup_reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -888,7 +888,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 		mds             []clusterv1.MachineDeployment
 		vSphereMachines []vmwarev1.VSphereMachine
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-		existingVMG *vmoprv1alpha2.VirtualMachineGroup
+		existingVMG *vmoprv1alpha5.VirtualMachineGroup
 		wantResult  ctrl.Result
 		wantVMG     *vmoprvhub.VirtualMachineGroup
 	}{
@@ -982,7 +982,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
 				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -992,10 +992,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								{Name: "m3", Kind: "VirtualMachine"},
@@ -1046,7 +1046,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createVSphereMachine("m6", clusterInitialized.Name, "md3", "", withCustomNamingStrategy()), // new
 				*createVSphereMachine("m7", clusterInitialized.Name, "md4", "zone3"),                        // new
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -1056,10 +1056,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								{Name: "m3", Kind: "VirtualMachine"},
@@ -1115,7 +1115,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				// m6 deleted
 				// m7 deleted
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -1126,10 +1126,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								// "m4-vm" not added, placement decision for md1 not yet completed
@@ -1185,7 +1185,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
 				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -1196,10 +1196,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								{Name: "m3", Kind: "VirtualMachine"},
@@ -1251,7 +1251,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createVSphereMachine("m5", clusterInitialized.Name, "md2", "zone1"), // new
 				*createVSphereMachine("m6", clusterInitialized.Name, "md3", "zone2"), // new
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -1262,10 +1262,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								{Name: "m3", Kind: "VirtualMachine"},
@@ -1320,7 +1320,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				// m5 deleted
 				// m5 deleted
 			},
-			existingVMG: &vmoprv1alpha2.VirtualMachineGroup{
+			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: clusterInitialized.Namespace,
 					Name:      clusterInitialized.Name,
@@ -1332,10 +1332,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 					},
 					// Not setting labels and ownerReferences for sake of simplicity
 				},
-				Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-					BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+				Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+					BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 						{
-							Members: []vmoprv1alpha2.GroupMember{
+							Members: []vmoprv1alpha5.GroupMember{
 								{Name: "m1-vm", Kind: "VirtualMachine"},
 								{Name: "m2-vm", Kind: "VirtualMachine"},
 								{Name: "m3", Kind: "VirtualMachine"},

--- a/controllers/vmware/vspheremachinetemplate_controller_test.go
+++ b/controllers/vmware/vspheremachinetemplate_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ func Test_vSphereMachineTemplateReconciler_Reconcile(t *testing.T) {
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(vmwarev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(vmoprvhub.AddToScheme(scheme)).To(Succeed())
-	g.Expect(vmoprv1alpha2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(vmoprv1alpha5.AddToScheme(scheme)).To(Succeed())
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -87,7 +87,7 @@ func Test_vSphereMachineTemplateReconciler_Reconcile(t *testing.T) {
 			name:                   "VirtualMachineClass does exist and has cpu and memory set",
 			vSphereMachineTemplate: vSphereMachineTemplate(namespace.Name, "with-class", "vm-class", nil),
 			objects: []client.Object{
-				virtualMachineClass(namespace.Name, "vm-class", &vmoprv1alpha2.VirtualMachineClassHardware{Cpus: 1, Memory: quantity(1024)}),
+				virtualMachineClass(namespace.Name, "vm-class", &vmoprv1alpha5.VirtualMachineClassHardware{Cpus: 1, Memory: quantity(1024)}),
 			},
 			wantErr: "",
 			wantStatus: &vmwarev1.VSphereMachineTemplateStatus{
@@ -106,7 +106,7 @@ func Test_vSphereMachineTemplateReconciler_Reconcile(t *testing.T) {
 				},
 			}),
 			objects: []client.Object{
-				virtualMachineClass(namespace.Name, "vm-class", &vmoprv1alpha2.VirtualMachineClassHardware{Cpus: 2, Memory: quantity(2048)}),
+				virtualMachineClass(namespace.Name, "vm-class", &vmoprv1alpha5.VirtualMachineClassHardware{Cpus: 2, Memory: quantity(2048)}),
 			},
 			wantErr: "",
 			wantStatus: &vmwarev1.VSphereMachineTemplateStatus{
@@ -189,8 +189,8 @@ func vSphereMachineTemplate(namespace, name, className string, status *vmwarev1.
 	return tpl
 }
 
-func virtualMachineClass(namespace, name string, hardware *vmoprv1alpha2.VirtualMachineClassHardware) *vmoprv1alpha2.VirtualMachineClass {
-	class := &vmoprv1alpha2.VirtualMachineClass{
+func virtualMachineClass(namespace, name string, hardware *vmoprv1alpha5.VirtualMachineClassHardware) *vmoprv1alpha5.VirtualMachineClass {
+	class := &vmoprv1alpha5.VirtualMachineClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/pkg/errors"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	"github.com/vmware/govmomi/simulator"
 	"golang.org/x/tools/go/packages"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -90,7 +90,7 @@ func init() {
 	utilruntime.Must(admissionv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(infrav1.AddToScheme(scheme))
-	utilruntime.Must(vmoprv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(vmoprv1alpha5.AddToScheme(scheme))
 
 	// Get the root of the current file to use in CRD paths.
 	_, filename, _, ok := goruntime.Caller(0)

--- a/internal/test/helpers/vmware/unit_test_context.go
+++ b/internal/test/helpers/vmware/unit_test_context.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +43,7 @@ type UnitTestContextForController struct {
 	Key client.ObjectKey
 
 	// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-	VirtualMachineImage      *vmoprv1alpha2.VirtualMachineImage
+	VirtualMachineImage      *vmoprv1alpha5.VirtualMachineImage
 	ControllerManagerContext *capvcontext.ControllerManagerContext
 }
 
@@ -79,24 +79,24 @@ func CreatePrototypePrereqs(ctx context.Context, c client.Client) {
 	})
 }
 
-func FakeVirtualMachineClass() *vmoprv1alpha2.VirtualMachineClass {
+func FakeVirtualMachineClass() *vmoprv1alpha5.VirtualMachineClass {
 	// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-	return &vmoprv1alpha2.VirtualMachineClass{
+	return &vmoprv1alpha5.VirtualMachineClass{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-",
 		},
-		Spec: vmoprv1alpha2.VirtualMachineClassSpec{
-			Hardware: vmoprv1alpha2.VirtualMachineClassHardware{
+		Spec: vmoprv1alpha5.VirtualMachineClassSpec{
+			Hardware: vmoprv1alpha5.VirtualMachineClassHardware{
 				Cpus:   int64(2),
 				Memory: resource.MustParse("4Gi"),
 			},
-			Policies: vmoprv1alpha2.VirtualMachineClassPolicies{
-				Resources: vmoprv1alpha2.VirtualMachineClassResources{
-					Requests: vmoprv1alpha2.VirtualMachineResourceSpec{
+			Policies: vmoprv1alpha5.VirtualMachineClassPolicies{
+				Resources: vmoprv1alpha5.VirtualMachineClassResources{
+					Requests: vmoprv1alpha5.VirtualMachineResourceSpec{
 						Cpu:    resource.MustParse("2Gi"),
 						Memory: resource.MustParse("4Gi"),
 					},
-					Limits: vmoprv1alpha2.VirtualMachineResourceSpec{
+					Limits: vmoprv1alpha5.VirtualMachineResourceSpec{
 						Cpu:    resource.MustParse("2Gi"),
 						Memory: resource.MustParse("4Gi"),
 					},

--- a/pkg/context/fake/fake_controller_manager_context.go
+++ b/pkg/context/fake/fake_controller_manager_context.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fake
 
 import (
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -46,7 +46,7 @@ func NewControllerManagerContext(initObjects ...client.Object) *capvcontext.Cont
 	utilruntime.Must(infrav1.AddToScheme(scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme))
 	utilruntime.Must(vmoprvhub.AddToScheme(scheme))
-	utilruntime.Must(vmoprv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(vmoprv1alpha5.AddToScheme(scheme))
 	utilruntime.Must(ipamv1.AddToScheme(scheme))
 
 	clientWithObjects := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(

--- a/pkg/conversion/api/converter.go
+++ b/pkg/conversion/api/converter.go
@@ -18,7 +18,7 @@ limitations under the License.
 package api //nolint:revive
 
 import (
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion"
@@ -38,5 +38,5 @@ func init() {
 	utilruntime.Must(vmoprv1alpha5conversion.AddToConverter(DefaultConverter))
 
 	// TODO: Add dynamic selection of target version.
-	DefaultConverter.SetTargetVersion(vmoprv1alpha2.GroupVersion.Version)
+	DefaultConverter.SetTargetVersion(vmoprv1alpha5.GroupVersion.Version)
 }

--- a/pkg/services/vmoperator/control_plane_endpoint_test.go
+++ b/pkg/services/vmoperator/control_plane_endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,12 +77,12 @@ func updateVMServiceWithVIP(ctx context.Context, clusterCtx *vmware.ClusterConte
 	vmService := getVirtualMachineService(ctx, clusterCtx, c, cpService)
 
 	// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-	s := &vmoprv1alpha2.VirtualMachineService{}
+	s := &vmoprv1alpha5.VirtualMachineService{}
 	err := c.Get(ctx, ctrlclient.ObjectKeyFromObject(vmService), s)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	sOriginal := s.DeepCopy()
-	s.Status.LoadBalancer.Ingress = []vmoprv1alpha2.LoadBalancerIngress{{IP: vip}}
+	s.Status.LoadBalancer.Ingress = []vmoprv1alpha5.LoadBalancerIngress{{IP: vip}}
 
 	err = c.Status().Patch(ctx, s, ctrlclient.MergeFrom(sOriginal))
 	Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/services/vmoperator/resource_policy_test.go
+++ b/pkg/services/vmoperator/resource_policy_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	capi_util "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -47,7 +47,7 @@ func TestRPService(t *testing.T) {
 		g.Expect(name).To(Equal(clusterName))
 
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-		resourcePolicy := &vmoprv1alpha2.VirtualMachineSetResourcePolicy{}
+		resourcePolicy := &vmoprv1alpha5.VirtualMachineSetResourcePolicy{}
 		err = rpService.Client.Get(ctx, client.ObjectKey{
 			Namespace: clusterCtx.Cluster.Namespace,
 			Name:      clusterCtx.Cluster.Name,

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
-	vmoprv1alpha2common "github.com/vmware-tanzu/vm-operator/api/v1alpha2/common"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	vmoprv1alpha5common "github.com/vmware-tanzu/vm-operator/api/v1alpha5/common"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -50,9 +50,9 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
-func getReconciledVM(ctx context.Context, vmService VmopMachineService, supervisorMachineContext *vmware.SupervisorMachineContext) *vmoprv1alpha2.VirtualMachine {
+func getReconciledVM(ctx context.Context, vmService VmopMachineService, supervisorMachineContext *vmware.SupervisorMachineContext) *vmoprv1alpha5.VirtualMachine {
 	// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-	vm := &vmoprv1alpha2.VirtualMachine{}
+	vm := &vmoprv1alpha5.VirtualMachine{}
 	nsname := types.NamespacedName{
 		Namespace: supervisorMachineContext.Machine.Namespace,
 		Name:      supervisorMachineContext.Machine.Name,
@@ -65,12 +65,12 @@ func getReconciledVM(ctx context.Context, vmService VmopMachineService, supervis
 	return vm
 }
 
-func patchReconciledVMStatus(ctx context.Context, vmService VmopMachineService, vm, original *vmoprv1alpha2.VirtualMachine) {
+func patchReconciledVMStatus(ctx context.Context, vmService VmopMachineService, vm, original *vmoprv1alpha5.VirtualMachine) {
 	err := vmService.Client.Status().Patch(ctx, vm, client.MergeFrom(original))
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func verifyVMAffinityRules(vmopVM *vmoprv1alpha2.VirtualMachine, machineDeploymentName string) {
+func verifyVMAffinityRules(vmopVM *vmoprv1alpha5.VirtualMachine, machineDeploymentName string) {
 	Expect(vmopVM.Spec.Affinity.VMAffinity).ShouldNot(BeNil())
 	Expect(vmopVM.Spec.Affinity.VMAffinity.RequiredDuringSchedulingPreferredDuringExecution).To(HaveLen(1))
 
@@ -79,7 +79,7 @@ func verifyVMAffinityRules(vmopVM *vmoprv1alpha2.VirtualMachine, machineDeployme
 	Expect(vmAffinityTerm.TopologyKey).To(Equal(corev1.LabelTopologyZone))
 }
 
-func verifyVMAntiAffinityRules(vmopVM *vmoprv1alpha2.VirtualMachine, machineDeploymentName string, extraMDs ...string) {
+func verifyVMAntiAffinityRules(vmopVM *vmoprv1alpha5.VirtualMachine, machineDeploymentName string, extraMDs ...string) {
 	Expect(vmopVM.Spec.Affinity.VMAntiAffinity).ShouldNot(BeNil())
 
 	expectedNumAntiAffinityTerms := 1
@@ -178,7 +178,7 @@ var _ = Describe("VirtualMachine tests", func() {
 		supervisorMachineContext *vmware.SupervisorMachineContext
 
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-		vmopVM    *vmoprv1alpha2.VirtualMachine
+		vmopVM    *vmoprv1alpha5.VirtualMachine
 		vmService VmopMachineService
 	)
 
@@ -230,7 +230,7 @@ var _ = Describe("VirtualMachine tests", func() {
 				Expect(vmopVM.Spec.Reserved).ToNot(BeNil())
 				Expect(vmopVM.Spec.Reserved.ResourcePolicyName).To(Equal(resourcePolicyName))
 				Expect(vmopVM.Spec.MinHardwareVersion).To(Equal(minHardwareVersion))
-				Expect(vmopVM.Spec.PowerState).To(Equal(vmoprv1alpha2.VirtualMachinePowerStateOn))
+				Expect(vmopVM.Spec.PowerState).To(Equal(vmoprv1alpha5.VirtualMachinePowerStateOn))
 				Expect(vmopVM.ObjectMeta.Annotations[ClusterModuleNameAnnotationKey]).To(Equal(ControlPlaneVMClusterModuleGroupName))
 				Expect(vmopVM.ObjectMeta.Annotations[ProviderTagsAnnotationKey]).To(Equal(ControlPlaneVMVMAntiAffinityTagValue))
 
@@ -312,7 +312,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal := vmopVM.DeepCopy()
 			vmopVM.Status.Conditions = append(vmopVM.Status.Conditions, metav1.Condition{
-				Type:               vmoprv1alpha2.VirtualMachineConditionCreated,
+				Type:               vmoprv1alpha5.VirtualMachineConditionCreated,
 				Status:             metav1.ConditionTrue,
 				LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
 				Reason:             string(metav1.ConditionTrue),
@@ -328,7 +328,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			By("VirtualMachine is powered on")
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal = vmopVM.DeepCopy()
-			vmopVM.Status.PowerState = vmoprv1alpha2.VirtualMachinePowerStateOn
+			vmopVM.Status.PowerState = vmoprv1alpha5.VirtualMachinePowerStateOn
 			patchReconciledVMStatus(ctx, vmService, vmopVM, vmopVMOriginal)
 			expectedState = vmwarev1.VirtualMachineStatePoweredOn
 			// we expect the reconciliation waiting for VM to have an IP
@@ -341,30 +341,30 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal = vmopVM.DeepCopy()
 			if vmopVM.Status.Network == nil {
-				vmopVM.Status.Network = &vmoprv1alpha2.VirtualMachineNetworkStatus{}
+				vmopVM.Status.Network = &vmoprv1alpha5.VirtualMachineNetworkStatus{}
 			}
 			vmopVM.Status.Network.PrimaryIP4 = vmIP
-			vmopVM.Status.Network.Interfaces = []vmoprv1alpha2.VirtualMachineNetworkInterfaceStatus{
+			vmopVM.Status.Network.Interfaces = []vmoprv1alpha5.VirtualMachineNetworkInterfaceStatus{
 				{
 					Name:      "eth0",
 					DeviceKey: 4000,
-					IP: &vmoprv1alpha2.VirtualMachineNetworkInterfaceIPStatus{
+					IP: &vmoprv1alpha5.VirtualMachineNetworkInterfaceIPStatus{
 						AutoConfigurationEnabled: ptr.To(true),
 						MACAddr:                  "00:50:56:00:00:01",
-						DHCP: &vmoprv1alpha2.VirtualMachineNetworkDHCPStatus{
-							IP4: vmoprv1alpha2.VirtualMachineNetworkDHCPOptionsStatus{
+						DHCP: &vmoprv1alpha5.VirtualMachineNetworkDHCPStatus{
+							IP4: vmoprv1alpha5.VirtualMachineNetworkDHCPOptionsStatus{
 								Enabled: true,
-								Config: []vmoprv1alpha2common.KeyValuePair{
+								Config: []vmoprv1alpha5common.KeyValuePair{
 									{Key: "1", Value: "timeout 60;"},
 									{Key: "2", Value: "reboot 10;"},
 								},
 							},
-							IP6: vmoprv1alpha2.VirtualMachineNetworkDHCPOptionsStatus{
+							IP6: vmoprv1alpha5.VirtualMachineNetworkDHCPOptionsStatus{
 								Enabled: false,
-								Config:  []vmoprv1alpha2common.KeyValuePair{},
+								Config:  []vmoprv1alpha5common.KeyValuePair{},
 							},
 						},
-						Addresses: []vmoprv1alpha2.VirtualMachineNetworkInterfaceIPAddrStatus{
+						Addresses: []vmoprv1alpha5.VirtualMachineNetworkInterfaceIPAddrStatus{
 							{
 								Address:  vmIP + "/24",
 								Lifetime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
@@ -373,7 +373,7 @@ var _ = Describe("VirtualMachine tests", func() {
 							},
 						},
 					},
-					DNS: &vmoprv1alpha2.VirtualMachineNetworkDNSStatus{
+					DNS: &vmoprv1alpha5.VirtualMachineNetworkDNSStatus{
 						DHCP:          true,
 						DomainName:    "test.local",
 						HostName:      "test-vm",
@@ -514,7 +514,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal := vmopVM.DeepCopy()
 			vmopVM.Status.Conditions = append(vmopVM.Status.Conditions, metav1.Condition{
-				Type:               vmoprv1alpha2.VirtualMachineConditionCreated,
+				Type:               vmoprv1alpha5.VirtualMachineConditionCreated,
 				Status:             metav1.ConditionTrue,
 				LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
 				Reason:             string(metav1.ConditionTrue),
@@ -529,7 +529,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			By("VirtualMachine is powered on")
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal = vmopVM.DeepCopy()
-			vmopVM.Status.PowerState = vmoprv1alpha2.VirtualMachinePowerStateOn
+			vmopVM.Status.PowerState = vmoprv1alpha5.VirtualMachinePowerStateOn
 			patchReconciledVMStatus(ctx, vmService, vmopVM, vmopVMOriginal)
 			expectedState = vmwarev1.VirtualMachineStatePoweredOn
 			expectedConditions[0].Reason = vmwarev1.WaitingForNetworkAddressReason
@@ -541,7 +541,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal = vmopVM.DeepCopy()
 			if vmopVM.Status.Network == nil {
-				vmopVM.Status.Network = &vmoprv1alpha2.VirtualMachineNetworkStatus{}
+				vmopVM.Status.Network = &vmoprv1alpha5.VirtualMachineNetworkStatus{}
 			}
 			vmopVM.Status.Network.PrimaryIP4 = vmIP
 			patchReconciledVMStatus(ctx, vmService, vmopVM, vmopVMOriginal)
@@ -574,7 +574,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 			vmopVMOriginal = vmopVM.DeepCopy()
 			if vmopVM.Status.Network == nil {
-				vmopVM.Status.Network = &vmoprv1alpha2.VirtualMachineNetworkStatus{}
+				vmopVM.Status.Network = &vmoprv1alpha5.VirtualMachineNetworkStatus{}
 			}
 			vmopVM.Status.Network.PrimaryIP4 = vmIP
 			patchReconciledVMStatus(ctx, vmService, vmopVM, vmopVMOriginal)
@@ -620,7 +620,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			vmopVMOriginal := vmopVM.DeepCopy()
 			errMessage := "TestVirtualMachineClassBinding not found"
 			vmopVM.Status.Conditions = append(vmopVM.Status.Conditions, metav1.Condition{
-				Type:               vmoprv1alpha2.VirtualMachineConditionClassReady,
+				Type:               vmoprv1alpha5.VirtualMachineConditionClassReady,
 				Status:             metav1.ConditionFalse,
 				LastTransitionTime: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
 				Reason:             "NotFound",
@@ -666,10 +666,10 @@ var _ = Describe("VirtualMachine tests", func() {
 			requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
 			verifyOutput(supervisorMachineContext)
 
-			vmVolume := vmoprv1alpha2.VirtualMachineVolume{
+			vmVolume := vmoprv1alpha5.VirtualMachineVolume{
 				Name: "test",
-				VirtualMachineVolumeSource: vmoprv1alpha2.VirtualMachineVolumeSource{
-					PersistentVolumeClaim: &vmoprv1alpha2.PersistentVolumeClaimVolumeSource{
+				VirtualMachineVolumeSource: vmoprv1alpha5.VirtualMachineVolumeSource{
+					PersistentVolumeClaim: &vmoprv1alpha5.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "test-pvc",
 							ReadOnly:  false,
@@ -680,7 +680,7 @@ var _ = Describe("VirtualMachine tests", func() {
 
 			By("Updating the Volumes field")
 			vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
-			vmopVM.Spec.Volumes = []vmoprv1alpha2.VirtualMachineVolume{vmVolume}
+			vmopVM.Spec.Volumes = []vmoprv1alpha5.VirtualMachineVolume{vmVolume}
 			Expect(vmService.Client.Update(ctx, vmopVM)).To(Succeed())
 
 			requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
@@ -725,10 +725,10 @@ var _ = Describe("VirtualMachine tests", func() {
 
 			for i, volume := range vsphereMachine.Spec.Volumes {
 				name := volumeName(vsphereMachine, volume)
-				vmVolume := vmoprv1alpha2.VirtualMachineVolume{
+				vmVolume := vmoprv1alpha5.VirtualMachineVolume{
 					Name: name,
-					VirtualMachineVolumeSource: vmoprv1alpha2.VirtualMachineVolumeSource{
-						PersistentVolumeClaim: &vmoprv1alpha2.PersistentVolumeClaimVolumeSource{
+					VirtualMachineVolumeSource: vmoprv1alpha5.VirtualMachineVolumeSource{
+						PersistentVolumeClaim: &vmoprv1alpha5.PersistentVolumeClaimVolumeSource{
 							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
 								ClaimName: name,
 								ReadOnly:  false,
@@ -801,7 +801,7 @@ var _ = Describe("VirtualMachine tests", func() {
 				var (
 					machineDeploymentName string
 					workerMachineName     string
-					vmGroup               *vmoprv1alpha2.VirtualMachineGroup
+					vmGroup               *vmoprv1alpha5.VirtualMachineGroup
 				)
 
 				BeforeEach(func() {
@@ -865,7 +865,7 @@ var _ = Describe("VirtualMachine tests", func() {
 						requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(requeue).Should(BeTrue())
-						vm := &vmoprv1alpha2.VirtualMachine{}
+						vm := &vmoprv1alpha5.VirtualMachine{}
 						nsname := types.NamespacedName{
 							Namespace: vsphereMachineNoVMG.Namespace,
 							Name:      vsphereMachineNoVMG.Name,
@@ -879,15 +879,15 @@ var _ = Describe("VirtualMachine tests", func() {
 				Context("when VirtualMachineGroup exists", func() {
 					BeforeEach(func() {
 						// Create a VirtualMachineGroup for the cluster
-						vmGroup = &vmoprv1alpha2.VirtualMachineGroup{
+						vmGroup = &vmoprv1alpha5.VirtualMachineGroup{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      clusterName,
 								Namespace: corev1.NamespaceDefault,
 							},
-							Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-								BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+							Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+								BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 									{
-										Members: []vmoprv1alpha2.GroupMember{
+										Members: []vmoprv1alpha5.GroupMember{
 											{
 												Name: workerMachineName,
 												Kind: "VirtualMachine",
@@ -940,7 +940,7 @@ var _ = Describe("VirtualMachine tests", func() {
 						requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(requeue).Should(BeTrue())
-						vm := &vmoprv1alpha2.VirtualMachine{}
+						vm := &vmoprv1alpha5.VirtualMachine{}
 						nsname := types.NamespacedName{
 							Namespace: vsphereMachineNotMember.Namespace,
 							Name:      vsphereMachineNotMember.Name,
@@ -1023,7 +1023,7 @@ var _ = Describe("VirtualMachine tests", func() {
 						supervisorMachineContext.ControllerManagerContext = fdControllerManagerContext
 
 						// Create a VirtualMachineGroup for the cluster with per-md zone annotation
-						vmGroup := &vmoprv1alpha2.VirtualMachineGroup{
+						vmGroup := &vmoprv1alpha5.VirtualMachineGroup{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      fdClusterName,
 								Namespace: corev1.NamespaceDefault,
@@ -1031,10 +1031,10 @@ var _ = Describe("VirtualMachine tests", func() {
 									fmt.Sprintf("%s/%s", ZoneAnnotationPrefix, machineDeploymentName): failureDomainName,
 								},
 							},
-							Spec: vmoprv1alpha2.VirtualMachineGroupSpec{
-								BootOrder: []vmoprv1alpha2.VirtualMachineGroupBootOrderGroup{
+							Spec: vmoprv1alpha5.VirtualMachineGroupSpec{
+								BootOrder: []vmoprv1alpha5.VirtualMachineGroupBootOrderGroup{
 									{
-										Members: []vmoprv1alpha2.GroupMember{
+										Members: []vmoprv1alpha5.GroupMember{
 											{
 												Name: workerMachineName,
 												Kind: "VirtualMachine",

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,7 +151,7 @@ func createScheme() *runtime.Scheme {
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(topologyv1.AddToScheme(scheme))
 	utilruntime.Must(vmoprvhub.AddToScheme(scheme))
-	utilruntime.Must(vmoprv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(vmoprv1alpha5.AddToScheme(scheme))
 	utilruntime.Must(netopv1.AddToScheme(scheme))
 	utilruntime.Must(ncpv1.AddToScheme(scheme))
 	return scheme
@@ -165,8 +165,8 @@ func CreateClusterContext(cluster *clusterv1.Cluster, vsphereCluster *vmwarev1.V
 			&vmoprvhub.VirtualMachineService{},
 			&vmoprvhub.VirtualMachine{},
 			// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-			&vmoprv1alpha2.VirtualMachineService{},
-			&vmoprv1alpha2.VirtualMachine{},
+			&vmoprv1alpha5.VirtualMachineService{},
+			&vmoprv1alpha5.VirtualMachine{},
 		).Build(),
 		conversionapi.DefaultConverter,
 	)

--- a/test/infrastructure/vcsim/controllers/virtualmachine_controller_test.go
+++ b/test/infrastructure/vcsim/controllers/virtualmachine_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -96,7 +96,7 @@ func Test_Reconcile_VirtualMachine(t *testing.T) {
 		}
 
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-		virtualMachine := &vmoprv1alpha2.VirtualMachine{
+		virtualMachine := &vmoprv1alpha5.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -230,7 +230,7 @@ func Test_Reconcile_VirtualMachine(t *testing.T) {
 		}
 
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
-		virtualMachine := &vmoprv1alpha2.VirtualMachine{
+		virtualMachine := &vmoprv1alpha5.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -246,13 +246,13 @@ func Test_Reconcile_VirtualMachine(t *testing.T) {
 					vcsimv1.VMFinalizer, // Adding this to move past the first reconcile
 				},
 			},
-			Status: vmoprv1alpha2.VirtualMachineStatus{
+			Status: vmoprv1alpha5.VirtualMachineStatus{
 				// Those values are required to unblock provisioning of node
 				BiosUUID: "foo",
-				Network: &vmoprv1alpha2.VirtualMachineNetworkStatus{
+				Network: &vmoprv1alpha5.VirtualMachineNetworkStatus{
 					PrimaryIP4: "1.2.3.4",
 				},
-				PowerState: vmoprv1alpha2.VirtualMachinePowerStateOn,
+				PowerState: vmoprv1alpha5.VirtualMachinePowerStateOn,
 			},
 		}
 

--- a/test/infrastructure/vcsim/controllers/vspherevm_controller_test.go
+++ b/test/infrastructure/vcsim/controllers/vspherevm_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -61,7 +61,7 @@ func init() {
 	utilruntime.Must(infrav1beta1.AddToScheme(scheme))
 	utilruntime.Must(vmwarev1beta1.AddToScheme(scheme))
 	utilruntime.Must(vmoprvhub.AddToScheme(scheme))
-	utilruntime.Must(vmoprv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(vmoprv1alpha5.AddToScheme(scheme))
 	utilruntime.Must(vcsimv1.AddToScheme(scheme))
 
 	// scheme used for operating on the cloud resource.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR moves CAPV unit tests and E2E tests to use v1alpha5 (note: temporarily we will use v1alpha5 only, in follow-up PRs we will introduce a dynamic switch and E2E test coverage for permutations of vm-operator version/vm-operator API version supported by CAPV)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
