### PR TITLE
[release-1.14] 🌱 Sync ci-e2e-lib.sh

### DIFF
--- a/hack/ci-e2e-lib.sh
+++ b/hack/ci-e2e-lib.sh
@@ -16,7 +16,7 @@
 
 # Note: This is a copy of cluster-api's scripts/ci-e2e-lib.sh.
 
-# k8s::prepareKindestImagesVariables defaults the environment variable KUBERNETES_VERSION_MANAGEMENT
+# k8s::prepareKindestImagesVariables defaults the environment variables KUBERNETES_VERSION_MANAGEMENT, KUBERNETES_VERSION_MANAGEMENT_LATEST_CI
 # depending on what is set in GINKGO_FOCUS.
 # Note: We do this to ensure that the kindest/node image gets built if it does
 # not already exist, e.g. for pre-releases, but only if necessary.
@@ -101,7 +101,7 @@ kind::prepareKindestImage() {
 
   # if pre-pull failed, or ALWAYS_BUILD_KIND_IMAGES is true build the images locally.
  if [[ "$retVal" != 0 ]] || [[ "$ALWAYS_BUILD_KIND_IMAGES" = "true" ]]; then
-    echo "+ building image for Kuberentes $version locally. This is either because the image wasn't available in docker hub or ALWAYS_BUILD_KIND_IMAGES is set to true"
+    echo "+ building image for Kubernetes $version locally. This is either because the image wasn't available in docker hub or ALWAYS_BUILD_KIND_IMAGES is set to true"
     kind::buildNodeImage "$version"
   fi
 }
@@ -123,8 +123,13 @@ kind::buildNodeImage() {
 
   # build the node image
   version="${version//+/_}"
-  echo "+ Building kindest/node:$version"
-  kind build node-image --image "kindest/node:$version"
+  if [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
+    echo "+ Building kindest/node:$version using pre-built binaries"
+    kind build node-image --image "kindest/node:$version" "$version"
+  else
+    echo "+ Building kindest/node:$version from source"
+    kind build node-image --image "kindest/node:$version"
+  fi
 
   # move back to Cluster API
   cd "$REPO_ROOT" || exit
@@ -147,16 +152,19 @@ k8s::checkoutBranch() {
   else
     # otherwise we are requiring a Kubernetes version that should be built from HEAD
     # of one of the existing branches
-    echo "+ checking for existing branches"
-    git fetch --all
-
     local major
     local minor
     major=$(echo "${version#v}" | awk '{split($0,a,"."); print a[1]}')
     minor=$(echo "${version#v}" | awk '{split($0,a,"."); print a[2]}')
 
+    echo "+ Trying to fetch branch release-$major.$minor"
+    # shellcheck disable=SC2015
+    git fetch --filter=blob:none https://github.com/kubernetes/kubernetes.git "release-$major.$minor" \
+      && git checkout FETCH_HEAD \
+      && git branch --force "release-$major.$minor" || true
+
     local releaseBranch
-    releaseBranch="$(git branch -r | grep "release-$major.$minor$" || true)"
+    releaseBranch="$(git branch | grep "release-$major.$minor$" | awk '{print $NF}' || true)"
     if [[ "$releaseBranch" != "" ]]; then
       # if there is already a release branch for the required Kubernetes branch, use it
       echo "+ checkout $releaseBranch branch"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/4037

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
