### PR TITLE
⚠️ Align failureDomain fields to CAPI contract

### DIFF
--- a/api/govmomi/v1beta1/conversion_test.go
+++ b/api/govmomi/v1beta1/conversion_test.go
@@ -288,6 +288,7 @@ func spokeVSphereMachineSpec(in *VSphereMachineSpec, c randfill.Continue) {
 	}
 
 	in.Network.PreferredAPIServerCIDR = "" // field has been dropped in v1beta2
+	in.FailureDomain = nil                 // field has been dropped in v1beta2
 }
 
 func spokeVSphereMachineStatus(in *VSphereMachineStatus, c randfill.Continue) {

--- a/api/govmomi/v1beta1/zz_generated.conversion.go
+++ b/api/govmomi/v1beta1/zz_generated.conversion.go
@@ -2030,9 +2030,7 @@ func autoConvert_v1beta1_VSphereMachineSpec_To_v1beta2_VSphereMachineSpec(in *VS
 	if err := v1.Convert_Pointer_string_To_string(&in.ProviderID, &out.ProviderID, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_string_To_string(&in.FailureDomain, &out.FailureDomain, s); err != nil {
-		return err
-	}
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.PowerOffMode = v1beta2.VirtualMachinePowerOpMode(in.PowerOffMode)
 	// WARNING: in.GuestSoftPowerOffTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NamingStrategy requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta1.VSphereVMNamingStrategy vs sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2.VSphereVMNamingStrategy)
@@ -2044,9 +2042,6 @@ func autoConvert_v1beta2_VSphereMachineSpec_To_v1beta1_VSphereMachineSpec(in *v1
 		return err
 	}
 	if err := v1.Convert_string_To_Pointer_string(&in.ProviderID, &out.ProviderID, s); err != nil {
-		return err
-	}
-	if err := v1.Convert_string_To_Pointer_string(&in.FailureDomain, &out.FailureDomain, s); err != nil {
 		return err
 	}
 	out.PowerOffMode = VirtualMachinePowerOpMode(in.PowerOffMode)

--- a/api/govmomi/v1beta2/vspheremachine_types.go
+++ b/api/govmomi/v1beta2/vspheremachine_types.go
@@ -118,13 +118,6 @@ type VSphereMachineSpec struct {
 	// +kubebuilder:validation:MaxLength=512
 	ProviderID string `json:"providerID,omitempty"`
 
-	// failureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
-	// For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
-	// +optional
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	FailureDomain string `json:"failureDomain,omitempty"`
-
 	// powerOffMode describes the desired behavior when powering off a VM.
 	//
 	// There are three, supported power off modes: hard, soft, and

--- a/api/supervisor/v1beta1/conversion.go
+++ b/api/supervisor/v1beta1/conversion.go
@@ -96,6 +96,7 @@ func (src *VSphereMachine) ConvertTo(dstRaw conversion.Hub) error {
 	if !reflect.DeepEqual(initialization, vmwarev1.VSphereMachineInitializationStatus{}) {
 		dst.Status.Initialization = initialization
 	}
+	dst.Status.FailureDomain = restored.Status.FailureDomain
 	return nil
 }
 

--- a/api/supervisor/v1beta1/conversion_test.go
+++ b/api/supervisor/v1beta1/conversion_test.go
@@ -181,6 +181,8 @@ func spokeVSphereMachineSpec(in *VSphereMachineSpec, c randfill.Continue) {
 	if in.NamingStrategy != nil && reflect.DeepEqual(in.NamingStrategy, &VirtualMachineNamingStrategy{}) {
 		in.NamingStrategy = nil
 	}
+
+	in.FailureDomain = nil // field has been dropped in v1beta2
 }
 
 func spokeVSphereMachineStatus(in *VSphereMachineStatus, c randfill.Continue) {

--- a/api/supervisor/v1beta1/zz_generated.conversion.go
+++ b/api/supervisor/v1beta1/zz_generated.conversion.go
@@ -1253,9 +1253,7 @@ func autoConvert_v1beta1_VSphereMachineSpec_To_v1beta2_VSphereMachineSpec(in *VS
 	if err := metav1.Convert_Pointer_string_To_string(&in.ProviderID, &out.ProviderID, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_string_To_string(&in.FailureDomain, &out.FailureDomain, s); err != nil {
-		return err
-	}
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.ImageName = in.ImageName
 	out.ClassName = in.ClassName
 	out.StorageClass = in.StorageClass
@@ -1271,9 +1269,6 @@ func autoConvert_v1beta1_VSphereMachineSpec_To_v1beta2_VSphereMachineSpec(in *VS
 
 func autoConvert_v1beta2_VSphereMachineSpec_To_v1beta1_VSphereMachineSpec(in *v1beta2.VSphereMachineSpec, out *VSphereMachineSpec, s conversion.Scope) error {
 	if err := metav1.Convert_string_To_Pointer_string(&in.ProviderID, &out.ProviderID, s); err != nil {
-		return err
-	}
-	if err := metav1.Convert_string_To_Pointer_string(&in.FailureDomain, &out.FailureDomain, s); err != nil {
 		return err
 	}
 	out.ImageName = in.ImageName
@@ -1329,6 +1324,7 @@ func autoConvert_v1beta2_VSphereMachineStatus_To_v1beta1_VSphereMachineStatus(in
 	}
 	// WARNING: in.Initialization requires manual conversion: does not exist in peer-type
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	// WARNING: in.BiosUUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.Phase requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta2_VSphereMachineNetworkStatus_To_v1beta1_VSphereMachineNetworkStatus(&in.Network, &out.Network, s); err != nil {

--- a/api/supervisor/v1beta2/vspheremachine_types.go
+++ b/api/supervisor/v1beta2/vspheremachine_types.go
@@ -55,13 +55,6 @@ type VSphereMachineSpec struct {
 	// +kubebuilder:validation:MaxLength=512
 	ProviderID string `json:"providerID,omitempty"`
 
-	// failureDomain is the failure domain the machine will be created in.
-	// Must match a FailureDomain name on the Cluster status.
-	// +optional
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
-	FailureDomain string `json:"failureDomain,omitempty"`
-
 	// imageName is the name of the base image used when specifying the
 	// underlying virtual machine
 	// +required
@@ -313,6 +306,12 @@ type VSphereMachineStatus struct {
 	// +optional
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
+	// failureDomain is the failure domain where the VirtualMachine has been scheduled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	FailureDomain string `json:"failureDomain,omitempty"`
+
 	// biosUUID is the biosUUID of the virtual machine.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
@@ -418,6 +417,7 @@ type VSphereMachineV1Beta1DeprecatedStatus struct {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 // +kubebuilder:printcolumn:name="Class",type="string",JSONPath=".spec.className",description="VirtualMachineClass name"
 // +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="Failure domain",type="string",JSONPath=".status.failureDomain",description="The failure domain where the VSphereMachine has been scheduled"
 // +kubebuilder:printcolumn:name="IP",type="string",JSONPath=`.status.addresses[?(@.type=="InternalIP")].address`,description="IP of the Machine",priority=10
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.imageName",description="Image name",priority=10
 // +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1059,13 +1059,6 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
-              failureDomain:
-                description: |-
-                  failureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
-                  For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
-                maxLength: 253
-                minLength: 1
-                type: string
               folder:
                 description: |-
                   folder is the name, inventory path, managed object reference or the managed

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -877,13 +877,6 @@ spec:
                         format: int32
                         minimum: 1
                         type: integer
-                      failureDomain:
-                        description: |-
-                          failureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
-                          For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
                       folder:
                         description: |-
                           folder is the name, inventory path, managed object reference or the managed

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -851,6 +851,10 @@ spec:
       name: Provider ID
       priority: 10
       type: string
+    - description: The failure domain where the VSphereMachine has been scheduled
+      jsonPath: .status.failureDomain
+      name: Failure domain
+      type: string
     - description: IP of the Machine
       jsonPath: .status.addresses[?(@.type=="InternalIP")].address
       name: IP
@@ -908,13 +912,6 @@ spec:
                   className is the name of the class used when specifying the underlying
                   virtual machine
                 maxLength: 253
-                minLength: 1
-                type: string
-              failureDomain:
-                description: |-
-                  failureDomain is the failure domain the machine will be created in.
-                  Must match a FailureDomain name on the Cluster status.
-                maxLength: 256
                 minLength: 1
                 type: string
               imageName:
@@ -1440,6 +1437,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              failureDomain:
+                description: failureDomain is the failure domain where the VirtualMachine
+                  has been scheduled.
+                maxLength: 256
+                minLength: 1
+                type: string
               initialization:
                 description: |-
                   initialization provides observations of the VSphereMachine initialization process.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -463,13 +463,6 @@ spec:
                         maxLength: 253
                         minLength: 1
                         type: string
-                      failureDomain:
-                        description: |-
-                          failureDomain is the failure domain the machine will be created in.
-                          Must match a FailureDomain name on the Cluster status.
-                        maxLength: 256
-                        minLength: 1
-                        type: string
                       imageName:
                         description: |-
                           imageName is the name of the base image used when specifying the

--- a/controllers/vmware/virtualmachinegroup_reconciler_test.go
+++ b/controllers/vmware/virtualmachinegroup_reconciler_test.go
@@ -54,12 +54,12 @@ func Test_shouldCreateVirtualMachineGroup(t *testing.T) {
 				*createMD("md3", "test-cluster", "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", ""),
-				*createVSphereMachine("m2", "test-cluster", "md1", "", func(vm *vmwarev1.VSphereMachine) {
+				*createVSphereMachine("m1", "test-cluster", "md1"),
+				*createVSphereMachine("m2", "test-cluster", "md1", func(vm *vmwarev1.VSphereMachine) {
 					vm.DeletionTimestamp = ptr.To(metav1.Now())
 				}),
-				*createVSphereMachine("m3", "test-cluster", "md2", ""),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m3", "test-cluster", "md2"),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: false, // tot replicas = 4, 3 VSphereMachine exist, 1 VSphereMachine in deleting.
 		},
@@ -71,10 +71,10 @@ func Test_shouldCreateVirtualMachineGroup(t *testing.T) {
 				*createMD("md3", "test-cluster", "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", ""),
-				*createVSphereMachine("m2", "test-cluster", "md1", ""),
-				*createVSphereMachine("m3", "test-cluster", "md2", ""),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m1", "test-cluster", "md1"),
+				*createVSphereMachine("m2", "test-cluster", "md1"),
+				*createVSphereMachine("m3", "test-cluster", "md2"),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: true, // tot replicas = 4, 4 VSphereMachine exist
 		},
@@ -88,9 +88,9 @@ func Test_shouldCreateVirtualMachineGroup(t *testing.T) {
 				*createMD("md3", "test-cluster", "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", ""),
-				*createVSphereMachine("m2", "test-cluster", "md1", ""),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m1", "test-cluster", "md1"),
+				*createVSphereMachine("m2", "test-cluster", "md1"),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: true, // tot replicas = 3 (one md is deleting, so not included in the total), 3 VSphereMachine exist
 		},
@@ -102,9 +102,9 @@ func Test_shouldCreateVirtualMachineGroup(t *testing.T) {
 				*createMD("md3", "test-cluster", "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", ""),
-				*createVSphereMachine("m3", "test-cluster", "md2", ""),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m1", "test-cluster", "md1"),
+				*createVSphereMachine("m3", "test-cluster", "md2"),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: false, // tot replicas = 4, 3 VSphereMachine exist
 		},
@@ -133,10 +133,10 @@ func Test_getVirtualMachineNameToMachineDeploymentMapping(t *testing.T) {
 		{
 			name: "mapping from VirtualMachineName to MachineDeployment is inferred from vSphereMachines",
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", ""),
-				*createVSphereMachine("m2", "test-cluster", "md1", ""),
-				*createVSphereMachine("m3", "test-cluster", "md2", ""),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m1", "test-cluster", "md1"),
+				*createVSphereMachine("m2", "test-cluster", "md1"),
+				*createVSphereMachine("m3", "test-cluster", "md2"),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: map[string]string{
 				// Note VirtualMachineName is equal to the VSphereMachine name because when using the default naming strategy
@@ -149,12 +149,12 @@ func Test_getVirtualMachineNameToMachineDeploymentMapping(t *testing.T) {
 		{
 			name: "mapping from VirtualMachineName to MachineDeployment is inferred from vSphereMachines (custom naming strategy)",
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", "test-cluster", "md1", "", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
+				*createVSphereMachine("m1", "test-cluster", "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", "test-cluster", "md1", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
 					m.DeletionTimestamp = ptr.To(metav1.Now())
 				}), // Should not be included in the mapping
-				*createVSphereMachine("m3", "test-cluster", "md2", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m3", "test-cluster", "md2", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: map[string]string{
 				"m1-vm": "md1",
@@ -166,12 +166,12 @@ func Test_getVirtualMachineNameToMachineDeploymentMapping(t *testing.T) {
 		{
 			name: "deleting vSphereMachines are not included in the mapping",
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", "test-cluster", "md1", "", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
+				*createVSphereMachine("m1", "test-cluster", "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", "test-cluster", "md1", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
 					m.DeletionTimestamp = ptr.To(metav1.Now())
 				}), // Should not be included in the mapping
-				*createVSphereMachine("m3", "test-cluster", "md2", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m3", "test-cluster", "md2", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: map[string]string{
 				"m1-vm": "md1",
@@ -183,12 +183,12 @@ func Test_getVirtualMachineNameToMachineDeploymentMapping(t *testing.T) {
 		{
 			name: "vSphereMachines without the MachineDeploymentNameLabel are not included in the mapping",
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", "test-cluster", "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", "test-cluster", "md1", "", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
+				*createVSphereMachine("m1", "test-cluster", "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", "test-cluster", "md1", withCustomNamingStrategy(), func(m *vmwarev1.VSphereMachine) {
 					delete(m.Labels, clusterv1.MachineDeploymentNameLabel)
 				}), // Should not be included in the mapping
-				*createVSphereMachine("m3", "test-cluster", "md2", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", "test-cluster", "md3", "zone1"),
+				*createVSphereMachine("m3", "test-cluster", "md2", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", "test-cluster", "md3"),
 			},
 			want: map[string]string{
 				"m1-vm": "md1",
@@ -627,10 +627,10 @@ func TestVirtualMachineGroupReconciler_computeVirtualMachineGroup(t *testing.T) 
 				*createMD("md3", cluster.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m3", cluster.Name, "md2", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", cluster.Name, "md3", "zone1"),
+				*createVSphereMachine("m1", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m3", cluster.Name, "md2", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", cluster.Name, "md3"),
 			},
 			existingVMG: nil,
 			want: &vmoprvhub.VirtualMachineGroup{
@@ -677,11 +677,11 @@ func TestVirtualMachineGroupReconciler_computeVirtualMachineGroup(t *testing.T) 
 				*createMD("md4", cluster.Name, "zone2", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m5", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", cluster.Name, "md3", "zone1"),
-				*createVSphereMachine("m6", cluster.Name, "md3", "zone1"),
-				*createVSphereMachine("m7", cluster.Name, "md4", "zone2"),
+				*createVSphereMachine("m1", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m5", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", cluster.Name, "md3"),
+				*createVSphereMachine("m6", cluster.Name, "md3"),
+				*createVSphereMachine("m7", cluster.Name, "md4"),
 			},
 			existingVMG: &vmoprvhub.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -771,11 +771,11 @@ func TestVirtualMachineGroupReconciler_computeVirtualMachineGroup(t *testing.T) 
 				*createMD("md4", cluster.Name, "zone2", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m5", cluster.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", cluster.Name, "md3", "zone1"),
-				*createVSphereMachine("m6", cluster.Name, "md3", "zone1"),
-				*createVSphereMachine("m7", cluster.Name, "md4", "zone2"),
+				*createVSphereMachine("m1", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m5", cluster.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", cluster.Name, "md3"),
+				*createVSphereMachine("m6", cluster.Name, "md3"),
+				*createVSphereMachine("m7", cluster.Name, "md4"),
 			},
 			existingVMG: &vmoprvhub.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -910,7 +910,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md2", clusterInitialized.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
 			},
 			existingVMG: nil,
 			wantResult:  ctrl.Result{},
@@ -924,8 +924,8 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md2", clusterInitialized.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 			},
 			existingVMG: nil,
 			wantResult:  ctrl.Result{},
@@ -939,9 +939,9 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md2", clusterInitialized.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 			},
 			existingVMG: nil,
 			wantResult:  ctrl.Result{},
@@ -978,9 +978,9 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md2", clusterInitialized.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 			},
 			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1038,13 +1038,13 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md4", clusterInitialized.Name, "zone2", 1), // new
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()), // new
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
-				*createVSphereMachine("m5", clusterInitialized.Name, "md2", "zone1"),                        // new
-				*createVSphereMachine("m6", clusterInitialized.Name, "md3", "", withCustomNamingStrategy()), // new
-				*createVSphereMachine("m7", clusterInitialized.Name, "md4", "zone3"),                        // new
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", clusterInitialized.Name, "md1", withCustomNamingStrategy()), // new
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
+				*createVSphereMachine("m5", clusterInitialized.Name, "md2"),                             // new
+				*createVSphereMachine("m6", clusterInitialized.Name, "md3", withCustomNamingStrategy()), // new
+				*createVSphereMachine("m7", clusterInitialized.Name, "md4"),                             // new
 			},
 			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1107,10 +1107,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				// md4 deleted
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
 				// m4 deleted
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 				// m5 deleted
 				// m6 deleted
 				// m7 deleted
@@ -1181,9 +1181,9 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				*createMD("md2", clusterInitialized.Name, "zone1", 1),
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 			},
 			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1244,12 +1244,12 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				// Adding a new MD without explicit placement is not supported at this stage
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m4", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()), // new
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
-				*createVSphereMachine("m5", clusterInitialized.Name, "md2", "zone1"), // new
-				*createVSphereMachine("m6", clusterInitialized.Name, "md3", "zone2"), // new
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m4", clusterInitialized.Name, "md1", withCustomNamingStrategy()), // new
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
+				*createVSphereMachine("m5", clusterInitialized.Name, "md2"), // new
+				*createVSphereMachine("m6", clusterInitialized.Name, "md3"), // new
 			},
 			existingVMG: &vmoprv1alpha5.VirtualMachineGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1313,10 +1313,10 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 				// md3 deleted
 			},
 			vSphereMachines: []vmwarev1.VSphereMachine{
-				*createVSphereMachine("m1", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
-				*createVSphereMachine("m2", clusterInitialized.Name, "md1", "", withCustomNamingStrategy()),
+				*createVSphereMachine("m1", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
+				*createVSphereMachine("m2", clusterInitialized.Name, "md1", withCustomNamingStrategy()),
 				// m4 deleted
-				*createVSphereMachine("m3", clusterInitialized.Name, "md2", "zone1"),
+				*createVSphereMachine("m3", clusterInitialized.Name, "md2"),
 				// m5 deleted
 				// m5 deleted
 			},
@@ -1459,7 +1459,7 @@ func withCustomNamingStrategy() func(m *vmwarev1.VSphereMachine) {
 	}
 }
 
-func createVSphereMachine(name, cluster, md, failureDomain string, options ...vSphereMachineOption) *vmwarev1.VSphereMachine {
+func createVSphereMachine(name, cluster, md string, options ...vSphereMachineOption) *vmwarev1.VSphereMachine {
 	m := &vmwarev1.VSphereMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
@@ -1468,9 +1468,6 @@ func createVSphereMachine(name, cluster, md, failureDomain string, options ...vS
 				clusterv1.ClusterNameLabel:           cluster,
 				clusterv1.MachineDeploymentNameLabel: md,
 			},
-		},
-		Spec: vmwarev1.VSphereMachineSpec{
-			FailureDomain: failureDomain,
 		},
 	}
 	for _, opt := range options {

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -234,9 +234,6 @@ func (r vmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.R
 	}
 
 	failureDomain := machine.Spec.FailureDomain
-	if failureDomain == "" && vsphereMachine.Spec.FailureDomain != "" {
-		failureDomain = vsphereMachine.Spec.FailureDomain
-	}
 
 	var vsphereFailureDomain *infrav1.VSphereFailureDomain
 	if failureDomain != "" {

--- a/pkg/conversion/api/vmoperator/hub/virtualmachine_types.go
+++ b/pkg/conversion/api/vmoperator/hub/virtualmachine_types.go
@@ -350,6 +350,14 @@ type VirtualMachineStatus struct {
 	// infrastructure provider that is exposed to the Guest OS BIOS as a unique
 	// hardware identifier.
 	BiosUUID string `json:"biosUUID,omitempty"`
+
+	// +optional
+
+	// Zone describes the availability zone where the VirtualMachine has been
+	// scheduled.
+	//
+	// Please note this field may be empty when the cluster is not zone-aware.
+	Zone string `json:"zone,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/conversion/api/vmoperator/v1alpha2/virtualmachine_conversion.go
+++ b/pkg/conversion/api/vmoperator/v1alpha2/virtualmachine_conversion.go
@@ -253,6 +253,7 @@ func convert_v1alpha2_VirtualMachine_To_hub_VirtualMachine(_ context.Context, sr
 	}
 	dst.Status.NodeName = src.Status.Host // Field renamed in hub
 	dst.Status.PowerState = vmoprvhub.VirtualMachinePowerState(src.Status.PowerState)
+	dst.Status.Zone = src.Status.Zone
 
 	return nil
 }
@@ -481,6 +482,7 @@ func convert_hub_VirtualMachine_To_v1alpha2_VirtualMachine(_ context.Context, sr
 		dst.Status.Network.PrimaryIP6 = src.Status.Network.PrimaryIP6
 	}
 	dst.Status.PowerState = vmoprv1alpha2.VirtualMachinePowerState(src.Status.PowerState)
+	dst.Status.Zone = src.Status.Zone
 
 	return nil
 }

--- a/pkg/conversion/api/vmoperator/v1alpha5/virtualmachine_conversion.go
+++ b/pkg/conversion/api/vmoperator/v1alpha5/virtualmachine_conversion.go
@@ -262,6 +262,7 @@ func convert_v1alpha5_VirtualMachine_To_hub_VirtualMachine(_ context.Context, sr
 	}
 	dst.Status.NodeName = src.Status.NodeName
 	dst.Status.PowerState = vmoprvhub.VirtualMachinePowerState(src.Status.PowerState)
+	dst.Status.Zone = src.Status.Zone
 
 	return nil
 }
@@ -499,6 +500,7 @@ func convert_hub_VirtualMachine_To_v1alpha5_VirtualMachine(_ context.Context, sr
 		dst.Status.Network.PrimaryIP6 = src.Status.Network.PrimaryIP6
 	}
 	dst.Status.PowerState = vmoprv1alpha5.VirtualMachinePowerState(src.Status.PowerState)
+	dst.Status.Zone = src.Status.Zone
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR aligns CAPV failureDomain fields to CAPI contract:
- spec.failureDomain has been dropped from VSphereMachine both govimomi and supervisor mode (*)
- status.failureDomain has been added from VSphereMachine in supervisor mode only (**)

(*) Field was used by CAPI before v1alpha3, after that it was preserved only for the transition; with CAPI v1beta2 contract this is going to be finally dropped.
(**) Info is already available in VirtualMachine CR, so this was a quick win. Instead, doing something similar for govmomi require additional research/work

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
