### PR TITLE
🌱 Skip 9.2 e2e tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -24,6 +24,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # shellcheck source=./hack/ci-e2e-lib.sh
 source "${REPO_ROOT}/hack/ci-e2e-lib.sh"
 
+# TODO: Remove on the PR that implement 9.2 e2e tests
+if [[ "${VM_OPERATOR_VERSION:-''}" == "9.2" ]]; then
+  echo "9.2 tests are not implemented yet, skipping tests"
+  exit 0
+fi
+
 RE_VCSIM='\[vcsim\\]'
 
 # In CI, ARTIFACTS is set to a different directory. This stores the value of


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
https://github.com/kubernetes/test-infra/pull/36971/changes is introducing new pre-submits and periodics for 9.2.

Let's skip the tests for now to avoid failures / alert mails. This PR should be reverted on the PR that implements 9.2 tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
