### PR TITLE
🌱 Move VSphereVM failureReason/failureMessage fields to deprecated

### DIFF
--- a/apis/v1beta1/conversion.go
+++ b/apis/v1beta1/conversion.go
@@ -840,11 +840,13 @@ func Convert_v1beta2_VSphereVMStatus_To_v1beta1_VSphereVMStatus(in *infrav1.VSph
 	// NOTE: v1beta2 conditions should not automatically be converted into legacy conditions (v1beta1).
 	out.Conditions = nil
 
-	// Retrieve legacy conditions (v1beta1) from the deprecated field.
+	// Retrieve legacy conditions (v1beta1), failureReason and failureMessage from the deprecated field.
 	if in.Deprecated != nil && in.Deprecated.V1Beta1 != nil {
 		if in.Deprecated.V1Beta1.Conditions != nil {
 			clusterv1beta1.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1beta1_Conditions(&in.Deprecated.V1Beta1.Conditions, &out.Conditions)
 		}
+		out.FailureReason = in.Deprecated.V1Beta1.FailureReason
+		out.FailureMessage = in.Deprecated.V1Beta1.FailureMessage
 	}
 
 	// Move new conditions (v1beta2) to the v1beta2 field.
@@ -870,8 +872,8 @@ func Convert_v1beta1_VSphereVMStatus_To_v1beta2_VSphereVMStatus(in *VSphereVMSta
 		out.Conditions = in.V1Beta2.Conditions
 	}
 
-	// Move legacy conditions (v1beta1) to the deprecated field.
-	if in.Conditions == nil {
+	// Move legacy conditions (v1beta1), failureReason and failureMessage to the deprecated field.
+	if in.FailureReason == nil && in.FailureMessage == nil && in.Conditions == nil {
 		return nil
 	}
 
@@ -884,6 +886,8 @@ func Convert_v1beta1_VSphereVMStatus_To_v1beta2_VSphereVMStatus(in *VSphereVMSta
 	if in.Conditions != nil {
 		clusterv1beta1.Convert_v1beta1_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
 	}
+	out.Deprecated.V1Beta1.FailureReason = in.FailureReason
+	out.Deprecated.V1Beta1.FailureMessage = in.FailureMessage
 	return nil
 }
 

--- a/apis/v1beta1/zz_generated.conversion.go
+++ b/apis/v1beta1/zz_generated.conversion.go
@@ -31,7 +31,6 @@ import (
 	v1beta2 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	corev1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	errors "sigs.k8s.io/cluster-api/errors"
 )
 
 func init() {
@@ -2349,8 +2348,8 @@ func autoConvert_v1beta1_VSphereVMStatus_To_v1beta2_VSphereVMStatus(in *VSphereV
 	} else {
 		out.Network = nil
 	}
-	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
-	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
+	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
+	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))
@@ -2400,8 +2399,6 @@ func autoConvert_v1beta2_VSphereVMStatus_To_v1beta1_VSphereVMStatus(in *v1beta2.
 	} else {
 		out.Network = nil
 	}
-	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
-	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.ModuleUUID = (*string)(unsafe.Pointer(in.ModuleUUID))
 	out.VMRef = in.VMRef
 	// WARNING: in.Deprecated requires manual conversion: does not exist in peer-type

--- a/apis/v1beta2/vspherevm_types.go
+++ b/apis/v1beta2/vspherevm_types.go
@@ -291,38 +291,6 @@ type VSphereVMStatus struct {
 	// +kubebuilder:validation:MaxItems=128
 	Network []NetworkStatus `json:"network,omitempty"`
 
-	// failureReason will be set in the event that there is a terminal problem
-	// reconciling the vspherevm and will contain a succinct value suitable
-	// for vm interpretation.
-	//
-	// This field should not be set for transitive errors that a controller
-	// faces that are expected to be fixed automatically over
-	// time (like service outages), but instead indicate that something is
-	// fundamentally wrong with the vm.
-	//
-	// Any transient errors that occur during the reconciliation of vspherevms
-	// can be added as events to the vspherevm object and/or logged in the
-	// controller's output.
-	// +optional
-	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
-
-	// failureMessage will be set in the event that there is a terminal problem
-	// reconciling the vspherevm and will contain a more verbose string suitable
-	// for logging and human consumption.
-	//
-	// This field should not be set for transitive errors that a controller
-	// faces that are expected to be fixed automatically over
-	// time (like service outages), but instead indicate that something is
-	// fundamentally wrong with the vm.
-	//
-	// Any transient errors that occur during the reconciliation of vspherevms
-	// can be added as events to the vspherevm object and/or logged in the
-	// controller's output.
-	// +optional
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=10240
-	FailureMessage *string `json:"failureMessage,omitempty"` //nolint:kubeapilinter // field will be removed when v1beta1 is removed
-
 	// moduleUUID is the unique identifier for the vCenter cluster module construct
 	// which is used to configure anti-affinity. Objects with the same ModuleUUID
 	// will be anti-affined, meaning that the vCenter DRS will best effort schedule
@@ -361,6 +329,44 @@ type VSphereVMV1Beta1DeprecatedStatus struct {
 	//
 	// +optional
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+
+	// failureReason will be set in the event that there is a terminal problem
+	// reconciling the vspherevm and will contain a succinct value suitable
+	// for vm interpretation.
+	//
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
+	// time (like service outages), but instead indicate that something is
+	// fundamentally wrong with the vm.
+	//
+	// Any transient errors that occur during the reconciliation of vspherevms
+	// can be added as events to the vspherevm object and/or logged in the
+	// controller's output.
+	//
+	// Deprecated: This field is deprecated and is going to be removed when support for v1beta1 will be dropped. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+	//
+	// +optional
+	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
+
+	// failureMessage will be set in the event that there is a terminal problem
+	// reconciling the vspherevm and will contain a more verbose string suitable
+	// for logging and human consumption.
+	//
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
+	// time (like service outages), but instead indicate that something is
+	// fundamentally wrong with the vm.
+	//
+	// Any transient errors that occur during the reconciliation of vspherevms
+	// can be added as events to the vspherevm object and/or logged in the
+	// controller's output.
+	//
+	// Deprecated: This field is deprecated and is going to be removed when support for v1beta1 will be dropped. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+	//
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=10240
+	FailureMessage *string `json:"failureMessage,omitempty"` //nolint:kubeapilinter // field will be removed when v1beta1 is removed
 }
 
 // +kubebuilder:object:root=true

--- a/apis/v1beta2/zz_generated.deepcopy.go
+++ b/apis/v1beta2/zz_generated.deepcopy.go
@@ -1595,16 +1595,6 @@ func (in *VSphereVMStatus) DeepCopyInto(out *VSphereVMStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.FailureReason != nil {
-		in, out := &in.FailureReason, &out.FailureReason
-		*out = new(errors.MachineStatusError)
-		**out = **in
-	}
-	if in.FailureMessage != nil {
-		in, out := &in.FailureMessage, &out.FailureMessage
-		*out = new(string)
-		**out = **in
-	}
 	if in.ModuleUUID != nil {
 		in, out := &in.ModuleUUID, &out.ModuleUUID
 		*out = new(string)
@@ -1636,6 +1626,16 @@ func (in *VSphereVMV1Beta1DeprecatedStatus) DeepCopyInto(out *VSphereVMV1Beta1De
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.FailureReason != nil {
+		in, out := &in.FailureReason, &out.FailureReason
+		*out = new(errors.MachineStatusError)
+		**out = **in
+	}
+	if in.FailureMessage != nil {
+		in, out := &in.FailureMessage, &out.FailureMessage
+		*out = new(string)
+		**out = **in
 	}
 }
 

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1844,40 +1844,44 @@ spec:
                           - type
                           type: object
                         type: array
+                      failureMessage:
+                        description: |-
+                          failureMessage will be set in the event that there is a terminal problem
+                          reconciling the vspherevm and will contain a more verbose string suitable
+                          for logging and human consumption.
+
+                          This field should not be set for transitive errors that a controller
+                          faces that are expected to be fixed automatically over
+                          time (like service outages), but instead indicate that something is
+                          fundamentally wrong with the vm.
+
+                          Any transient errors that occur during the reconciliation of vspherevms
+                          can be added as events to the vspherevm object and/or logged in the
+                          controller's output.
+
+                          Deprecated: This field is deprecated and is going to be removed when support for v1beta1 will be dropped. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                        maxLength: 10240
+                        minLength: 1
+                        type: string
+                      failureReason:
+                        description: |-
+                          failureReason will be set in the event that there is a terminal problem
+                          reconciling the vspherevm and will contain a succinct value suitable
+                          for vm interpretation.
+
+                          This field should not be set for transitive errors that a controller
+                          faces that are expected to be fixed automatically over
+                          time (like service outages), but instead indicate that something is
+                          fundamentally wrong with the vm.
+
+                          Any transient errors that occur during the reconciliation of vspherevms
+                          can be added as events to the vspherevm object and/or logged in the
+                          controller's output.
+
+                          Deprecated: This field is deprecated and is going to be removed when support for v1beta1 will be dropped. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                        type: string
                     type: object
                 type: object
-              failureMessage:
-                description: |-
-                  failureMessage will be set in the event that there is a terminal problem
-                  reconciling the vspherevm and will contain a more verbose string suitable
-                  for logging and human consumption.
-
-                  This field should not be set for transitive errors that a controller
-                  faces that are expected to be fixed automatically over
-                  time (like service outages), but instead indicate that something is
-                  fundamentally wrong with the vm.
-
-                  Any transient errors that occur during the reconciliation of vspherevms
-                  can be added as events to the vspherevm object and/or logged in the
-                  controller's output.
-                maxLength: 10240
-                minLength: 1
-                type: string
-              failureReason:
-                description: |-
-                  failureReason will be set in the event that there is a terminal problem
-                  reconciling the vspherevm and will contain a succinct value suitable
-                  for vm interpretation.
-
-                  This field should not be set for transitive errors that a controller
-                  faces that are expected to be fixed automatically over
-                  time (like service outages), but instead indicate that something is
-                  fundamentally wrong with the vm.
-
-                  Any transient errors that occur during the reconciliation of vspherevms
-                  can be added as events to the vspherevm object and/or logged in the
-                  controller's output.
-                type: string
               host:
                 description: |-
                   host describes the hostname or IP address of the infrastructure host

--- a/pkg/services/vimmachine.go
+++ b/pkg/services/vimmachine.go
@@ -137,15 +137,16 @@ func (v *VimMachineService) SyncFailureReason(ctx context.Context, machineCtx ca
 	}
 	if vsphereVM != nil {
 		// Reconcile VSphereMachine's failures
-		if vsphereVM.Status.FailureReason != nil || vsphereVM.Status.FailureMessage != nil {
+		if vsphereVM.Status.Deprecated != nil && vsphereVM.Status.Deprecated.V1Beta1 != nil &&
+			(vsphereVM.Status.Deprecated.V1Beta1.FailureReason != nil || vsphereVM.Status.Deprecated.V1Beta1.FailureMessage != nil) {
 			if vimMachineCtx.VSphereMachine.Status.Deprecated == nil {
 				vimMachineCtx.VSphereMachine.Status.Deprecated = &infrav1.VSphereMachineDeprecatedStatus{}
 			}
 			if vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1 == nil {
 				vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1 = &infrav1.VSphereMachineV1Beta1DeprecatedStatus{}
 			}
-			vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1.FailureReason = vsphereVM.Status.FailureReason
-			vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1.FailureMessage = vsphereVM.Status.FailureMessage
+			vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1.FailureReason = vsphereVM.Status.Deprecated.V1Beta1.FailureReason
+			vimMachineCtx.VSphereMachine.Status.Deprecated.V1Beta1.FailureMessage = vsphereVM.Status.Deprecated.V1Beta1.FailureMessage
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3452
