### PR TITLE
🐛 Fix immutability validation of VSphereMachineTemplate

### DIFF
--- a/internal/webhooks/vmware/vspheremachinetemplate.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate.go
@@ -62,12 +62,16 @@ func (webhook *VSphereMachineTemplate) Default(ctx context.Context, c *vmwarev1.
 	if topology.IsDryRunRequest(req, c) {
 		// In case of dry-run requests from the topology controller, apply defaults from older versions of CAPV
 		// so we do not trigger rollouts when dealing with objects created before dropping those defaults.
-		if c.Spec.Template.Spec.PowerOffMode == "" {
-			c.Spec.Template.Spec.PowerOffMode = vmwarev1.VirtualMachinePowerOpModeHard
-		}
+		applyPreviousVSphereMachineTemplateDefaults(c)
 	}
 
 	return nil
+}
+
+func applyPreviousVSphereMachineTemplateDefaults(c *vmwarev1.VSphereMachineTemplate) {
+	if c.Spec.Template.Spec.PowerOffMode == "" {
+		c.Spec.Template.Spec.PowerOffMode = vmwarev1.VirtualMachinePowerOpModeHard
+	}
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
@@ -82,6 +86,11 @@ func (webhook *VSphereMachineTemplate) ValidateUpdate(ctx context.Context, oldOb
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
 	}
 	if !topology.IsDryRunRequest(req, newObj) {
+		// Apply defaults from older versions of CAPV so the following checks do not report differences when
+		// dealing with objects created before dropping those defaults.
+		applyPreviousVSphereMachineTemplateDefaults(oldObj)
+		applyPreviousVSphereMachineTemplateDefaults(newObj)
+
 		equal, diff, err := util.Diff(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
 		if err != nil {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new VSphereMachineTemplate: %v", err))

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -309,7 +309,7 @@ func TestVSphereMachineTemplate_ValidateInterfaces(t *testing.T) {
 }
 
 func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
-	oldTemplate := vmwarev1.VSphereMachineTemplate{
+	oldTemplate := &vmwarev1.VSphereMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-template",
 			Namespace: "default",
@@ -328,6 +328,11 @@ func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
 	newTemplate := oldTemplate.DeepCopy()
 	newTemplate.Spec.Template.Spec.ImageName = "ubuntu-22.04"
 
+	oldTemplateWithDefaultedPowerOffMode := oldTemplate.DeepCopy()
+	oldTemplateWithDefaultedPowerOffMode.Spec.Template.Spec.PowerOffMode = vmwarev1.VirtualMachinePowerOpModeHard
+	newTemplateWithoutPowerOffMode := oldTemplate.DeepCopy()
+	newTemplateWithoutPowerOffMode.Spec.Template.Spec.PowerOffMode = ""
+
 	newTemplateSkipImmutabilityAnnotationSet := newTemplate.DeepCopy()
 	newTemplateSkipImmutabilityAnnotationSet.SetAnnotations(map[string]string{clusterv1.TopologyDryRunAnnotation: ""})
 
@@ -341,23 +346,30 @@ func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
 	}{
 		{
 			name:        "return no error if no modification",
-			newTemplate: &oldTemplate,
-			oldTemplate: &oldTemplate,
+			newTemplate: oldTemplate,
+			oldTemplate: oldTemplate,
 			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}},
 			wantError:   false,
 		},
 		{
 			name:        "don't allow modification of spec.template.spec",
 			newTemplate: newTemplate,
-			oldTemplate: &oldTemplate,
+			oldTemplate: oldTemplate,
 			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}},
 			wantError:   true,
 			wantErrMsg:  "VSphereMachineTemplate spec.template.spec field is immutable",
 		},
 		{
+			name:        "allow differences between defaulted value and empty of spec.template.spec.powerOffMode",
+			newTemplate: newTemplateWithoutPowerOffMode,
+			oldTemplate: oldTemplateWithDefaultedPowerOffMode,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}},
+			wantError:   false,
+		},
+		{
 			name:        "don't allow modification even with skip immutability annotation when not dry run",
 			newTemplate: newTemplateSkipImmutabilityAnnotationSet,
-			oldTemplate: &oldTemplate,
+			oldTemplate: oldTemplate,
 			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}},
 			wantError:   true,
 			wantErrMsg:  "VSphereMachineTemplate spec.template.spec field is immutable",
@@ -365,7 +377,7 @@ func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
 		{
 			name:        "don't allow modification when dry run but no skip immutability annotation",
 			newTemplate: newTemplate,
-			oldTemplate: &oldTemplate,
+			oldTemplate: oldTemplate,
 			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}},
 			wantError:   true,
 			wantErrMsg:  "VSphereMachineTemplate spec.template.spec field is immutable",
@@ -373,7 +385,7 @@ func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
 		{
 			name:        "skip immutability check when dry run and skip immutability annotation set",
 			newTemplate: newTemplateSkipImmutabilityAnnotationSet,
-			oldTemplate: &oldTemplate,
+			oldTemplate: oldTemplate,
 			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}},
 			wantError:   false,
 		},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
