### PR TITLE
✨ Optimize cache configuration for supervisor mode

### DIFF
--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -64,13 +64,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	testEnv, clusterCache = setup(ctx)
+	testEnv, _, clusterCache = setup(ctx)
 	code := m.Run()
 	teardown()
 	os.Exit(code)
 }
 
-func setup(ctx context.Context) (*helpers.TestEnvironment, clustercache.ClusterCache) {
+func setup(ctx context.Context) (*helpers.TestEnvironment, client.Client, clustercache.ClusterCache) {
 	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vmwarev1.AddToScheme(scheme.Scheme))
@@ -113,7 +113,7 @@ func setup(ctx context.Context) (*helpers.TestEnvironment, clustercache.ClusterC
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 
-	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
+	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, secretCachingClient, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ServiceAccount controller: %v", err))
 	}
 	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
@@ -141,7 +141,7 @@ func setup(ctx context.Context) (*helpers.TestEnvironment, clustercache.ClusterC
 		panic(fmt.Sprintf("unable to create controller namespace: %v", err))
 	}
 
-	return testEnv, clusterCache
+	return testEnv, secretCachingClient, clusterCache
 }
 
 func teardown() {

--- a/controllers/vmware/serviceaccount_controller.go
+++ b/controllers/vmware/serviceaccount_controller.go
@@ -65,11 +65,12 @@ const (
 )
 
 // AddServiceAccountProviderControllerToManager adds this controller to the provided manager.
-func AddServiceAccountProviderControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterCache clustercache.ClusterCache, options controller.Options) error {
+func AddServiceAccountProviderControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterCache clustercache.ClusterCache, secretCachingClient client.Client, options controller.Options) error {
 	r := &ServiceAccountReconciler{
-		Client:       controllerManagerCtx.Client,
-		Recorder:     mgr.GetEventRecorderFor("providerserviceaccount-controller"),
-		clusterCache: clusterCache,
+		Client:              controllerManagerCtx.Client,
+		SecretCachingClient: secretCachingClient,
+		Recorder:            mgr.GetEventRecorderFor("providerserviceaccount-controller"),
+		clusterCache:        clusterCache,
 	}
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "providerserviceaccount")
 
@@ -106,9 +107,10 @@ func AddServiceAccountProviderControllerToManager(ctx context.Context, controlle
 
 // ServiceAccountReconciler reconciles changes to ProviderServiceAccounts.
 type ServiceAccountReconciler struct {
-	Client       client.Client
-	Recorder     record.EventRecorder
-	clusterCache clustercache.ClusterCache
+	Client              client.Client
+	SecretCachingClient client.Reader
+	Recorder            record.EventRecorder
+	clusterCache        clustercache.ClusterCache
 }
 
 func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, reterr error) {
@@ -265,7 +267,7 @@ func (r *ServiceAccountReconciler) ensureProviderServiceAccounts(ctx context.Con
 		}
 
 		// 2. Ensure secret of ServiceAccountToken type for the ServiceAccount
-		if err := r.ensureServiceAccountSecret(ctx, pSvcAccount); err != nil {
+		if err := r.ensureServiceAccountSecret(ctx, pSvcAccount, guestClusterCtx.Cluster); err != nil {
 			return errors.Wrapf(err, "failed to ensure ServiceAcountToken secret %s", getServiceAccountSecretName(pSvcAccount))
 		}
 
@@ -322,7 +324,7 @@ func (r *ServiceAccountReconciler) ensureServiceAccount(ctx context.Context, pSv
 	return nil
 }
 
-func (r *ServiceAccountReconciler) ensureServiceAccountSecret(ctx context.Context, pSvcAccount vmwarev1.ProviderServiceAccount) error {
+func (r *ServiceAccountReconciler) ensureServiceAccountSecret(ctx context.Context, pSvcAccount vmwarev1.ProviderServiceAccount, cluster *clusterv1.Cluster) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	secret := &corev1.Secret{
@@ -330,6 +332,9 @@ func (r *ServiceAccountReconciler) ensureServiceAccountSecret(ctx context.Contex
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getServiceAccountSecretName(pSvcAccount),
 			Namespace: pSvcAccount.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: cluster.Name,
+			},
 			Annotations: map[string]string{
 				// denotes that this secret holds the token for the service account
 				corev1.ServiceAccountNameKey: getServiceAccountName(pSvcAccount),
@@ -345,7 +350,7 @@ func (r *ServiceAccountReconciler) ensureServiceAccountSecret(ctx context.Contex
 	}
 
 	testObj := secret.DeepCopyObject().(client.Object)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), testObj); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.SecretCachingClient.Get(ctx, client.ObjectKeyFromObject(secret), testObj); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to check if Secret %s already exists", klog.KObj(secret))
 	} else if err == nil {
 		// If Secret already exists, nothing left to do
@@ -354,7 +359,26 @@ func (r *ServiceAccountReconciler) ensureServiceAccountSecret(ctx context.Contex
 
 	log.Info("Creating ServiceAccount Secret")
 	err = r.Client.Create(ctx, secret)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Add the ClusterNameLabel to the Secret if necessary to make it visible in the cache, so on next reconcile
+			// the Client.Get above will see it.
+			// This is done so that we can configure our cache to only watch secrets with the ClusterNameLabel.
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+				return err
+			}
+			if _, ok := secret.Labels[clusterv1.ClusterNameLabel]; !ok {
+				original := secret.DeepCopy()
+				if secret.Labels == nil {
+					secret.Labels = map[string]string{}
+				}
+				secret.Labels[clusterv1.ClusterNameLabel] = cluster.Name
+				if err := r.Client.Patch(ctx, secret, client.MergeFrom(original)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		// Note: We skip updating the ServiceAccount Secret because the token controller updates the service account with a
 		// secret and we don't want to overwrite it with an empty secret.
 		return errors.Wrapf(err, "failed to create ServiceAccount Secret %s", klog.KObj(secret))

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -46,16 +47,17 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 	// Otherwise the workload cluster's kube-apiserver would not shutdown due to the global
 	// test's clustercache still being running.
 	var (
-		intCtx             *vmwarehelpers.IntegrationTestContext
-		testEnv            *helpers.TestEnvironment
-		clusterCache       clustercache.ClusterCache
-		clusterCacheCancel context.CancelFunc
+		intCtx              *vmwarehelpers.IntegrationTestContext
+		testEnv             *helpers.TestEnvironment
+		secretCachingClient client.Client
+		clusterCache        clustercache.ClusterCache
+		clusterCacheCancel  context.CancelFunc
 	)
 
 	BeforeEach(func() {
 		var clusterCacheCtx context.Context
 		clusterCacheCtx, clusterCacheCancel = context.WithCancel(ctx)
-		testEnv, clusterCache = setup(clusterCacheCtx)
+		testEnv, secretCachingClient, clusterCache = setup(clusterCacheCtx)
 		intCtx = vmwarehelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 	})
 
@@ -133,6 +135,38 @@ var _ = Describe("ProviderServiceAccount controller integration tests", func() {
 			It("Should reconcile", func() {
 				By("Creating the target secret in the target namespace")
 				assertTargetSecret(ctx, intCtx.GuestClient, pSvcAccount.Spec.TargetNamespace, testTargetSecret)
+
+				secretKey := client.ObjectKey{
+					Namespace: pSvcAccount.Namespace,
+					Name:      getServiceAccountSecretName(*pSvcAccount),
+				}
+
+				By("Validate ServiceAccount secret is available in the secretCachingClient")
+				secret := &corev1.Secret{}
+				Eventually(func(g Gomega) {
+					g.Expect(secretCachingClient.Get(ctx, secretKey, secret)).To(Succeed())
+				}, 10*time.Second).Should(Succeed())
+				Expect(secret.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, intCtx.Cluster.Name))
+
+				By("Removing the cluster name label to simulate the adoption case")
+				original := secret.DeepCopy()
+				delete(secret.Labels, clusterv1.ClusterNameLabel)
+				Expect(intCtx.Client.Patch(ctx, secret, client.MergeFrom(original))).To(Succeed())
+				Expect(secret.Labels).ToNot(HaveKeyWithValue(clusterv1.ClusterNameLabel, intCtx.Cluster.Name))
+
+				By("Patch the ProviderServiceAccount to trigger a reconcile (we are not watching Secrets without cluster-name label)")
+				originalPSA := pSvcAccount.DeepCopy()
+				if pSvcAccount.Labels == nil {
+					pSvcAccount.Labels = map[string]string{}
+				}
+				pSvcAccount.Labels["reconcile"] = "now"
+				Expect(intCtx.Client.Patch(ctx, pSvcAccount, client.MergeFrom(originalPSA))).To(Succeed())
+
+				By("Validate ServiceAccount secret is available (again) in the secretCachingClient after adoption")
+				Eventually(func(g Gomega) {
+					g.Expect(secretCachingClient.Get(ctx, secretKey, secret)).To(Succeed())
+				}, 10*time.Second).Should(Succeed())
+				Expect(secret.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, intCtx.Cluster.Name))
 			})
 		})
 

--- a/controllers/vmware/serviceaccount_controller_unit_test.go
+++ b/controllers/vmware/serviceaccount_controller_unit_test.go
@@ -48,7 +48,8 @@ func unitTestsReconcileNormal() {
 		// Note: The service account provider requires a reference to the vSphereCluster hence the need to create
 		// a fake vSphereCluster in the test and pass it to during context setup.
 		reconciler = ServiceAccountReconciler{
-			Client: controllerCtx.ControllerManagerContext.Client,
+			Client:              controllerCtx.ControllerManagerContext.Client,
+			SecretCachingClient: controllerCtx.ControllerManagerContext.Client,
 		}
 		_, err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -46,14 +46,12 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
@@ -83,19 +81,6 @@ func AddServiceDiscoveryControllerToManager(ctx context.Context, controllerManag
 	}
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "servicediscovery/vspherecluster")
 
-	configMapCache, err := cache.New(mgr.GetConfig(), cache.Options{
-		Scheme: mgr.GetScheme(),
-		Mapper: mgr.GetRESTMapper(),
-		// TODO: Reintroduce the cache sync period
-		// Resync:    ctx.SyncPeriod,
-		DefaultNamespaces: map[string]cache.Config{metav1.NamespacePublic: {}},
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to create ConfigMap cache")
-	}
-	if err := mgr.Add(configMapCache); err != nil {
-		return errors.Wrapf(err, "failed to add ConfigMap cache")
-	}
 	return capicontrollerutil.NewControllerManagedBy(mgr, predicateLog).
 		For(&vmwarev1.VSphereCluster{}).
 		Named("servicediscovery/vspherecluster").
@@ -104,12 +89,9 @@ func AddServiceDiscoveryControllerToManager(ctx context.Context, controllerManag
 			&corev1.Service{},
 			handler.EnqueueRequestsFromMapFunc(r.serviceToClusters),
 		).
-		WatchesRawSource(
-			source.Kind(
-				configMapCache,
-				&corev1.ConfigMap{},
-				handler.TypedEnqueueRequestsFromMapFunc(r.configMapToClusters),
-			),
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.configMapToClusters),
 		).
 		// watch the CAPI cluster
 		Watches(
@@ -508,7 +490,7 @@ func (r *serviceDiscoveryReconciler) serviceToClusters(ctx context.Context, o cl
 
 // configMapToClusters is a mapper function used to enqueue reconcile.Requests
 // It watches for cluster-info configmaps for the supervisor api-server.
-func (r *serviceDiscoveryReconciler) configMapToClusters(ctx context.Context, o *corev1.ConfigMap) []reconcile.Request {
+func (r *serviceDiscoveryReconciler) configMapToClusters(ctx context.Context, o client.Object) []reconcile.Request {
 	if o.GetNamespace() != metav1.NamespacePublic || o.GetName() != bootstrapapi.ConfigMapClusterInfo {
 		return nil
 	}

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Service Discovery controller integration tests", func() {
 	BeforeEach(func() {
 		var clusterCacheCtx context.Context
 		clusterCacheCtx, clusterCacheCancel = context.WithCancel(ctx)
-		testEnv, clusterCache = setup(clusterCacheCtx)
+		testEnv, _, clusterCache = setup(clusterCacheCtx)
 		intCtx = vmwarehelpers.NewIntegrationTestContextWithClusters(ctx, testEnv.Manager.GetClient())
 
 		By(fmt.Sprintf("Creating the Cluster (%s), vSphereCluster (%s) and KubeconfigSecret", intCtx.Cluster.Name, intCtx.VSphereCluster.Name), func() {

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -37,7 +37,9 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,6 +52,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -176,8 +179,38 @@ func NewTestEnvironment(ctx context.Context) *TestEnvironment {
 		}
 	}
 
+	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
+	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
+
 	managerOpts := manager.Options{
 		Options: ctrl.Options{
+			Cache: cache.Options{
+				ByObject: map[client.Object]cache.ByObject{
+					&corev1.Secret{}: {
+						Label: clusterSecretCacheSelector,
+						// Drop data of secrets that we don't use.
+						Transform: func(in any) (any, error) {
+							if s, ok := in.(*corev1.Secret); ok {
+								s.SetManagedFields(nil)
+								if !strings.HasSuffix(s.Name, "-kubeconfig") && s.Type != corev1.SecretTypeServiceAccountToken {
+									s.Data = nil
+								}
+							}
+							return in, nil
+						},
+					},
+				},
+			},
+			Client: client.Options{
+				Cache: &client.CacheOptions{
+					DisableFor: []client.Object{
+						// We are configuring the mgr.GetClient() to not use the cache for secrets, so that if we miss some
+						// Secret Get calls they are not hitting a cache with partial data.
+						// If Secrets from the cache should be accessed, we should use the secretCachingClient instead.
+						&corev1.Secret{},
+					},
+				},
+			},
 			Controller: config.Controller{
 				UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
 			},

--- a/internal/test/helpers/vmware/intg_test_context.go
+++ b/internal/test/helpers/vmware/intg_test_context.go
@@ -137,6 +137,9 @@ func NewIntegrationTestContextWithClusters(ctx context.Context, integrationTestC
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: testCtx.Namespace,
 				Name:      fmt.Sprintf("%s-kubeconfig", testCtx.Cluster.Name),
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: testCtx.Cluster.Name,
+				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion: clusterv1.GroupVersion.String(),

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"reflect"
 	goruntime "runtime"
+	"strings"
 	"time"
 
 	perrors "github.com/pkg/errors"
@@ -33,6 +34,7 @@ import (
 	"gopkg.in/fsnotify.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -73,6 +75,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/version"
 	"sigs.k8s.io/cluster-api-provider-vsphere/webhooks"
 	vmwarewebhooks "sigs.k8s.io/cluster-api-provider-vsphere/webhooks/vmware"
@@ -345,9 +348,6 @@ func main() {
 		}
 	}
 
-	req, _ := labels.NewRequirement(vmoperator.ClusterSelectorKey, selection.Exists, nil)
-	virtualMachineCacheSelector := labels.NewSelector().Add(*req)
-
 	var vm runtime.Object
 	var converter *conversion.Converter
 	if isSupervisorCRDLoaded {
@@ -385,21 +385,75 @@ func main() {
 		}
 	}
 
+	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
+	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
+
+	req, _ = labels.NewRequirement(vmoperator.ClusterSelectorKey, selection.Exists, nil)
+	virtualMachineCacheSelector := labels.NewSelector().Add(*req)
+
 	managerOpts.Cache = cache.Options{
 		DefaultNamespaces: watchNamespaces,
 		SyncPeriod:        &syncPeriod,
+		DefaultTransform:  cache.TransformStripManagedFields(),
 		ByObject: func() map[client.Object]cache.ByObject {
 			byObject := map[client.Object]cache.ByObject{}
+			// Optimize the cache for supervisor mode. govmomi mode might have different caching requirements
 			if isSupervisorCRDLoaded {
 				// Note: Only VirtualMachines with the cluster name label are cached (vmopmachine.go sets this label).
 				// NOTE: use vm-operator native types for cache filters (the reconciler uses the internal hub version).
 				byObject[vm.(client.Object)] = cache.ByObject{
 					Label: virtualMachineCacheSelector,
 				}
+				byObject[&corev1.Secret{}] = cache.ByObject{
+					Label: clusterSecretCacheSelector,
+					// Drop data of secrets that we don't use.
+					Transform: func(in any) (any, error) {
+						if s, ok := in.(*corev1.Secret); ok {
+							s.SetManagedFields(nil)
+							if !strings.HasSuffix(s.Name, "-kubeconfig") && s.Type != corev1.SecretTypeServiceAccountToken {
+								s.Data = nil
+							}
+						}
+						return in, nil
+					},
+				}
+				byObject[&corev1.ConfigMap{}] = cache.ByObject{
+					Namespaces: map[string]cache.Config{
+						metav1.NamespacePublic: {},
+						util.NCPNamespace:      {},
+					},
+				}
+				byObject[&clusterv1.MachineSet{}] = cache.ByObject{
+					// Drop data of MachineSets as we only use ownerRefs of MachineSets in clog.AddOwners.
+					Transform: func(in any) (any, error) {
+						if m, ok := in.(*clusterv1.MachineSet); ok {
+							m.SetManagedFields(nil)
+							m.Spec = clusterv1.MachineSetSpec{}
+							m.Status = clusterv1.MachineSetStatus{}
+						}
+						return in, nil
+					},
+				}
 			}
 			return byObject
 		}(),
 	}
+	managerOpts.Client = func() client.Options {
+		// Optimize the cache for supervisor mode. govmomi mode might have different caching requirements
+		if isSupervisorCRDLoaded {
+			return client.Options{
+				Cache: &client.CacheOptions{
+					DisableFor: []client.Object{
+						// We are configuring the mgr.GetClient() to not use the cache for secrets, so that if we miss some
+						// Secret Get calls they are not hitting a cache with partial data.
+						// If Secrets from the cache should be accessed, we should use the secretCachingClient instead.
+						&corev1.Secret{},
+					},
+				},
+			}
+		}
+		return client.Options{}
+	}()
 
 	if enableContentionProfiling {
 		goruntime.SetBlockProfileRate(1)
@@ -413,7 +467,17 @@ func main() {
 
 	// Create a function that adds all the controllers and webhooks to the manager.
 	addToManager := func(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-		clusterCache, err := setupClusterCache(ctx, mgr)
+		secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
+			HTTPClient: mgr.GetHTTPClient(),
+			Cache: &client.CacheOptions{
+				Reader: mgr.GetCache(),
+			},
+		})
+		if err != nil {
+			return perrors.Wrapf(err, "unable to create secret caching client")
+		}
+
+		clusterCache, err := setupClusterCache(ctx, mgr, secretCachingClient, isSupervisorCRDLoaded)
 		if err != nil {
 			return perrors.Wrapf(err, "unable to create remote cluster cache tracker")
 		}
@@ -427,7 +491,7 @@ func main() {
 		}
 
 		if isSupervisorCRDLoaded {
-			if err := setupSupervisorControllers(ctx, controllerCtx, mgr, clusterCache); err != nil {
+			if err := setupSupervisorControllers(ctx, controllerCtx, mgr, clusterCache, secretCachingClient); err != nil {
 				return fmt.Errorf("setupSupervisorControllers: %w", err)
 			}
 		} else {
@@ -555,7 +619,7 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 	return controllers.AddVSphereDeploymentZoneControllerToManager(ctx, controllerCtx, mgr, concurrency(vSphereDeploymentZoneConcurrency))
 }
 
-func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache) error {
+func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache, secretCachingClient client.Client) error {
 	if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
 		return err
 	}
@@ -577,7 +641,7 @@ func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.
 		return err
 	}
 
-	if err := vmware.AddServiceAccountProviderControllerToManager(ctx, controllerCtx, mgr, clusterCache, concurrency(providerServiceAccountConcurrency)); err != nil {
+	if err := vmware.AddServiceAccountProviderControllerToManager(ctx, controllerCtx, mgr, clusterCache, secretCachingClient, concurrency(providerServiceAccountConcurrency)); err != nil {
 		return err
 	}
 
@@ -617,20 +681,49 @@ func concurrency(c int) controller.Options {
 	return controller.Options{MaxConcurrentReconciles: c}
 }
 
-func setupClusterCache(ctx context.Context, mgr ctrlmgr.Manager) (clustercache.ClusterCache, error) {
-	secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
-		HTTPClient: mgr.GetHTTPClient(),
-		Cache: &client.CacheOptions{
-			Reader: mgr.GetCache(),
-		},
-	})
-	if err != nil {
-		return nil, perrors.Wrapf(err, "unable to create secret caching client")
-	}
-
+func setupClusterCache(ctx context.Context, mgr ctrlmgr.Manager, secretCachingClient client.Client, isSupervisorCRDLoaded bool) (clustercache.ClusterCache, error) {
 	clusterCache, err := clustercache.SetupWithManager(ctx, mgr, clustercache.Options{
 		SecretClient: secretCachingClient,
-		Cache:        clustercache.CacheOptions{},
+		Cache: func() clustercache.CacheOptions {
+			if isSupervisorCRDLoaded {
+				return clustercache.CacheOptions{
+					ByObject: map[client.Object]cache.ByObject{
+						&corev1.Service{}: {
+							Namespaces: map[string]cache.Config{
+								vmwarev1.SupervisorHeadlessSvcNamespace: {
+									Transform: func(in any) (any, error) {
+										if s, ok := in.(*corev1.Service); ok {
+											s.SetManagedFields(nil)
+											if s.Name != vmwarev1.SupervisorHeadlessSvcName {
+												s.Spec = corev1.ServiceSpec{}
+												s.Status = corev1.ServiceStatus{}
+											}
+										}
+										return in, nil
+									},
+								},
+							},
+						},
+						&corev1.Endpoints{}: {
+							Namespaces: map[string]cache.Config{
+								vmwarev1.SupervisorHeadlessSvcNamespace: {
+									Transform: func(in any) (any, error) {
+										if s, ok := in.(*corev1.Endpoints); ok {
+											s.SetManagedFields(nil)
+											if s.Name != vmwarev1.SupervisorHeadlessSvcName {
+												s.Subsets = nil
+											}
+										}
+										return in, nil
+									},
+								},
+							},
+						},
+					},
+				}
+			}
+			return clustercache.CacheOptions{}
+		}(),
 		Client: clustercache.ClientOptions{
 			QPS:       clusterCacheClientQPS,
 			Burst:     clusterCacheClientBurst,
@@ -640,6 +733,8 @@ func setupClusterCache(ctx context.Context, mgr ctrlmgr.Manager) (clustercache.C
 					// Don't cache ConfigMaps & Secrets.
 					&corev1.ConfigMap{},
 					&corev1.Secret{},
+					// Don't cache Namespaces (used in ProviderServiceAccount controller).
+					&corev1.Namespace{},
 				},
 			},
 		},

--- a/pkg/context/fake/fake_cluster_context.go
+++ b/pkg/context/fake/fake_cluster_context.go
@@ -34,21 +34,21 @@ func NewClusterContext(ctx context.Context, controllerManagerCtx *capvcontext.Co
 	vsphereCluster := newVSphereCluster(cluster)
 
 	// Add the cluster resources to the fake cluster client.
-	if err := controllerManagerCtx.Client.Create(ctx, &cluster); err != nil {
+	if err := controllerManagerCtx.Client.Create(ctx, cluster); err != nil {
 		panic(err)
 	}
-	if err := controllerManagerCtx.Client.Create(ctx, &vsphereCluster); err != nil {
+	if err := controllerManagerCtx.Client.Create(ctx, vsphereCluster); err != nil {
 		panic(err)
 	}
 
 	return &capvcontext.ClusterContext{
-		Cluster:        &cluster,
-		VSphereCluster: &vsphereCluster,
+		Cluster:        cluster,
+		VSphereCluster: vsphereCluster,
 	}
 }
 
-func newClusterV1() clusterv1.Cluster {
-	return clusterv1.Cluster{
+func newClusterV1() *clusterv1.Cluster {
+	return &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: Namespace,
 			Name:      Clusterv1a2Name,
@@ -70,8 +70,8 @@ func newClusterV1() clusterv1.Cluster {
 	}
 }
 
-func newVSphereCluster(owner clusterv1.Cluster) infrav1.VSphereCluster {
-	return infrav1.VSphereCluster{
+func newVSphereCluster(owner *clusterv1.Cluster) *infrav1.VSphereCluster {
+	return &infrav1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: owner.Namespace,
 			Name:      owner.Name,

--- a/pkg/context/fake/fake_vmware_cluster_context.go
+++ b/pkg/context/fake/fake_vmware_cluster_context.go
@@ -35,7 +35,7 @@ func NewVmwareClusterContext(ctx context.Context, controllerManagerCtx *capvcont
 	}
 
 	// Add the cluster resources to the fake cluster client.
-	if err := controllerManagerCtx.Client.Create(ctx, &cluster); err != nil {
+	if err := controllerManagerCtx.Client.Create(ctx, cluster); err != nil {
 		panic(err)
 	}
 	if err := controllerManagerCtx.Client.Create(ctx, vsphereCluster); err != nil {
@@ -43,6 +43,7 @@ func NewVmwareClusterContext(ctx context.Context, controllerManagerCtx *capvcont
 	}
 
 	return &vmware.ClusterContext{
+		Cluster:        cluster,
 		VSphereCluster: vsphereCluster,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3822
