### PR TITLE
✨add validation on control plane failure domain selector

### DIFF
--- a/config/supervisor/webhook/manifests.yaml
+++ b/config/supervisor/webhook/manifests.yaml
@@ -58,6 +58,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vsphereclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vsphereclustertemplate.vmware.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - vmware.infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vsphereclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vspheremachine
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -277,6 +277,9 @@ func getManager(cfg *rest.Config, networkProvider string, withWebhooks bool) man
 			if err := (&vmwarewebhooks.VSphereCluster{}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
+			if err := (&vmwarewebhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+				return err
+			}
 		}
 		if err := vmware.AddVSphereMachineTemplateControllerToManager(ctx, controllerCtx, mgr, controllerOpts); err != nil {
 			return err

--- a/internal/webhooks/vmware/vspherecluster.go
+++ b/internal/webhooks/vmware/vspherecluster.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -48,12 +49,12 @@ func (webhook *VSphereCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *VSphereCluster) ValidateCreate(_ context.Context, obj *vmwarev1.VSphereCluster) (admission.Warnings, error) {
-	return webhook.validateClusterNetwork(obj)
+	return webhook.validate(obj)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *VSphereCluster) ValidateUpdate(_ context.Context, _, newTyped *vmwarev1.VSphereCluster) (admission.Warnings, error) {
-	return webhook.validateClusterNetwork(newTyped)
+	return webhook.validate(newTyped)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -61,16 +62,75 @@ func (webhook *VSphereCluster) ValidateDelete(_ context.Context, _ *vmwarev1.VSp
 	return nil, nil
 }
 
-func (webhook *VSphereCluster) validateClusterNetwork(cluster *vmwarev1.VSphereCluster) (admission.Warnings, error) {
+// validateClusterNetwork validates the network configuration of the VSphereCluster.
+func (webhook *VSphereCluster) validateClusterNetwork(cluster *vmwarev1.VSphereCluster) field.ErrorList {
+	var allErrs field.ErrorList
+
 	if !feature.Gates.Enabled(feature.MultiNetworks) && cluster.Spec.Network.NSXVPC.CreateSubnetSet != nil {
-		return nil, apierrors.NewInvalid(cluster.GroupVersionKind().GroupKind(), cluster.Name, field.ErrorList{
-			field.Forbidden(field.NewPath("spec", "network", "nsxVPC", "createSubnetSet"), "createSubnetSet can only be set when MultiNetworks feature gate is enabled"),
-		})
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "network", "nsxVPC", "createSubnetSet"),
+			"createSubnetSet can only be set when MultiNetworks feature gate is enabled",
+		))
 	}
 	if cluster.Spec.Network.NSXVPC.IsDefined() && webhook.NetworkProvider != manager.NSXVPCNetworkProvider {
-		return nil, apierrors.NewInvalid(cluster.GroupVersionKind().GroupKind(), cluster.Name, field.ErrorList{
-			field.Forbidden(field.NewPath("spec", "network", "nsxVPC"), "nsxVPC can only be set when network provider is NSX-VPC"),
-		})
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "network", "nsxVPC"),
+			"nsxVPC can only be set when network provider is NSX-VPC",
+		))
 	}
+
+	return allErrs
+}
+
+// validate aggregates all shared validations for the VSphereCluster.
+func (webhook *VSphereCluster) validate(cluster *vmwarev1.VSphereCluster) (admission.Warnings, error) {
+	allErrs := webhook.validateClusterNetwork(cluster)
+	allErrs = append(allErrs, validateFailureDomainsControlPlaneSelector(
+		cluster.Spec.FailureDomains.ControlPlane.Selector,
+		field.NewPath("spec", "failureDomains", "controlPlane", "selector"),
+	)...)
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(cluster.GroupVersionKind().GroupKind(), cluster.Name, allErrs)
+	}
+
 	return nil, nil
+}
+
+// validateFailureDomainsControlPlaneSelector validates the control plane failure domain selector.
+func validateFailureDomainsControlPlaneSelector(selector *metav1.LabelSelector, fldPath *field.Path) field.ErrorList {
+	if selector == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	// Validate Feature Gate is enabled.
+	if !feature.Gates.Enabled(feature.NamespaceScopedZones) {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath,
+			"control plane zone selector is not supported on this cluster: requires NamespaceScopedZones feature gate to be enabled",
+		))
+		return allErrs
+	}
+
+	// Validate the selector syntax is valid.
+	parsedSelector, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(fldPath, selector, err.Error()),
+		)
+		return allErrs
+	}
+
+	// Validate the selector is not empty.
+	if parsedSelector.Empty() {
+		allErrs = append(
+			allErrs,
+			field.Invalid(fldPath, selector, "selector must not be empty"),
+		)
+	}
+
+	return allErrs
 }

--- a/internal/webhooks/vmware/vspherecluster.go
+++ b/internal/webhooks/vmware/vspherecluster.go
@@ -109,7 +109,7 @@ func validateFailureDomainsControlPlaneSelector(selector *metav1.LabelSelector, 
 	if !feature.Gates.Enabled(feature.NamespaceScopedZones) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,
-			"control plane zone selector is not supported on this cluster: requires NamespaceScopedZones feature gate to be enabled",
+			"control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		))
 		return allErrs
 	}

--- a/internal/webhooks/vmware/vspherecluster_test.go
+++ b/internal/webhooks/vmware/vspherecluster_test.go
@@ -43,7 +43,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 	}{
 		{
 			name:            "successful VSphereCluster creation without network",
-			vsphereCluster:  createVSphereCluster("test-cluster", vmwarev1.Network{}),
+			vsphereCluster:  createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         false,
@@ -54,7 +54,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 				NSXVPC: vmwarev1.NSXVPC{
 					CreateSubnetSet: ptr.To(true),
 				},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         false,
@@ -65,7 +65,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 				NSXVPC: vmwarev1.NSXVPC{
 					CreateSubnetSet: ptr.To(true),
 				},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": false},
 			wantErr:         true,
@@ -78,7 +78,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 				NSXVPC: vmwarev1.NSXVPC{
 					CreateSubnetSet: ptr.To(false),
 				},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": false},
 			wantErr:         true,
@@ -89,7 +89,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			name: "successful VSphereCluster creation with nsxVPC and createSubnetSet is nil and MultiNetworks disabled",
 			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
 				NSXVPC: vmwarev1.NSXVPC{},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": false},
 			wantErr:         false,
@@ -100,7 +100,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 				NSXVPC: vmwarev1.NSXVPC{
 					CreateSubnetSet: ptr.To(true),
 				},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.VDSNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
@@ -113,12 +113,65 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 				NSXVPC: vmwarev1.NSXVPC{
 					CreateSubnetSet: ptr.To(false),
 				},
-			}),
+			}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXNetworkProvider,
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
 			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+		},
+		{
+			name: "successful VSphereCluster creation with valid control plane selector and feature gate enabled",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      false,
+		},
+		{
+			name: "failed VSphereCluster creation with control plane selector but feature gate disabled",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": false},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "control plane zone selector is not supported on this cluster",
+		},
+		{
+			name: "failed VSphereCluster creation with invalid control plane selector syntax",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "k", Operator: "InvalidOp", Values: []string{"v"}},
+						},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+		},
+		{
+			name: "failed VSphereCluster creation with empty control plane selector",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{}, // Empty selector
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "selector must not be empty",
 		},
 	}
 
@@ -162,11 +215,27 @@ func TestVSphereCluster_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:              "successful VSphereCluster update without network",
-			oldVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}),
-			newVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}),
+			oldVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider:   manager.NSXVPCNetworkProvider,
 			featureGates:      map[string]bool{"MultiNetworks": true},
 			wantErr:           false,
+		},
+		{
+			name:              "failed update with control plane selector when feature gate disabled",
+			oldVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"NamespaceScopedZones": false},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "control plane zone selector is not supported on this cluster",
 		},
 	}
 
@@ -201,7 +270,7 @@ func TestVSphereCluster_ValidateDelete(t *testing.T) {
 	g := NewWithT(t)
 
 	webhook := &VSphereCluster{}
-	cluster := createVSphereCluster("test-cluster", vmwarev1.Network{})
+	cluster := createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{})
 
 	warnings, err := webhook.ValidateDelete(context.Background(), cluster)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -209,13 +278,14 @@ func TestVSphereCluster_ValidateDelete(t *testing.T) {
 }
 
 // Helper functions.
-func createVSphereCluster(name string, network vmwarev1.Network) *vmwarev1.VSphereCluster {
+func createVSphereCluster(name string, network vmwarev1.Network, failureDomains vmwarev1.FailureDomainsSpec) *vmwarev1.VSphereCluster {
 	return &vmwarev1.VSphereCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: vmwarev1.VSphereClusterSpec{
-			Network: network,
+			Network:        network,
+			FailureDomains: failureDomains,
 		},
 	}
 }
@@ -226,6 +296,9 @@ func setupFeatureGates(t *testing.T, featureGates map[string]bool) {
 	for featureName, enabled := range featureGates {
 		if featureName == "MultiNetworks" {
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, enabled)
+		}
+		if featureName == "NamespaceScopedZones" {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.NamespaceScopedZones, enabled)
 		}
 	}
 }

--- a/internal/webhooks/vmware/vspherecluster_test.go
+++ b/internal/webhooks/vmware/vspherecluster_test.go
@@ -42,10 +42,10 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 		errMsg          string // expected error message or substring
 	}{
 		{
-			name:            "successful VSphereCluster creation without network",
+			name:            "successful VSphereCluster creation without network and failure domain selector",
 			vsphereCluster:  createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
 			networkProvider: manager.NSXVPCNetworkProvider,
-			featureGates:    map[string]bool{"MultiNetworks": true},
+			featureGates:    map[string]bool{"NamespaceScopedZones": true, "MultiNetworks": true},
 			wantErr:         false,
 		},
 		{
@@ -144,7 +144,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			featureGates: map[string]bool{"NamespaceScopedZones": false},
 			wantErr:      true,
 			errType:      &apierrors.StatusError{},
-			errMsg:       "control plane zone selector is not supported on this cluster",
+			errMsg:       "control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		},
 		{
 			name: "failed VSphereCluster creation with invalid control plane selector syntax",
@@ -235,7 +235,7 @@ func TestVSphereCluster_ValidateUpdate(t *testing.T) {
 			featureGates:    map[string]bool{"NamespaceScopedZones": false},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
-			errMsg:          "control plane zone selector is not supported on this cluster",
+			errMsg:          "control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		},
 	}
 

--- a/internal/webhooks/vmware/vsphereclustertemplate.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate.go
@@ -26,12 +26,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vsphereclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclustertemplates,versions=v1beta2,name=validation.vsphereclustertemplate.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
 
 // VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
-type VSphereClusterTemplate struct{}
+type VSphereClusterTemplate struct {
+	NetworkProvider string
+}
 
 var _ admission.Validator[*vmwarev1.VSphereClusterTemplate] = &VSphereClusterTemplate{}
 
@@ -57,12 +61,33 @@ func (webhook *VSphereClusterTemplate) ValidateDelete(_ context.Context, _ *vmwa
 	return nil, nil
 }
 
+// validateClusterTemplateNetwork validates the network configuration of the VSphereClusterTemplate.
+func (webhook *VSphereClusterTemplate) validateClusterTemplateNetwork(template *vmwarev1.VSphereClusterTemplate) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if !feature.Gates.Enabled(feature.MultiNetworks) && template.Spec.Template.Spec.Network.NSXVPC.CreateSubnetSet != nil {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "template", "spec", "network", "nsxVPC", "createSubnetSet"),
+			"createSubnetSet can only be set when MultiNetworks feature gate is enabled",
+		))
+	}
+	if template.Spec.Template.Spec.Network.NSXVPC.IsDefined() && webhook.NetworkProvider != manager.NSXVPCNetworkProvider {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "template", "spec", "network", "nsxVPC"),
+			"nsxVPC can only be set when network provider is NSX-VPC",
+		))
+	}
+
+	return allErrs
+}
+
 // validate aggregates all validations for the VSphereClusterTemplate.
 func (webhook *VSphereClusterTemplate) validate(template *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
-	allErrs := validateFailureDomainsControlPlaneSelector(
+	allErrs := webhook.validateClusterTemplateNetwork(template)
+	allErrs = append(allErrs, validateFailureDomainsControlPlaneSelector(
 		template.Spec.Template.Spec.FailureDomains.ControlPlane.Selector,
 		field.NewPath("spec", "template", "spec", "failureDomains", "controlPlane", "selector"),
-	)
+	)...)
 
 	if len(allErrs) > 0 {
 		return nil, apierrors.NewInvalid(template.GroupVersionKind().GroupKind(), template.Name, allErrs)

--- a/internal/webhooks/vmware/vsphereclustertemplate.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vmware is the package for webhooks of vmware resources.
+package vmware
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+)
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-vmware-infrastructure-cluster-x-k8s-io-v1beta2-vsphereclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclustertemplates,versions=v1beta2,name=validation.vsphereclustertemplate.vmware.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
+
+// VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
+type VSphereClusterTemplate struct{}
+
+var _ admission.Validator[*vmwarev1.VSphereClusterTemplate] = &VSphereClusterTemplate{}
+
+// SetupWebhookWithManager sets up the webhook with the Manager.
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &vmwarev1.VSphereClusterTemplate{}).
+		WithValidator(webhook).
+		Complete()
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *VSphereClusterTemplate) ValidateCreate(_ context.Context, obj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	return webhook.validate(obj)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *VSphereClusterTemplate) ValidateUpdate(_ context.Context, _, newObj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	return webhook.validate(newObj)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *VSphereClusterTemplate) ValidateDelete(_ context.Context, _ *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validate aggregates all validations for the VSphereClusterTemplate.
+func (webhook *VSphereClusterTemplate) validate(template *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	allErrs := validateFailureDomainsControlPlaneSelector(
+		template.Spec.Template.Spec.FailureDomains.ControlPlane.Selector,
+		field.NewPath("spec", "template", "spec", "failureDomains", "controlPlane", "selector"),
+	)
+
+	if len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(template.GroupVersionKind().GroupKind(), template.Name, allErrs)
+	}
+
+	return nil, nil
+}

--- a/internal/webhooks/vmware/vsphereclustertemplate_test.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+)
+
+func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     *vmwarev1.VSphereClusterTemplate
+		featureGates map[string]bool
+		wantErr      bool
+		errType      *apierrors.StatusError
+		errMsg       string // expected error message or substring
+	}{
+		{
+			name:         "successful creation without a failure domain selector",
+			template:     createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      false,
+		},
+		{
+			name: "successful creation with valid control plane selector and feature gate enabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      false,
+		},
+		{
+			name: "failed creation with control plane selector but feature gate disabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": false},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "control plane zone selector is not supported on this cluster",
+		},
+		{
+			name: "failed creation with invalid control plane selector syntax",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: "k", Operator: "InvalidOp", Values: []string{"v"}},
+						},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+		},
+		{
+			name: "failed creation with empty control plane selector",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{}, // Empty selector
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "selector must not be empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Set up feature gates for this test case
+			setupTemplateFeatureGates(t, tc.featureGates)
+
+			webhook := &VSphereClusterTemplate{}
+
+			_, err := webhook.ValidateCreate(context.Background(), tc.template)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errType != nil {
+					g.Expect(err).To(BeAssignableToTypeOf(tc.errType))
+				}
+				if tc.errMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errMsg))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestVSphereClusterTemplate_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldTemplate  *vmwarev1.VSphereClusterTemplate
+		newTemplate  *vmwarev1.VSphereClusterTemplate
+		featureGates map[string]bool
+		wantErr      bool
+		errType      *apierrors.StatusError
+		errMsg       string // expected error message or substring
+	}{
+		{
+			name:         "successful update without a failure domain selector",
+			oldTemplate:  createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
+			newTemplate:  createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"NamespaceScopedZones": true},
+			wantErr:      false,
+		},
+		{
+			name:        "failed update with control plane selector when feature gate disabled",
+			oldTemplate: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
+			newTemplate: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "management"},
+					},
+				},
+			}),
+			featureGates: map[string]bool{"NamespaceScopedZones": false},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "control plane zone selector is not supported on this cluster",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Set up feature gates for this test case
+			setupTemplateFeatureGates(t, tc.featureGates)
+
+			webhook := &VSphereClusterTemplate{}
+
+			_, err := webhook.ValidateUpdate(context.Background(), tc.oldTemplate, tc.newTemplate)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errType != nil {
+					g.Expect(err).To(BeAssignableToTypeOf(tc.errType))
+				}
+				if tc.errMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errMsg))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestVSphereClusterTemplate_ValidateDelete(t *testing.T) {
+	g := NewWithT(t)
+
+	webhook := &VSphereClusterTemplate{}
+	template := createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{})
+
+	warnings, err := webhook.ValidateDelete(context.Background(), template)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(warnings).To(BeNil())
+}
+
+// Helper functions.
+func createVSphereClusterTemplate(name string, failureDomains vmwarev1.FailureDomainsSpec) *vmwarev1.VSphereClusterTemplate {
+	return &vmwarev1.VSphereClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: vmwarev1.VSphereClusterTemplateSpec{
+			Template: vmwarev1.VSphereClusterTemplateResource{
+				Spec: vmwarev1.VSphereClusterSpec{
+					FailureDomains: failureDomains,
+				},
+			},
+		},
+	}
+}
+
+func setupTemplateFeatureGates(t *testing.T, featureGates map[string]bool) {
+	t.Helper()
+	// Set up feature gates for the test duration
+	for featureName, enabled := range featureGates {
+		if featureName == "NamespaceScopedZones" {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.NamespaceScopedZones, enabled)
+		}
+	}
+}

--- a/internal/webhooks/vmware/vsphereclustertemplate_test.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate_test.go
@@ -23,30 +23,104 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
-	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
 func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 	tests := []struct {
-		name         string
-		template     *vmwarev1.VSphereClusterTemplate
-		featureGates map[string]bool
-		wantErr      bool
-		errType      *apierrors.StatusError
-		errMsg       string // expected error message or substring
+		name            string
+		template        *vmwarev1.VSphereClusterTemplate
+		networkProvider string
+		featureGates    map[string]bool
+		wantErr         bool
+		errType         *apierrors.StatusError
+		errMsg          string // expected error message or substring
 	}{
 		{
-			name:         "successful creation without a failure domain selector",
-			template:     createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
-			featureGates: map[string]bool{"NamespaceScopedZones": true},
-			wantErr:      false,
+			name:            "successful creation without network and failure domain selector",
+			template:        createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"NamespaceScopedZones": true, "MultiNetworks": true},
+			wantErr:         false,
+		},
+		{
+			name: "successful creation with nsxVPC and createSubnetSet is true and MultiNetworks enabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": true},
+			wantErr:         false,
+		},
+		{
+			name: "failed creation with nsxVPC and createSubnetSet is true but MultiNetworks disabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": false},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "createSubnetSet can only be set when MultiNetworks feature gate is enabled",
+		},
+		{
+			name: "failed creation with nsxVPC and createSubnetSet is false but MultiNetworks disabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(false),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": false},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "createSubnetSet can only be set when MultiNetworks feature gate is enabled",
+		},
+		{
+			name: "successful creation with nsxVPC and createSubnetSet is nil and MultiNetworks disabled",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": false},
+			wantErr:         false,
+		},
+		{
+			name: "failed creation with nsxVPC when network provider is vsphere-network",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.VDSNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": true},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+		},
+		{
+			name: "failed creation with nsxVPC when network provider is NSX",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(false),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": true},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
 		},
 		{
 			name: "successful creation with valid control plane selector and feature gate enabled",
-			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"type": "management"},
@@ -58,7 +132,7 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "failed creation with control plane selector but feature gate disabled",
-			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"type": "management"},
@@ -68,11 +142,11 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 			featureGates: map[string]bool{"NamespaceScopedZones": false},
 			wantErr:      true,
 			errType:      &apierrors.StatusError{},
-			errMsg:       "control plane zone selector is not supported on this cluster",
+			errMsg:       "control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		},
 		{
 			name: "failed creation with invalid control plane selector syntax",
-			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
 					Selector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -87,7 +161,7 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "failed creation with empty control plane selector",
-			template: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
 					Selector: &metav1.LabelSelector{}, // Empty selector
 				},
@@ -104,9 +178,11 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 			g := NewWithT(t)
 
 			// Set up feature gates for this test case
-			setupTemplateFeatureGates(t, tc.featureGates)
+			setupFeatureGates(t, tc.featureGates)
 
-			webhook := &VSphereClusterTemplate{}
+			webhook := &VSphereClusterTemplate{
+				NetworkProvider: tc.networkProvider,
+			}
 
 			_, err := webhook.ValidateCreate(context.Background(), tc.template)
 			if tc.wantErr {
@@ -126,35 +202,38 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 
 func TestVSphereClusterTemplate_ValidateUpdate(t *testing.T) {
 	tests := []struct {
-		name         string
-		oldTemplate  *vmwarev1.VSphereClusterTemplate
-		newTemplate  *vmwarev1.VSphereClusterTemplate
-		featureGates map[string]bool
-		wantErr      bool
-		errType      *apierrors.StatusError
-		errMsg       string // expected error message or substring
+		name            string
+		oldTemplate     *vmwarev1.VSphereClusterTemplate
+		newTemplate     *vmwarev1.VSphereClusterTemplate
+		networkProvider string
+		featureGates    map[string]bool
+		wantErr         bool
+		errType         *apierrors.StatusError
+		errMsg          string // expected error message or substring
 	}{
 		{
-			name:         "successful update without a failure domain selector",
-			oldTemplate:  createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
-			newTemplate:  createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
-			featureGates: map[string]bool{"NamespaceScopedZones": true},
-			wantErr:      false,
+			name:            "successful update without a failure domain selector",
+			oldTemplate:     createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newTemplate:     createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"NamespaceScopedZones": true},
+			wantErr:         false,
 		},
 		{
 			name:        "failed update with control plane selector when feature gate disabled",
-			oldTemplate: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{}),
-			newTemplate: createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{
+			oldTemplate: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newTemplate: createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"type": "management"},
 					},
 				},
 			}),
-			featureGates: map[string]bool{"NamespaceScopedZones": false},
-			wantErr:      true,
-			errType:      &apierrors.StatusError{},
-			errMsg:       "control plane zone selector is not supported on this cluster",
+			networkProvider: manager.NSXVPCNetworkProvider,
+			featureGates:    map[string]bool{"NamespaceScopedZones": false},
+			wantErr:         true,
+			errType:         &apierrors.StatusError{},
+			errMsg:          "control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		},
 	}
 
@@ -163,9 +242,11 @@ func TestVSphereClusterTemplate_ValidateUpdate(t *testing.T) {
 			g := NewWithT(t)
 
 			// Set up feature gates for this test case
-			setupTemplateFeatureGates(t, tc.featureGates)
+			setupFeatureGates(t, tc.featureGates)
 
-			webhook := &VSphereClusterTemplate{}
+			webhook := &VSphereClusterTemplate{
+				NetworkProvider: tc.networkProvider,
+			}
 
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldTemplate, tc.newTemplate)
 			if tc.wantErr {
@@ -187,7 +268,7 @@ func TestVSphereClusterTemplate_ValidateDelete(t *testing.T) {
 	g := NewWithT(t)
 
 	webhook := &VSphereClusterTemplate{}
-	template := createVSphereClusterTemplate("test-template", vmwarev1.FailureDomainsSpec{})
+	template := createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{})
 
 	warnings, err := webhook.ValidateDelete(context.Background(), template)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -195,7 +276,7 @@ func TestVSphereClusterTemplate_ValidateDelete(t *testing.T) {
 }
 
 // Helper functions.
-func createVSphereClusterTemplate(name string, failureDomains vmwarev1.FailureDomainsSpec) *vmwarev1.VSphereClusterTemplate {
+func createVSphereClusterTemplate(name string, network vmwarev1.Network, failureDomains vmwarev1.FailureDomainsSpec) *vmwarev1.VSphereClusterTemplate {
 	return &vmwarev1.VSphereClusterTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -203,19 +284,10 @@ func createVSphereClusterTemplate(name string, failureDomains vmwarev1.FailureDo
 		Spec: vmwarev1.VSphereClusterTemplateSpec{
 			Template: vmwarev1.VSphereClusterTemplateResource{
 				Spec: vmwarev1.VSphereClusterSpec{
+					Network:        network,
 					FailureDomains: failureDomains,
 				},
 			},
 		},
-	}
-}
-
-func setupTemplateFeatureGates(t *testing.T, featureGates map[string]bool) {
-	t.Helper()
-	// Set up feature gates for the test duration
-	for featureName, enabled := range featureGates {
-		if featureName == "NamespaceScopedZones" {
-			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.NamespaceScopedZones, enabled)
-		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -650,6 +650,9 @@ func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.
 	if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
 		return err
 	}
+	if err := (&vmwarewebhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
+		return err
+	}
 	if err := (&vmwarewebhooks.VSphereCluster{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
 		return err
 	}

--- a/webhooks/vmware/alias.go
+++ b/webhooks/vmware/alias.go
@@ -45,3 +45,11 @@ type VSphereCluster struct{}
 func (webhook *VSphereCluster) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
 	return (&vmware.VSphereCluster{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
 }
+
+// VSphereClusterTemplate implements a validation and defaulting webhook for VSphereClusterTemplate.
+type VSphereClusterTemplate struct{}
+
+// SetupWebhookWithManager sets up VSphereClusterTemplate webhooks.
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
+	return (&vmware.VSphereClusterTemplate{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This is  follow-up PR of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/4003 for validation of the control plane failure domain selector.

1. Add the validation in VSphereCluster and VSphereClusterTemplate:

- the selector is only set if the feature gate is on

- validate that the selector is valid

2. Add test cases to cover the code change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
