### PR TITLE
🌱 Extend govmomi test runtime extension, change quickstart to use runtime extension

### DIFF
--- a/hack/tools/boskosctl/main.go
+++ b/hack/tools/boskosctl/main.go
@@ -82,7 +82,7 @@ func setupCommands(ctx context.Context) *cobra.Command {
 		Args: cobra.NoArgs,
 		RunE: runCmd(ctx),
 	}
-	acquireCmd.PersistentFlags().StringVar(&resourceType, "resource-type", "", "Type of the resource. Should be one of: vsphere-project-cluster-api-provider, vsphere-project-cloud-provider, vsphere-project-image-builder")
+	acquireCmd.PersistentFlags().StringVar(&resourceType, "resource-type", "", "Type of the resource. Should be one of: gcve-vsphere-project")
 	rootCmd.AddCommand(acquireCmd)
 
 	// heartbeat command

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -70,14 +70,17 @@ var _ = Describe("ClusterClass Creation using Cluster API quick-start test [vcsi
 	Setup(specName, func(testSpecificSettingsGetter func() testSettings) {
 		capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 			return capi_e2e.QuickStartSpecInput{
-				E2EConfig:               e2eConfig,
-				ClusterctlConfigPath:    testSpecificSettingsGetter().ClusterctlConfigPath,
-				BootstrapClusterProxy:   bootstrapClusterProxy,
-				ArtifactFolder:          artifactFolder,
-				SkipCleanup:             skipCleanup,
-				Flavor:                  ptr.To(testSpecificSettingsGetter().FlavorForMode("topology")),
-				PostNamespaceCreated:    testSpecificSettingsGetter().PostNamespaceCreatedFunc,
-				PostMachinesProvisioned: checkAllPodsReady,
+				E2EConfig:                 e2eConfig,
+				ClusterctlConfigPath:      testSpecificSettingsGetter().ClusterctlConfigPath,
+				BootstrapClusterProxy:     bootstrapClusterProxy,
+				ArtifactFolder:            artifactFolder,
+				SkipCleanup:               skipCleanup,
+				Flavor:                    ptr.To(testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk")),
+				ExtensionConfigName:       "quick-start-cluster-class",
+				ExtensionServiceNamespace: "capv-test-extension",
+				ExtensionServiceName:      "capv-test-extension-webhook-service",
+				PostNamespaceCreated:      testSpecificSettingsGetter().PostNamespaceCreatedFunc,
+				PostMachinesProvisioned:   checkAllPodsReady,
 			}
 		})
 	})
@@ -94,6 +97,7 @@ var _ = Describe("ClusterClass v1beta1 Creation using Cluster API quick-start te
 				ArtifactFolder:            artifactFolder,
 				SkipCleanup:               skipCleanup,
 				Flavor:                    ptr.To(testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk-v1beta1")),
+				ExtensionConfigName:       "quick-start-cluster-class-v1beta1",
 				ExtensionServiceNamespace: "capv-test-extension",
 				ExtensionServiceName:      "capv-test-extension-webhook-service",
 				PostNamespaceCreated:      testSpecificSettingsGetter().PostNamespaceCreatedFunc,


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
