### PR TITLE
🌱 Drop or reduce verbosity for noisy logs

### DIFF
--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -284,7 +284,7 @@ func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx cont
 		return nil
 	}
 
-	log.Info("Discovered supervisor API server endpoint", "host", supervisorHost, "port", supervisorPort)
+	log.V(5).Info("Discovered supervisor API server endpoint", "host", supervisorHost, "port", supervisorPort)
 	// CreateOrPatch the newEndpoints with the discovered supervisor api server address
 	newEndpoints := newSupervisorHeadlessServiceEndpoints(
 		supervisorHost,

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -234,6 +234,8 @@ func (r *ClusterReconciler) reconcileDelete(clusterCtx *vmware.ClusterContext) {
 }
 
 func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	// Get any failure domains to report back to the CAPI core controller.
 	failureDomains, err := r.getFailureDomains(ctx, clusterCtx.VSphereCluster.Namespace)
 	if err != nil {
@@ -277,6 +279,9 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmw
 		return errors.Wrapf(err, "unexpected error while reconciling control plane endpoint for %s", clusterCtx.VSphereCluster.Name)
 	}
 
+	if !ptr.Deref(clusterCtx.VSphereCluster.Status.Initialization.Provisioned, false) {
+		log.Info("VSphereCluster provisioning complete")
+	}
 	clusterCtx.VSphereCluster.Status.Initialization.Provisioned = ptr.To(true)
 	return nil
 }
@@ -287,6 +292,12 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 	if !clusterCtx.Cluster.Spec.ControlPlaneEndpoint.IsZero() {
 		clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.Host = clusterCtx.Cluster.Spec.ControlPlaneEndpoint.Host
 		clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.Port = clusterCtx.Cluster.Spec.ControlPlaneEndpoint.Port
+		if !conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterLoadBalancerReadyCondition) {
+			log.Info("Skipping control plane endpoint reconciliation",
+				"reason", "ControlPlaneEndpoint already set on Cluster",
+				"controlPlaneEndpoint", clusterCtx.Cluster.Spec.ControlPlaneEndpoint.String())
+		}
+
 		conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
 			Type:   vmwarev1.VSphereClusterLoadBalancerReadyCondition,
 			Status: metav1.ConditionTrue,
@@ -295,13 +306,16 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 		if r.NetworkProvider.HasLoadBalancer() {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.LoadBalancerReadyV1Beta1Condition)
 		}
-		log.Info("Skipping control plane endpoint reconciliation",
-			"reason", "ControlPlaneEndpoint already set on Cluster",
-			"controlPlaneEndpoint", clusterCtx.Cluster.Spec.ControlPlaneEndpoint.String())
 		return nil
 	}
 
 	if !clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.IsZero() {
+		if !conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterLoadBalancerReadyCondition) {
+			log.Info("Skipping control plane endpoint reconciliation",
+				"reason", "ControlPlaneEndpoint already set on VSphereCluster",
+				"controlPlaneEndpoint", clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.String())
+		}
+
 		conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
 			Type:   vmwarev1.VSphereClusterLoadBalancerReadyCondition,
 			Status: metav1.ConditionTrue,
@@ -310,9 +324,6 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 		if r.NetworkProvider.HasLoadBalancer() {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.LoadBalancerReadyV1Beta1Condition)
 		}
-		log.Info("Skipping control plane endpoint reconciliation",
-			"reason", "ControlPlaneEndpoint already set on VSphereCluster",
-			"controlPlaneEndpoint", clusterCtx.VSphereCluster.Spec.ControlPlaneEndpoint.String())
 		return nil
 	}
 

--- a/pkg/services/vmoperator/control_plane_endpoint.go
+++ b/pkg/services/vmoperator/control_plane_endpoint.go
@@ -71,9 +71,6 @@ type CPService struct {
 
 // ReconcileControlPlaneEndpointService manages the lifecycle of a control plane endpoint managed by a vmoperator VirtualMachineService.
 func (s *CPService) ReconcileControlPlaneEndpointService(ctx context.Context, clusterCtx *vmware.ClusterContext, netProvider services.NetworkProvider) (*vmwarev1.APIEndpoint, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.V(4).Info("Reconciling control plane VirtualMachineService for cluster")
-
 	// If the NetworkProvider does not support a load balancer, this should be a no-op
 	if !netProvider.HasLoadBalancer() {
 		return nil, nil

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -114,7 +114,7 @@ func (v *VmopMachineService) ReconcileDelete(ctx context.Context, machineCtx cap
 	if !ok {
 		return errors.New("received unexpected SupervisorMachineContext type")
 	}
-	log.Info("Destroying VM")
+	log.Info("Deleting VirtualMachine")
 
 	// If debug logging is enabled, report the number of vms in the cluster before and after the reconcile
 	if log.V(5).Enabled() {
@@ -200,6 +200,9 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 	if err != nil {
 		return false, err
 	}
+
+	log = log.WithValues("VirtualMachine", klog.KRef(vmKey.Namespace, vmKey.Name))
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// When creating a new cluster and the user doesn't provide info about placement of VMs in a specific failure domain,
 	// CAPV will define affinity rules to ensure proper placement of the machine.
@@ -391,7 +394,7 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 				Reason:  c.Reason,
 				Message: c.Message,
 			})
-			return false, errors.Errorf("vm prerequisites check failed for condition %s: %s", condition, supervisorMachineCtx)
+			return false, errors.Errorf("vm prerequisites check failed for condition %s: %s", condition, klog.KObj(vmOperatorVM))
 		}
 
 		// All the pre-requisites are in place but the machines is not yet created, report it.
@@ -427,7 +430,7 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 			Status: metav1.ConditionFalse,
 			Reason: infrav1.VSphereMachineVirtualMachineWaitingForNetworkAddressReason,
 		})
-		log.Info(fmt.Sprintf("VM does not have an IP address: %s", supervisorMachineCtx))
+		log.Info("VM does not have an IP address")
 		return true, nil
 	}
 
@@ -438,7 +441,7 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 			Status: metav1.ConditionFalse,
 			Reason: infrav1.VSphereMachineVirtualMachineWaitingForBIOSUUIDReason,
 		})
-		log.Info(fmt.Sprintf("VM does not have a BIOS UUID: %s", supervisorMachineCtx))
+		log.Info("VM does not have a BIOS UUID")
 		return true, nil
 	}
 
@@ -454,18 +457,19 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 	providerID := fmt.Sprintf("vsphere://%s", vmOperatorVM.Status.BiosUUID)
 	if supervisorMachineCtx.VSphereMachine.Spec.ProviderID != providerID {
 		supervisorMachineCtx.VSphereMachine.Spec.ProviderID = providerID
-		log.Info("Updated providerID", "providerID", providerID)
 	}
 
 	if supervisorMachineCtx.VSphereMachine.Status.BiosUUID != vmOperatorVM.Status.BiosUUID {
 		supervisorMachineCtx.VSphereMachine.Status.BiosUUID = vmOperatorVM.Status.BiosUUID
-		log.Info("Updated VM ID", "vmID", vmOperatorVM.Status.BiosUUID)
 	}
 
 	// Surface placement.
 	supervisorMachineCtx.VSphereMachine.Status.FailureDomain = vmOperatorVM.Status.Zone
 
 	// Mark the VSphereMachine as Ready
+	if !ptr.Deref(supervisorMachineCtx.VSphereMachine.Status.Initialization.Provisioned, false) {
+		log.Info("VSphereMachine provisioning complete")
+	}
 	supervisorMachineCtx.VSphereMachine.Status.Initialization.Provisioned = ptr.To(true)
 	deprecatedv1beta1conditions.MarkTrue(supervisorMachineCtx.VSphereMachine, infrav1.VMProvisionedV1Beta1Condition)
 	conditions.Set(supervisorMachineCtx.VSphereMachine, metav1.Condition{

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -91,7 +91,6 @@ const (
 func ReconcileDependencies(ctx context.Context, c client.Client, dependenciesConfig *vcsimv1.VMOperatorDependencies) error {
 	var retryError error
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling dependencies for the VMOperator Deployment")
 
 	config := dependenciesConfig.DeepCopy()
 

--- a/test/infrastructure/net-operator/controllers/networkinterface_controller.go
+++ b/test/infrastructure/net-operator/controllers/networkinterface_controller.go
@@ -47,7 +47,6 @@ type NetworkInterfaceReconciler struct {
 
 func (r *NetworkInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling NetworkInterface")
 
 	// Fetch the NetworkInterface instance
 	networkInterface := &netopv1alpha1.NetworkInterface{}

--- a/test/infrastructure/vcsim/controllers/controlplaneendpoint_controller.go
+++ b/test/infrastructure/vcsim/controllers/controlplaneendpoint_controller.go
@@ -88,10 +88,7 @@ func (r *ControlPlaneEndpointReconciler) Reconcile(ctx context.Context, req ctrl
 	return ctrl.Result{}, r.reconcileNormal(ctx, controlPlaneEndpoint)
 }
 
-func (r *ControlPlaneEndpointReconciler) reconcileNormal(ctx context.Context, controlPlaneEndpoint *vcsimv1.ControlPlaneEndpoint) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling VCSim ControlPlaneEndpoint")
-
+func (r *ControlPlaneEndpointReconciler) reconcileNormal(_ context.Context, controlPlaneEndpoint *vcsimv1.ControlPlaneEndpoint) error {
 	// Initialize a listener for the workload cluster.
 	// IMPORTANT: The fact that both the listener and the resourceGroup for a workload cluster have
 	// the same name is used as assumptions in other part of the implementation.
@@ -107,9 +104,7 @@ func (r *ControlPlaneEndpointReconciler) reconcileNormal(ctx context.Context, co
 	return nil
 }
 
-func (r *ControlPlaneEndpointReconciler) reconcileDelete(ctx context.Context, controlPlaneEndpoint *vcsimv1.ControlPlaneEndpoint) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling delete VCSim ControlPlaneEndpoint")
+func (r *ControlPlaneEndpointReconciler) reconcileDelete(_ context.Context, controlPlaneEndpoint *vcsimv1.ControlPlaneEndpoint) error {
 	listenerName := klog.KObj(controlPlaneEndpoint).String()
 
 	// Delete the resource group hosting all the cloud resources belonging the workload cluster;

--- a/test/infrastructure/vcsim/controllers/envvar_controller.go
+++ b/test/infrastructure/vcsim/controllers/envvar_controller.go
@@ -137,9 +137,6 @@ func (r *EnvVarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 }
 
 func (r *EnvVarReconciler) reconcileNormal(ctx context.Context, envVar *vcsimv1.EnvVar, vCenterSimulator *vcsimv1.VCenterSimulator, controlPlaneEndpoint *vcsimv1.ControlPlaneEndpoint) (ctrl.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling VCSim EnvVar")
-
 	if controlPlaneEndpoint.Status.Host == "" {
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -171,7 +168,6 @@ func (r *EnvVarReconciler) reconcileNormal(ctx context.Context, envVar *vcsimv1.
 
 		sshKey = string(publicKeyBytes)
 		r.sshKeys[key] = sshKey
-		log.Info("Created ssh authorized key")
 	}
 
 	// Variables required only when the vcsim controller is used in combination with Tilt (E2E tests provide this value in other ways)

--- a/test/infrastructure/vcsim/controllers/vcsim_controller.go
+++ b/test/infrastructure/vcsim/controllers/vcsim_controller.go
@@ -129,7 +129,6 @@ func (r *VCenterSimulatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 func (r *VCenterSimulatorReconciler) reconcileNormal(ctx context.Context, vCenterSimulator *vcsimv1.VCenterSimulator) error {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling VCenter")
 
 	// When simulating vm-operator, there is no need of a vcenter/vcsim.
 	// Note. We keep using the VCenterSimulator CR also in this case to avoid introducing code branches in the test framework.
@@ -307,8 +306,6 @@ func createGovmomiFailureDomainTags(vCenterSimulator *vcsimv1.VCenterSimulator) 
 
 func (r *VCenterSimulatorReconciler) reconcileDelete(ctx context.Context, vCenterSimulator *vcsimv1.VCenterSimulator) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling delete VCenter server")
-
 	r.lock.Lock()
 	defer r.lock.Unlock()
 

--- a/test/infrastructure/vcsim/controllers/virtualmachine_controller.go
+++ b/test/infrastructure/vcsim/controllers/virtualmachine_controller.go
@@ -76,7 +76,6 @@ type VirtualMachineReconciler struct {
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
 func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling VirtualMachine")
 
 	// Fetch the VirtualMachine instance
 	virtualMachine := &vmoprvhub.VirtualMachine{}
@@ -191,9 +190,8 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 
 			listenerName := klog.KObj(&c).String()
-			log.Info("Registering ResourceGroup for ControlPlaneEndpoint", "ResourceGroup", resourceGroup, "ControlPlaneEndpoint", listenerName)
-			err := r.APIServerMux.RegisterResourceGroup(listenerName, resourceGroup)
-			if err != nil {
+			log.V(4).Info("Registering ResourceGroup for ControlPlaneEndpoint", "ResourceGroup", resourceGroup, "ControlPlaneEndpoint", listenerName)
+			if err := r.APIServerMux.RegisterResourceGroup(listenerName, resourceGroup); err != nil {
 				return ctrl.Result{}, err
 			}
 			found = true

--- a/test/infrastructure/vcsim/controllers/vmoperatordependencies_controller.go
+++ b/test/infrastructure/vcsim/controllers/vmoperatordependencies_controller.go
@@ -78,9 +78,6 @@ func (r *VMOperatorDependenciesReconciler) Reconcile(ctx context.Context, req ct
 }
 
 func (r *VMOperatorDependenciesReconciler) reconcileNormal(ctx context.Context, vmOperatorDependencies *vcsimv1.VMOperatorDependencies) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling VCSim VMOperatorDependencies")
-
 	// When simulating vm-operator, only a minimal part of the
 	// VMOperatorDependencies is required because used by CAPV.
 	if r.VMOperatorSimMode {

--- a/test/infrastructure/vcsim/controllers/vspherevm_controller.go
+++ b/test/infrastructure/vcsim/controllers/vspherevm_controller.go
@@ -189,7 +189,7 @@ func (r *VSphereVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			listenerName := klog.KObj(&c).String()
-			log.Info("Registering ResourceGroup for ControlPlaneEndpoint", "ResourceGroup", resourceGroup, "ControlPlaneEndpoint", listenerName)
+			log.V(4).Info("Registering ResourceGroup for ControlPlaneEndpoint", "ResourceGroup", resourceGroup, "ControlPlaneEndpoint", listenerName)
 			err := r.APIServerMux.RegisterResourceGroup(listenerName, resourceGroup)
 			if err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
