### PR TITLE
⚠️ Drop VSphereCluster.status.resourcePolicyName (supervisor)

### DIFF
--- a/api/supervisor/v1beta1/conversion_test.go
+++ b/api/supervisor/v1beta1/conversion_test.go
@@ -116,6 +116,8 @@ func spokeVSphereClusterStatus(in *VSphereClusterStatus, c randfill.Continue) {
 			in.V1Beta2 = nil
 		}
 	}
+
+	in.ResourcePolicyName = "" // Field does not exist in v1beta1.
 }
 
 func VSphereClusterTemplateFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {

--- a/api/supervisor/v1beta1/zz_generated.conversion.go
+++ b/api/supervisor/v1beta1/zz_generated.conversion.go
@@ -813,7 +813,7 @@ func Convert_v1beta2_VSphereClusterSpec_To_v1beta1_VSphereClusterSpec(in *v1beta
 
 func autoConvert_v1beta1_VSphereClusterStatus_To_v1beta2_VSphereClusterStatus(in *VSphereClusterStatus, out *v1beta2.VSphereClusterStatus, s conversion.Scope) error {
 	// WARNING: in.Ready requires manual conversion: does not exist in peer-type
-	out.ResourcePolicyName = in.ResourcePolicyName
+	// WARNING: in.ResourcePolicyName requires manual conversion: does not exist in peer-type
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))
@@ -843,7 +843,6 @@ func autoConvert_v1beta2_VSphereClusterStatus_To_v1beta1_VSphereClusterStatus(in
 		out.Conditions = nil
 	}
 	// WARNING: in.Initialization requires manual conversion: does not exist in peer-type
-	out.ResourcePolicyName = in.ResourcePolicyName
 	// WARNING: in.FailureDomains requires manual conversion: inconvertible types ([]sigs.k8s.io/cluster-api/api/core/v1beta2.FailureDomain vs sigs.k8s.io/cluster-api/api/core/v1beta1.FailureDomains)
 	// WARNING: in.Deprecated requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/supervisor/v1beta2/vspherecluster_types.go
+++ b/api/supervisor/v1beta2/vspherecluster_types.go
@@ -211,13 +211,6 @@ type VSphereClusterStatus struct {
 	// +optional
 	Initialization VSphereClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
 
-	// resourcePolicyName is the name of the VirtualMachineSetResourcePolicy for
-	// the cluster, if one exists
-	// +optional
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	ResourcePolicyName string `json:"resourcePolicyName,omitempty"`
-
 	// failureDomains is a list of failure domain objects synced from the infrastructure provider.
 	// +optional
 	// +listType=map

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -518,13 +518,6 @@ spec:
                       NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Cluster provisioning.
                     type: boolean
                 type: object
-              resourcePolicyName:
-                description: |-
-                  resourcePolicyName is the name of the VirtualMachineSetResourcePolicy for
-                  the cluster, if one exists
-                maxLength: 253
-                minLength: 1
-                type: string
             type: object
         type: object
     served: true

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -245,8 +245,7 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmw
 	// Reconcile ResourcePolicy before we create the machines. If the ResourcePolicy is not reconciled before we create the Node VMs,
 	// it will be handled by vm operator by relocating the VMs to the ResourcePool and Folder specified by the ResourcePolicy.
 	// Reconciling the ResourcePolicy early potentially saves us the extra relocate operation.
-	resourcePolicyName, err := r.ResourcePolicyService.ReconcileResourcePolicy(ctx, clusterCtx)
-	if err != nil {
+	if err := r.ResourcePolicyService.ReconcileResourcePolicy(ctx, clusterCtx); err != nil {
 		deprecatedv1beta1conditions.MarkFalse(clusterCtx.VSphereCluster, vmwarev1.ResourcePolicyReadyV1Beta1Condition, vmwarev1.ResourcePolicyCreationFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%v", err)
 		conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
 			Type:    vmwarev1.VSphereClusterResourcePolicyReadyCondition,
@@ -264,8 +263,6 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmw
 		Status: metav1.ConditionTrue,
 		Reason: vmwarev1.VSphereClusterResourcePolicyReadyReason,
 	})
-
-	clusterCtx.VSphereCluster.Status.ResourcePolicyName = resourcePolicyName
 
 	// Configure the cluster for the cluster network
 	err = r.NetworkProvider.ProvisionClusterNetwork(ctx, clusterCtx)

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -97,7 +97,7 @@ type ControlPlaneEndpointService interface {
 type ResourcePolicyService interface {
 	// ReconcileResourcePolicy ensures that a VirtualMachineSetResourcePolicy exists for the cluster
 	// Returns the name of a policy if it exists, otherwise returns an error
-	ReconcileResourcePolicy(ctx context.Context, clusterCtx *vmware.ClusterContext) (string, error)
+	ReconcileResourcePolicy(ctx context.Context, clusterCtx *vmware.ClusterContext) error
 }
 
 // NetworkProvider provision network resources and configures VM based on network type.

--- a/pkg/services/vmoperator/resource_policy_test.go
+++ b/pkg/services/vmoperator/resource_policy_test.go
@@ -42,9 +42,8 @@ func TestRPService(t *testing.T) {
 
 	t.Run("Creates Resource Policy using the cluster name", func(t *testing.T) {
 		g := NewWithT(t)
-		name, err := rpService.ReconcileResourcePolicy(ctx, clusterCtx)
+		err := rpService.ReconcileResourcePolicy(ctx, clusterCtx)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(name).To(Equal(clusterName))
 
 		// NOTE: use vm-operator native types for testing (the reconciler uses the internal hub version).
 		resourcePolicy := &vmoprv1alpha5.VirtualMachineSetResourcePolicy{}

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -565,13 +565,11 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 		vmOperatorVM.Spec.StorageClass = supervisorMachineCtx.VSphereMachine.Spec.StorageClass
 	}
 	vmOperatorVM.Spec.PowerState = vmoprvhub.VirtualMachinePowerStateOn
-	if supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName != "" {
-		if vmOperatorVM.Spec.Reserved == nil {
-			vmOperatorVM.Spec.Reserved = &vmoprvhub.VirtualMachineReservedSpec{}
-		}
-		if vmOperatorVM.Spec.Reserved.ResourcePolicyName == "" {
-			vmOperatorVM.Spec.Reserved.ResourcePolicyName = supervisorMachineCtx.VSphereCluster.Status.ResourcePolicyName
-		}
+	if vmOperatorVM.Spec.Reserved == nil {
+		vmOperatorVM.Spec.Reserved = &vmoprvhub.VirtualMachineReservedSpec{}
+	}
+	if vmOperatorVM.Spec.Reserved.ResourcePolicyName == "" {
+		vmOperatorVM.Spec.Reserved.ResourcePolicyName = supervisorMachineCtx.Cluster.Name
 	}
 	if vmOperatorVM.Spec.Bootstrap == nil {
 		vmOperatorVM.Spec.Bootstrap = &vmoprvhub.VirtualMachineBootstrapSpec{}

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -121,7 +121,7 @@ const (
 	className                = "test-className"
 	imageName                = "test-imageName"
 	storageClass             = "test-storageClass"
-	resourcePolicyName       = "test-resourcePolicy"
+	resourcePolicyName       = clusterName
 	minHardwareVersion       = int32(17)
 	vmIP                     = "127.0.0.1"
 	biosUUID                 = "test-biosUuid"
@@ -193,7 +193,6 @@ var _ = Describe("VirtualMachine tests", func() {
 		// Create all necessary dependencies
 		cluster = util.CreateCluster(clusterName)
 		vsphereCluster = util.CreateVSphereCluster(clusterName)
-		vsphereCluster.Status.ResourcePolicyName = resourcePolicyName
 		machine = util.CreateMachine(machineName, clusterName, k8sVersion, controlPlaneLabelTrue)
 		vsphereMachine = util.CreateVSphereMachine(machineName, clusterName, className, imageName, storageClass, controlPlaneLabelTrue)
 		clusterContext, controllerManagerContext := util.CreateClusterContext(cluster, vsphereCluster)
@@ -470,7 +469,6 @@ var _ = Describe("VirtualMachine tests", func() {
 				vsphereMachine.Spec.ClassName = "new-class"
 				vsphereMachine.Spec.StorageClass = "new-storageclass"
 				vsphereMachine.Spec.MinHardwareVersion = "vmx-9999"
-				vsphereCluster.Status.ResourcePolicyName = "new-resourcepolicy"
 
 				requeue, err = vmService.ReconcileNormal(ctx, supervisorMachineContext)
 				verifyOutput(supervisorMachineContext)
@@ -1009,7 +1007,6 @@ var _ = Describe("VirtualMachine tests", func() {
 						// Create a separate cluster for this test to avoid VirtualMachineGroup conflicts
 						fdCluster := util.CreateCluster(fdClusterName)
 						fdVSphereCluster := util.CreateVSphereCluster(fdClusterName)
-						fdVSphereCluster.Status.ResourcePolicyName = resourcePolicyName
 
 						// Create a worker machine with failure domain
 						machine = util.CreateMachine(workerMachineName, fdClusterName, k8sVersion, false)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452
