### PR TITLE
✨ Dynamically choose API version for vm-operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
         - --v=4
         - "--feature-gates=MultiNetworks=${EXP_MULTI_NETWORKS:=false},NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false},NamespaceScopedZones=${EXP_NAMESPACE_SCOPED_ZONES:=false},NodeAutoPlacement=${EXP_NODE_AUTO_PLACEMENT:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=true}"
+        - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -51,6 +51,7 @@ import (
 	vmwarewebhooks "sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	conversionapi "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
@@ -246,6 +247,7 @@ func getManager(cfg *rest.Config, networkProvider string, withWebhooks bool) man
 		},
 		KubeConfig:      cfg,
 		NetworkProvider: networkProvider,
+		Converter:       conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 	}
 
 	if withWebhooks {

--- a/controllers/vmware/virtualmachinegroup_reconciler_test.go
+++ b/controllers/vmware/virtualmachinegroup_reconciler_test.go
@@ -1395,7 +1395,7 @@ func TestVirtualMachineGroupReconciler_ReconcileSequence(t *testing.T) {
 
 			c, err := conversionclient.NewWithConverter(
 				fake.NewClientBuilder().WithObjects(objects...).WithScheme(scheme.Scheme).Build(),
-				conversionapi.DefaultConverter,
+				conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			r := &VirtualMachineGroupReconciler{

--- a/controllers/vmware/vspheremachinetemplate_controller_test.go
+++ b/controllers/vmware/vspheremachinetemplate_controller_test.go
@@ -141,7 +141,7 @@ func Test_vSphereMachineTemplateReconciler_Reconcile(t *testing.T) {
 
 			c, err := conversionclient.NewWithConverter(
 				fakeClientBuilder.Build(),
-				conversionapi.DefaultConverter,
+				conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -135,7 +135,7 @@ export VSPHERE_USERNAME="${GOVC_USERNAME:-}"
 export VSPHERE_PASSWORD="${GOVC_PASSWORD:-}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/vsphere.yaml"
 export E2E_CONF_OVERRIDE_FILE=""
-export E2E_VM_OPERATOR_VERSION="${VM_OPERATOR_VERSION:-v1.8.6-0-gde75746a}"
+export E2E_VM_OPERATOR_VERSION="${VM_OPERATOR_VERSION:-v1.9.0-567-g93918c59}"
 export DOCKER_IMAGE_TAR="/tmp/images/image.tar"
 
 SSH_KEY_DIR=$(mktemp -d)

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -62,6 +62,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vcsim"
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	conversionapi "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
@@ -195,6 +196,7 @@ func NewTestEnvironment(ctx context.Context) *TestEnvironment {
 		KubeConfig: env.Config,
 		Username:   simr.Username(),
 		Password:   simr.Password(),
+		Converter:  conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 	}
 	managerOpts.AddToManager = func(_ context.Context, _ *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 		if err := (&webhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {

--- a/pkg/conversion/api/vmoperator/v1alpha2/conversion_test.go
+++ b/pkg/conversion/api/vmoperator/v1alpha2/conversion_test.go
@@ -21,54 +21,57 @@ import (
 
 	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/randfill"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/test"
+	conversiontest "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/test"
 )
 
 func TestFuzzyConversion(t *testing.T) {
-	converter := conversion.NewConverter()
+	converter := conversion.NewConverter(func(_ schema.GroupKind) (string, error) {
+		return vmoprv1alpha2.GroupVersion.Version, nil
+	})
 	utilruntime.Must(vmoprvhub.AddToConverter(converter))
 	utilruntime.Must(AddToConverter(converter))
 
-	t.Run("for VirtualMachine", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachine", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachine{},
 		Spoke:     &vmoprv1alpha2.VirtualMachine{},
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{
 			virtualMachineFuncs,
 		},
-		CheckTypes: test.RoundTripCheckTypesInput{
+		CheckTypes: conversiontest.RoundTripCheckTypesInput{
 			FieldNameMap: map[string]string{
 				"VirtualMachine.Status.NodeName": "Host",
 			},
 		},
 	}))
-	t.Run("for VirtualMachineClass", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineClass", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineClass{},
 		Spoke:     &vmoprv1alpha2.VirtualMachineClass{},
 	}))
-	t.Run("for VirtualMachineGroup", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineGroup", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineGroup{},
 		Spoke:     &vmoprv1alpha2.VirtualMachineGroup{},
 	}))
-	t.Run("for VirtualMachineImage", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineImage", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineImage{},
 		Spoke:     &vmoprv1alpha2.VirtualMachineImage{},
 	}))
-	t.Run("for VirtualMachineService", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineService", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineService{},
 		Spoke:     &vmoprv1alpha2.VirtualMachineService{},
 	}))
-	t.Run("for VirtualMachineSetResourcePolicy", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineSetResourcePolicy", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineSetResourcePolicy{},
 		Spoke:     &vmoprv1alpha2.VirtualMachineSetResourcePolicy{},

--- a/pkg/conversion/api/vmoperator/v1alpha5/conversion_test.go
+++ b/pkg/conversion/api/vmoperator/v1alpha5/conversion_test.go
@@ -20,44 +20,47 @@ import (
 	"testing"
 
 	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/test"
+	conversiontest "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/test"
 )
 
 func TestFuzzyConversion(t *testing.T) {
-	converter := conversion.NewConverter()
+	converter := conversion.NewConverter(func(_ schema.GroupKind) (string, error) {
+		return vmoprv1alpha5.GroupVersion.Version, nil
+	})
 	utilruntime.Must(vmoprvhub.AddToConverter(converter))
 	utilruntime.Must(AddToConverter(converter))
 
-	t.Run("for VirtualMachine", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachine", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachine{},
 		Spoke:     &vmoprv1alpha5.VirtualMachine{},
 	}))
-	t.Run("for VirtualMachineClass", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineClass", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineClass{},
 		Spoke:     &vmoprv1alpha5.VirtualMachineClass{},
 	}))
-	t.Run("for VirtualMachineGroup", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineGroup", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineGroup{},
 		Spoke:     &vmoprv1alpha5.VirtualMachineGroup{},
 	}))
-	t.Run("for VirtualMachineImage", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineImage", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineImage{},
 		Spoke:     &vmoprv1alpha5.VirtualMachineImage{},
 	}))
-	t.Run("for VirtualMachineService", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineService", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineService{},
 		Spoke:     &vmoprv1alpha5.VirtualMachineService{},
 	}))
-	t.Run("for VirtualMachineSetResourcePolicy", test.RoundTripTest(test.RoundTripTestInput{
+	t.Run("for VirtualMachineSetResourcePolicy", conversiontest.RoundTripTest(conversiontest.RoundTripTestInput{
 		Converter: converter,
 		Hub:       &vmoprvhub.VirtualMachineSetResourcePolicy{},
 		Spoke:     &vmoprv1alpha5.VirtualMachineSetResourcePolicy{},

--- a/pkg/conversion/client/patches_test.go
+++ b/pkg/conversion/client/patches_test.go
@@ -33,9 +33,8 @@ import (
 
 func Test_MergeFrom(t *testing.T) {
 	g := NewWithT(t)
-	converter.SetTargetVersion(vmoprv1alpha5.GroupVersion.Version)
 
-	cc, err := NewWithConverter(fake.NewClientBuilder().WithScheme(scheme).Build(), converter)
+	cc, err := NewWithConverter(fake.NewClientBuilder().WithScheme(scheme).Build(), v1alpha5Converter)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	fromHub := &vmoprvhub.VirtualMachine{
@@ -128,7 +127,9 @@ func Test_MergeFrom(t *testing.T) {
 
 func Test_conversionMergePatch_Data(t *testing.T) {
 	g := NewWithT(t)
-	cc, err := NewWithConverter(fake.NewClientBuilder().WithScheme(scheme).Build(), converter)
+	v1alpha2ConversionClient, err := NewWithConverter(fake.NewClientBuilder().WithScheme(scheme).Build(), v1alpha2Converter)
+	g.Expect(err).NotTo(HaveOccurred())
+	v1alpha5ConversionClient, err := NewWithConverter(fake.NewClientBuilder().WithScheme(scheme).Build(), v1alpha5Converter)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	tests := []struct {
@@ -149,7 +150,7 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 						Namespace: "test-ns",
 					},
 				},
-				client: cc.(*conversionClient),
+				client: v1alpha5ConversionClient.(*conversionClient),
 			},
 			obj: &vmoprvhub.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -172,7 +173,7 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 						Namespace: "test-ns",
 					},
 				},
-				client: cc.(*conversionClient),
+				client: v1alpha5ConversionClient.(*conversionClient),
 			},
 			obj: &vmoprv1alpha5.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +196,7 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 						Namespace: "test-ns",
 					},
 				},
-				client: cc.(*conversionClient),
+				client: v1alpha2ConversionClient.(*conversionClient),
 			},
 			obj: &vmoprvhub.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -218,7 +219,7 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 						Namespace: "test-ns",
 					},
 				},
-				client: cc.(*conversionClient),
+				client: v1alpha2ConversionClient.(*conversionClient),
 			},
 			obj: &vmoprv1alpha2.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -241,7 +242,7 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 						Namespace: "test-ns",
 					},
 				},
-				client: cc.(*conversionClient),
+				client: v1alpha5ConversionClient.(*conversionClient),
 			},
 			obj: &vmoprv1alpha2.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -258,8 +259,6 @@ func Test_conversionMergePatch_Data(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-
-			converter.SetTargetVersion(tt.targetVersion)
 
 			gotData, err := tt.patch.Data(tt.obj)
 			if tt.wantErr {

--- a/pkg/conversion/client/watches_test.go
+++ b/pkg/conversion/client/watches_test.go
@@ -50,20 +50,19 @@ func Test_WatchObject(t *testing.T) {
 			wantObj:       &vmoprv1alpha5.VirtualMachine{},
 		},
 		{
-			name:    "Fails for non hub objects",
-			obj:     &corev1.Node{},
-			wantErr: true,
+			name:          "Fails for non hub objects",
+			targetVersion: vmoprv1alpha5.GroupVersion.Version,
+			obj:           &corev1.Node{},
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			converter.SetTargetVersion(tt.targetVersion)
-
 			c := &conversionClient{
 				internalClient: fake.NewClientBuilder().WithScheme(scheme).Build(),
-				converter:      converter,
+				converter:      converterForVersion(tt.targetVersion),
 			}
 
 			gotObj, err := WatchObject(c, tt.obj)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -42,7 +42,6 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	topologyv1 "sigs.k8s.io/cluster-api-provider-vsphere/internal/apis/topology/v1alpha1"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
-	conversionapi "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
 	conversionclient "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/client"
 )
@@ -84,9 +83,12 @@ func New(ctx context.Context, opts Options) (Manager, error) {
 		return nil, errors.Wrap(err, "unable to create manager")
 	}
 
-	cc, err := conversionclient.NewWithConverter(mgr.GetClient(), conversionapi.DefaultConverter)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create a conversion client")
+	cc := mgr.GetClient()
+	if opts.Converter != nil {
+		cc, err = conversionclient.NewWithConverter(mgr.GetClient(), opts.Converter)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create a conversion client")
+		}
 	}
 
 	// Build the controller manager context.

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion"
 )
 
 // AddToManagerFunc is a function that can be optionally specified with
@@ -58,6 +59,10 @@ type Options struct {
 	// Password is the password for the account used to access remote vSphere
 	// endpoints.
 	Password string
+
+	// Converter is the API resource converter to use when reading and writing supervisor resources,
+	// e.g. the VirtualMachine resource in the vmoperator.vmware.com group.
+	Converter *conversion.Converter
 
 	// CredentialsFile is the file that contains credentials of CAPV
 	CredentialsFile string

--- a/pkg/util/testutil.go
+++ b/pkg/util/testutil.go
@@ -168,7 +168,7 @@ func CreateClusterContext(cluster *clusterv1.Cluster, vsphereCluster *vmwarev1.V
 			&vmoprv1alpha5.VirtualMachineService{},
 			&vmoprv1alpha5.VirtualMachine{},
 		).Build(),
-		conversionapi.DefaultConverter,
+		conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 	)
 	if err != nil {
 		panic(err)

--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -18,7 +18,7 @@ images:
     loadBehavior: mustLoad
   - name: gcr.io/k8s-staging-capi-vsphere/cluster-api-vsphere-test-extension-{ARCH}:dev
     loadBehavior: mustLoad
-  - name: gcr.io/k8s-staging-capi-vsphere/extra/vm-operator:v1.8.6-0-gde75746a
+  - name: gcr.io/k8s-staging-capi-vsphere/extra/vm-operator:v1.9.0-567-g93918c59
     loadBehavior: tryLoad
 
 providers:

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -238,6 +238,10 @@ func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesCon
 		_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			retryError = nil
 			if err := c.Get(ctx, client.ObjectKeyFromObject(spu), spu); err != nil {
+				if meta.IsNoMatchError(err) {
+					log.Info("Skipping creation of vm-operator StoragePolicyUsage, this CR is only required when using vm-operator >= 1.9")
+					return true, nil
+				}
 				if !apierrors.IsNotFound(err) {
 					retryError = errors.Wrapf(err, "failed to get vm-operator StoragePolicyUsage %s", spu.Name)
 					return false, nil

--- a/test/infrastructure/net-operator/config/manager/manager.yaml
+++ b/test/infrastructure/net-operator/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
         - "--leader-elect"
         - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+        - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
         image: controller:latest
         name: manager
         ports:

--- a/test/infrastructure/net-operator/main.go
+++ b/test/infrastructure/net-operator/main.go
@@ -40,6 +40,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
@@ -83,6 +84,7 @@ var (
 	// net operator specific flags.
 	networkInterfaceConcurrency int
 	virtualMachineConcurrency   int
+	apiVersionVMOperator        string
 )
 
 func init() {
@@ -97,6 +99,13 @@ func init() {
 // InitFlags initializes the flags.
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
+
+	fs.StringVar(
+		&apiVersionVMOperator,
+		"vm-operator-api-version",
+		vmoprv1alpha5.GroupVersion.Version,
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s, %s", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version),
+	)
 
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
@@ -165,11 +174,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	if apiVersionVMOperator != vmoprv1alpha2.GroupVersion.Version && apiVersionVMOperator != vmoprv1alpha5.GroupVersion.Version {
+		fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s, %s\n", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version)
+		os.Exit(1)
+	}
+
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 
 	// Note: setupLog can only be used after ctrl.SetLogger was called
 	setupLog.Info(fmt.Sprintf("Version: %s (git commit: %s)", version.Get().String(), version.Get().GitCommit))
+	setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, apiVersionVMOperator))
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = restConfigQPS
@@ -279,10 +294,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, _ bool) {
 		os.Exit(1)
 	}
 
-	cc, err := conversionclient.NewWithConverter(
-		mgr.GetClient(),
-		conversionapi.DefaultConverter,
+	converter := conversionapi.DefaultConverterFor(
+		schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: apiVersionVMOperator},
 	)
+
+	cc, err := conversionclient.NewWithConverter(mgr.GetClient(), converter)
 	if err != nil {
 		setupLog.Error(err, "failed to create a conversion client")
 		os.Exit(1)

--- a/test/infrastructure/vcsim/config/manager/manager.yaml
+++ b/test/infrastructure/vcsim/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
         - "--leader-elect"
         - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+        - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
         image: controller:latest
         name: manager
         env:

--- a/test/infrastructure/vcsim/controllers/virtualmachine_controller_test.go
+++ b/test/infrastructure/vcsim/controllers/virtualmachine_controller_test.go
@@ -117,7 +117,7 @@ func Test_Reconcile_VirtualMachine(t *testing.T) {
 		// Controller runtime client
 		crclient, err := conversionclient.NewWithConverter(
 			fake.NewClientBuilder().WithObjects(cluster, vsphereCluster, machine, vSphereMachine, virtualMachine).WithScheme(scheme).Build(),
-			conversionapi.DefaultConverter,
+			conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -259,7 +259,7 @@ func Test_Reconcile_VirtualMachine(t *testing.T) {
 		// Controller runtime client
 		crclient, err := conversionclient.NewWithConverter(
 			fake.NewClientBuilder().WithObjects(cluster, vsphereCluster, machine, vSphereMachine, virtualMachine).WithScheme(scheme).Build(),
-			conversionapi.DefaultConverter,
+			conversionapi.DefaultConverterFor(vmoprv1alpha5.GroupVersion),
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3758
