### PR TITLE
[release-1.15] 🐛 Set VM.spec.affinity only on create

### DIFF
--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -648,7 +648,8 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 		// for a MachineDeployment are placed in the same failureDomain.
 		// Note: no matter of the different placement behaviour, we are setting affinity rules on all machines for consistency.
 		if affinityInfo != nil {
-			if vmOperatorVM.Spec.Affinity == nil {
+			// Only set spec.affinity on create as the field is immutable.
+			if vmOperatorVM.CreationTimestamp.IsZero() {
 				vmOperatorVM.Spec.Affinity = &affinityInfo.affinitySpec
 			}
 			if vmOperatorVM.Spec.GroupName == "" {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cherry-pick of #3835

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
