### PR TITLE
🌱 Block direct usage of vm-operator APIs in prod code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - bidichk # dangerous unicode sequences
     - bodyclose # unclosed http bodies
     - containedctx # context.Context nested in a struct
+    - depguard # blocks dependencies
     - dogsled # too many blank identifiers in assignments
     - dupword # duplicate words
     - durationcheck # multiplying two durations
@@ -48,6 +49,12 @@ linters:
     # TODO: It will be dropped when the Go version migration is done.
     - usetesting
   settings:
+    depguard:
+      rules:
+        vm-operator:
+          deny:
+            - pkg: "github.com/vmware-tanzu/vm-operator/api"
+              desc: Use vmoprvhub in prod code instead
     ginkgolinter:
       forbid-focus-container: true
     gocritic:
@@ -235,14 +242,6 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: mgr.GetEventRecorderFor is deprecated'
-        # Deprecations for AutoConfigure
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*AutoConfigure is deprecated'
-        # Deprecations for PreferredAPIServerCIDR
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*PreferredAPIServerCIDR is deprecated'
         # Deprecations for FailureReason
       - linters:
           - staticcheck
@@ -260,7 +259,11 @@ linters:
           - revive
         path: pkg/conversion/api/vmoperator/hub/(.+)_types.go
         text: 'exported (type|const) (.+) should have comment \(or a comment on this block\) or be unexported'
-
+        # Allow direct usage of vm-operator APIs in a few places like e.g. tests and main.go
+      - linters:
+          - depguard
+        path: main.go|pkg/manager/manager.go|.*_test.go|internal/test/helpers/.*|pkg/context/fake/fake_controller_manager_context.go|pkg/conversion/.*|pkg/util/testutil.go
+        text: 'Use vmoprvhub in prod code instead'
       - linters:
           - staticcheck
         text: 'SA1019: "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/.*" is deprecated'


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3758