### PR TITLE
🐛 Fix release notes for first pre-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -771,8 +771,15 @@ ifneq (,$(findstring -,$(RELEASE_TAG)))
 	_RELEASE_TAG_MINOR ?= $(word 2,$(subst ., ,$(RELEASE_TAG:v%=%)))
 	# Find the previous release of the same major + minor version (including pre-releases) or the previous .0 minor release.
 	_PREVIOUS_RELEASE_TAG ?= $(shell git tag -l | grep -E -e '^v[0-9]+\.[0-9]+\.0+$$|^v$(_RELEASE_TAG_MAJOR)\.$(_RELEASE_TAG_MINOR)\.' | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
-	# Set the argument for release-notes generator to provide the for pre-releases mandatory `--previous-release-version` flag.
-	RELEASE_NOTES_PRE_RELEASE_ARG ?= "--previous-release-version=tags/$(_PREVIOUS_RELEASE_TAG)"
+	# Set the argument for release-notes generator to provide the for pre-releases mandatory
+	# `--previous-release-version` flag, but only if the previous release is also a pre-release.
+	# For the first pre-release (e.g. v1.15.0-beta.0 after v1.14.0), the generator must NOT
+	# receive `--previous-release-version`.
+	ifneq (,$(findstring alpha.,$(_PREVIOUS_RELEASE_TAG))$(findstring beta.,$(_PREVIOUS_RELEASE_TAG))$(findstring rc.,$(_PREVIOUS_RELEASE_TAG)))
+		RELEASE_NOTES_PRE_RELEASE_ARG ?= "--previous-release-version=tags/$(_PREVIOUS_RELEASE_TAG)"
+	else
+		RELEASE_NOTES_PRE_RELEASE_ARG ?=
+	endif
 endif
 ## set by Prow, ref name of the base branch, e.g., main
 RELEASE_ALIAS_TAG := $(PULL_BASE_REF)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Skip --previous-release-version when generating release notes for the first alpha/beta/rc after a stable release to avoid release-notes generator failures

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3679 
