### PR TITLE
🐛 Fix duplicate prometheus port name in generated CSI cluster-template manifests

### DIFF
--- a/packaging/flavorgen/cloudprovider/csi/vsphere-csi-driver.yaml
+++ b/packaging/flavorgen/cloudprovider/csi/vsphere-csi-driver.yaml
@@ -348,7 +348,7 @@ spec:
           imagePullPolicy: "Always"
           ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -742,7 +742,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -961,7 +961,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -878,7 +878,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template-supervisor.yaml
+++ b/templates/cluster-template-supervisor.yaml
@@ -826,7 +826,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template-topology-supervisor.yaml
+++ b/templates/cluster-template-topology-supervisor.yaml
@@ -632,7 +632,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -647,7 +647,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -866,7 +866,7 @@ data:
             name: vsphere-syncer
             ports:
             - containerPort: 2113
-              name: prometheus
+              name: prometheus-sync
               protocol: TCP
             securityContext:
               runAsGroup: 65532


### PR DESCRIPTION
## Summary

Renames the vsphere-syncer container's metrics port from `prometheus` to `prometheus-sync` in the CSI flavorgen source manifest and regenerates the affected cluster templates, removing the duplicate `prometheus` port name within the generated CSI manifests.

## Why this matters

Two containers in the generated CSI manifests both declared a port named `prometheus`, which is a duplicate port name within the pod spec and is rejected by stricter validation. Giving the syncer port a distinct name (`prometheus-sync`) resolves the collision; the existing Services target the numeric port, so no in-repo references break. Reported in #3535.

## Testing

Regenerated all affected cluster templates via `make generate-flavors` and confirmed the only change is the port-name rename, with no other manifest drift.

Closes #3535

AI was used for assistance.
