### PR TITLE
⚠️ Align NumCPUs & NumCoresPerSocket to API conventions

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -111,12 +111,6 @@ linters:
       linters:
         - kubeapilinter
 
-    ## TODO: Think about CPU configuration, context: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3664
-    - path: "api/govmomi/v1beta2/types.go"
-      text: "optionalfields: field (NumCPUs|NumCoresPerSocket) has a valid zero value"
-      linters:
-        - kubeapilinter
-
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/api/govmomi/v1beta1/conversion.go
+++ b/api/govmomi/v1beta1/conversion.go
@@ -197,6 +197,8 @@ func (src *VSphereMachine) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
+	clusterv1.Convert_int32_To_Pointer_int32(src.Spec.NumCoresPerSocket, ok, restored.Spec.NumCoresPerSocket, &dst.Spec.NumCoresPerSocket)
+
 	if len(src.Spec.Network.Routes) == len(dst.Spec.Network.Routes) {
 		for i, dstRoute := range dst.Spec.Network.Routes {
 			srcRoute := src.Spec.Network.Routes[i]
@@ -296,6 +298,8 @@ func (src *VSphereMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
+	clusterv1.Convert_int32_To_Pointer_int32(src.Spec.Template.Spec.NumCoresPerSocket, ok, restored.Spec.Template.Spec.NumCoresPerSocket, &dst.Spec.Template.Spec.NumCoresPerSocket)
+
 	if len(src.Spec.Template.Spec.Network.Routes) == len(dst.Spec.Template.Spec.Network.Routes) {
 		for i, dstRoute := range dst.Spec.Template.Spec.Network.Routes {
 			srcRoute := src.Spec.Template.Spec.Network.Routes[i]
@@ -374,6 +378,8 @@ func (src *VSphereVM) ConvertTo(dstRaw conversion.Hub) error {
 	if err != nil {
 		return err
 	}
+
+	clusterv1.Convert_int32_To_Pointer_int32(src.Spec.NumCoresPerSocket, ok, restored.Spec.NumCoresPerSocket, &dst.Spec.NumCoresPerSocket)
 
 	if src.Spec.BootstrapRef != nil {
 		dst.Spec.BootstrapRef.Name = src.Spec.BootstrapRef.Name

--- a/api/govmomi/v1beta1/zz_generated.conversion.go
+++ b/api/govmomi/v1beta1/zz_generated.conversion.go
@@ -2470,7 +2470,9 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1beta2_VirtualMachineCloneS
 		return err
 	}
 	out.NumCPUs = in.NumCPUs
-	out.NumCoresPerSocket = in.NumCoresPerSocket
+	if err := v1.Convert_int32_To_Pointer_int32(&in.NumCoresPerSocket, &out.NumCoresPerSocket, s); err != nil {
+		return err
+	}
 	if err := Convert_v1beta1_VirtualMachineResources_To_v1beta2_VirtualMachineResources(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
@@ -2506,7 +2508,9 @@ func autoConvert_v1beta2_VirtualMachineCloneSpec_To_v1beta1_VirtualMachineCloneS
 		return err
 	}
 	out.NumCPUs = in.NumCPUs
-	out.NumCoresPerSocket = in.NumCoresPerSocket
+	if err := v1.Convert_Pointer_int32_To_int32(&in.NumCoresPerSocket, &out.NumCoresPerSocket, s); err != nil {
+		return err
+	}
 	if err := Convert_v1beta2_VirtualMachineResources_To_v1beta1_VirtualMachineResources(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}

--- a/api/govmomi/v1beta2/types.go
+++ b/api/govmomi/v1beta2/types.go
@@ -180,14 +180,17 @@ type VirtualMachineCloneSpec struct {
 	// Defaults to the eponymous property value in the template from which the
 	// virtual machine is cloned.
 	// +optional
+	// +kubebuilder:validation:Minimum=2
 	NumCPUs int32 `json:"numCPUs,omitempty"`
 
 	// numCoresPerSocket is the number of cores among which to distribute CPUs in this
 	// virtual machine.
 	// Defaults to the eponymous property value in the template from which the
 	// virtual machine is cloned.
+	// Note: Starting with vSphere 8 numCoresPerSocket can be set to 0 to enable "Assigned at power on".
 	// +optional
-	NumCoresPerSocket int32 `json:"numCoresPerSocket,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	NumCoresPerSocket *int32 `json:"numCoresPerSocket,omitempty"`
 
 	// resources is the definition of the VM's cpu and memory
 	// reservations, limits and shares.

--- a/api/govmomi/v1beta2/zz_generated.deepcopy.go
+++ b/api/govmomi/v1beta2/zz_generated.deepcopy.go
@@ -1674,6 +1674,11 @@ func (in *VSphereVMV1Beta1DeprecatedStatus) DeepCopy() *VSphereVMV1Beta1Deprecat
 func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 	*out = *in
 	in.Network.DeepCopyInto(&out.Network)
+	if in.NumCoresPerSocket != nil {
+		in, out := &in.NumCoresPerSocket, &out.NumCoresPerSocket
+		*out = new(int32)
+		**out = **in
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.AdditionalDisksGiB != nil {
 		in, out := &in.AdditionalDisksGiB, &out.AdditionalDisksGiB

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1474,6 +1474,7 @@ spec:
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
+                minimum: 2
                 type: integer
               numCoresPerSocket:
                 description: |-
@@ -1481,7 +1482,9 @@ spec:
                   virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
+                  Note: Starting with vSphere 8 numCoresPerSocket can be set to 0 to enable "Assigned at power on".
                 format: int32
+                minimum: 0
                 type: integer
               os:
                 description: |-

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1296,6 +1296,7 @@ spec:
                           Defaults to the eponymous property value in the template from which the
                           virtual machine is cloned.
                         format: int32
+                        minimum: 2
                         type: integer
                       numCoresPerSocket:
                         description: |-
@@ -1303,7 +1304,9 @@ spec:
                           virtual machine.
                           Defaults to the eponymous property value in the template from which the
                           virtual machine is cloned.
+                          Note: Starting with vSphere 8 numCoresPerSocket can be set to 0 to enable "Assigned at power on".
                         format: int32
+                        minimum: 0
                         type: integer
                       os:
                         description: |-

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1455,6 +1455,7 @@ spec:
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
+                minimum: 2
                 type: integer
               numCoresPerSocket:
                 description: |-
@@ -1462,7 +1463,9 @@ spec:
                   virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
+                  Note: Starting with vSphere 8 numCoresPerSocket can be set to 0 to enable "Assigned at power on".
                 format: int32
+                minimum: 0
                 type: integer
               os:
                 description: |-

--- a/main.go
+++ b/main.go
@@ -323,6 +323,11 @@ func main() {
 		setupLog.Error(err, "Unable to start manager")
 		os.Exit(1)
 	}
+	if isGovmomiCRDLoaded && isSupervisorCRDLoaded {
+		err := fmt.Errorf("both supervisor and govmomi CRDs detected (unsupported configuration)")
+		setupLog.Error(err, "Unable to start manager")
+		os.Exit(1)
+	}
 
 	var watchNamespaces map[string]cache.Config
 	if watchNamespace != "" {

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -175,9 +175,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 		numCPUs = 2
 	}
 	numCoresPerSocket := vmCtx.VSphereVM.Spec.NumCoresPerSocket
-	if numCoresPerSocket == 0 {
-		numCoresPerSocket = numCPUs
-	}
+
 	memMiB := vmCtx.VSphereVM.Spec.MemoryMiB
 	if memMiB == 0 {
 		memMiB = 2048
@@ -197,7 +195,7 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 			DeviceChange:      deviceSpecs,
 			ExtraConfig:       extraConfig,
 			NumCPUs:           numCPUs,
-			NumCoresPerSocket: ptr.To(numCoresPerSocket),
+			NumCoresPerSocket: numCoresPerSocket,
 			MemoryMB:          memMiB,
 			VAppConfigRemoved: &vappConfigRemoved,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
Fixes #3664