### PR TITLE
🌱 Validate supervisor endpoint host is IP in service discovery

### DIFF
--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -286,10 +286,23 @@ func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx cont
 
 	log.V(5).Info("Discovered supervisor API server endpoint", "host", supervisorHost, "port", supervisorPort)
 	// CreateOrPatch the newEndpoints with the discovered supervisor api server address
-	newEndpoints := newSupervisorHeadlessServiceEndpoints(
+	newEndpoints, err := newSupervisorHeadlessServiceEndpoints(
 		supervisorHost,
 		supervisorPort,
 	)
+	if err != nil {
+		// Note: We have watches on the LB Svc (VIP) & the cluster-info configmap (FIP).
+		// There is no need to return an error to keep re-trying.
+		deprecatedv1beta1conditions.MarkFalse(guestClusterCtx.VSphereCluster, vmwarev1.ServiceDiscoveryReadyV1Beta1Condition, vmwarev1.SupervisorHeadlessServiceSetupFailedV1Beta1Reason,
+			clusterv1.ConditionSeverityWarning, "%v", err)
+		conditions.Set(guestClusterCtx.VSphereCluster, metav1.Condition{
+			Type:    vmwarev1.VSphereClusterServiceDiscoveryReadyCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  vmwarev1.VSphereClusterServiceDiscoveryNotReadyReason,
+			Message: err.Error(),
+		})
+		return nil
+	}
 	endpointsKey := types.NamespacedName{
 		Namespace: newEndpoints.Namespace,
 		Name:      newEndpoints.Name,
@@ -376,12 +389,10 @@ func newSupervisorHeadlessService(port, targetPort int) *corev1.Service {
 }
 
 // newSupervisorHeadlessServiceEndpoints returns Kubernetes Endpoints for the supervisor apiserver address.
-func newSupervisorHeadlessServiceEndpoints(targetHost string, targetPort int) *corev1.Endpoints {
-	var endpointAddr corev1.EndpointAddress
-	if ip := net.ParseIP(targetHost); ip != nil {
-		endpointAddr.IP = ip.String()
-	} else {
-		endpointAddr.Hostname = targetHost
+func newSupervisorHeadlessServiceEndpoints(targetHost string, targetPort int) (*corev1.Endpoints, error) {
+	ip := net.ParseIP(targetHost)
+	if ip == nil {
+		return nil, errors.Errorf("invalid supervisor API server endpoint %q: must be an IP address", targetHost)
 	}
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
@@ -391,7 +402,7 @@ func newSupervisorHeadlessServiceEndpoints(targetHost string, targetPort int) *c
 		Subsets: []corev1.EndpointSubset{
 			{
 				Addresses: []corev1.EndpointAddress{
-					endpointAddr,
+					{IP: ip.String()},
 				},
 				Ports: []corev1.EndpointPort{
 					{
@@ -400,7 +411,7 @@ func newSupervisorHeadlessServiceEndpoints(targetHost string, targetPort int) *c
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 // getSupervisorAPIServerVIP finds the load balancer IP of the Supervisor APIServer.

--- a/controllers/vmware/servicediscovery_controller_suite_test.go
+++ b/controllers/vmware/servicediscovery_controller_suite_test.go
@@ -95,27 +95,11 @@ func assertHeadlessSvcWithVIPEndpoints(ctx context.Context, guestClient client.C
 	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(supervisorAPIServerPort)))
 }
 
-func assertHeadlessSvcWithVIPHostnameEndpoints(ctx context.Context, guestClient client.Client, namespace, name string) {
-	assertHeadlessSvc(ctx, guestClient, namespace, name)
-	headlessEndpoints := &corev1.Endpoints{}
-	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, headlessEndpoints)
-	Expect(headlessEndpoints.Subsets[0].Addresses[0].Hostname).To(Equal(testSupervisorAPIServerVIPHostName))
-	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(supervisorAPIServerPort)))
-}
-
 func assertHeadlessSvcWithFIPEndpoints(ctx context.Context, guestClient client.Client, namespace, name string) {
 	assertHeadlessSvc(ctx, guestClient, namespace, name)
 	headlessEndpoints := &corev1.Endpoints{}
 	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, headlessEndpoints)
 	Expect(headlessEndpoints.Subsets[0].Addresses[0].IP).To(Equal(testSupervisorAPIServerFIP))
-	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(testSupervisorAPIServerPort)))
-}
-
-func assertHeadlessSvcWithFIPHostNameEndpoints(ctx context.Context, guestClient client.Client, namespace, name string) {
-	assertHeadlessSvc(ctx, guestClient, namespace, name)
-	headlessEndpoints := &corev1.Endpoints{}
-	assertEventuallyExistsInNamespace(ctx, guestClient, namespace, name, headlessEndpoints)
-	Expect(headlessEndpoints.Subsets[0].Addresses[0].Hostname).To(Equal(testSupervisorAPIServerFIPHostName))
 	Expect(headlessEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(testSupervisorAPIServerPort)))
 }
 

--- a/controllers/vmware/servicediscovery_controller_unit_test.go
+++ b/controllers/vmware/servicediscovery_controller_unit_test.go
@@ -110,9 +110,10 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				newTestSupervisorLBServiceWithHostnameStatus()}
 		})
 		It("Should reconcile headless svc", func() {
-			By("creating a service and endpoints using the VIP in the guest cluster")
-			assertHeadlessSvcWithVIPHostnameEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyReason)
+			By("creating a service and no endpoint in the guest cluster")
+			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "must be an IP address",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyReason)
 		})
 	})
 	Context("When FIP is an hostname", func() {
@@ -122,9 +123,10 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			}
 		})
 		It("Should reconcile headless svc", func() {
-			By("creating a service and endpoints using the FIP in the guest cluster")
-			assertHeadlessSvcWithFIPHostNameEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
-			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionTrue, "", vmwarev1.VSphereClusterServiceDiscoveryReadyReason)
+			By("creating a service and no endpoint in the guest cluster")
+			assertHeadlessSvcWithNoEndpoints(ctx, controllerCtx.GuestClient, supervisorHeadlessSvcNamespace, supervisorHeadlessSvcName)
+			assertServiceDiscoveryCondition(controllerCtx.VSphereCluster, metav1.ConditionFalse, "must be an IP address",
+				vmwarev1.VSphereClusterServiceDiscoveryNotReadyReason)
 		})
 	})
 	Context("When FIP is an empty hostname", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fail fast when creating headless Service Endpoints using non-IP supervisor API endpoints.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3409 
