### PR TITLE
🌱 Split supervisor and govmomi feature gates, add support for gates depending on vm-operator-version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -267,7 +267,7 @@ linters:
         # Allow direct usage of vm-operator APIs in a few places like e.g. tests and main.go
       - linters:
           - depguard
-        path: main.go|pkg/manager/manager.go|.*_test.go|internal/test/helpers/.*|pkg/context/fake/fake_controller_manager_context.go|pkg/conversion/.*|pkg/util/testutil.go
+        path: main.go|feature/gates.go|pkg/manager/manager.go|.*_test.go|internal/test/helpers/.*|pkg/context/fake/fake_controller_manager_context.go|pkg/conversion/.*|pkg/util/testutil.go
         text: 'Use vmoprvhub in prod code instead'
       - linters:
           - staticcheck

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,6 @@ spec:
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
         - --v=4
         - "--feature-gates=PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false}"
-        - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
         - --v=4
-        - "--feature-gates=MultiNetworks=${EXP_MULTI_NETWORKS:=false},NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false},NamespaceScopedZones=${EXP_NAMESPACE_SCOPED_ZONES:=false},NodeAutoPlacement=${EXP_NODE_AUTO_PLACEMENT:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true}"
+        - "--feature-gates=PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},NodeAntiAffinity=${EXP_NODE_ANTI_AFFINITY:=false}"
         - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
         image: controller:latest
         imagePullPolicy: IfNotPresent

--- a/config/supervisor/kustomization.yaml
+++ b/config/supervisor/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
   - ./crd
   - ./webhook
 
+patches:
+  - path: ./manager.yaml
+
 vars:
   - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
     objref:

--- a/config/supervisor/manager.yaml
+++ b/config/supervisor/manager.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
+        - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+        - --v=4
+        - "--feature-gates=PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},MultiNetworks=${EXP_MULTI_NETWORKS:=false},NamespaceScopedZones=${EXP_NAMESPACE_SCOPED_ZONES:=false},NodeAutoPlacement=${EXP_NODE_AUTO_PLACEMENT:=false}"
+        - "--vm-operator-api-version=${VM_OPERATOR_API_VERSION:=v1alpha5}"
+        name: manager

--- a/controllers/vspherevm_controller_test.go
+++ b/controllers/vspherevm_controller_test.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirecord "k8s.io/client-go/tools/record"
+	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
@@ -603,7 +604,7 @@ func Test_reconcile(t *testing.T) {
 			})
 
 			t.Run("when anti affinity feature gate is turned on", func(t *testing.T) {
-				_ = feature.MutableGates.Set("NodeAntiAffinity=true")
+				utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.NodeAntiAffinity, true)
 				r := setupReconciler(new(fake_svc.VMService), initObjs...)
 				_, err := r.reconcile(ctx, &capvcontext.VMContext{
 					ControllerManagerContext: r.ControllerManagerContext,

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -18,7 +18,6 @@ limitations under the License.
 package feature
 
 import (
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
 )
 
@@ -63,17 +62,30 @@ const (
 	ReconcilerRateLimiting featuregate.Feature = "ReconcilerRateLimiting"
 )
 
-func init() {
-	runtime.Must(MutableGates.Add(defaultCAPVFeatureGates))
-}
+var (
+	commonGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		PriorityQueue:          {Default: true, PreRelease: featuregate.Beta},
+		ReconcilerRateLimiting: {Default: true, PreRelease: featuregate.Beta},
+	}
 
-// defaultCAPVFeatureGates consists of all known capv-specific feature keys.
-// To add a new feature, define a key for it above and add it here.
-var defaultCAPVFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PriorityQueue:          {Default: true, PreRelease: featuregate.Beta},
-	ReconcilerRateLimiting: {Default: true, PreRelease: featuregate.Beta},
-	NodeAntiAffinity:       {Default: false, PreRelease: featuregate.Alpha},
-	NamespaceScopedZones:   {Default: false, PreRelease: featuregate.Alpha},
-	NodeAutoPlacement:      {Default: false, PreRelease: featuregate.Alpha},
-	MultiNetworks:          {Default: false, PreRelease: featuregate.Alpha},
-}
+	govmomiGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		NodeAntiAffinity: {Default: false, PreRelease: featuregate.Alpha},
+	}
+
+	supervisorGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		NamespaceScopedZones: {Default: false, PreRelease: featuregate.Alpha},
+		NodeAutoPlacement:    {Default: false, PreRelease: featuregate.Alpha},
+		MultiNetworks:        {Default: false, PreRelease: featuregate.Alpha},
+	}
+
+	supervisorVersionedGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+		// NOTE: Supervisor features gates depending on a specific vm-operator version should be added here.
+		// e.g.
+		// FeatureDependingOnV1alpha5: {
+		//  {Version: toFeatureVersion(vmoprv1alpha5.GroupVersion.Version), Default: false, PreRelease: featuregate.Alpha},
+		// },
+		// FeatureDependingOnV1alpha6: {
+		// 	{Version: toFeatureVersion(vmoprv1alpha6.GroupVersion.Version), Default: false, PreRelease: featuregate.Alpha},
+		// },
+	}
+)

--- a/feature/gates.go
+++ b/feature/gates.go
@@ -17,17 +17,210 @@ limitations under the License.
 package feature
 
 import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
 
 var (
-	// MutableGates is a mutable version of DefaultFeatureGate.
-	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
-	// Tests that need to modify featuregate gates for the duration of their test should use:
-	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
-	MutableGates = featuregate.NewFeatureGate()
+	allGates featuregate.MutableVersionedFeatureGate
 
 	// Gates is a shared global FeatureGate.
-	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
-	Gates featuregate.FeatureGate = MutableGates
+	Gates featuregate.FeatureGate
 )
+
+func init() {
+	// Add all gates to avoid issue in test code that assumes gates are properly set up.
+	// Note: When the controller starts, only a subset of those gates will be allowed depending on mode / vm-operator version.
+	allGates = featuregate.NewVersionedFeatureGate(toFeatureVersion(vmoprv1alpha5.GroupVersion.Version))
+	utilruntime.Must(allGates.Add(commonGates))
+	utilruntime.Must(allGates.Add(govmomiGates))
+	utilruntime.Must(allGates.Add(supervisorGates))
+	utilruntime.Must(allGates.AddVersioned(supervisorVersionedGates))
+	Gates = allGates
+}
+
+// AddFlag adds a flag for setting global feature gates to the specified FlagSet.
+func AddFlag(fs *pflag.FlagSet, p *string, supportedVersions []string) {
+	fs.StringVar(p, "feature-gates", "", getFlagDescription(commonGates, govmomiGates, supervisorGates, supervisorVersionedGates, supportedVersions))
+}
+
+// SetGovmomiGates set Gates for govmomi mode.
+func SetGovmomiGates(p string) error {
+	allowedGates := getGovmomiGates(commonGates, govmomiGates)
+	return set(allGates, allowedGates, nil, p)
+}
+
+// SetSupervisorGates sets Gates for supervisor mode / for a specific vm-operator API version.
+func SetSupervisorGates(vmOperatorAPIVersion string, p string) error {
+	allowedGates := getSupervisorGates(commonGates, supervisorGates, supervisorVersionedGates, vmOperatorAPIVersion)
+	return set(allGates, allowedGates, supervisorVersionedGates, p)
+}
+
+// getFlagDescription return description for the feature-gates flags that shows flags available in all the supported permutations of mode and vm-operator API version.
+func getFlagDescription(commonGates, govmomiGates, supervisorGates map[featuregate.Feature]featuregate.FeatureSpec, supervisorVersionedGates map[featuregate.Feature]featuregate.VersionedSpecs, supportedVersions []string) string {
+	commonMutableGates := featuregate.NewFeatureGate()
+	utilruntime.Must(commonMutableGates.Add(commonGates))
+
+	govmomiMutableGates := featuregate.NewFeatureGate()
+	utilruntime.Must(govmomiMutableGates.Add(govmomiGates))
+
+	// Generate flag description
+	fix := func(know []string, dropAll bool) []string {
+		r := []string{}
+		for _, k := range know {
+			if dropAll && (strings.HasPrefix(k, "AllAlpha=") || strings.HasPrefix(k, "AllBeta=")) {
+				continue
+			}
+			r = append(r, fmt.Sprintf("  %s", k))
+		}
+		sort.Strings(r)
+		return r
+	}
+
+	description := "A set of key=value pairs that describe feature gates for alpha/experimental features.\n"
+	description += fmt.Sprintf("Common options are:\n%s\n", strings.Join(fix(commonMutableGates.KnownFeatures(), false), "\n"))
+	description += fmt.Sprintf("Options for govmomi mode are:\n%s\n", strings.Join(fix(govmomiMutableGates.KnownFeatures(), true), "\n"))
+	for _, v := range supportedVersions {
+		supervisorMutableGates := featuregate.NewVersionedFeatureGate(toFeatureVersion(v))
+		utilruntime.Must(supervisorMutableGates.Add(supervisorGates))
+		utilruntime.Must(supervisorMutableGates.AddVersioned(supervisorVersionedGates))
+		description += fmt.Sprintf("Options for supervisor mode when --vm-operator-api-version=%s are:\n%s\n", v, strings.Join(fix(supervisorMutableGates.KnownFeatures(), true), "\n"))
+	}
+	return description
+}
+
+// getGovmomiGates gets a featuregate.FeatureGate instance for govmomi mode.
+func getGovmomiGates(commonGates, govmomiGates map[featuregate.Feature]featuregate.FeatureSpec) featuregate.MutableFeatureGate {
+	mutableGates := featuregate.NewFeatureGate()
+	utilruntime.Must(mutableGates.Add(commonGates))
+	utilruntime.Must(mutableGates.Add(govmomiGates))
+	mutableGates.Close()
+	return mutableGates
+}
+
+// getSupervisorGates gets a featuregate.FeatureGate instance for supervisor mode / for a specific vm-operator API version.
+func getSupervisorGates(commonGates, supervisorGates map[featuregate.Feature]featuregate.FeatureSpec, supervisorVersionedGates map[featuregate.Feature]featuregate.VersionedSpecs, vmOperatorAPIVersion string) featuregate.MutableFeatureGate {
+	mutableGates := featuregate.NewVersionedFeatureGate(toFeatureVersion(vmOperatorAPIVersion))
+	utilruntime.Must(mutableGates.Add(commonGates))
+	utilruntime.Must(mutableGates.Add(supervisorGates))
+	utilruntime.Must(mutableGates.AddVersioned(supervisorVersionedGates))
+	mutableGates.Close()
+	return mutableGates
+}
+
+func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates map[featuregate.Feature]featuregate.VersionedSpecs, value string) error {
+	// Kubernetes featuregate.MutableVersionedFeatureGate does not allow setting flags that are supported only in future version.
+	// In CAPV we want to tolerate setting flags that are supported only in future version only if set to false.
+	// The following code drops unknown flags set to false.
+	versioned := sets.New[string]()
+	for gate := range versionedGates {
+		versioned.Insert(string(gate))
+	}
+
+	known := sets.New[string]()
+	for _, gate := range allowedGates.KnownFeatures() {
+		known.Insert(gate[0:strings.Index(gate, "=")])
+	}
+
+	var values []string
+	for _, s := range strings.Split(value, ",") {
+		if s == "" {
+			continue
+		}
+
+		// Gets the name of the feature flag.
+		arr := strings.SplitN(s, "=", 2)
+		k := strings.TrimSpace(arr[0])
+		if len(arr) != 2 {
+			values = append(values, s)
+			continue
+		}
+
+		// If it is not versioned, keep it in the list of gates.
+		if !versioned.Has(k) {
+			values = append(values, s)
+			continue
+		}
+
+		// If it is versioned, drop it from the list of flags only if
+		// it is not a know gate for the current version (it is supported in future versions only)
+		// and the value is false.
+		v := strings.TrimSpace(arr[1])
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			values = append(values, s)
+			continue
+		}
+		if !boolValue && !known.Has(k) {
+			continue
+		}
+		values = append(values, s)
+	}
+	cleanedValue := strings.Join(values, ",")
+
+	// First set and validate feature gate value on the allowedGates.
+	allowedGates = allowedGates.DeepCopy()
+	err := allowedGates.Set(cleanedValue)
+	if err != nil {
+		if aggregateErr, ok := errors.AsType[kerrors.Aggregate](err); ok && aggregateErr != nil {
+			cleanedErrors := make([]error, 0, len(aggregateErr.Errors()))
+			for _, err := range aggregateErr.Errors() {
+				// Surface all the errors except for the error that is generated when the user sets a featureFlag that is supported only in future version
+				if !strings.Contains(err.Error(), "feature is PreAlpha at emulated version") {
+					cleanedErrors = append(cleanedErrors, err)
+					continue
+				}
+
+				// Kubernetes featuregate.MutableVersionedFeatureGate do not allow setting flags that are supported only in future version entirely.
+				// In CAPV we want to tolerate setting flags that are supported only in future version only if set to false;
+				// as a consequence we ignore messages that are generated in this case.
+				// NOTE: this should not happen since we are filtering on Set.
+				if strings.Contains(err.Error(), " to false,") {
+					continue
+				}
+
+				// If instead the user sets a featureFlag that is supported only in future version to true,
+				// change the error message so it is easier to understand for CAPV users.
+				i := strings.Index(err.Error(), " to true,")
+				cleanedErrors = append(cleanedErrors, fmt.Errorf("%s to true, feature requires a newer vm-operator API version", err.Error()[0:i]))
+			}
+			if len(cleanedErrors) > 0 {
+				return kerrors.NewAggregate(cleanedErrors)
+			}
+		} else {
+			return err
+		}
+	}
+
+	// If there are no error, set values on allGates
+	// Note: at this point there should not be errors.
+	return allGates.Set(cleanedValue)
+}
+
+// toFeatureVersion transforms a vm-operator API version in a version.Version
+// that can be used for versioned feature gates.
+// Note: The value of the returned version.Version (major.minor) does not have any specific
+// meaning, it is only intended to express v1alpha2 < v1alpha5 etc.
+func toFeatureVersion(v string) *version.Version {
+	versions := map[string]*version.Version{
+		vmoprv1alpha2.GroupVersion.Version: version.MustParse("0.2"),
+		vmoprv1alpha5.GroupVersion.Version: version.MustParse("0.5"),
+	}
+	featureVersion, ok := versions[v]
+	if !ok {
+		panic(fmt.Errorf("unknown vm-operator version: %s", v))
+	}
+	return featureVersion
+}

--- a/feature/gates.go
+++ b/feature/gates.go
@@ -51,7 +51,7 @@ func init() {
 	Gates = allGates
 }
 
-// AddFlag adds a flag for setting global feature gates to the specified FlagSet.
+// AddFlag adds a flag for setting feature gates to the specified FlagSet.
 func AddFlag(fs *pflag.FlagSet, p *string, supportedVersions []string) {
 	fs.StringVar(p, "feature-gates", "", getFlagDescription(commonGates, govmomiGates, supervisorGates, supervisorVersionedGates, supportedVersions))
 }
@@ -68,7 +68,7 @@ func SetSupervisorGates(vmOperatorAPIVersion string, p string) error {
 	return set(allGates, allowedGates, supervisorVersionedGates, p)
 }
 
-// getFlagDescription return description for the feature-gates flags that shows flags available in all the supported permutations of mode and vm-operator API version.
+// getFlagDescription return description for the feature-gates flag that shows which feature gates are available in all the supported permutations of mode and vm-operator API version.
 func getFlagDescription(commonGates, govmomiGates, supervisorGates map[featuregate.Feature]featuregate.FeatureSpec, supervisorVersionedGates map[featuregate.Feature]featuregate.VersionedSpecs, supportedVersions []string) string {
 	commonMutableGates := featuregate.NewFeatureGate()
 	utilruntime.Must(commonMutableGates.Add(commonGates))
@@ -121,9 +121,10 @@ func getSupervisorGates(commonGates, supervisorGates map[featuregate.Feature]fea
 }
 
 func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates map[featuregate.Feature]featuregate.VersionedSpecs, value string) error {
-	// Kubernetes featuregate.MutableVersionedFeatureGate does not allow setting flags that are supported only in future version.
-	// In CAPV we want to tolerate setting flags that are supported only in future version only if set to false.
-	// The following code drops unknown flags set to false.
+	// Kubernetes featuregate.MutableVersionedFeatureGate does not allow setting feature gates that are supported only in future version.
+	// In CAPV we want to tolerate setting _versioned_ feature gates that are supported only in future version to false (and only to false),
+	// and in order to make this possible the following code drops unknown feature gates set to false.
+	// Unknown in this context means feature gates not in allowedGates, and allowedGates will only have feature gates for the current mode / vm-operator version.
 	versioned := sets.New[string]()
 	for gate := range versionedGates {
 		versioned.Insert(string(gate))
@@ -134,13 +135,21 @@ func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates m
 		known.Insert(gate[0:strings.Index(gate, "=")])
 	}
 
+	// Note: the code in the following loop mimics the code that parses the comma separated list of feature gates
+	// in Kubernetes's SetWithLogger func.
+	//
+	// In this case, we parse the comma separated list of feature gates and drop from this list only
+	// unknown, versioned feature gates set to false, while we keep everything else, including
+	// invalid feature gates so that errors will surface when we call allowedGates.Set later in this func.
 	var values []string
 	for _, s := range strings.Split(value, ",") {
 		if s == "" {
 			continue
 		}
 
-		// Gets the name of the feature flag.
+		// Get the name of the feature gate.
+		// If it is not possible to split the feature gate name from its value (e.g. a feature gate without the value),
+		// keep the invalid item in the list of feature gates and continue.
 		arr := strings.SplitN(s, "=", 2)
 		k := strings.TrimSpace(arr[0])
 		if len(arr) != 2 {
@@ -148,21 +157,23 @@ func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates m
 			continue
 		}
 
-		// If it is not versioned, keep it in the list of gates.
+		// If the feature gate is not versioned, keep this item in the list of feature gates and continue.
 		if !versioned.Has(k) {
 			values = append(values, s)
 			continue
 		}
 
-		// If it is versioned, drop it from the list of flags only if
-		// it is not a know gate for the current version (it is supported in future versions only)
-		// and the value is false.
+		// If the feature gate is versioned, we need to get its value.
+		// If it is not possible to parse the value of feature gate (e.g. a feature gate set to a non-boolean value),
+		// keep the invalid item in the list of feature gates and continue.
 		v := strings.TrimSpace(arr[1])
 		boolValue, err := strconv.ParseBool(v)
 		if err != nil {
 			values = append(values, s)
 			continue
 		}
+
+		// Drop the feature gate from the list feature gates only if set to false.
 		if !boolValue && !known.Has(k) {
 			continue
 		}
@@ -170,29 +181,29 @@ func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates m
 	}
 	cleanedValue := strings.Join(values, ",")
 
-	// First set and validate feature gate value on the allowedGates.
+	// Apply the resulting comma separated list of feature gates to allowedGates, and check if there are errors indicating that
+	// those feature gates are not compliant with the current mode / vm-operator version or if they have "syntax" errors.
 	allowedGates = allowedGates.DeepCopy()
-	err := allowedGates.Set(cleanedValue)
-	if err != nil {
+	if err := allowedGates.Set(cleanedValue); err != nil {
 		if aggregateErr, ok := errors.AsType[kerrors.Aggregate](err); ok && aggregateErr != nil {
 			cleanedErrors := make([]error, 0, len(aggregateErr.Errors()))
 			for _, err := range aggregateErr.Errors() {
-				// Surface all the errors except for the error that is generated when the user sets a featureFlag that is supported only in future version
+				// Surface all the errors except for the error that is generated when the user sets a featureGate that is supported only in future version
 				if !strings.Contains(err.Error(), "feature is PreAlpha at emulated version") {
 					cleanedErrors = append(cleanedErrors, err)
 					continue
 				}
 
-				// Kubernetes featuregate.MutableVersionedFeatureGate do not allow setting flags that are supported only in future version entirely.
-				// In CAPV we want to tolerate setting flags that are supported only in future version only if set to false;
+				// Kubernetes featuregate.MutableVersionedFeatureGate do not allow setting feature gates that are supported only in future versions.
+				// In CAPV we want to tolerate setting feature gates that are supported only in future version only if set to false;
 				// as a consequence we ignore messages that are generated in this case.
-				// NOTE: this should not happen since we are filtering on Set.
+				// NOTE: this should not happen since we are filtering out such those feature gates before calling allowedGates.Set.
 				if strings.Contains(err.Error(), " to false,") {
 					continue
 				}
 
-				// If instead the user sets a featureFlag that is supported only in future version to true,
-				// change the error message so it is easier to understand for CAPV users.
+				// If instead the error is surfacing that the user set a feature gate that is supported only in future version to true,
+				// change the error message so it is easier to understand in the CAPV context.
 				i := strings.Index(err.Error(), " to true,")
 				cleanedErrors = append(cleanedErrors, fmt.Errorf("%s to true, feature requires a newer vm-operator API version", err.Error()[0:i]))
 			}
@@ -204,7 +215,7 @@ func set(allGates, allowedGates featuregate.MutableFeatureGate, versionedGates m
 		}
 	}
 
-	// If there are no error, set values on allGates
+	// If there are no error, set values on allGates.
 	// Note: at this point there should not be errors.
 	return allGates.Set(cleanedValue)
 }

--- a/feature/gates_test.go
+++ b/feature/gates_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	CommonFeature                      featuregate.Feature = "CommonFeature"
+	CommonFeatureTrue                  featuregate.Feature = "CommonFeatureTrue"
 	GovmomiFeature                     featuregate.Feature = "GovmomiFeature"
 	SupervisorFeature                  featuregate.Feature = "SupervisorFeature"
 	SupervisorFeatureEnabledOnV1Alpha2 featuregate.Feature = "SupervisorFeatureEnabledOnV1Alpha2"
@@ -38,7 +39,8 @@ const (
 
 var (
 	commonTestGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		CommonFeature: {Default: false, PreRelease: featuregate.Alpha},
+		CommonFeature:     {Default: false, PreRelease: featuregate.Alpha},
+		CommonFeatureTrue: {Default: true, PreRelease: featuregate.Beta},
 	}
 
 	govmomiTestGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -72,6 +74,7 @@ func TestGetFlagDescription(t *testing.T) {
 		"  AllAlpha=true|false (ALPHA - default=false)\n" +
 		"  AllBeta=true|false (BETA - default=false)\n" +
 		"  CommonFeature=true|false (ALPHA - default=false)\n" +
+		"  CommonFeatureTrue=true|false (BETA - default=true)\n" +
 		"Options for govmomi mode are:\n" +
 		"  GovmomiFeature=true|false (ALPHA - default=false)\n" +
 		"Options for supervisor mode when --vm-operator-api-version=v1alpha2 are:\n" +
@@ -98,12 +101,14 @@ func TestGetGovmomiGates(t *testing.T) {
 	err := set(allTestGates, allowedGates, nil, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(GovmomiFeature)).To(BeFalse())
 
 	// set a known feature gate
 	err = set(allTestGates, allowedGates, nil, "GovmomiFeature=true")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(GovmomiFeature)).To(BeTrue())
 
 	// set unknown feature gates
@@ -132,6 +137,7 @@ func TestGetSupervisorGatesV1Alpha2(t *testing.T) {
 	err := set(allTestGates, allowedGates, supervisorVersionedTestGates, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -140,6 +146,7 @@ func TestGetSupervisorGatesV1Alpha2(t *testing.T) {
 	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeature=true")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -149,6 +156,7 @@ func TestGetSupervisorGatesV1Alpha2(t *testing.T) {
 	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha2=true")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -158,6 +166,7 @@ func TestGetSupervisorGatesV1Alpha2(t *testing.T) {
 	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha5=false")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -189,6 +198,7 @@ func TestGetSupervisorGatesV1Alpha5(t *testing.T) {
 	err := set(allTestGates, allowedGates, supervisorVersionedTestGates, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -197,6 +207,7 @@ func TestGetSupervisorGatesV1Alpha5(t *testing.T) {
 	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeature=true")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
@@ -206,6 +217,7 @@ func TestGetSupervisorGatesV1Alpha5(t *testing.T) {
 	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha2=true,SupervisorFeatureEnabledOnV1Alpha5=true")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(CommonFeatureTrue)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeTrue())
 	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeTrue())

--- a/feature/gates_test.go
+++ b/feature/gates_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	vmoprv1alpha2 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
+	vmoprv1alpha5 "github.com/vmware-tanzu/vm-operator/api/v1alpha5"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	CommonFeature                      featuregate.Feature = "CommonFeature"
+	GovmomiFeature                     featuregate.Feature = "GovmomiFeature"
+	SupervisorFeature                  featuregate.Feature = "SupervisorFeature"
+	SupervisorFeatureEnabledOnV1Alpha2 featuregate.Feature = "SupervisorFeatureEnabledOnV1Alpha2"
+	SupervisorFeatureEnabledOnV1Alpha5 featuregate.Feature = "SupervisorFeatureEnabledOnV1Alpha5"
+)
+
+var (
+	commonTestGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		CommonFeature: {Default: false, PreRelease: featuregate.Alpha},
+	}
+
+	govmomiTestGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		GovmomiFeature: {Default: false, PreRelease: featuregate.Alpha},
+	}
+
+	supervisorTestGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		SupervisorFeature: {Default: false, PreRelease: featuregate.Alpha},
+	}
+
+	supervisorVersionedTestGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+		SupervisorFeatureEnabledOnV1Alpha2: {
+			{Version: toFeatureVersion(vmoprv1alpha2.GroupVersion.Version), Default: false, PreRelease: featuregate.Alpha},
+		},
+		SupervisorFeatureEnabledOnV1Alpha5: {
+			{Version: toFeatureVersion(vmoprv1alpha5.GroupVersion.Version), Default: false, PreRelease: featuregate.Alpha},
+		},
+	}
+
+	supportedVMOperatorAPIVersions = []string{vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version}
+)
+
+func TestGetFlagDescription(t *testing.T) {
+	g := NewWithT(t)
+
+	description := getFlagDescription(commonTestGates, govmomiTestGates, supervisorTestGates, supervisorVersionedTestGates, supportedVMOperatorAPIVersions)
+
+	g.Expect(description).To(Equal("" + "" +
+		"A set of key=value pairs that describe feature gates for alpha/experimental features.\n" +
+		"Common options are:\n" +
+		"  AllAlpha=true|false (ALPHA - default=false)\n" +
+		"  AllBeta=true|false (BETA - default=false)\n" +
+		"  CommonFeature=true|false (ALPHA - default=false)\n" +
+		"Options for govmomi mode are:\n" +
+		"  GovmomiFeature=true|false (ALPHA - default=false)\n" +
+		"Options for supervisor mode when --vm-operator-api-version=v1alpha2 are:\n" +
+		"  SupervisorFeature=true|false (ALPHA - default=false)\n" +
+		"  SupervisorFeatureEnabledOnV1Alpha2=true|false (ALPHA - default=false)\n" +
+		"Options for supervisor mode when --vm-operator-api-version=v1alpha5 are:\n" +
+		"  SupervisorFeature=true|false (ALPHA - default=false)\n" +
+		"  SupervisorFeatureEnabledOnV1Alpha2=true|false (ALPHA - default=false)\n" +
+		"  SupervisorFeatureEnabledOnV1Alpha5=true|false (ALPHA - default=false)\n"))
+}
+
+func TestGetGovmomiGates(t *testing.T) {
+	g := NewWithT(t)
+
+	allTestGates := featuregate.NewVersionedFeatureGate(toFeatureVersion(vmoprv1alpha5.GroupVersion.Version))
+	utilruntime.Must(allTestGates.Add(commonTestGates))
+	utilruntime.Must(allTestGates.Add(govmomiTestGates))
+	utilruntime.Must(allTestGates.Add(supervisorTestGates))
+	utilruntime.Must(allTestGates.AddVersioned(supervisorVersionedTestGates))
+
+	allowedGates := getGovmomiGates(commonTestGates, govmomiTestGates)
+
+	// default (no feature gates set)
+	err := set(allTestGates, allowedGates, nil, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(GovmomiFeature)).To(BeFalse())
+
+	// set a known feature gate
+	err = set(allTestGates, allowedGates, nil, "GovmomiFeature=true")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(GovmomiFeature)).To(BeTrue())
+
+	// set unknown feature gates
+	err = set(allTestGates, allowedGates, nil, "SupervisorFeature=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: SupervisorFeature")})))
+
+	err = set(allTestGates, allowedGates, nil, "SupervisorFeatureEnabledOnV1Alpha2=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: SupervisorFeatureEnabledOnV1Alpha2")})))
+
+	err = set(allTestGates, allowedGates, nil, "Foo=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: Foo")})))
+}
+
+func TestGetSupervisorGatesV1Alpha2(t *testing.T) {
+	g := NewWithT(t)
+
+	allTestGates := featuregate.NewVersionedFeatureGate(toFeatureVersion(vmoprv1alpha5.GroupVersion.Version))
+	utilruntime.Must(allTestGates.Add(commonTestGates))
+	utilruntime.Must(allTestGates.Add(govmomiTestGates))
+	utilruntime.Must(allTestGates.Add(supervisorTestGates))
+	utilruntime.Must(allTestGates.AddVersioned(supervisorVersionedTestGates))
+
+	allowedGates := getSupervisorGates(commonTestGates, supervisorTestGates, supervisorVersionedTestGates, vmoprv1alpha2.GroupVersion.Version)
+
+	// default (no feature gates set)
+	err := set(allTestGates, allowedGates, supervisorVersionedTestGates, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+
+	// set a known feature gate (not versioned)
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeature=true")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeTrue())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+	g.Expect(allTestGates.ResetFeatureValueToDefault(SupervisorFeature)).To(Succeed())
+
+	// set a known versioned feature gate, supported in this version
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha2=true")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeTrue())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+	g.Expect(allTestGates.ResetFeatureValueToDefault(SupervisorFeatureEnabledOnV1Alpha2)).To(Succeed())
+
+	// set a known versioned feature, NOT supported in this version, set to false
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha5=false")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+
+	// set a known versioned feature, NOT supported in this version, set to true
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha5=true")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("cannot set feature gate SupervisorFeatureEnabledOnV1Alpha5 to true, feature requires a newer vm-operator API version")})))
+
+	// set unknown feature gates
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "GovmomiFeature=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: GovmomiFeature")})))
+
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "Foo=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: Foo")})))
+}
+
+func TestGetSupervisorGatesV1Alpha5(t *testing.T) {
+	g := NewWithT(t)
+
+	allTestGates := featuregate.NewVersionedFeatureGate(toFeatureVersion(vmoprv1alpha5.GroupVersion.Version))
+	utilruntime.Must(allTestGates.Add(commonTestGates))
+	utilruntime.Must(allTestGates.Add(govmomiTestGates))
+	utilruntime.Must(allTestGates.Add(supervisorTestGates))
+	utilruntime.Must(allTestGates.AddVersioned(supervisorVersionedTestGates))
+
+	allowedGates := getSupervisorGates(commonTestGates, supervisorTestGates, supervisorVersionedTestGates, vmoprv1alpha5.GroupVersion.Version)
+
+	// default (no feature gates set)
+	err := set(allTestGates, allowedGates, supervisorVersionedTestGates, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+
+	// set a known feature gate (not versioned)
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeature=true")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeTrue())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeFalse())
+	g.Expect(allTestGates.ResetFeatureValueToDefault(SupervisorFeature)).To(Succeed())
+
+	// set a known versioned feature gate, supported in this version
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "SupervisorFeatureEnabledOnV1Alpha2=true,SupervisorFeatureEnabledOnV1Alpha5=true")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(allTestGates.Enabled(CommonFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeature)).To(BeFalse())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha2)).To(BeTrue())
+	g.Expect(allTestGates.Enabled(SupervisorFeatureEnabledOnV1Alpha5)).To(BeTrue())
+
+	// set unknown feature gates
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "GovmomiFeature=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: GovmomiFeature")})))
+
+	err = set(allTestGates, allowedGates, supervisorVersionedTestGates, "Foo=false")
+	g.Expect(err).To(Equal(kerrors.NewAggregate([]error{fmt.Errorf("unrecognized feature gate: Foo")})))
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -98,7 +99,8 @@ var (
 	syncPeriod                  time.Duration
 	webhookOpts                 webhook.Options
 	watchNamespace              string
-	apiVersionVMOperator        string
+	vmOperatorAPIVersion        string
+	featureGates                string
 
 	clusterCacheConcurrency           int
 	vSphereClusterConcurrency         int
@@ -118,6 +120,8 @@ var (
 	defaultSyncPeriod       = manager.DefaultSyncPeriod
 	defaultLeaderElectionID = manager.DefaultLeaderElectionID
 	defaultPodName          = manager.DefaultPodName
+
+	supportedVMOperatorAPIVersions = []string{vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version}
 )
 
 // InitFlags initializes the flags.
@@ -181,10 +185,10 @@ func InitFlags(fs *pflag.FlagSet) {
 	)
 
 	fs.StringVar(
-		&apiVersionVMOperator,
+		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s, %s", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
 	)
 
 	// Flags common between CAPI and CAPV
@@ -250,7 +254,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	)
 
 	capiflags.AddManagerOptions(fs, &managerOptions)
-	feature.MutableGates.AddFlag(fs)
+	feature.AddFlag(fs, &featureGates, supportedVMOperatorAPIVersions)
 }
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -266,6 +270,8 @@ func InitFlags(fs *pflag.FlagSet) {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates;vsphereclustertemplates,verbs=get;list;watch;patch;update
 
 func main() {
+	time.Sleep(10 * time.Second)
+
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -352,17 +358,29 @@ func main() {
 		}
 	}
 
+	if isGovmomiCRDLoaded {
+		if err := feature.SetGovmomiGates(featureGates); err != nil {
+			setupLog.Error(err, "invalid argument: --feature-gates")
+			os.Exit(1)
+		}
+	}
+
 	var vm runtime.Object
 	var converter *conversion.Converter
 	if isSupervisorCRDLoaded {
-		if apiVersionVMOperator != vmoprv1alpha2.GroupVersion.Version && apiVersionVMOperator != vmoprv1alpha5.GroupVersion.Version {
-			fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s, %s\n", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version)
+		if !sets.New(supportedVMOperatorAPIVersions...).Has(vmOperatorAPIVersion) {
+			setupLog.Info(fmt.Sprintf("Invalid argument: --vm-operator-api-version must be one of : %s\n", strings.Join(supportedVMOperatorAPIVersions, ", ")))
 			os.Exit(1)
 		}
-		setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, apiVersionVMOperator))
+		setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, vmOperatorAPIVersion))
+
+		if err := feature.SetSupervisorGates(vmOperatorAPIVersion, featureGates); err != nil {
+			setupLog.Error(err, "invalid argument: --feature-gates")
+			os.Exit(1)
+		}
 
 		converter = conversionapi.DefaultConverterFor(
-			schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: apiVersionVMOperator},
+			schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: vmOperatorAPIVersion},
 		)
 
 		// Get vm-operator native types in the preferred version for cache filters.
@@ -462,8 +480,6 @@ func main() {
 	if enableContentionProfiling {
 		goruntime.SetBlockProfileRate(1)
 	}
-
-	setupLog.Info(fmt.Sprintf("Feature gates: %+v\n", feature.Gates))
 
 	managerOpts.LeaseDuration = &leaderElectionLeaseDuration
 	managerOpts.RenewDeadline = &leaderElectionRenewDeadline

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ", ")),
 	)
 
 	// Flags common between CAPI and CAPV
@@ -270,8 +270,6 @@ func InitFlags(fs *pflag.FlagSet) {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates;vsphereclustertemplates,verbs=get;list;watch;patch;update
 
 func main() {
-	time.Sleep(10 * time.Second)
-
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/test/infrastructure/net-operator/main.go
+++ b/test/infrastructure/net-operator/main.go
@@ -109,7 +109,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ", ")),
 	)
 
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,

--- a/test/infrastructure/net-operator/main.go
+++ b/test/infrastructure/net-operator/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"reflect"
 	goruntime "runtime"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -44,7 +46,6 @@ import (
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
-	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
@@ -55,6 +56,7 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	vmwarev1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	conversionapi "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
 	conversionclient "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/client"
@@ -84,7 +86,10 @@ var (
 	// net operator specific flags.
 	networkInterfaceConcurrency int
 	virtualMachineConcurrency   int
-	apiVersionVMOperator        string
+	vmOperatorAPIVersion        string
+	featureGates                string
+
+	supportedVMOperatorAPIVersions = []string{vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version}
 )
 
 func init() {
@@ -101,10 +106,10 @@ func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
 	fs.StringVar(
-		&apiVersionVMOperator,
+		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s, %s", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
 	)
 
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -151,7 +156,7 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	flags.AddManagerOptions(fs, &managerOptions)
 
-	feature.MutableGates.AddFlag(fs)
+	feature.AddFlag(fs, &featureGates, supportedVMOperatorAPIVersions)
 }
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -178,8 +183,13 @@ func main() {
 		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
 
-	if apiVersionVMOperator != vmoprv1alpha2.GroupVersion.Version && apiVersionVMOperator != vmoprv1alpha5.GroupVersion.Version {
-		fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s, %s\n", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version)
+	if !sets.New(supportedVMOperatorAPIVersions...).Has(vmOperatorAPIVersion) {
+		fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s\n", strings.Join(supportedVMOperatorAPIVersions, ", "))
+		os.Exit(1)
+	}
+
+	if err := feature.SetSupervisorGates(vmOperatorAPIVersion, featureGates); err != nil {
+		setupLog.Error(err, "invalid argument: --feature-gates")
 		os.Exit(1)
 	}
 
@@ -188,7 +198,7 @@ func main() {
 
 	// Note: setupLog can only be used after ctrl.SetLogger was called
 	setupLog.Info(fmt.Sprintf("Version: %s (git commit: %s)", version.Get().String(), version.Get().GitCommit))
-	setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, apiVersionVMOperator))
+	setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, vmOperatorAPIVersion))
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = restConfigQPS
@@ -299,7 +309,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, _ bool) {
 	}
 
 	converter := conversionapi.DefaultConverterFor(
-		schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: apiVersionVMOperator},
+		schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: vmOperatorAPIVersion},
 	)
 
 	cc, err := conversionclient.NewWithConverter(mgr.GetClient(), converter)

--- a/test/infrastructure/vcsim/main.go
+++ b/test/infrastructure/vcsim/main.go
@@ -144,7 +144,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ", ")),
 	)
 
 	fs.BoolVar(

--- a/test/infrastructure/vcsim/main.go
+++ b/test/infrastructure/vcsim/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"reflect"
 	goruntime "runtime"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -52,7 +54,6 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
-	"sigs.k8s.io/cluster-api/feature"
 	inmemoryruntime "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/runtime"
 	inmemoryserver "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
@@ -67,6 +68,7 @@ import (
 
 	infrav1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta1"
 	vmwarev1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	conversionapi "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
 	conversionclient "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/client"
@@ -102,8 +104,11 @@ var (
 	controlPlaneEndpointConcurrency   int
 	envsubstConcurrency               int
 	vmOperatorDependenciesConcurrency int
-	apiVersionVMOperator              string
+	vmOperatorAPIVersion              string
 	vmOperatorSimMode                 bool
+	featureGates                      string
+
+	supportedVMOperatorAPIVersions = []string{vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version}
 )
 
 func init() {
@@ -136,10 +141,10 @@ func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
 	fs.StringVar(
-		&apiVersionVMOperator,
+		&vmOperatorAPIVersion,
 		"vm-operator-api-version",
 		vmoprv1alpha5.GroupVersion.Version,
-		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s, %s", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version),
+		fmt.Sprintf("the API version to use when reading and writing VM Operator resources in supervisor mode. Valid values are: %s", strings.Join(supportedVMOperatorAPIVersions, ",")),
 	)
 
 	fs.BoolVar(
@@ -209,7 +214,7 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	flags.AddManagerOptions(fs, &managerOptions)
 
-	feature.MutableGates.AddFlag(fs)
+	feature.AddFlag(fs, &featureGates, supportedVMOperatorAPIVersions)
 }
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -236,8 +241,13 @@ func main() {
 		klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
 
-	if apiVersionVMOperator != vmoprv1alpha2.GroupVersion.Version && apiVersionVMOperator != vmoprv1alpha5.GroupVersion.Version {
-		fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s, %s\n", vmoprv1alpha2.GroupVersion.Version, vmoprv1alpha5.GroupVersion.Version)
+	if !sets.New(supportedVMOperatorAPIVersions...).Has(vmOperatorAPIVersion) {
+		fmt.Printf("Invalid argument: --vm-operator-api-version must be one of : %s\n", strings.Join(supportedVMOperatorAPIVersions, ", "))
+		os.Exit(1)
+	}
+
+	if err := feature.SetSupervisorGates(vmOperatorAPIVersion, featureGates); err != nil {
+		setupLog.Error(err, "invalid argument: --feature-gates")
 		os.Exit(1)
 	}
 
@@ -246,7 +256,7 @@ func main() {
 
 	// Note: setupLog can only be used after ctrl.SetLogger was called
 	setupLog.Info(fmt.Sprintf("Version: %s (git commit: %s)", version.Get().String(), version.Get().GitCommit))
-	setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, apiVersionVMOperator))
+	setupLog.Info(fmt.Sprintf("Target API Version for group %s: %s", vmoprvhub.GroupVersion.Group, vmOperatorAPIVersion))
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = restConfigQPS
@@ -384,7 +394,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, supervisorMode bool
 	}
 
 	converter := conversionapi.DefaultConverterFor(
-		schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: apiVersionVMOperator},
+		schema.GroupVersion{Group: vmoprvhub.GroupVersion.Group, Version: vmOperatorAPIVersion},
 	)
 
 	cc, err := conversionclient.NewWithConverter(mgr.GetClient(), converter)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
