### PR TITLE
✨ Improve v1beta2 CRD columns (govmomi+supervisor)

### DIFF
--- a/apis/v1beta2/vspherecluster_types.go
+++ b/apis/v1beta2/vspherecluster_types.go
@@ -252,9 +252,11 @@ type VSphereClusterV1Beta2Status struct {
 // +kubebuilder:resource:path=vsphereclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereCluster is provisioned"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 // +kubebuilder:printcolumn:name="Server",type="string",JSONPath=".spec.server",description="Server is the address of the vSphere endpoint."
-// +kubebuilder:printcolumn:name="ControlPlaneEndpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint",priority=1
+// +kubebuilder:printcolumn:name="ControlPlane Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint"
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereCluster is provisioned"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereCluster"
 
 // VSphereCluster is the Schema for the vsphereclusters API.

--- a/apis/v1beta2/vsphereclustertemplate_types.go
+++ b/apis/v1beta2/vsphereclustertemplate_types.go
@@ -31,6 +31,8 @@ type VSphereClusterTemplateSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=vsphereclustertemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="ClusterClass",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="ClusterClass")].name`,description="Name of the ClusterClass owning this template"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereClusterTemplate"
 
 // VSphereClusterTemplate is the Schema for the vsphereclustertemplates API.
 type VSphereClusterTemplate struct {

--- a/apis/v1beta2/vspheremachine_types.go
+++ b/apis/v1beta2/vspheremachine_types.go
@@ -296,9 +296,10 @@ type VSphereMachineV1Beta1DeprecatedStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+// +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="Template",type="string",JSONPath=".spec.template",description="Template is the name, inventory path, managed object reference or the managed object ID of the template used to clone the VM",priority=10
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
 // +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereMachine is provisioned"
-// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="VSphereMachine instance ID"
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this VSphereMachine",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereMachine"
 
 // VSphereMachine is the Schema for the vspheremachines API.

--- a/apis/v1beta2/vspheremachinetemplate_types.go
+++ b/apis/v1beta2/vspheremachinetemplate_types.go
@@ -30,6 +30,9 @@ type VSphereMachineTemplateSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=vspheremachinetemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="ClusterClass",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="ClusterClass")].name`,description="Name of the ClusterClass owning this template"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="Cluster")].name`,description="Name of the Cluster owning this template"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereMachineTemplate"
 
 // VSphereMachineTemplate is the Schema for the vspheremachinetemplates API.
 type VSphereMachineTemplate struct {

--- a/apis/vmware/v1beta2/vspherecluster_types.go
+++ b/apis/vmware/v1beta2/vspherecluster_types.go
@@ -263,6 +263,11 @@ type VSphereClusterV1Beta1DeprecatedStatus struct {
 // +kubebuilder:resource:path=vsphereclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+// +kubebuilder:printcolumn:name="ControlPlane Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="API Endpoint"
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereCluster is provisioned"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereCluster"
 
 // VSphereCluster is the Schema for the VSphereClusters API.
 type VSphereCluster struct {

--- a/apis/vmware/v1beta2/vsphereclustertemplate_types.go
+++ b/apis/vmware/v1beta2/vsphereclustertemplate_types.go
@@ -28,9 +28,11 @@ type VSphereClusterTemplateSpec struct {
 	Template VSphereClusterTemplateResource `json:"template,omitempty,omitzero"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 // +kubebuilder:resource:path=vsphereclustertemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="ClusterClass",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="ClusterClass")].name`,description="Name of the ClusterClass owning this template"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereClusterTemplate"
 
 // VSphereClusterTemplate is the Schema for the vsphereclustertemplates API.
 type VSphereClusterTemplate struct {

--- a/apis/vmware/v1beta2/vspheremachine_types.go
+++ b/apis/vmware/v1beta2/vspheremachine_types.go
@@ -422,9 +422,15 @@ type VSphereMachineV1Beta1DeprecatedStatus struct {
 // +kubebuilder:resource:path=vspheremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".spec.failureDomain",description="Zone"
-// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
-// +kubebuilder:printcolumn:name="IPAddr",type="string",JSONPath=".status.vmIp",description="IP address"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+// +kubebuilder:printcolumn:name="Class",type="string",JSONPath=".spec.className",description="VirtualMachineClass name"
+// +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="IP",type="string",JSONPath=`.status.addresses[?(@.type=="InternalIP")].address`,description="IP of the Machine",priority=10
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.imageName",description="Image name",priority=10
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereMachine is provisioned"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.vmstatus",description="VSphereMachine status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereMachine"
 type VSphereMachine struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/apis/vmware/v1beta2/vspheremachinetemplate_types.go
+++ b/apis/vmware/v1beta2/vspheremachinetemplate_types.go
@@ -51,6 +51,9 @@ type VSphereMachineTemplateStatus struct {
 // +kubebuilder:resource:path=vspheremachinetemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ClusterClass",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="ClusterClass")].name`,description="Name of the ClusterClass owning this template"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=`.metadata.ownerReferences[?(@.kind=="Cluster")].name`,description="Name of the Cluster owning this template"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereMachineTemplate"
 
 // VSphereMachineTemplate is the Schema for the vspheremachinetemplates API.
 type VSphereMachineTemplate struct {

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -344,9 +344,9 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: VSphereCluster is provisioned
-      jsonPath: .status.initialization.provisioned
-      name: Provisioned
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
       type: string
     - description: Server is the address of the vSphere endpoint.
       jsonPath: .spec.server
@@ -354,8 +354,16 @@ spec:
       type: string
     - description: API Endpoint
       jsonPath: .spec.controlPlaneEndpoint.host
-      name: ControlPlaneEndpoint
-      priority: 1
+      name: ControlPlane Endpoint
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: VSphereCluster is provisioned
+      jsonPath: .status.initialization.provisioned
+      name: Provisioned
       type: string
     - description: Time duration since creation of VSphereCluster
       jsonPath: .metadata.creationTimestamp

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -186,7 +186,16 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Name of the ClusterClass owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="ClusterClass")].name
+      name: ClusterClass
+      type: string
+    - description: Time duration since creation of VSphereClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
@@ -398,3 +407,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -918,18 +918,25 @@ spec:
       jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
       name: Cluster
       type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: Provider ID
+      priority: 10
+      type: string
+    - description: Template is the name, inventory path, managed object reference
+        or the managed object ID of the template used to clone the VM
+      jsonPath: .spec.template
+      name: Template
+      priority: 10
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
     - description: VSphereMachine is provisioned
       jsonPath: .status.initialization.provisioned
       name: Provisioned
-      type: string
-    - description: VSphereMachine instance ID
-      jsonPath: .spec.providerID
-      name: ProviderID
-      type: string
-    - description: Machine object which owns with this VSphereMachine
-      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
-      name: Machine
-      priority: 1
       type: string
     - description: Time duration since creation of VSphereMachine
       jsonPath: .metadata.creationTimestamp

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -713,7 +713,20 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Name of the ClusterClass owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="ClusterClass")].name
+      name: ClusterClass
+      type: string
+    - description: Name of the Cluster owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Cluster")].name
+      name: Cluster
+      type: string
+    - description: Time duration since creation of VSphereMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
@@ -1500,3 +1513,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -245,7 +245,29 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: ControlPlane Endpoint
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: VSphereCluster is provisioned
+      jsonPath: .status.initialization.provisioned
+      name: Provisioned
+      type: string
+    - description: Time duration since creation of VSphereCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VSphereCluster is the Schema for the VSphereClusters API.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -103,7 +103,16 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Name of the ClusterClass owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="ClusterClass")].name
+      name: ClusterClass
+      type: string
+    - description: Time duration since creation of VSphereClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
@@ -218,3 +227,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -838,18 +838,46 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: Zone
-      jsonPath: .spec.failureDomain
-      name: Zone
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: VirtualMachineClass name
+      jsonPath: .spec.className
+      name: Class
       type: string
     - description: Provider ID
       jsonPath: .spec.providerID
-      name: ProviderID
+      name: Provider ID
+      priority: 10
       type: string
-    - description: IP address
-      jsonPath: .status.vmIp
-      name: IPAddr
+    - description: IP of the Machine
+      jsonPath: .status.addresses[?(@.type=="InternalIP")].address
+      name: IP
+      priority: 10
       type: string
+    - description: Image name
+      jsonPath: .spec.imageName
+      name: Image
+      priority: 10
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: VSphereMachine is provisioned
+      jsonPath: .status.initialization.provisioned
+      name: Provisioned
+      type: string
+    - description: VSphereMachine status
+      jsonPath: .status.vmstatus
+      name: Phase
+      type: string
+    - description: Time duration since creation of VSphereMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta2
     schema:
       openAPIV3Schema:

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -384,7 +384,20 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Name of the ClusterClass owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="ClusterClass")].name
+      name: ClusterClass
+      type: string
+    - description: Name of the Cluster owning this template
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Cluster")].name
+      name: Cluster
+      type: string
+    - description: Time duration since creation of VSphereMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Cluster view
```
┌Every───┐┌Command──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌Time───────────────┐
│1s      ││kubectl --kubeconfig /Users/buringerst/.kube/config --context kind-capi-test --namespace default get cluster,vspherecluster,kcp,md,vspheremachinetemplate,kubeadmconfigtemplate,machine,vspheremachine,kubeadmconfig -A -o wide                                                          ││2026-01-22 13:47:12│
└────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘└───────────────────┘
NAMESPACE            NAME                                          CLUSTERCLASS             AVAILABLE   CP DESIRED   CP CURRENT   CP READY   CP AVAILABLE   CP UP-TO-DATE   W DESIRED   W CURRENT   W READY   W AVAILABLE   W UP-TO-DATE   PAUSED   PHASE         AGE   VERSION
quick-start-8akodu   cluster.cluster.x-k8s.io/quick-start-rrg6cq   quick-start-supervisor   True        1            1            1          1              1               1           1           1         1             1              False    Provisioned   19m   v1.35.0

NAMESPACE            NAME                                                                             CLUSTER              CONTROLPLANE ENDPOINT   PAUSED   PROVISIONED   AGE
quick-start-8akodu   vspherecluster.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-zj954   quick-start-rrg6cq   192.168.35.32           False    true          19m

NAMESPACE            NAME                                                                            CLUSTER              AVAILABLE   DESIRED   CURRENT   READY   AVAILABLE   UP-TO-DATE   PAUSED   INITIALIZED   AGE   VERSION
quick-start-8akodu   kubeadmcontrolplane.controlplane.cluster.x-k8s.io/quick-start-rrg6cq-cp-2s7m6   quick-start-rrg6cq   True        1         1         1       1           1            False    true          19m   v1.35.0

NAMESPACE            NAME                                                                  CLUSTER              AVAILABLE   DESIRED   CURRENT   READY   AVAILABLE   UP-TO-DATE   PAUSED   PHASE     AGE   VERSION
quick-start-8akodu   machinedeployment.cluster.x-k8s.io/quick-start-rrg6cq-md-md-0-s7nbf   quick-start-rrg6cq   True        1         1         1       1           1            False    Running   19m   v1.35.0

NAMESPACE            NAME                                                                                                          CLUSTERCLASS             CLUSTER              AGE
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-d8dw2                                                 quick-start-rrg6cq   19m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-md-0-wxxdb                                            quick-start-rrg6cq   19m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-supervisor-template                 quick-start-supervisor                        19m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-supervisor-worker-machinetemplate   quick-start-supervisor                        19m

NAMESPACE            NAME                                                                                                CLUSTERCLASS             CLUSTER              AGE
quick-start-8akodu   kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/quick-start-rrg6cq-md-0-wqbjx                                               quick-start-rrg6cq   19m
quick-start-8akodu   kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/quick-start-supervisor-worker-bootstrap-template   quick-start-supervisor                        19m

NAMESPACE            NAME                                                                    CLUSTER              NODE NAME              PROVIDER ID                                      READY   AVAILABLE   UP-TO-DATE   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE             PAUSED   PHASE     AGE   VERSION
quick-start-8akodu   machine.cluster.x-k8s.io/quick-start-rrg6cq-cp-2s7m6-ssr7g              quick-start-rrg6cq   quick-start-rr-ssr7g   vsphere://66a71cc3-b0c9-41ca-a8f9-28a1d1d304e7   True    True        True         192.168.32.176                 Ubuntu 24.04.3 LTS   False    Running   19m   v1.35.0
quick-start-8akodu   machine.cluster.x-k8s.io/quick-start-rrg6cq-md-md-0-s7nbf-9rhb9-lsx4x   quick-start-rrg6cq   quick-start-rr-lsx4x   vsphere://0868d61b-28d4-4aaf-b812-5024054d39ed   True    True        True         192.168.33.74                  Ubuntu 24.04.3 LTS   False    Running   19m   v1.35.0

NAMESPACE            NAME                                                                                                 CLUSTER              PROVIDER ID                                      IP               PAUSED   PROVISIONED   PHASE   AGE
quick-start-8akodu   vspheremachine.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-cp-2s7m6-ssr7g              quick-start-rrg6cq   vsphere://66a71cc3-b0c9-41ca-a8f9-28a1d1d304e7   192.168.32.176   False    true          ready   19m
quick-start-8akodu   vspheremachine.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-md-md-0-s7nbf-9rhb9-lsx4x   quick-start-rrg6cq   vsphere://0868d61b-28d4-4aaf-b812-5024054d39ed   192.168.33.74    False    true          ready   19m

NAMESPACE            NAME                                                                                    CLUSTER              PAUSED   DATA SECRET CREATED   AGE
quick-start-8akodu   kubeadmconfig.bootstrap.cluster.x-k8s.io/quick-start-rrg6cq-cp-2s7m6-ssr7g              quick-start-rrg6cq   False    true                  19m
quick-start-8akodu   kubeadmconfig.bootstrap.cluster.x-k8s.io/quick-start-rrg6cq-md-md-0-s7nbf-9rhb9-lsx4x   quick-start-rrg6cq   False    true                  19m
```

ClusterClass view
```
┌Every───┐┌Command──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌Time───────────────┐
│1s      ││kubectl --kubeconfig /Users/buringerst/.kube/config --context kind-capi-test --namespace default get clusterclass,vsphereclustertemplate,kubeadmcontrolplanetemplate,vspheremachinetemplate,kubeadmconfigtemplate -A -o wide                                                             ││2026-01-22 13:47:30│
└────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘└───────────────────┘

NAMESPACE            NAME                                                                                   CLUSTERCLASS             AGE
quick-start-8akodu   vsphereclustertemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-supervisor   quick-start-supervisor   20m

NAMESPACE            NAME                                                                                            CLUSTERCLASS             AGE
quick-start-8akodu   kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/quick-start-supervisor-controlplane   quick-start-supervisor   20m

NAMESPACE            NAME                                                                                                          CLUSTERCLASS             CLUSTER              AGE
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-d8dw2                                                 quick-start-rrg6cq   20m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-rrg6cq-md-0-wxxdb                                            quick-start-rrg6cq   20m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-supervisor-template                 quick-start-supervisor                        20m
quick-start-8akodu   vspheremachinetemplate.vmware.infrastructure.cluster.x-k8s.io/quick-start-supervisor-worker-machinetemplate   quick-start-supervisor                        20m

NAMESPACE            NAME                                                                                                CLUSTERCLASS             CLUSTER              AGE
quick-start-8akodu   kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/quick-start-rrg6cq-md-0-wqbjx                                               quick-start-rrg6cq   20m
quick-start-8akodu   kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/quick-start-supervisor-worker-bootstrap-template   quick-start-supervisor                        20m
```



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
