### PR TITLE
🌱 Cleanup RuntimeExtension provider e2e test setup

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -229,7 +229,6 @@ providers:
       - name: v1.16.99
         # Use manifest from source files
         value: ../../../../cluster-api-provider-vsphere/test/infrastructure/vcsim/config/default
-        contract: v1beta1
         files:
           # Note: We have to make this look like a v1beta1 provider for clusterctl upgrade tests, because clusterctl v1.10 can only install v1beta1 providers.
           - sourcePath: "../data/shared/rx/main/metadata.yaml"
@@ -241,7 +240,6 @@ providers:
         # Use manifest from source files
         value: "file://../../../../cluster-api-provider-vsphere/test/infrastructure/vm-operator/vm-operator-v1.8.6-0-gde75746a.yaml"
         type: "url"
-        contract: v1beta1
         files:
           - sourcePath: "../data/shared/vmoperator/v1.8/metadata.yaml"
         replacements:
@@ -251,7 +249,6 @@ providers:
         # Use manifest from source files
         value: "file://../../../../cluster-api-provider-vsphere/test/infrastructure/vm-operator/vm-operator-v1.9.0-567-g93918c59.yaml"
         type: "url"
-        contract: v1beta1
         files:
           - sourcePath: "../data/shared/vmoperator/v1.9/metadata.yaml"
         replacements:
@@ -264,7 +261,6 @@ providers:
       - name: v1.16.99
         # Use manifest from source files
         value: ../../../../cluster-api-provider-vsphere/test/infrastructure/net-operator/config/default
-        contract: v1beta1
         files:
           # Note: We have to make this look like a v1beta1 provider for clusterctl upgrade tests, because clusterctl v1.10 can only install v1beta1 providers.
           - sourcePath: "../data/shared/rx/main/metadata.yaml"
@@ -278,7 +274,6 @@ providers:
       - name: v1.16.99
         # Use manifest from source files
         value: ../../../../cluster-api-provider-vsphere/test/extension/config/default
-        contract: v1beta1
         files:
           # Note: We have to make this look like a v1beta1 provider for clusterctl upgrade tests, because clusterctl v1.10 can only install v1beta1 providers.
           - sourcePath: "../data/shared/rx/main/metadata.yaml"

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -128,6 +128,12 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			}
 		}
 
+		// Note: Setting runtimeExtensionProviders to an empty array to ensure that the clusterctl upgrade test does not install
+		// any RuntimeExtensionProviders as a fallback.
+		// Note: Today this variable is only used in the clusterctl upgrade test so it only affects the providers
+		// we install in that test.
+		runtimeExtensionProviders = []string{}
+
 		// Enable additional providers depending on testMode and testTarget.
 		if testMode == SupervisorTestMode {
 			// Use latest vm-operator or the vm-operator version defined in the VM_OPERATOR_VERSION env var.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to #3778 