### PR TITLE
🌱 Extend ownerRef tests to cover VirtualMachineSetResourcePolicy

### DIFF
--- a/test/e2e/ownerrefs_finalizers_test.go
+++ b/test/e2e/ownerrefs_finalizers_test.go
@@ -197,7 +197,7 @@ var (
 				[]metav1.OwnerReference{kubeadmConfigController},
 				// Secrets created as a resource for a ClusterResourceSet can be owned by the ClusterResourceSet.
 				[]metav1.OwnerReference{clusterResourceSetOwner},
-				// Secrets created as an identityReference for a vSphereCluster should be owned but the vSphereCluster.
+				// Secrets created as an identityReference for a vSphereCluster should be owned by the vSphereCluster.
 				[]metav1.OwnerReference{vSphereClusterOwner},
 			)
 		},
@@ -228,17 +228,19 @@ var (
 				"VirtualMachine": func(_ types.NamespacedName, owners []metav1.OwnerReference) error {
 					return framework.HasExactOwners(owners, vmwareVSphereMachineController)
 				},
+				"VirtualMachineSetResourcePolicy": func(_ types.NamespacedName, owners []metav1.OwnerReference) error {
+					return framework.HasExactOwners(owners, vmwareVSphereClusterOwner)
+				},
 
 				// Following objects are for vm-operator (not managed by CAPV), so checking ownerReferences is not relevant.
-				"VirtualMachineImage":             func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"NetworkInterface":                func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"ContentSourceBinding":            func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"VirtualMachineSetResourcePolicy": func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"VirtualMachineClassBinding":      func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"VirtualMachineClass":             func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"VMOperatorDependencies":          func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"StoragePolicyUsage":              func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
-				"Zone":                            func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"VirtualMachineImage":        func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"NetworkInterface":           func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"ContentSourceBinding":       func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"VirtualMachineClassBinding": func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"VirtualMachineClass":        func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"VMOperatorDependencies":     func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"StoragePolicyUsage":         func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
+				"Zone":                       func(_ types.NamespacedName, _ []metav1.OwnerReference) error { return nil },
 			}
 		}
 
@@ -283,6 +285,7 @@ var (
 	vSphereDeploymentZoneOwner  = metav1.OwnerReference{Kind: "VSphereDeploymentZone", APIVersion: infrav1.GroupVersion.String()}
 	vSphereClusterIdentityOwner = metav1.OwnerReference{Kind: "VSphereClusterIdentity", APIVersion: infrav1.GroupVersion.String()}
 
+	vmwareVSphereClusterOwner      = metav1.OwnerReference{Kind: "VSphereCluster", APIVersion: vmwarev1.GroupVersion.String()}
 	vmwareVSphereMachineController = metav1.OwnerReference{Kind: "VSphereMachine", APIVersion: vmwarev1.GroupVersion.String(), Controller: ptr.To(true)}
 
 	// CAPI owners.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3452