### PR TITLE
🌱 Drop usage of v1beta1 conditions

### DIFF
--- a/controllers/clustermodule_reconciler_test.go
+++ b/controllers/clustermodule_reconciler_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2"
@@ -146,8 +146,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.BeElementOf(kcpUUID+"a", mdUUID+"a"))
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[1].ModuleUUID).To(gomega.BeElementOf(kcpUUID+"a", mdUUID+"a"))
 				// Check that condition got set.
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
+				g.Expect(conditions.IsTrue(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
 			},
 		},
 		{
@@ -175,9 +174,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.BeElementOf(kcpUUID, mdUUID))
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[1].ModuleUUID).To(gomega.BeElementOf(kcpUUID, mdUUID))
 				// Check that condition got set.
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
 			},
 		},
 		{
@@ -205,9 +203,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.BeElementOf(kcpUUID, mdUUID))
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[1].ModuleUUID).To(gomega.BeElementOf(kcpUUID, mdUUID))
 				// Check that condition got set.
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
 			},
 		},
 		{
@@ -236,9 +233,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.BeElementOf(kcpUUID+"a", mdUUID))
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[1].ModuleUUID).To(gomega.BeElementOf(kcpUUID+"a", mdUUID))
 				// Check that condition got set.
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring(vCenter500err.Error()))
 			},
 		},
 		{
@@ -254,9 +250,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.Equal(mdUUID))
 				g.Expect(ptr.Deref(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ControlPlane, false)).To(gomega.BeFalse())
 
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring("kcp"))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring("kcp"))
 			},
 		},
 		{
@@ -274,9 +269,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ModuleUUID).To(gomega.Equal(kcpUUID))
 				g.Expect(ptr.Deref(clusterCtx.VSphereCluster.Spec.ClusterModules[0].ControlPlane, false)).To(gomega.BeTrue())
 
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring("md"))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring("md"))
 			},
 		},
 		{
@@ -290,9 +284,8 @@ func TestReconciler_Reconcile(t *testing.T) {
 			haveError: false,
 			customAssert: func(g *gomega.WithT, clusterCtx *capvcontext.ClusterContext) {
 				g.Expect(clusterCtx.VSphereCluster.Spec.ClusterModules).To(gomega.BeEmpty())
-				g.Expect(deprecatedv1beta1conditions.Has(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition)).To(gomega.BeTrue())
-				g.Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, infrav1.ClusterModulesAvailableCondition).Message).To(gomega.ContainSubstring("kcp"))
+				g.Expect(conditions.IsFalse(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition)).To(gomega.BeTrue())
+				g.Expect(conditions.Get(clusterCtx.VSphereCluster, infrav1.VSphereClusterClusterModulesReadyV1Beta2Condition).Message).To(gomega.ContainSubstring("kcp"))
 			},
 		},
 		{

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -174,7 +174,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				vsphereCluster := &vmwarev1.VSphereCluster{}
 				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: intCtx.VSphereCluster.GetName()}
 				Expect(intCtx.Client.Get(ctx, key, vsphereCluster)).To(Succeed())
-				Expect(deprecatedv1beta1conditions.Has(vsphereCluster, vmwarev1.ProviderServiceAccountsReadyCondition)).To(BeFalse())
+				Expect(conditions.Has(vsphereCluster, vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Condition)).To(BeFalse())
 			})
 		})
 	})
@@ -196,7 +196,7 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 				vsphereCluster := &vmwarev1.VSphereCluster{}
 				key := client.ObjectKey{Namespace: intCtx.Namespace, Name: intCtx.VSphereCluster.GetName()}
 				Expect(intCtx.Client.Get(ctx, key, vsphereCluster)).To(Succeed())
-				Expect(deprecatedv1beta1conditions.Has(vsphereCluster, vmwarev1.ProviderServiceAccountsReadyCondition)).To(BeFalse())
+				Expect(conditions.Has(vsphereCluster, vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Condition)).To(BeFalse())
 			})
 		})
 	})

--- a/controllers/vmware/serviceaccount_controller_suite_test.go
+++ b/controllers/vmware/serviceaccount_controller_suite_test.go
@@ -27,8 +27,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta2"
@@ -154,12 +153,11 @@ func assertRoleBinding(ctx context.Context, ctrlClient client.Client, namespace,
 }
 
 // assertProviderServiceAccountsCondition asserts the condition on the ProviderServiceAccount CR.
-func assertProviderServiceAccountsCondition(vCluster *vmwarev1.VSphereCluster, status corev1.ConditionStatus, message string, reason string, severity clusterv1.ConditionSeverity) {
-	c := deprecatedv1beta1conditions.Get(vCluster, vmwarev1.ProviderServiceAccountsReadyCondition)
+func assertProviderServiceAccountsCondition(vCluster *vmwarev1.VSphereCluster, status metav1.ConditionStatus, message string, reason string) {
+	c := conditions.Get(vCluster, vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Condition)
 	Expect(c).NotTo(BeNil())
 	Expect(c.Status).To(Equal(status))
 	Expect(c.Reason).To(Equal(reason))
-	Expect(c.Severity).To(Equal(severity))
 	if message == "" {
 		Expect(c.Message).To(BeEmpty())
 	} else {

--- a/controllers/vmware/serviceaccount_controller_unit_test.go
+++ b/controllers/vmware/serviceaccount_controller_unit_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -62,7 +63,7 @@ func unitTestsReconcileNormal() {
 		It("Should reconcile", func() {
 			By("Not creating any entities")
 			assertNoEntities(ctx, controllerCtx.ControllerManagerContext.Client, namespace)
-			assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Reason)
 		})
 	})
 
@@ -92,7 +93,7 @@ func unitTestsReconcileNormal() {
 				assertTargetNamespace(ctx, controllerCtx.GuestClient, testTargetNS, true)
 				By("Creating the target secret in the target namespace")
 				assertTargetSecret(ctx, controllerCtx.GuestClient, testTargetNS, testTargetSecret)
-				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Reason)
 			})
 		})
 		Context("When serviceaccount secret is modified", func() {
@@ -102,7 +103,7 @@ func unitTestsReconcileNormal() {
 				updateServiceAccountSecretAndReconcileNormal(ctx, controllerCtx, reconciler, vsphereCluster)
 				By("Updating the target secret in the target namespace")
 				assertTargetSecret(ctx, controllerCtx.GuestClient, testTargetNS, testTargetSecret)
-				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Reason)
 			})
 		})
 		Context("When invalid role exists", func() {
@@ -111,7 +112,7 @@ func unitTestsReconcileNormal() {
 			})
 			It("Should update role", func() {
 				assertRoleWithGetPVC(ctx, controllerCtx.ControllerManagerContext.Client, namespace, vsphereCluster.GetName())
-				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Reason)
 			})
 		})
 		Context("When invalid rolebinding exists", func() {
@@ -120,7 +121,7 @@ func unitTestsReconcileNormal() {
 			})
 			It("Should update rolebinding", func() {
 				assertRoleBinding(ctx, controllerCtx.ControllerManagerContext.Client, namespace, vsphereCluster.GetName())
-				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+				assertProviderServiceAccountsCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterProviderServiceAccountsReadyV1Beta2Reason)
 			})
 		})
 	})

--- a/controllers/vmware/servicediscovery_controller_suite_test.go
+++ b/controllers/vmware/servicediscovery_controller_suite_test.go
@@ -28,8 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta2"
@@ -120,9 +119,9 @@ func assertHeadlessSvcWithFIPHostNameEndpoints(ctx context.Context, guestClient 
 	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(testSupervisorAPIServerPort)))
 }
 
-func assertServiceDiscoveryCondition(vsphereCluster *vmwarev1.VSphereCluster, status corev1.ConditionStatus,
-	message string, reason string, severity clusterv1.ConditionSeverity) {
-	c := deprecatedv1beta1conditions.Get(vsphereCluster, vmwarev1.ServiceDiscoveryReadyCondition)
+func assertServiceDiscoveryCondition(vsphereCluster *vmwarev1.VSphereCluster, status metav1.ConditionStatus,
+	message string, reason string) {
+	c := conditions.Get(vsphereCluster, vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Condition)
 	Expect(c).NotTo(BeNil())
 	if message == "" {
 		Expect(c.Message).To(BeEmpty())
@@ -131,7 +130,6 @@ func assertServiceDiscoveryCondition(vsphereCluster *vmwarev1.VSphereCluster, st
 	}
 	Expect(c.Status).To(Equal(status))
 	Expect(c.Reason).To(Equal(reason))
-	Expect(c.Severity).To(Equal(severity))
 }
 
 func assertHeadlessSvcWithUpdatedVIPEndpoints(ctx context.Context, guestClient client.Client, namespace, name string) {

--- a/controllers/vmware/servicediscovery_controller_unit_test.go
+++ b/controllers/vmware/servicediscovery_controller_unit_test.go
@@ -19,9 +19,8 @@ package vmware
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,8 +55,8 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and no endpoint in the guest cluster")
 			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionFalse, "Failed to discover supervisor API server endpoint",
-				vmwarev1.SupervisorHeadlessServiceSetupFailedReason, clusterv1.ConditionSeverityWarning)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "Failed to discover supervisor API server endpoint",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyV1Beta2Reason)
 		})
 	})
 	Context("When VIP is available", func() {
@@ -70,7 +69,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			assertHeadlessSvcWithVIPEndpoints(ctx, controllerCtx.GuestClient, vmwarev1.SupervisorHeadlessSvcNamespace, vmwarev1.SupervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Reason)
 		})
 		It("Should get supervisor master endpoint IP", func() {
 			r := &serviceDiscoveryReconciler{
@@ -89,7 +88,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the FIP in the guest cluster")
 			assertHeadlessSvcWithFIPEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Reason)
 		})
 	})
 	Context("When VIP and FIP are available", func() {
@@ -102,7 +101,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			assertHeadlessSvcWithVIPEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Reason)
 		})
 	})
 	Context("When VIP is an hostname", func() {
@@ -113,7 +112,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the VIP in the guest cluster")
 			assertHeadlessSvcWithVIPHostnameEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Reason)
 		})
 	})
 	Context("When FIP is an hostname", func() {
@@ -125,7 +124,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and endpoints using the FIP in the guest cluster")
 			assertHeadlessSvcWithFIPHostNameEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionTrue, "", "", "")
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyV1Beta2Reason)
 		})
 	})
 	Context("When FIP is an empty hostname", func() {
@@ -137,8 +136,8 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and no endpoint in the guest cluster")
 			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionFalse, "Failed to discover supervisor API server endpoint",
-				vmwarev1.SupervisorHeadlessServiceSetupFailedReason, clusterv1.ConditionSeverityWarning)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "Failed to discover supervisor API server endpoint",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyV1Beta2Reason)
 		})
 	})
 	Context("When FIP is an invalid host", func() {
@@ -150,8 +149,8 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and no endpoint in the guest cluster")
 			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionFalse, "Failed to discover supervisor API server endpoint",
-				vmwarev1.SupervisorHeadlessServiceSetupFailedReason, clusterv1.ConditionSeverityWarning)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "Failed to discover supervisor API server endpoint",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyV1Beta2Reason)
 		})
 	})
 	Context("When FIP config map has invalid kubeconfig data", func() {
@@ -166,8 +165,8 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and no endpoint in the guest cluster")
 			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionFalse, "Failed to discover supervisor API server endpoint",
-				vmwarev1.SupervisorHeadlessServiceSetupFailedReason, clusterv1.ConditionSeverityWarning)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "Failed to discover supervisor API server endpoint",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyV1Beta2Reason)
 		})
 	})
 	Context("When FIP config map has invalid kubeconfig key", func() {
@@ -182,8 +181,8 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		It("Should reconcile headless svc", func() {
 			By("creating a service and no endpoint in the guest cluster")
 			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, corev1.ConditionFalse, "Failed to discover supervisor API server endpoint",
-				vmwarev1.SupervisorHeadlessServiceSetupFailedReason, clusterv1.ConditionSeverityWarning)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "Failed to discover supervisor API server endpoint",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyV1Beta2Reason)
 		})
 	})
 }

--- a/controllers/vsphereclusteridentity_controller_test.go
+++ b/controllers/vsphereclusteridentity_controller_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterutilv1 "sigs.k8s.io/cluster-api/util"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2"
@@ -170,7 +170,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					return false
 				}
 
-				if !ptr.Deref(i.Status.Ready, false) && deprecatedv1beta1conditions.GetReason(i, infrav1.CredentialsAvailableCondition) == infrav1.SecretAlreadyInUseReason {
+				if !ptr.Deref(i.Status.Ready, false) && conditions.GetReason(i, infrav1.VSphereClusterIdentityAvailableV1Beta2Condition) == infrav1.VSphereClusterIdentitySecretAlreadyInUseV1Beta2Reason {
 					return true
 				}
 				return false
@@ -194,7 +194,7 @@ var _ = Describe("VSphereClusterIdentity Reconciler", func() {
 					return false
 				}
 
-				if !ptr.Deref(i.Status.Ready, false) && deprecatedv1beta1conditions.GetReason(i, infrav1.CredentialsAvailableCondition) == infrav1.SecretNotAvailableReason {
+				if !ptr.Deref(i.Status.Ready, false) && conditions.GetReason(i, infrav1.VSphereClusterIdentityAvailableV1Beta2Condition) == infrav1.VSphereClusterIdentitySecretNotAvailableV1Beta2Reason {
 					return true
 				}
 				return false

--- a/controllers/vspheredeploymentzone_controller_test.go
+++ b/controllers/vspheredeploymentzone_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2"
@@ -135,9 +135,9 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 			if err := testEnv.Get(ctx, deploymentZoneKey, vsphereDeploymentZone); err != nil {
 				return false
 			}
-			return deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.VCenterAvailableCondition) &&
-				deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition) &&
-				deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+			return conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZoneVCenterAvailableV1Beta2Condition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZonePlacementConstraintReadyV1Beta2Condition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZoneFailureDomainValidatedV1Beta2Condition)
 		}, timeout).Should(BeTrue())
 
 		Expect(testEnv.Get(ctx, failureDomainKey, vsphereFailureDomain)).To(Succeed())
@@ -200,7 +200,7 @@ var _ = Describe("VSphereDeploymentZoneReconciler", func() {
 				if err := testEnv.Get(ctx, deploymentZoneKey, vsphereDeploymentZone); err != nil {
 					return false
 				}
-				return deprecatedv1beta1conditions.IsFalse(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition)
+				return conditions.IsFalse(vsphereDeploymentZone, infrav1.VSphereDeploymentZonePlacementConstraintReadyV1Beta2Condition)
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -375,9 +375,9 @@ func TestVSphereDeploymentZone_Reconcile(t *testing.T) {
 			if err := testEnv.Get(ctx, client.ObjectKeyFromObject(vsphereDeploymentZone), vsphereDeploymentZone); err != nil {
 				return false
 			}
-			return deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.VCenterAvailableCondition) &&
-				deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.PlacementConstraintMetCondition) &&
-				deprecatedv1beta1conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereFailureDomainValidatedCondition)
+			return conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZoneVCenterAvailableV1Beta2Condition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZonePlacementConstraintReadyV1Beta2Condition) &&
+				conditions.IsTrue(vsphereDeploymentZone, infrav1.VSphereDeploymentZoneFailureDomainValidatedV1Beta2Condition)
 		}, timeout).Should(BeTrue())
 
 		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(vsphereFailureDomain), vsphereFailureDomain)).To(Succeed())

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -273,7 +273,7 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 		// Before computing ready condition, make sure that VirtualMachineProvisioned is always set.
 		// NOTE: This is required because v1beta2 conditions comply to guideline requiring conditions to be set at the
 		// first reconcile.
-		if c := conditions.Get(vmContext.VSphereVM, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition); c != nil {
+		if c := conditions.Get(vmContext.VSphereVM, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition); c == nil {
 			if ptr.Deref(vmContext.VSphereVM.Status.Ready, false) {
 				conditions.Set(vmContext.VSphereVM, metav1.Condition{
 					Type:   infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition,

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -34,7 +34,7 @@ import (
 	ipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/util"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -209,10 +209,10 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		vmKey := util.ObjectKey(vsphereVM)
 		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
 
-		g.Expect(deprecatedv1beta1conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
-		vmProvisionCondition := deprecatedv1beta1conditions.Get(vm, infrav1.VMProvisionedCondition)
-		g.Expect(vmProvisionCondition.Status).To(Equal(corev1.ConditionFalse))
-		g.Expect(vmProvisionCondition.Reason).To(Equal(infrav1.WaitingForStaticIPAllocationReason))
+		g.Expect(conditions.Has(vm, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)).To(BeTrue())
+		vmProvisionCondition := conditions.Get(vm, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)
+		g.Expect(vmProvisionCondition.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(vmProvisionCondition.Reason).To(Equal(infrav1.VSphereVMVirtualMachineWaitingForStaticIPAllocationV1Beta2Reason))
 	})
 
 	t.Run("Waiting for IP addr allocation", func(t *testing.T) {
@@ -245,10 +245,10 @@ func TestReconcileNormal_WaitingForIPAddrAllocation(t *testing.T) {
 		vmKey := util.ObjectKey(vsphereVM)
 		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
 
-		g.Expect(deprecatedv1beta1conditions.Has(vm, infrav1.VMProvisionedCondition)).To(BeTrue())
-		vmProvisionCondition := deprecatedv1beta1conditions.Get(vm, infrav1.VMProvisionedCondition)
-		g.Expect(vmProvisionCondition.Status).To(Equal(corev1.ConditionFalse))
-		g.Expect(vmProvisionCondition.Reason).To(Equal(infrav1.WaitingForIPAllocationReason))
+		g.Expect(conditions.Has(vm, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)).To(BeTrue())
+		vmProvisionCondition := conditions.Get(vm, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)
+		g.Expect(vmProvisionCondition.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(vmProvisionCondition.Reason).To(Equal(infrav1.VSphereVMVirtualMachineWaitingForIPAllocationV1Beta2Reason))
 	})
 
 	t.Run("Deleting a VM with IPAddressClaims", func(t *testing.T) {
@@ -501,9 +501,7 @@ func TestRetrievingVCenterCredentialsFromCluster(t *testing.T) {
 		vm := &infrav1.VSphereVM{}
 		vmKey := util.ObjectKey(vsphereVM)
 		g.Expect(r.Client.Get(context.Background(), vmKey, vm)).NotTo(HaveOccurred())
-		g.Expect(deprecatedv1beta1conditions.Has(vm, infrav1.VCenterAvailableCondition)).To(BeTrue())
-		vCenterCondition := deprecatedv1beta1conditions.Get(vm, infrav1.VCenterAvailableCondition)
-		g.Expect(vCenterCondition.Status).To(Equal(corev1.ConditionTrue))
+		g.Expect(conditions.IsTrue(vm, infrav1.VSphereVMVCenterAvailableV1Beta2Condition)).To(BeTrue())
 	},
 	)
 

--- a/controllers/vspherevm_ipaddress_reconciler_test.go
+++ b/controllers/vspherevm_ipaddress_reconciler_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -94,10 +94,10 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 				g.Expect(claim.Labels).To(gomega.HaveKeyWithValue(clusterv1.ClusterNameLabel, "my-cluster"))
 			}
 
-			claimedCondition := deprecatedv1beta1conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
+			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.VSphereVMIPAddressClaimsFulfilledV1Beta2Condition)
 			g.Expect(claimedCondition).NotTo(gomega.BeNil())
-			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionFalse))
-			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.IPAddressClaimsBeingCreatedReason))
+			g.Expect(claimedCondition.Status).To(gomega.Equal(metav1.ConditionFalse))
+			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.VSphereVMIPAddressClaimsBeingCreatedV1Beta2Reason))
 			g.Expect(claimedCondition.Message).To(gomega.Equal("3/3 claims being created"))
 		})
 
@@ -127,10 +127,10 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			err := vmReconciler{}.reconcileIPAddressClaims(ctx, testCtx)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			claimedCondition := deprecatedv1beta1conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
+			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.VSphereVMIPAddressClaimsFulfilledV1Beta2Condition)
 			g.Expect(claimedCondition).NotTo(gomega.BeNil())
-			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionFalse))
-			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.WaitingForIPAddressReason))
+			g.Expect(claimedCondition.Status).To(gomega.Equal(metav1.ConditionFalse))
+			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.VSphereVMIPAddressClaimsWaitingForIPAddressV1Beta2Reason))
 			g.Expect(claimedCondition.Message).To(gomega.Equal("3/3 claims being processed"))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
@@ -163,9 +163,9 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			err := vmReconciler{}.reconcileIPAddressClaims(ctx, testCtx)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			claimedCondition := deprecatedv1beta1conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
+			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.VSphereVMIPAddressClaimsFulfilledV1Beta2Condition)
 			g.Expect(claimedCondition).NotTo(gomega.BeNil())
-			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionTrue))
+			g.Expect(claimedCondition.Status).To(gomega.Equal(metav1.ConditionTrue))
 
 			ipAddrClaimList := &ipamv1.IPAddressClaimList{}
 			g.Expect(testCtx.Client.List(ctx, ipAddrClaimList)).To(gomega.Succeed())
@@ -207,9 +207,9 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			err := vmReconciler{}.reconcileIPAddressClaims(ctx, testCtx)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			claimedCondition := deprecatedv1beta1conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
+			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.VSphereVMIPAddressClaimsFulfilledV1Beta2Condition)
 			g.Expect(claimedCondition).NotTo(gomega.BeNil())
-			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionFalse))
+			g.Expect(claimedCondition.Status).To(gomega.Equal(metav1.ConditionFalse))
 		})
 
 		t.Run("when some existing claims have Ready Condition set", func(t *testing.T) {
@@ -236,10 +236,10 @@ func Test_vmReconciler_reconcileIPAddressClaims(t *testing.T) {
 			err := vmReconciler{}.reconcileIPAddressClaims(ctx, testCtx)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			claimedCondition := deprecatedv1beta1conditions.Get(testCtx.VSphereVM, infrav1.IPAddressClaimedCondition)
+			claimedCondition := conditions.Get(testCtx.VSphereVM, infrav1.VSphereVMIPAddressClaimsFulfilledV1Beta2Condition)
 			g.Expect(claimedCondition).NotTo(gomega.BeNil())
-			g.Expect(claimedCondition.Status).To(gomega.Equal(corev1.ConditionFalse))
-			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.WaitingForIPAddressReason))
+			g.Expect(claimedCondition.Status).To(gomega.Equal(metav1.ConditionFalse))
+			g.Expect(claimedCondition.Reason).To(gomega.Equal(infrav1.VSphereVMIPAddressClaimsWaitingForIPAddressV1Beta2Reason))
 			g.Expect(claimedCondition.Message).To(gomega.Equal("2/3 claims being processed"))
 		})
 	})

--- a/pkg/services/govmomi/util_test.go
+++ b/pkg/services/govmomi/util_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta2"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
@@ -104,7 +104,7 @@ func Test_ShouldRetryTask(t *testing.T) {
 			reconciled, err := checkAndRetryTask(ctx, vmCtx, &task)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(reconciled).To(BeTrue())
-			g.Expect(deprecatedv1beta1conditions.IsFalse(vmCtx.VSphereVM, infrav1.VMProvisionedCondition)).To(BeTrue())
+			g.Expect(conditions.IsFalse(vmCtx.VSphereVM, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)).To(BeTrue())
 			g.Expect(vmCtx.VSphereVM.Status.TaskRef).To(BeEmpty())
 			g.Expect(vmCtx.VSphereVM.Status.RetryAfter.IsZero()).To(BeTrue())
 		})
@@ -123,7 +123,7 @@ func Test_ShouldRetryTask(t *testing.T) {
 		reconciled, err := checkAndRetryTask(ctx, vmCtx, &task)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(reconciled).To(BeTrue())
-		g.Expect(deprecatedv1beta1conditions.IsFalse(vmCtx.VSphereVM, infrav1.VMProvisionedCondition)).To(BeTrue())
+		g.Expect(conditions.IsFalse(vmCtx.VSphereVM, infrav1.VSphereVMVirtualMachineProvisionedV1Beta2Condition)).To(BeTrue())
 		g.Expect(vmCtx.VSphereVM.Status.RetryAfter.Unix()).To(BeNumerically("<=", metav1.Now().Add(1*time.Minute).Unix()))
 	})
 

--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -63,6 +63,11 @@ func (m *MockNSXTNetworkProvider) ProvisionClusterNetwork(ctx context.Context, c
 		// Check if the error contains the string "virtual network ready status"
 		if strings.Contains(err.Error(), "virtual network ready status") {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)
+			conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
+				Type:   vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition,
+				Status: metav1.ConditionTrue,
+				Reason: vmwarev1.VSphereClusterNetworkReadyV1Beta2Reason,
+			})
 			return nil
 		}
 		// return the original error if it doesn't contain the specific string
@@ -83,6 +88,11 @@ func (m *MockNSXTVpcNetworkProvider) ProvisionClusterNetwork(ctx context.Context
 		// Check if the error contains the string "subnetset ready status"
 		if strings.Contains(err.Error(), "subnetset ready status") {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)
+			conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
+				Type:   vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition,
+				Status: metav1.ConditionTrue,
+				Reason: vmwarev1.VSphereClusterNetworkReadyV1Beta2Reason,
+			})
 			return nil
 		}
 		// return the original error if it doesn't contain the specific string
@@ -663,7 +673,7 @@ var _ = Describe("Network provider", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should succeed", func() {
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -697,7 +707,7 @@ var _ = Describe("Network provider", func() {
 				annotations, err := np.GetVMServiceAnnotations(ctx, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(annotations).To(HaveKeyWithValue("ncp.vmware.com/virtual-network-name", GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -729,7 +739,7 @@ var _ = Describe("Network provider", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(createdVNET.Spec.WhitelistSourceRanges).To(BeEmpty())
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -756,7 +766,7 @@ var _ = Describe("Network provider", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(createdVNET.Spec.WhitelistSourceRanges).To(Equal(fakeSNATIP + "/32"))
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -790,7 +800,7 @@ var _ = Describe("Network provider", func() {
 				Expect(createdVNET.Spec.WhitelistSourceRanges).To(Equal(fakeSNATIP + "/32"))
 				// err is not empty, but it is because vnetObj does not have status mocked in this test
 
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -820,7 +830,7 @@ var _ = Describe("Network provider", func() {
 				Expect(createdVNET.Spec.WhitelistSourceRanges).To(BeEmpty())
 				// err is not empty, but it is because vnetObj does not have status mocked in this test
 
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 
 			AfterEach(func() {
@@ -858,7 +868,7 @@ var _ = Describe("Network provider", func() {
 				expectedErrorMessage := fmt.Sprintf("virtual network ready status is: '%s' in cluster %s. reason: %s, message: %s",
 					"False", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster}, testNetworkNotRealizedReason, testNetworkNotRealizedMessage)
 				Expect(err).To(MatchError(expectedErrorMessage))
-				Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 
 			It("should return error when vnet ready status is not set", func() {
@@ -875,7 +885,7 @@ var _ = Describe("Network provider", func() {
 
 				expectedErrorMessage := fmt.Sprintf("virtual network ready status in cluster %s has not been set", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster})
 				Expect(err).To(MatchError(expectedErrorMessage))
-				Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -1023,7 +1033,7 @@ var _ = Describe("Network provider", func() {
 				expectedErrorMessage := fmt.Sprintf("subnetset ready status is: '%s' in cluster %s. reason: %s, message: %s",
 					"False", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster}, testNetworkNotRealizedReason, testNetworkNotRealizedMessage)
 				Expect(err).To(MatchError(expectedErrorMessage))
-				Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 
 			It("should return error when subnetset ready status is not set", func() {
@@ -1041,7 +1051,7 @@ var _ = Describe("Network provider", func() {
 				err = np.VerifyNetworkStatus(ctx, clusterCtx, subnetsetObj)
 				expectedErrorMessage := fmt.Sprintf("subnetset ready status in cluster %s has not been set", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster})
 				Expect(err).To(MatchError(expectedErrorMessage))
-				Expect(deprecatedv1beta1conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
+				Expect(conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 		})
 
@@ -1069,7 +1079,6 @@ var _ = Describe("Network provider", func() {
 					Namespace: dummyNs,
 				}, subnetSet)
 				Expect(apierrors.IsNotFound(getErr)).To(BeTrue())
-				Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyCondition)).To(BeTrue())
 				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyV1Beta2Condition)).To(BeTrue())
 			})
 

--- a/pkg/services/vmoperator/control_plane_endpoint_test.go
+++ b/pkg/services/vmoperator/control_plane_endpoint_test.go
@@ -24,11 +24,10 @@ import (
 	netopv1 "github.com/vmware-tanzu/net-operator-api/api/v1alpha1"
 	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	ncpv1 "github.com/vmware-tanzu/vm-operator/external/ncp/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta2"
@@ -104,7 +103,7 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 		expectedPort                int
 		expectedAnnotations         map[string]string
 		expectedClusterRoleVMLabels map[string]string
-		expectedConditions          clusterv1.Conditions
+		expectedConditions          []metav1.Condition
 
 		cluster                  *clusterv1.Cluster
 		vsphereCluster           *vmwarev1.VSphereCluster
@@ -163,7 +162,7 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			}
 
 			for _, expectedCondition := range expectedConditions {
-				c := deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, expectedCondition.Type)
+				c := conditions.Get(clusterCtx.VSphereCluster, expectedCondition.Type)
 				Expect(c).NotTo(BeNil())
 				Expect(c.Status).To(Equal(expectedCondition.Status))
 				Expect(c.Reason).To(Equal(expectedCondition.Reason))
@@ -181,7 +180,7 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			expectAPIEndpoint = false
 			expectVMS = false
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, network.DummyNetworkProvider())
-			Expect(deprecatedv1beta1conditions.Get(clusterCtx.VSphereCluster, vmwarev1.LoadBalancerReadyCondition)).To(BeNil())
+			Expect(conditions.Get(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterLoadBalancerReadyV1Beta2Condition)).To(BeNil())
 			verifyOutput()
 		})
 
@@ -229,10 +228,10 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			By("NetOp NetworkProvider has no Network")
 			netOpProvider := network.NetOpNetworkProvider(c)
 			// we expect the reconciliation fail because lack of bootstrap data
-			expectedConditions = append(expectedConditions, clusterv1.Condition{
-				Type:    vmwarev1.LoadBalancerReadyCondition,
-				Status:  corev1.ConditionFalse,
-				Reason:  vmwarev1.LoadBalancerCreationFailedReason,
+			expectedConditions = append(expectedConditions, metav1.Condition{
+				Type:    vmwarev1.VSphereClusterLoadBalancerReadyV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  vmwarev1.VSphereClusterLoadBalancerNotReadyV1Beta2Reason,
 				Message: noNetworkFailure,
 			})
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, netOpProvider)
@@ -244,7 +243,7 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			expectedAnnotations["netoperator.vmware.com/network-name"] = "dummy-network"
 			expectVMS = true
 			createDefaultNetwork(ctx, clusterCtx, c)
-			expectedConditions[0].Reason = vmwarev1.WaitingForLoadBalancerIPReason
+			expectedConditions[0].Reason = vmwarev1.VSphereClusterLoadBalancerWaitingForIPV1Beta2Reason
 			expectedConditions[0].Message = waitingForVIPFailure
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, netOpProvider)
 			verifyOutput()
@@ -256,8 +255,8 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			expectedPort = defaultAPIBindPort
 			expectedHost = vip
 			updateVMServiceWithVIP(ctx, clusterCtx, c, cpService, vip)
-			expectedConditions[0].Status = corev1.ConditionTrue
-			expectedConditions[0].Reason = ""
+			expectedConditions[0].Status = metav1.ConditionTrue
+			expectedConditions[0].Reason = vmwarev1.VSphereClusterLoadBalancerReadyV1Beta2Reason
 			expectedConditions[0].Message = ""
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, netOpProvider)
 			verifyOutput()
@@ -271,10 +270,10 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			// A VirtualMachineService is only created once all prerequisites have been met
 			expectVMS = false
 			expectedType = vmoprvhub.VirtualMachineServiceTypeLoadBalancer
-			expectedConditions = append(expectedConditions, clusterv1.Condition{
-				Type:    vmwarev1.LoadBalancerReadyCondition,
-				Status:  corev1.ConditionFalse,
-				Reason:  vmwarev1.LoadBalancerCreationFailedReason,
+			expectedConditions = append(expectedConditions, metav1.Condition{
+				Type:    vmwarev1.VSphereClusterLoadBalancerReadyV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  vmwarev1.VSphereClusterLoadBalancerNotReadyV1Beta2Reason,
 				Message: noNetworkFailure,
 			})
 
@@ -290,7 +289,7 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			expectedVnetName := network.GetNSXTVirtualNetworkName(clusterName)
 			expectedAnnotations["ncp.vmware.com/virtual-network-name"] = expectedVnetName
 			expectVMS = true
-			expectedConditions[0].Reason = vmwarev1.WaitingForLoadBalancerIPReason
+			expectedConditions[0].Reason = vmwarev1.VSphereClusterLoadBalancerWaitingForIPV1Beta2Reason
 			expectedConditions[0].Message = waitingForVIPFailure
 			createVnet(ctx, clusterCtx, c)
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, nsxtProvider)
@@ -302,8 +301,8 @@ var _ = Describe("ControlPlaneEndpoint Tests", func() {
 			expectAPIEndpoint = true
 			expectedPort = defaultAPIBindPort
 			expectedHost = vip
-			expectedConditions[0].Status = corev1.ConditionTrue
-			expectedConditions[0].Reason = ""
+			expectedConditions[0].Status = metav1.ConditionTrue
+			expectedConditions[0].Reason = vmwarev1.VSphereClusterLoadBalancerReadyV1Beta2Reason
 			expectedConditions[0].Message = ""
 			updateVMServiceWithVIP(ctx, clusterCtx, c, cpService, vip)
 			apiEndpoint, err = cpService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, nsxtProvider)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3452
