### PR TITLE
🌱 Set WithOwnedV1Beta1Conditions patchHelper option consistently

### DIFF
--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -182,6 +182,7 @@ func (r *ClusterReconciler) patch(ctx context.Context, clusterCtx *vmware.Cluste
 
 	return clusterCtx.PatchHelper.Patch(ctx, clusterCtx.VSphereCluster,
 		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
 			vmwarev1.ResourcePolicyReadyV1Beta1Condition,
 			vmwarev1.ClusterNetworkReadyV1Beta1Condition,
 			vmwarev1.LoadBalancerReadyV1Beta1Condition,

--- a/controllers/vspherecluster_reconciler.go
+++ b/controllers/vspherecluster_reconciler.go
@@ -164,6 +164,11 @@ func (r *clusterReconciler) patch(ctx context.Context, clusterCtx *capvcontext.C
 	}
 
 	return clusterCtx.PatchHelper.Patch(ctx, clusterCtx.VSphereCluster,
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav1.VCenterAvailableV1Beta1Condition,
+			infrav1.ClusterModulesAvailableV1Beta1Condition,
+		}},
 		patch.WithOwnedConditions{Conditions: []string{
 			clusterv1.PausedCondition,
 			infrav1.VSphereClusterReadyCondition,

--- a/controllers/vsphereclusteridentity_controller.go
+++ b/controllers/vsphereclusteridentity_controller.go
@@ -102,10 +102,15 @@ func (r clusterIdentityReconciler) Reconcile(ctx context.Context, req reconcile.
 	defer func() {
 		deprecatedv1beta1conditions.SetSummary(identity, deprecatedv1beta1conditions.WithConditions(infrav1.CredentialsAvailableV1Beta1Condition))
 
-		if err := patchHelper.Patch(ctx, identity, patch.WithOwnedConditions{Conditions: []string{
-			clusterv1.PausedCondition,
-			infrav1.VSphereClusterIdentityAvailableCondition,
-		}}); err != nil {
+		if err := patchHelper.Patch(ctx, identity,
+			patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+				clusterv1.ReadyV1Beta1Condition,
+				infrav1.CredentialsAvailableV1Beta1Condition,
+			}},
+			patch.WithOwnedConditions{Conditions: []string{
+				clusterv1.PausedCondition,
+				infrav1.VSphereClusterIdentityAvailableCondition,
+			}}); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/controllers/vspheredeploymentzone_controller.go
+++ b/controllers/vspheredeploymentzone_controller.go
@@ -167,6 +167,12 @@ func (r vsphereDeploymentZoneReconciler) patch(ctx context.Context, vsphereDeplo
 	}
 
 	return vsphereDeploymentZoneContext.PatchHelper.Patch(ctx, vsphereDeploymentZoneContext.VSphereDeploymentZone,
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav1.PlacementConstraintMetV1Beta1Condition,
+			infrav1.VCenterAvailableV1Beta1Condition,
+			infrav1.VSphereFailureDomainValidatedV1Beta1Condition,
+		}},
 		patch.WithOwnedConditions{Conditions: []string{
 			clusterv1.PausedCondition,
 			infrav1.VSphereDeploymentZoneReadyCondition,

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -60,11 +60,16 @@ func (c *VIMMachineContext) String() string {
 
 // Patch updates the object and its status on the API server.
 func (c *VIMMachineContext) Patch(ctx context.Context) error {
-	return c.PatchHelper.Patch(ctx, c.VSphereMachine, patch.WithOwnedConditions{Conditions: []string{
-		infrav1.VSphereMachineReadyCondition,
-		infrav1.VSphereMachineVirtualMachineProvisionedCondition,
-		clusterv1.PausedCondition,
-	}})
+	return c.PatchHelper.Patch(ctx, c.VSphereMachine,
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav1.VMProvisionedV1Beta1Condition,
+		}},
+		patch.WithOwnedConditions{Conditions: []string{
+			infrav1.VSphereMachineReadyCondition,
+			infrav1.VSphereMachineVirtualMachineProvisionedCondition,
+			clusterv1.PausedCondition,
+		}})
 }
 
 // GetVSphereMachine sets the VSphereMachine for the VIMMachineContext.

--- a/pkg/context/vm_context.go
+++ b/pkg/context/vm_context.go
@@ -45,15 +45,22 @@ func (c *VMContext) String() string {
 
 // Patch updates the object and its status on the API server.
 func (c *VMContext) Patch(ctx context.Context) error {
-	return c.PatchHelper.Patch(ctx, c.VSphereVM, patch.WithOwnedConditions{Conditions: []string{
-		infrav1.VSphereVMReadyCondition,
-		infrav1.VSphereVMVCenterAvailableCondition,
-		infrav1.VSphereVMVirtualMachineProvisionedCondition,
-		infrav1.VSphereVMIPAddressClaimsFulfilledCondition,
-		infrav1.VSphereVMGuestSoftPowerOffSucceededCondition,
-		infrav1.VSphereVMPCIDevicesDetachedCondition,
-		clusterv1.PausedCondition,
-	}})
+	return c.PatchHelper.Patch(ctx, c.VSphereVM,
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav1.VCenterAvailableV1Beta1Condition,
+			infrav1.IPAddressClaimedV1Beta1Condition,
+			infrav1.VMProvisionedV1Beta1Condition,
+		}},
+		patch.WithOwnedConditions{Conditions: []string{
+			infrav1.VSphereVMReadyCondition,
+			infrav1.VSphereVMVCenterAvailableCondition,
+			infrav1.VSphereVMVirtualMachineProvisionedCondition,
+			infrav1.VSphereVMIPAddressClaimsFulfilledCondition,
+			infrav1.VSphereVMGuestSoftPowerOffSucceededCondition,
+			infrav1.VSphereVMPCIDevicesDetachedCondition,
+			clusterv1.PausedCondition,
+		}})
 }
 
 // GetSession returns this context's session.

--- a/pkg/context/vmware/machine_context.go
+++ b/pkg/context/vmware/machine_context.go
@@ -50,11 +50,16 @@ func (c *SupervisorMachineContext) String() string {
 
 // Patch updates the object and its status on the API server.
 func (c *SupervisorMachineContext) Patch(ctx context.Context) error {
-	return c.PatchHelper.Patch(ctx, c.VSphereMachine, patch.WithOwnedConditions{Conditions: []string{
-		infrav1.VSphereMachineReadyCondition,
-		infrav1.VSphereMachineVirtualMachineProvisionedCondition,
-		clusterv1.PausedCondition,
-	}})
+	return c.PatchHelper.Patch(ctx, c.VSphereMachine,
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav1.VMProvisionedV1Beta1Condition,
+		}},
+		patch.WithOwnedConditions{Conditions: []string{
+			infrav1.VSphereMachineReadyCondition,
+			infrav1.VSphereMachineVirtualMachineProvisionedCondition,
+			clusterv1.PausedCondition,
+		}})
 }
 
 // GetVSphereMachine returns the VSphereMachine from the SupervisorMachineContext.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
