### PR TITLE
🐛 Fixup e2e tests

### DIFF
--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -435,7 +435,7 @@ func setupNamespaceWithVMOperatorDependenciesVCenter(managementClusterProxy fram
 	c, err := conversionclient.NewWithConverter(managementClusterProxy.GetClient(), converter)
 	Expect(err).NotTo(HaveOccurred())
 
-	Byf("Creating VMOperatorDependencies %s", klog.KRef(workloadClusterNamespace, "vcsim"))
+	Byf("Creating VMOperatorDependencies %s", klog.KRef(workloadClusterNamespace, "vcenter"))
 	mustParseInt64 := func(s string) int64 {
 		i, err := strconv.Atoi(s)
 		if err != nil {

--- a/test/framework/vmoperator/vmoperator.go
+++ b/test/framework/vmoperator/vmoperator.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
@@ -889,19 +890,21 @@ func createVirtualMachineClass(ctx context.Context, c client.Client, config *vcs
 				},
 			},
 		}
-		_ = wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-			retryError = nil
+		retryError = nil
+		// Note: Using 1m as timeout as we might just have deployed the vm-operator ConfigMap, so it might take some time for vm-operator to be available.
+		_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := c.Get(ctx, client.ObjectKeyFromObject(vmClass), vmClass); err != nil {
 				if !apierrors.IsNotFound(err) {
-					retryError = errors.Wrapf(err, "failed to get vm-operator VirtualMachineClass %s", vmClass.Name)
+					retryError = kerrors.NewAggregate([]error{retryError, errors.Wrapf(err, "failed to get vm-operator VirtualMachineClass %s", vmClass.Name)})
 					return false, nil
 				}
 				if err := c.Create(ctx, vmClass); err != nil {
-					retryError = errors.Wrapf(err, "failed to create vm-operator VirtualMachineClass %s", vmClass.Name)
+					retryError = kerrors.NewAggregate([]error{retryError, errors.Wrapf(err, "failed to create vm-operator VirtualMachineClass %s", vmClass.Name)})
 					return false, nil
 				}
 				log.Info("Created vm-operator VirtualMachineClass", "VirtualMachineClass", klog.KObj(vmClass))
 			}
+			retryError = nil
 			return true, nil
 		})
 		if retryError != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Example failure:
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-e2e-supervisor-main/2069918538465808384

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
