### PR TITLE
🌱 Declare contents: read permissions for pr-verify action

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# Runs in pull_request_target context but only reads the PR title and
+# shells out to hack/verify-pr-title.sh.
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit `permissions: contents: read` block to `pr-verify.yaml`. The workflow runs in `pull_request_target` context (broader default scope) but only reads `github.event.pull_request.title` and runs `./hack/verify-pr-title.sh` — no GitHub API writes. Pinning the scope is especially useful for `pull_request_target` workflows.

YAML validated locally with `yaml.safe_load`.