### PR TITLE
🌱 Complete bump to CAPI v1.13.0-beta.1

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -22,14 +22,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -52,11 +49,6 @@ var _ = Describe("When testing the machinery for scale testing using vcsim provi
 			if testMode == GovmomiTestMode {
 				flavor = testSpecificSettingsGetter().FlavorForMode("topology-runtimesdk")
 			}
-
-			// Cleanup from previous test runs. // TODO: consider moving this into the core CAPI scale test
-			Expect(ctrlclient.IgnoreNotFound(bootstrapClusterProxy.GetClient().Delete(ctx, &runtimev1.ExtensionConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: "capv-scale-test-extension"},
-			}))).To(Succeed(), "Failed to delete the ExtensionConfig")
 
 			return capi_e2e.ScaleSpecInput{
 				E2EConfig:              e2eConfig,

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.13.0-beta.1
 
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.13.0-beta.0
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.13.0-beta.1
 
 replace sigs.k8s.io/cluster-api-provider-vsphere => ../
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -475,8 +475,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.13.0-beta.1 h1:ePK9r+ZeRNz2b8h9RhDcytq4LL6FdrqnD10d1w6AMFg=
 sigs.k8s.io/cluster-api v1.13.0-beta.1/go.mod h1:ccNAETmL0s+NVrqXeL1/emE8pcv0hza5InlOALB89qQ=
-sigs.k8s.io/cluster-api/test v1.13.0-beta.0 h1:kOMfJG9NgVAS7a675NnwAsr1JxH1yGq9IB+o+AWKbF8=
-sigs.k8s.io/cluster-api/test v1.13.0-beta.0/go.mod h1:ESHqwOD5qkZbwguMeGRVALCzdVVjf4dGyoJnLZQgL0s=
+sigs.k8s.io/cluster-api/test v1.13.0-beta.1 h1:MioZ79nQGNleMZvAU/K+YEVVQ7kqF3PSwN5aZt0qr0U=
+sigs.k8s.io/cluster-api/test v1.13.0-beta.1/go.mod h1:E22NwSa21D4/58mAgdNFMa7yWcp9nUdoDpMMhYfViWw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Follow-up to https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3911

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
