### PR TITLE
✨Add per-cluster network provider support

### DIFF
--- a/api/supervisor/v1beta1/vspherecluster_types.go
+++ b/api/supervisor/v1beta1/vspherecluster_types.go
@@ -163,11 +163,18 @@ func (r *NSXVPC) IsDefined() bool {
 
 // Network defines the network configuration for the cluster with different network providers.
 // +kubebuilder:validation:XValidation:rule="has(self.nsxVPC) == has(oldSelf.nsxVPC)",message="field 'nsxVPC' cannot be added or removed after creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.provider) || self.provider == oldSelf.provider",message="provider is immutable once set"
 // +kubebuilder:validation:MinProperties=1
 type Network struct {
 	// nsxVPC defines the configuration when the network provider is NSX-VPC.
 	// +optional
 	NSXVPC NSXVPC `json:"nsxVPC,omitempty,omitzero"`
+
+	// provider is the network provider used by the cluster.
+	// The value is immutable once set.
+	// +optional
+	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC
+	Provider string `json:"provider,omitempty"`
 }
 
 // IsDefined returns true if the Network is defined.
@@ -176,7 +183,7 @@ func (r *Network) IsDefined() bool {
 }
 
 // VSphereClusterSpec defines the desired state of VSphereCluster.
-// +kubebuilder:validation:XValidation:rule="has(self.network) == has(oldSelf.network)",message="field 'network' cannot be added or removed after creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.network) || has(self.network)",message="field 'network' cannot be removed once set"
 type VSphereClusterSpec struct {
 	// controlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional

--- a/api/supervisor/v1beta1/zz_generated.conversion.go
+++ b/api/supervisor/v1beta1/zz_generated.conversion.go
@@ -639,6 +639,7 @@ func autoConvert_v1beta1_Network_To_v1beta2_Network(in *Network, out *v1beta2.Ne
 	if err := Convert_v1beta1_NSXVPC_To_v1beta2_NSXVPC(&in.NSXVPC, &out.NSXVPC, s); err != nil {
 		return err
 	}
+	out.Provider = in.Provider
 	return nil
 }
 
@@ -651,6 +652,7 @@ func autoConvert_v1beta2_Network_To_v1beta1_Network(in *v1beta2.Network, out *Ne
 	if err := Convert_v1beta2_NSXVPC_To_v1beta1_NSXVPC(&in.NSXVPC, &out.NSXVPC, s); err != nil {
 		return err
 	}
+	out.Provider = in.Provider
 	return nil
 }
 

--- a/api/supervisor/v1beta2/vspherecluster_types.go
+++ b/api/supervisor/v1beta2/vspherecluster_types.go
@@ -165,11 +165,18 @@ func (r *NSXVPC) IsDefined() bool {
 
 // Network defines the network configuration for the cluster with different network providers.
 // +kubebuilder:validation:XValidation:rule="has(self.nsxVPC) == has(oldSelf.nsxVPC)",message="field 'nsxVPC' cannot be added or removed after creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.provider) || self.provider == oldSelf.provider",message="provider is immutable once set"
 // +kubebuilder:validation:MinProperties=1
 type Network struct {
 	// nsxVPC defines the configuration when the network provider is NSX-VPC.
 	// +optional
 	NSXVPC NSXVPC `json:"nsxVPC,omitempty,omitzero"`
+
+	// provider is the network provider used by the cluster.
+	// The value is immutable once set.
+	// +optional
+	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC
+	Provider string `json:"provider,omitempty"`
 }
 
 // IsDefined returns true if the Network is defined.
@@ -178,7 +185,7 @@ func (r *Network) IsDefined() bool {
 }
 
 // VSphereClusterSpec defines the desired state of VSphereCluster.
-// +kubebuilder:validation:XValidation:rule="has(self.network) == has(oldSelf.network)",message="field 'network' cannot be added or removed after creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.network) || has(self.network)",message="field 'network' cannot be removed once set"
 // +kubebuilder:validation:MinProperties=1
 type VSphereClusterSpec struct {
 	// controlPlaneEndpoint represents the endpoint used to communicate with the control plane.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -135,14 +135,25 @@ spec:
                     - message: createSubnetSet value cannot be changed after creation
                       rule: has(self.createSubnetSet) == has(oldSelf.createSubnetSet)
                         && self.createSubnetSet == oldSelf.createSubnetSet
+                  provider:
+                    description: |-
+                      provider is the network provider used by the cluster.
+                      The value is immutable once set.
+                    enum:
+                    - VSphereDistributed
+                    - NSXTier1
+                    - VPC
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: field 'nsxVPC' cannot be added or removed after creation
                   rule: has(self.nsxVPC) == has(oldSelf.nsxVPC)
+                - message: provider is immutable once set
+                  rule: '!has(oldSelf.provider) || self.provider == oldSelf.provider'
             type: object
             x-kubernetes-validations:
-            - message: field 'network' cannot be added or removed after creation
-              rule: has(self.network) == has(oldSelf.network)
+            - message: field 'network' cannot be removed once set
+              rule: '!has(oldSelf.network) || has(self.network)'
           status:
             description: status is the observed state of VSphereCluster.
             properties:
@@ -450,14 +461,25 @@ spec:
                     - message: createSubnetSet value cannot be changed after creation
                       rule: has(self.createSubnetSet) == has(oldSelf.createSubnetSet)
                         && self.createSubnetSet == oldSelf.createSubnetSet
+                  provider:
+                    description: |-
+                      provider is the network provider used by the cluster.
+                      The value is immutable once set.
+                    enum:
+                    - VSphereDistributed
+                    - NSXTier1
+                    - VPC
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: field 'nsxVPC' cannot be added or removed after creation
                   rule: has(self.nsxVPC) == has(oldSelf.nsxVPC)
+                - message: provider is immutable once set
+                  rule: '!has(oldSelf.provider) || self.provider == oldSelf.provider'
             type: object
             x-kubernetes-validations:
-            - message: field 'network' cannot be added or removed after creation
-              rule: has(self.network) == has(oldSelf.network)
+            - message: field 'network' cannot be removed once set
+              rule: '!has(oldSelf.network) || has(self.network)'
           status:
             description: status is the observed state of VSphereCluster.
             minProperties: 1

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -147,15 +147,26 @@ spec:
                                 creation
                               rule: has(self.createSubnetSet) == has(oldSelf.createSubnetSet)
                                 && self.createSubnetSet == oldSelf.createSubnetSet
+                          provider:
+                            description: |-
+                              provider is the network provider used by the cluster.
+                              The value is immutable once set.
+                            enum:
+                            - VSphereDistributed
+                            - NSXTier1
+                            - VPC
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: field 'nsxVPC' cannot be added or removed after
                             creation
                           rule: has(self.nsxVPC) == has(oldSelf.nsxVPC)
+                        - message: provider is immutable once set
+                          rule: '!has(oldSelf.provider) || self.provider == oldSelf.provider'
                     type: object
                     x-kubernetes-validations:
-                    - message: field 'network' cannot be added or removed after creation
-                      rule: has(self.network) == has(oldSelf.network)
+                    - message: field 'network' cannot be removed once set
+                      rule: '!has(oldSelf.network) || has(self.network)'
                 required:
                 - spec
                 type: object
@@ -335,15 +346,26 @@ spec:
                                 creation
                               rule: has(self.createSubnetSet) == has(oldSelf.createSubnetSet)
                                 && self.createSubnetSet == oldSelf.createSubnetSet
+                          provider:
+                            description: |-
+                              provider is the network provider used by the cluster.
+                              The value is immutable once set.
+                            enum:
+                            - VSphereDistributed
+                            - NSXTier1
+                            - VPC
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: field 'nsxVPC' cannot be added or removed after
                             creation
                           rule: has(self.nsxVPC) == has(oldSelf.nsxVPC)
+                        - message: provider is immutable once set
+                          rule: '!has(oldSelf.provider) || self.provider == oldSelf.provider'
                     type: object
                     x-kubernetes-validations:
-                    - message: field 'network' cannot be added or removed after creation
-                      rule: has(self.network) == has(oldSelf.network)
+                    - message: field 'network' cannot be removed once set
+                      rule: '!has(oldSelf.network) || has(self.network)'
                 type: object
             required:
             - template

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -105,10 +105,10 @@ func setup() {
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 
-	if err := AddClusterControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts); err != nil {
+	if err := AddClusterControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts, nil); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereCluster controller: %v", err))
 	}
-	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts); err != nil {
+	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts, nil); err != nil {
 		panic(fmt.Sprintf("unable to setup VsphereMachine controller: %v", err))
 	}
 	if err := AddVMControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {

--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -118,7 +118,11 @@ func setup(ctx context.Context) (*helpers.TestEnvironment, client.Client, cluste
 	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, secretCachingClient, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ServiceAccount controller: %v", err))
 	}
-	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts); err != nil {
+	networkProviderFactory, err := manager.NewStaticNetworkProviderFactory(ctx, testEnv.GetControllerManagerContext().Client, testEnv.GetControllerManagerContext().NetworkProvider)
+	if err != nil {
+		panic(fmt.Sprintf("unable to create network provider factory: %v", err))
+	}
+	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, clusterCache, controllerOpts, networkProviderFactory); err != nil {
 		panic(fmt.Sprintf("unable to setup SvcDiscovery controller: %v", err))
 	}
 

--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -18,6 +18,7 @@ package vmware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -76,17 +77,12 @@ const (
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get
 
 // AddServiceDiscoveryControllerToManager adds the ServiceDiscovery controller to the provided manager.
-func AddServiceDiscoveryControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterCache clustercache.ClusterCache, options controller.Options) error {
-	networkProvider, err := inframanager.GetNetworkProvider(ctx, controllerManagerCtx.Client, controllerManagerCtx.NetworkProvider)
-	if err != nil {
-		return pkgerrors.Wrap(err, "failed to create network provider")
-	}
-
+func AddServiceDiscoveryControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, clusterCache clustercache.ClusterCache, options controller.Options, networkProviderFactory inframanager.NetworkProviderFactory) error {
 	r := &serviceDiscoveryReconciler{
-		Client:          controllerManagerCtx.Client,
-		Recorder:        mgr.GetEventRecorderFor("servicediscovery/vspherecluster-controller"),
-		NetworkProvider: networkProvider,
-		clusterCache:    clusterCache,
+		Client:                 controllerManagerCtx.Client,
+		Recorder:               mgr.GetEventRecorderFor("servicediscovery/vspherecluster-controller"),
+		NetworkProviderFactory: networkProviderFactory,
+		clusterCache:           clusterCache,
 	}
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "servicediscovery/vspherecluster")
 
@@ -138,9 +134,9 @@ func clusterToSupervisorVSphereClusterFunc(ctrlclient client.Client) func(ctx co
 }
 
 type serviceDiscoveryReconciler struct {
-	Client          client.Client
-	Recorder        record.EventRecorder
-	NetworkProvider services.NetworkProvider
+	Client                 client.Client
+	Recorder               record.EventRecorder
+	NetworkProviderFactory inframanager.NetworkProviderFactory
 
 	clusterCache clustercache.ClusterCache
 }
@@ -206,11 +202,23 @@ func (r *serviceDiscoveryReconciler) Reconcile(ctx context.Context, req reconcil
 		return reconcile.Result{}, nil
 	}
 
+	// Resolve the network provider for the VSphereCluster.
+	np, err := r.NetworkProviderFactory.ForCluster(ctx, vsphereCluster)
+	if err != nil {
+		if errors.Is(err, inframanager.ErrNetworkProviderEmpty) {
+			log.Info("Network Provider is empty, wait for a valid value")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, pkgerrors.Wrapf(err,
+			"failed to resolve network provider for VSphereCluster %s",
+			klog.KObj(vsphereCluster))
+	}
+
 	// We cannot proceed until we are able to access the target cluster. Until
 	// then just return a no-op and wait for the next sync.
 	guestClient, err := r.clusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))
 	if err != nil {
-		if pkgerrors.Is(err, clustercache.ErrClusterNotConnected) {
+		if errors.Is(err, clustercache.ErrClusterNotConnected) {
 			log.V(5).Info("Requeuing because connection to the workload cluster is down")
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
@@ -222,7 +230,7 @@ func (r *serviceDiscoveryReconciler) Reconcile(ctx context.Context, req reconcil
 	return reconcile.Result{}, r.reconcileNormal(ctx, &vmwarecontext.GuestClusterContext{
 		ClusterContext: clusterContext,
 		GuestClient:    guestClient,
-	})
+	}, np)
 }
 
 func (r *serviceDiscoveryReconciler) patch(ctx context.Context, clusterCtx *vmwarecontext.ClusterContext) error {
@@ -237,8 +245,8 @@ func (r *serviceDiscoveryReconciler) patch(ctx context.Context, clusterCtx *vmwa
 	)
 }
 
-func (r *serviceDiscoveryReconciler) reconcileNormal(ctx context.Context, guestClusterCtx *vmwarecontext.GuestClusterContext) error {
-	if err := r.reconcileSupervisorHeadlessService(ctx, guestClusterCtx); err != nil {
+func (r *serviceDiscoveryReconciler) reconcileNormal(ctx context.Context, guestClusterCtx *vmwarecontext.GuestClusterContext, np services.NetworkProvider) error {
+	if err := r.reconcileSupervisorHeadlessService(ctx, guestClusterCtx, np); err != nil {
 		deprecatedv1beta1conditions.MarkFalse(guestClusterCtx.VSphereCluster, vmwarev1.ServiceDiscoveryReadyV1Beta1Condition, vmwarev1.SupervisorHeadlessServiceSetupFailedV1Beta1Reason,
 			clusterv1.ConditionSeverityWarning, "%v", err)
 		conditions.Set(guestClusterCtx.VSphereCluster, metav1.Condition{
@@ -256,7 +264,7 @@ func (r *serviceDiscoveryReconciler) reconcileNormal(ctx context.Context, guestC
 // reconcileSupervisorHeadlessService sets up a local k8s service in the workload cluster that
 // proxies to the Supervisor Cluster API Server. The add-ons are depend on this local service
 // to connect to the Supervisor Cluster.
-func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx context.Context, guestClusterCtx *vmwarecontext.GuestClusterContext) error {
+func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx context.Context, guestClusterCtx *vmwarecontext.GuestClusterContext, np services.NetworkProvider) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Create the headless service to the supervisor api server on the target cluster.
@@ -281,7 +289,7 @@ func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx cont
 
 	var supervisorHosts []string
 	var err error
-	supervisorHosts, err = r.getSupervisorAPIServerAddresses(ctx, guestClusterCtx.Cluster)
+	supervisorHosts, err = r.getSupervisorAPIServerAddresses(ctx, guestClusterCtx.Cluster, np)
 	if err != nil {
 		// Note: We have watches on the LB Svc (VIP) & the cluster-info configmap (FIP).
 		// There is no need to return an error to keep re-trying.
@@ -363,8 +371,8 @@ func (r *serviceDiscoveryReconciler) reconcileSupervisorHeadlessService(ctx cont
 	return nil
 }
 
-func (r *serviceDiscoveryReconciler) getSupervisorAPIServerAddresses(ctx context.Context, cluster *clusterv1.Cluster) ([]string, error) {
-	if r.NetworkProvider.SupportsIPv6DualStack() {
+func (r *serviceDiscoveryReconciler) getSupervisorAPIServerAddresses(ctx context.Context, cluster *clusterv1.Cluster, np services.NetworkProvider) ([]string, error) {
+	if np.SupportsIPv6DualStack() {
 		// 1. If dual stack IS supported, we determine the intended IP family from the cluster configuration.
 		ipFamily, err := util.DetermineClusterIPFamily(cluster)
 		if err != nil {

--- a/controllers/vmware/servicediscovery_controller_unit_test.go
+++ b/controllers/vmware/servicediscovery_controller_unit_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vmware
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +31,7 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	vmwarehelpers "sigs.k8s.io/cluster-api-provider-vsphere/internal/test/helpers/vmware"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
+	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/network"
 )
@@ -43,6 +46,22 @@ func (d *dummyDualStackNetworkProvider) SupportsIPv6DualStack() bool {
 
 func (d *dummyDualStackNetworkProvider) HasLoadBalancer() bool {
 	return true
+}
+
+type testNetworkProviderFactory struct {
+	np services.NetworkProvider
+}
+
+func (f *testNetworkProviderFactory) ForCluster(_ context.Context, _ *vmwarev1.VSphereCluster) (services.NetworkProvider, error) {
+	return f.np, nil
+}
+
+func (f *testNetworkProviderFactory) ForObject(_ context.Context, _ client.Client, _ metav1.Object) (services.NetworkProvider, error) {
+	return f.np, nil
+}
+
+func newTestNetworkProviderFactory(np services.NetworkProvider) inframanager.NetworkProviderFactory {
+	return &testNetworkProviderFactory{np: np}
 }
 
 var _ = Describe("ServiceDiscoveryReconciler reconcileNormal", serviceDiscoveryUnitTestsReconcileNormal)
@@ -63,10 +82,10 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		vsphereCluster = fake.NewVSphereCluster(namespace)
 		controllerCtx = vmwarehelpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
 		reconciler = serviceDiscoveryReconciler{
-			Client:          controllerCtx.ControllerManagerContext.Client,
-			NetworkProvider: netProvider,
+			Client:                 controllerCtx.ControllerManagerContext.Client,
+			NetworkProviderFactory: newTestNetworkProviderFactory(netProvider),
 		}
-		err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext)
+		err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext, netProvider)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	JustAfterEach(func() {
@@ -94,10 +113,9 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 		})
 		It("Should get supervisor master endpoint IP", func() {
 			r := &serviceDiscoveryReconciler{
-				Client:          controllerCtx.ControllerManagerContext.Client,
-				NetworkProvider: network.DummyNetworkProvider(),
+				Client: controllerCtx.ControllerManagerContext.Client,
 			}
-			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, network.DummyNetworkProvider())
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(supervisorEndpointIPs).To(Equal([]string{testSupervisorAPIServerVIP}))
 		})
@@ -192,10 +210,9 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			}
 
 			r := &serviceDiscoveryReconciler{
-				Client:          controllerCtx.ControllerManagerContext.Client,
-				NetworkProvider: &dummyDualStackNetworkProvider{},
+				Client: controllerCtx.ControllerManagerContext.Client,
 			}
-			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, &dummyDualStackNetworkProvider{})
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(supervisorEndpointIPs).To(Equal([]string{testSupervisorAPIServerVIP, testSupervisorAPIServerIPv6VIP}))
 		})
@@ -214,10 +231,9 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			}
 
 			r := &serviceDiscoveryReconciler{
-				Client:          controllerCtx.ControllerManagerContext.Client,
-				NetworkProvider: &dummyDualStackNetworkProvider{},
+				Client: controllerCtx.ControllerManagerContext.Client,
 			}
-			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			supervisorEndpointIPs, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, &dummyDualStackNetworkProvider{})
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(supervisorEndpointIPs).To(Equal([]string{testSupervisorAPIServerIPv6VIP}))
 		})
@@ -236,22 +252,24 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			}
 
 			r := &serviceDiscoveryReconciler{
-				Client:          controllerCtx.ControllerManagerContext.Client,
-				NetworkProvider: &dummyDualStackNetworkProvider{},
+				Client: controllerCtx.ControllerManagerContext.Client,
 			}
-			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, &dummyDualStackNetworkProvider{})
 			Expect(err).To(HaveOccurred())
 			// Updated assertion: Verifies that failing to parse an IP correctly returns a distinct API server VIP error.
 			Expect(err.Error()).To(ContainSubstring("failed to discover supervisor API server VIPs"))
 		})
 	})
 	Context("getSupervisorAPIServerAddresses permutations", func() {
-		var r serviceDiscoveryReconciler
+		var (
+			r  serviceDiscoveryReconciler
+			np services.NetworkProvider
+		)
 
 		JustBeforeEach(func() {
+			np = &dummyDualStackNetworkProvider{}
 			r = serviceDiscoveryReconciler{
-				Client:          controllerCtx.ControllerManagerContext.Client,
-				NetworkProvider: &dummyDualStackNetworkProvider{},
+				Client: controllerCtx.ControllerManagerContext.Client,
 			}
 		})
 
@@ -265,7 +283,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"fd00:1::/64"}},
 			}
 
-			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no supervisor apiserver IPv6 VIP found for IPv6 single stack cluster"))
 		})
@@ -286,7 +304,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:1::/64"}},
 			}
 
-			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("found too many VIPs"))
 		})
@@ -305,7 +323,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:1::/64"}},
 			}
 
-			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			_, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must be an IP address"))
 		})
@@ -320,7 +338,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:1::/64"}},
 			}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerVIP}))
 		})
@@ -335,14 +353,14 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:1::/64"}},
 			}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerIPv6VIP}))
 		})
 
 		It("should succeed via FIP/VIP fallback when dual stack is NOT supported and cluster has NO CIDR blocks", func() {
 			// Setup: NetworkProvider does not support dual stack
-			r.NetworkProvider = network.DummyNetworkProvider()
+			np = network.DummyNetworkProvider()
 
 			// Setup: VIP and FIP are available
 			initObjects = []client.Object{
@@ -356,14 +374,14 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			// Setup: Cluster has NO CIDR blocks
 			controllerCtx.Cluster.Spec.ClusterNetwork = clusterv1.ClusterNetwork{}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerVIP}))
 		})
 
 		It("should return IPv4 only for IPv4SingleStack cluster in a dual-stack enabled environment", func() {
 			// Setup: NetworkProvider supports dual stack
-			r.NetworkProvider = &dummyDualStackNetworkProvider{}
+			np = &dummyDualStackNetworkProvider{}
 
 			// Setup: VIP and FIP are available
 			initObjects = []client.Object{
@@ -379,13 +397,13 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16"}},
 			}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerVIP}))
 		})
 
 		It("should return addresses in correct order for DualStackIPv4Primary", func() {
-			r.NetworkProvider = &dummyDualStackNetworkProvider{}
+			np = &dummyDualStackNetworkProvider{}
 			initObjects = []client.Object{newTestSupervisorLBServiceWithDualStackStatus()}
 			vsphereCluster = fake.NewVSphereCluster(namespace)
 			controllerCtx = vmwarehelpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
@@ -396,13 +414,13 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:1::/64"}},
 			}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerVIP, testSupervisorAPIServerIPv6VIP}))
 		})
 
 		It("should return addresses in correct order for DualStackIPv6Primary", func() {
-			r.NetworkProvider = &dummyDualStackNetworkProvider{}
+			np = &dummyDualStackNetworkProvider{}
 			initObjects = []client.Object{newTestSupervisorLBServiceWithDualStackStatus()}
 			vsphereCluster = fake.NewVSphereCluster(namespace)
 			controllerCtx = vmwarehelpers.NewUnitTestContextForController(ctx, namespace, &vsphereCluster, false, initObjects, nil)
@@ -413,7 +431,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 				Pods: clusterv1.NetworkRanges{CIDRBlocks: []string{"fd00:1::/64", "192.168.0.0/16"}},
 			}
 
-			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster)
+			vips, err := r.getSupervisorAPIServerAddresses(ctx, controllerCtx.Cluster, np)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vips).To(Equal([]string{testSupervisorAPIServerIPv6VIP, testSupervisorAPIServerVIP}))
 		})
@@ -433,7 +451,7 @@ func serviceDiscoveryUnitTestsReconcileNormal() {
 			}
 
 			// We need to re-run reconcileNormal because JustBeforeEach already ran with the default cluster network
-			err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext)
+			err := reconciler.reconcileNormal(ctx, controllerCtx.GuestClusterContext, netProvider)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a service and endpoints using both VIPs in the guest cluster")

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -264,21 +264,26 @@ func getManager(cfg *rest.Config, networkProvider string, withWebhooks bool) man
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10, SkipNameValidation: ptr.To(true)}
 
 	opts.AddToManager = func(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
-		if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, controllerOpts); err != nil {
+		networkProviderFactory, err := manager.NewStaticNetworkProviderFactory(ctx, controllerCtx.Client, controllerCtx.NetworkProvider)
+		if err != nil {
+			return err
+		}
+
+		if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, controllerOpts, networkProviderFactory); err != nil {
 			return err
 		}
 
 		if withWebhooks {
-			if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereMachineTemplate{Client: mgr.GetClient(), NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
-			if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereMachine{Client: mgr.GetClient(), NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
-			if err := (&vmwarewebhooks.VSphereCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereCluster{NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
-			if err := (&vmwarewebhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+			if err := (&vmwarewebhooks.VSphereClusterTemplate{NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr); err != nil {
 				return err
 			}
 			if err := (&vmwarewebhooks.ProviderServiceAccount{}).SetupWebhookWithManager(mgr); err != nil {
@@ -289,7 +294,7 @@ func getManager(cfg *rest.Config, networkProvider string, withWebhooks bool) man
 			return err
 		}
 
-		return controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, true, controllerOpts)
+		return controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, true, controllerOpts, networkProviderFactory)
 	}
 
 	mgr, err := manager.New(ctx, opts)

--- a/controllers/vmware/vspherecluster_reconciler.go
+++ b/controllers/vmware/vspherecluster_reconciler.go
@@ -20,6 +20,7 @@ package vmware
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -50,6 +51,7 @@ import (
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
+	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
@@ -60,11 +62,11 @@ const (
 
 // ClusterReconciler reconciles VSphereClusters.
 type ClusterReconciler struct {
-	Client                client.Client
-	Recorder              record.EventRecorder
-	NetworkProvider       services.NetworkProvider
-	ControlPlaneService   services.ControlPlaneEndpointService
-	ResourcePolicyService services.ResourcePolicyService
+	Client                 client.Client
+	Recorder               record.EventRecorder
+	NetworkProviderFactory inframanager.NetworkProviderFactory
+	ControlPlaneService    services.ControlPlaneEndpointService
+	ResourcePolicyService  services.ResourcePolicyService
 }
 
 // +kubebuilder:rbac:groups=vmware.infrastructure.cluster.x-k8s.io,resources=vsphereclusters,verbs=get;list;watch;create;update;patch;delete
@@ -141,8 +143,20 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		return reconcile.Result{}, nil
 	}
 
+	// Resolve the network provider for the VSphereCluster.
+	np, err := r.NetworkProviderFactory.ForCluster(ctx, clusterContext.VSphereCluster)
+	if err != nil {
+		if errors.Is(err, inframanager.ErrNetworkProviderEmpty) {
+			log.Info("Network Provider is empty, wait for a valid value")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, pkgerrors.Wrapf(err,
+			"failed to resolve network provider for VSphereCluster %s",
+			klog.KObj(clusterContext.VSphereCluster))
+	}
+
 	// Handle non-deleted clusters
-	return ctrl.Result{}, r.reconcileNormal(ctx, clusterContext)
+	return ctrl.Result{}, r.reconcileNormal(ctx, clusterContext, np)
 }
 
 func (r *ClusterReconciler) patch(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
@@ -244,7 +258,7 @@ func (r *ClusterReconciler) reconcileDelete(clusterCtx *vmware.ClusterContext) {
 	controllerutil.RemoveFinalizer(clusterCtx.VSphereCluster, vmwarev1.ClusterFinalizer)
 }
 
-func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmware.ClusterContext, np services.NetworkProvider) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Discover and reconcile failure domains to report back to the CAPI core controller.
@@ -278,14 +292,14 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmw
 	})
 
 	// Configure the cluster for the cluster network
-	err = r.NetworkProvider.ProvisionClusterNetwork(ctx, clusterCtx)
+	err = np.ProvisionClusterNetwork(ctx, clusterCtx)
 	if err != nil {
 		return pkgerrors.Wrapf(err,
 			"failed to configure cluster network for VSphereCluster %s/%s",
 			clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
 	}
 
-	if err := r.reconcileControlPlaneEndpoint(ctx, clusterCtx); err != nil {
+	if err := r.reconcileControlPlaneEndpoint(ctx, clusterCtx, np); err != nil {
 		return pkgerrors.Wrapf(err, "unexpected error while reconciling control plane endpoint for %s", clusterCtx.VSphereCluster.Name)
 	}
 
@@ -300,7 +314,7 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterCtx *vmw
 	return nil
 }
 
-func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, clusterCtx *vmware.ClusterContext, np services.NetworkProvider) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if !clusterCtx.Cluster.Spec.ControlPlaneEndpoint.IsZero() {
@@ -317,7 +331,7 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 			Status: metav1.ConditionTrue,
 			Reason: vmwarev1.VSphereClusterLoadBalancerReadyReason,
 		})
-		if r.NetworkProvider.HasLoadBalancer() {
+		if np.HasLoadBalancer() {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.LoadBalancerReadyV1Beta1Condition)
 		}
 		return nil
@@ -335,14 +349,14 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 			Status: metav1.ConditionTrue,
 			Reason: vmwarev1.VSphereClusterLoadBalancerReadyReason,
 		})
-		if r.NetworkProvider.HasLoadBalancer() {
+		if np.HasLoadBalancer() {
 			deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.LoadBalancerReadyV1Beta1Condition)
 		}
 		return nil
 	}
 
-	if r.NetworkProvider.HasLoadBalancer() {
-		if err := r.reconcileLoadBalancedEndpoint(ctx, clusterCtx); err != nil {
+	if np.HasLoadBalancer() {
+		if err := r.reconcileLoadBalancedEndpoint(ctx, clusterCtx, np); err != nil {
 			return pkgerrors.Wrapf(err,
 				"failed to reconcile loadbalanced endpoint for VSphereCluster %s/%s",
 				clusterCtx.VSphereCluster.Namespace, clusterCtx.VSphereCluster.Name)
@@ -360,11 +374,11 @@ func (r *ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, c
 	return nil
 }
 
-func (r *ClusterReconciler) reconcileLoadBalancedEndpoint(ctx context.Context, clusterCtx *vmware.ClusterContext) error {
+func (r *ClusterReconciler) reconcileLoadBalancedEndpoint(ctx context.Context, clusterCtx *vmware.ClusterContext, np services.NetworkProvider) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Will create a VirtualMachineService for a NetworkProvider that supports load balancing
-	cpEndpoint, err := r.ControlPlaneService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, r.NetworkProvider)
+	cpEndpoint, err := r.ControlPlaneService.ReconcileControlPlaneEndpointService(ctx, clusterCtx, np)
 	if err != nil {
 		return err
 	}

--- a/controllers/vmware/vspherecluster_reconciler_test.go
+++ b/controllers/vmware/vspherecluster_reconciler_test.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
-	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/network"
+	inframanager "sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
@@ -70,10 +70,12 @@ var _ = Describe("Cluster Controller Tests", func() {
 		clusterCtx, controllerManagerContext = util.CreateClusterContext(cluster, vsphereCluster)
 		vsphereMachine = util.CreateVSphereMachine(machineName, clusterName, className, imageName, storageClass, controlPlaneLabelTrue)
 
+		networkProviderFactory, err := inframanager.NewStaticNetworkProviderFactory(ctx, controllerManagerContext.Client, "")
+		Expect(err).ToNot(HaveOccurred())
 		reconciler = &ClusterReconciler{
-			Client:          controllerManagerContext.Client,
-			Recorder:        apirecord.NewFakeRecorder(100),
-			NetworkProvider: network.DummyNetworkProvider(),
+			Client:                 controllerManagerContext.Client,
+			Recorder:               apirecord.NewFakeRecorder(100),
+			NetworkProviderFactory: networkProviderFactory,
 			ControlPlaneService: &vmoperator.CPService{
 				Client: controllerManagerContext.Client,
 			},

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"slices"
 
-	pkgerrors "github.com/pkg/errors"
 	topologyv1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 	"k8s.io/klog/v2"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
@@ -62,14 +61,10 @@ import (
 
 // AddClusterControllerToManager adds the cluster controller to the provided
 // manager.
-func AddClusterControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, supervisorBased bool, options controller.Options) error {
+func AddClusterControllerToManager(ctx context.Context, controllerManagerCtx *capvcontext.ControllerManagerContext, mgr manager.Manager, supervisorBased bool, options controller.Options, networkProviderFactory inframanager.NetworkProviderFactory) error {
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "vspherecluster")
 
 	if supervisorBased {
-		networkProvider, err := inframanager.GetNetworkProvider(ctx, controllerManagerCtx.Client, controllerManagerCtx.NetworkProvider)
-		if err != nil {
-			return pkgerrors.Wrap(err, "failed to create a network provider")
-		}
 		reconciler := &vmware.ClusterReconciler{
 			Client:   controllerManagerCtx.Client,
 			Recorder: mgr.GetEventRecorderFor("vspherecluster-controller"),
@@ -79,7 +74,7 @@ func AddClusterControllerToManager(ctx context.Context, controllerManagerCtx *ca
 			ControlPlaneService: &vmoperator.CPService{
 				Client: controllerManagerCtx.Client,
 			},
-			NetworkProvider: networkProvider,
+			NetworkProviderFactory: networkProviderFactory,
 		}
 		builder := capicontrollerutil.NewControllerManagedBy(mgr, predicateLog).
 			For(&vmwarev1.VSphereCluster{}).
@@ -98,8 +93,10 @@ func AddClusterControllerToManager(ctx context.Context, controllerManagerCtx *ca
 			)
 		}
 
-		// Conditionally add a Watch for KCP when the network provider supports IPv6 and dual-stack
-		if networkProvider.SupportsIPv6DualStack() {
+		// Conditionally add a Watch for KCP when IPv6/dual-stack support is enabled.
+		// Per-cluster provider capability is evaluated at reconcile time; the watch must be
+		// registered whenever the IPv6DualStack gate is on so VPC clusters are requeued.
+		if feature.Gates.Enabled(feature.IPv6DualStack) {
 			builder = builder.Watches(
 				&controlplanev1.KubeadmControlPlane{},
 				handler.EnqueueRequestsFromMapFunc(reconciler.KubeadmControlPlaneToCluster),

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -86,7 +87,7 @@ const (
 
 // AddMachineControllerToManager adds the machine controller to the provided
 // manager.
-func AddMachineControllerToManager(ctx context.Context, controllerManagerContext *capvcontext.ControllerManagerContext, mgr manager.Manager, supervisorBased bool, options controller.Options) error {
+func AddMachineControllerToManager(ctx context.Context, controllerManagerContext *capvcontext.ControllerManagerContext, mgr manager.Manager, supervisorBased bool, options controller.Options, networkProviderFactory inframanager.NetworkProviderFactory) error {
 	r := &machineReconciler{
 		Client:          controllerManagerContext.Client,
 		Recorder:        mgr.GetEventRecorderFor("vspheremachine-controller"),
@@ -96,12 +97,8 @@ func AddMachineControllerToManager(ctx context.Context, controllerManagerContext
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "vspheremachine")
 
 	if supervisorBased {
-		networkProvider, err := inframanager.GetNetworkProvider(ctx, controllerManagerContext.Client, controllerManagerContext.NetworkProvider)
-		if err != nil {
-			return pkgerrors.Wrap(err, "failed to create a network provider")
-		}
-		r.networkProvider = networkProvider
-		r.VMService = &vmoperator.VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: r.networkProvider.SupportsVMReadinessProbe()}
+		r.networkProviderFactory = networkProviderFactory
+		r.VMService = &vmoperator.VmopMachineService{Client: controllerManagerContext.Client}
 
 		// NOTE: use vm-operator native types for watches (the reconciler uses the internal hub version).
 		vm, err := conversionclient.WatchObject(r.Client, &vmoprvhub.VirtualMachine{})
@@ -181,11 +178,11 @@ func AddMachineControllerToManager(ctx context.Context, controllerManagerContext
 }
 
 type machineReconciler struct {
-	Client          client.Client
-	Recorder        record.EventRecorder
-	VMService       services.VSphereMachineService
-	networkProvider services.NetworkProvider
-	supervisorBased bool
+	Client                 client.Client
+	Recorder               record.EventRecorder
+	VMService              services.VSphereMachineService
+	networkProviderFactory inframanager.NetworkProviderFactory
+	supervisorBased        bool
 }
 
 // Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
@@ -366,8 +363,29 @@ func (r *machineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		return reconcile.Result{}, pkgerrors.Wrapf(err, "failed to get VSphereCluster")
 	}
 
+	// For supervisor based clusters, resolve the network provider for this cluster and seed the
+	// machine context with provider-specific configuration.
+	var np services.NetworkProvider
+	if r.supervisorBased {
+		supervisorMachineCtx, ok := machineContext.(*vmware.SupervisorMachineContext)
+		if !ok {
+			return reconcile.Result{}, pkgerrors.New("received unexpected SupervisorMachineContext type")
+		}
+		np, err = r.networkProviderFactory.ForCluster(ctx, supervisorMachineCtx.VSphereCluster)
+		if err != nil {
+			if errors.Is(err, inframanager.ErrNetworkProviderEmpty) {
+				log.Info("Network Provider is empty, wait for a valid value")
+				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+			return reconcile.Result{}, pkgerrors.Wrapf(err,
+				"failed to resolve network provider for VSphereCluster %s",
+				klog.KObj(supervisorMachineCtx.VSphereCluster))
+		}
+		supervisorMachineCtx.ConfigureControlPlaneVMReadinessProbe = np.SupportsVMReadinessProbe()
+	}
+
 	// Handle non-deleted machines
-	return r.reconcileNormal(ctx, machineContext)
+	return r.reconcileNormal(ctx, machineContext, np)
 }
 
 func (r *machineReconciler) reconcileDelete(ctx context.Context, machineCtx capvcontext.MachineContext) (reconcile.Result, error) {
@@ -403,7 +421,7 @@ func (r *machineReconciler) reconcileDelete(ctx context.Context, machineCtx capv
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (r *machineReconciler) reconcileNormal(ctx context.Context, machineCtx capvcontext.MachineContext) (reconcile.Result, error) {
+func (r *machineReconciler) reconcileNormal(ctx context.Context, machineCtx capvcontext.MachineContext, np services.NetworkProvider) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	err := r.VMService.SyncFailureReason(ctx, machineCtx)
@@ -427,7 +445,7 @@ func (r *machineReconciler) reconcileNormal(ctx context.Context, machineCtx capv
 			return reconcile.Result{}, nil
 		}
 	} else {
-		if err := r.setVMModifiers(ctx, machineCtx); err != nil {
+		if err := r.setVMModifiers(ctx, machineCtx, np); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -507,7 +525,7 @@ func (r *machineReconciler) patchMachineLabelsWithHostInfo(ctx context.Context, 
 }
 
 // Return hooks that will be invoked when a VirtualMachine is created.
-func (r *machineReconciler) setVMModifiers(ctx context.Context, machineCtx capvcontext.MachineContext) error {
+func (r *machineReconciler) setVMModifiers(ctx context.Context, machineCtx capvcontext.MachineContext, np services.NetworkProvider) error {
 	log := ctrl.LoggerFrom(ctx)
 	supervisorMachineCtx, ok := machineCtx.(*vmware.SupervisorMachineContext)
 	if !ok {
@@ -518,7 +536,7 @@ func (r *machineReconciler) setVMModifiers(ctx context.Context, machineCtx capvc
 		// No need to check the type. We know this will be a VirtualMachine
 		vm, _ := obj.(*vmoprvhub.VirtualMachine)
 		log.V(3).Info("Applying network config to VM")
-		err := r.networkProvider.ConfigureVirtualMachine(ctx, supervisorMachineCtx.GetClusterContext(), supervisorMachineCtx.VSphereMachine, vm)
+		err := np.ConfigureVirtualMachine(ctx, supervisorMachineCtx.GetClusterContext(), supervisorMachineCtx.VSphereMachine, vm)
 		if err != nil {
 			return nil, pkgerrors.Errorf("failed to configure machine network: %+v", err)
 		}

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -50,6 +50,13 @@ const (
 	// alpha: v1.15
 	NodeAutoPlacement featuregate.Feature = "NodeAutoPlacement"
 
+	// ClusterNetworkProvider is a feature gate for the per-cluster network provider functionality
+	// for supervisor. When enabled, the network provider is resolved per-cluster from
+	// VSphereCluster.spec.network.provider instead of the static --network-provider flag.
+	//
+	// alpha: v1.17
+	ClusterNetworkProvider featuregate.Feature = "ClusterNetworkProvider"
+
 	// InfrastructurePolicies is a feature gate for the Support for Supervisor infrastructure policies.
 	// When enabled, VSphereMachine.spec.policies are validated on admission and
 	// mapped to the underlying VirtualMachine spec.
@@ -93,9 +100,10 @@ var (
 	}
 
 	supervisorGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		NamespaceScopedZones: {Default: false, PreRelease: featuregate.Alpha},
-		NodeAutoPlacement:    {Default: false, PreRelease: featuregate.Alpha},
-		MultiNetworks:        {Default: false, PreRelease: featuregate.Alpha},
+		NamespaceScopedZones:   {Default: false, PreRelease: featuregate.Alpha},
+		NodeAutoPlacement:      {Default: false, PreRelease: featuregate.Alpha},
+		ClusterNetworkProvider: {Default: false, PreRelease: featuregate.Alpha},
+		MultiNetworks:          {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	supervisorVersionedGates = map[featuregate.Feature]featuregate.VersionedSpecs{

--- a/internal/webhooks/vmware/helpers_test.go
+++ b/internal/webhooks/vmware/helpers_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmware
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
+)
+
+// newTestNetworkProviderFactory returns a NetworkProviderFactory for webhook unit tests.
+// When the ClusterNetworkProvider gate is enabled it returns a per-cluster factory;
+// otherwise it returns a static factory for the given provider name.
+func newTestNetworkProviderFactory(t *testing.T, networkProvider string) manager.NetworkProviderFactory {
+	t.Helper()
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+
+	var (
+		factory manager.NetworkProviderFactory
+		err     error
+	)
+	if feature.Gates.Enabled(feature.ClusterNetworkProvider) {
+		factory, err = manager.NewPerClusterNetworkProviderFactory(ctx, c)
+	} else {
+		factory, err = manager.NewStaticNetworkProviderFactory(ctx, c, networkProvider)
+	}
+	if err != nil {
+		t.Fatalf("failed to create network provider factory: %v", err)
+	}
+	return factory
+}
+
+// newTestStaticNetworkProviderFactory returns a static NetworkProviderFactory for webhook unit tests.
+func newTestStaticNetworkProviderFactory(t *testing.T, networkProvider string) manager.NetworkProviderFactory {
+	t.Helper()
+	factory, err := manager.NewStaticNetworkProviderFactory(context.Background(), fake.NewClientBuilder().Build(), networkProvider)
+	if err != nil {
+		t.Fatalf("failed to create static network provider factory: %v", err)
+	}
+	return factory
+}

--- a/internal/webhooks/vmware/vspherecluster.go
+++ b/internal/webhooks/vmware/vspherecluster.go
@@ -19,10 +19,12 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -36,8 +38,8 @@ import (
 
 // VSphereCluster implements a validation and defaulting webhook for VSphereCluster.
 type VSphereCluster struct {
-	// NetworkProvider is the network provider used by Supervisor based clusters
-	NetworkProvider string
+	// NetworkProviderFactory resolves the network provider for the cluster.
+	NetworkProviderFactory manager.NetworkProviderFactory
 }
 
 var _ admission.Validator[*vmwarev1.VSphereCluster] = &VSphereCluster{}
@@ -50,13 +52,13 @@ func (webhook *VSphereCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereCluster) ValidateCreate(_ context.Context, obj *vmwarev1.VSphereCluster) (admission.Warnings, error) {
-	return webhook.validate(obj)
+func (webhook *VSphereCluster) ValidateCreate(ctx context.Context, obj *vmwarev1.VSphereCluster) (admission.Warnings, error) {
+	return webhook.validate(ctx, obj)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereCluster) ValidateUpdate(_ context.Context, _, newTyped *vmwarev1.VSphereCluster) (admission.Warnings, error) {
-	return webhook.validate(newTyped)
+func (webhook *VSphereCluster) ValidateUpdate(ctx context.Context, _, newTyped *vmwarev1.VSphereCluster) (admission.Warnings, error) {
+	return webhook.validate(ctx, newTyped)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -65,7 +67,7 @@ func (webhook *VSphereCluster) ValidateDelete(_ context.Context, _ *vmwarev1.VSp
 }
 
 // validateClusterNetwork validates the network configuration of the VSphereCluster.
-func (webhook *VSphereCluster) validateClusterNetwork(cluster *vmwarev1.VSphereCluster) field.ErrorList {
+func (webhook *VSphereCluster) validateClusterNetwork(ctx context.Context, cluster *vmwarev1.VSphereCluster, skipEmptyProvider bool) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if !feature.Gates.Enabled(feature.MultiNetworks) && cluster.Spec.Network.NSXVPC.CreateSubnetSet != nil {
@@ -74,10 +76,44 @@ func (webhook *VSphereCluster) validateClusterNetwork(cluster *vmwarev1.VSphereC
 			"createSubnetSet can only be set when MultiNetworks feature gate is enabled",
 		))
 	}
-	if cluster.Spec.Network.NSXVPC.IsDefined() && webhook.NetworkProvider != manager.NSXVPCNetworkProvider {
+
+	// When the ClusterNetworkProvider gate is enabled, the provider to validate against is
+	// resolved from the cluster itself; otherwise it is the static flag-based provider.
+	if feature.Gates.Enabled(feature.ClusterNetworkProvider) {
+		if cluster.Spec.Network.Provider == "" {
+			// Topology SSA dry-runs the original object (still without provider) before the
+			// Runtime Extension's write is applied. Allow empty only for those dry-run requests.
+			if skipEmptyProvider {
+				return allErrs
+			}
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "network", "provider"),
+				"spec.network.provider must be set",
+			))
+			return allErrs
+		}
+	} else if cluster.Spec.Network.Provider != "" {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "network", "provider"),
+			"provider can only be set when ClusterNetworkProvider feature gate is enabled",
+		))
+		return allErrs
+	}
+
+	np, err := webhook.NetworkProviderFactory.ForCluster(ctx, cluster)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "network", "provider"),
+			cluster.Spec.Network.Provider,
+			err.Error(),
+		))
+		return allErrs
+	}
+
+	if cluster.Spec.Network.NSXVPC.IsDefined() && np.Name() != manager.NSXVPCNetworkProvider {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("spec", "network", "nsxVPC"),
-			"nsxVPC can only be set when network provider is NSX-VPC",
+			fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
 		))
 	}
 
@@ -85,8 +121,13 @@ func (webhook *VSphereCluster) validateClusterNetwork(cluster *vmwarev1.VSphereC
 }
 
 // validate aggregates all shared validations for the VSphereCluster.
-func (webhook *VSphereCluster) validate(cluster *vmwarev1.VSphereCluster) (admission.Warnings, error) {
-	allErrs := webhook.validateClusterNetwork(cluster)
+func (webhook *VSphereCluster) validate(ctx context.Context, cluster *vmwarev1.VSphereCluster) (admission.Warnings, error) {
+	skipEmptyProvider := false
+	if req, err := admission.RequestFromContext(ctx); err == nil {
+		skipEmptyProvider = topology.IsDryRunRequest(req, cluster)
+	}
+
+	allErrs := webhook.validateClusterNetwork(ctx, cluster, skipEmptyProvider)
 	allErrs = append(allErrs, validateFailureDomainsControlPlaneSelector(
 		cluster.Spec.FailureDomains.ControlPlane.Selector,
 		field.NewPath("spec", "failureDomains", "controlPlane", "selector"),

--- a/internal/webhooks/vmware/vspherecluster_test.go
+++ b/internal/webhooks/vmware/vspherecluster_test.go
@@ -18,13 +18,17 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
@@ -105,7 +109,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
-			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+			errMsg:          fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
 		},
 		{
 			name: "failed VSphereCluster creation with nsxVPC when network provider is NSX",
@@ -118,7 +122,49 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
-			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+			errMsg:          fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+		},
+		{
+			name: "gate on: successful creation with nsxVPC when spec.network.provider is VPC",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+				Provider: manager.NSXVPCNetworkProvider,
+			}, vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"MultiNetworks": true, "ClusterNetworkProvider": true},
+			wantErr:      false,
+		},
+		{
+			name: "gate on: failed creation with nsxVPC when spec.network.provider is VSphereDistributed",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+				Provider: manager.VDSNetworkProvider,
+			}, vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"MultiNetworks": true, "ClusterNetworkProvider": true},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+		},
+		{
+			name: "gate off: failed creation with spec.network.provider set",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
+				Provider: manager.NSXVPCNetworkProvider,
+			}, vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"ClusterNetworkProvider": false},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "provider can only be set when ClusterNetworkProvider feature gate is enabled",
+		},
+		{
+			name:           "gate on: failed creation with empty spec.network.provider",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			featureGates:   map[string]bool{"ClusterNetworkProvider": true},
+			wantErr:        true,
+			errType:        &apierrors.StatusError{},
+			errMsg:         "spec.network.provider must be set",
 		},
 		{
 			name: "successful VSphereCluster creation with valid control plane selector and feature gate enabled",
@@ -183,7 +229,7 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			setupFeatureGates(t, tc.featureGates)
 
 			webhook := &VSphereCluster{
-				NetworkProvider: tc.networkProvider,
+				NetworkProviderFactory: newTestNetworkProviderFactory(t, tc.networkProvider),
 			}
 
 			_, err := webhook.ValidateCreate(context.Background(), tc.vsphereCluster)
@@ -203,12 +249,17 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 }
 
 func TestVSphereCluster_ValidateUpdate(t *testing.T) {
+	emptyProviderCluster := createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{})
+	emptyProviderClusterDryRun := emptyProviderCluster.DeepCopy()
+	emptyProviderClusterDryRun.SetAnnotations(map[string]string{clusterv1.TopologyDryRunAnnotation: ""})
+
 	tests := []struct {
 		name              string
 		oldVSphereCluster *vmwarev1.VSphereCluster
 		newVSphereCluster *vmwarev1.VSphereCluster
 		networkProvider   string
 		featureGates      map[string]bool
+		req               *admission.Request
 		wantErr           bool
 		errType           *apierrors.StatusError
 		errMsg            string // expected error message or substring
@@ -237,6 +288,40 @@ func TestVSphereCluster_ValidateUpdate(t *testing.T) {
 			errType:         &apierrors.StatusError{},
 			errMsg:          "control plane zone selector can only be set when feature gate NamespaceScopedZones is enabled",
 		},
+		{
+			name:              "gate off: failed update with spec.network.provider set",
+			oldVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{Provider: manager.NSXVPCNetworkProvider}, vmwarev1.FailureDomainsSpec{}),
+			featureGates:      map[string]bool{"ClusterNetworkProvider": false},
+			wantErr:           true,
+			errType:           &apierrors.StatusError{},
+			errMsg:            "provider can only be set when ClusterNetworkProvider feature gate is enabled",
+		},
+		{
+			name:              "gate on: failed update with empty spec.network.provider",
+			oldVSphereCluster: emptyProviderCluster,
+			newVSphereCluster: emptyProviderCluster,
+			featureGates:      map[string]bool{"ClusterNetworkProvider": true},
+			req:               &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}},
+			wantErr:           true,
+			errType:           &apierrors.StatusError{},
+			errMsg:            "spec.network.provider must be set",
+		},
+		{
+			name:              "gate on: allow empty provider on topology SSA dry-run",
+			oldVSphereCluster: emptyProviderCluster,
+			newVSphereCluster: emptyProviderClusterDryRun,
+			featureGates:      map[string]bool{"ClusterNetworkProvider": true},
+			req:               &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}},
+			wantErr:           false,
+		},
+		{
+			name:              "gate on: successful update setting spec.network.provider",
+			oldVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{}),
+			newVSphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{Provider: manager.NSXVPCNetworkProvider}, vmwarev1.FailureDomainsSpec{}),
+			featureGates:      map[string]bool{"ClusterNetworkProvider": true},
+			wantErr:           false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -247,10 +332,15 @@ func TestVSphereCluster_ValidateUpdate(t *testing.T) {
 			setupFeatureGates(t, tc.featureGates)
 
 			webhook := &VSphereCluster{
-				NetworkProvider: tc.networkProvider,
+				NetworkProviderFactory: newTestNetworkProviderFactory(t, tc.networkProvider),
 			}
 
-			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereCluster, tc.newVSphereCluster)
+			ctx := context.Background()
+			if tc.req != nil {
+				ctx = admission.NewContextWithRequest(ctx, *tc.req)
+			}
+
+			_, err := webhook.ValidateUpdate(ctx, tc.oldVSphereCluster, tc.newVSphereCluster)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				if tc.errType != nil {
@@ -269,7 +359,7 @@ func TestVSphereCluster_ValidateUpdate(t *testing.T) {
 func TestVSphereCluster_ValidateDelete(t *testing.T) {
 	g := NewWithT(t)
 
-	webhook := &VSphereCluster{}
+	webhook := &VSphereCluster{NetworkProviderFactory: newTestNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 	cluster := createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{})
 
 	warnings, err := webhook.ValidateDelete(context.Background(), cluster)
@@ -299,6 +389,9 @@ func setupFeatureGates(t *testing.T, featureGates map[string]bool) {
 		}
 		if featureName == "NamespaceScopedZones" {
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.NamespaceScopedZones, enabled)
+		}
+		if featureName == "ClusterNetworkProvider" {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterNetworkProvider, enabled)
 		}
 	}
 }

--- a/internal/webhooks/vmware/vsphereclustertemplate.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate.go
@@ -19,6 +19,7 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,7 +36,9 @@ import (
 
 // VSphereClusterTemplate implements a validation webhook for VSphereClusterTemplate.
 type VSphereClusterTemplate struct {
-	NetworkProvider string
+	// NetworkProviderFactory resolves the static network provider when the
+	// ClusterNetworkProvider feature gate is disabled.
+	NetworkProviderFactory manager.NetworkProviderFactory
 }
 
 var _ admission.Validator[*vmwarev1.VSphereClusterTemplate] = &VSphereClusterTemplate{}
@@ -49,13 +52,13 @@ func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager)
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereClusterTemplate) ValidateCreate(_ context.Context, obj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
-	return webhook.validate(obj)
+func (webhook *VSphereClusterTemplate) ValidateCreate(ctx context.Context, obj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	return webhook.validate(ctx, obj)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereClusterTemplate) ValidateUpdate(_ context.Context, _, newObj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
-	return webhook.validate(newObj)
+func (webhook *VSphereClusterTemplate) ValidateUpdate(ctx context.Context, _, newObj *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	return webhook.validate(ctx, newObj)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -64,7 +67,7 @@ func (webhook *VSphereClusterTemplate) ValidateDelete(_ context.Context, _ *vmwa
 }
 
 // validateClusterTemplateNetwork validates the network configuration of the VSphereClusterTemplate.
-func (webhook *VSphereClusterTemplate) validateClusterTemplateNetwork(template *vmwarev1.VSphereClusterTemplate) field.ErrorList {
+func (webhook *VSphereClusterTemplate) validateClusterTemplateNetwork(ctx context.Context, template *vmwarev1.VSphereClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if !feature.Gates.Enabled(feature.MultiNetworks) && template.Spec.Template.Spec.Network.NSXVPC.CreateSubnetSet != nil {
@@ -73,19 +76,34 @@ func (webhook *VSphereClusterTemplate) validateClusterTemplateNetwork(template *
 			"createSubnetSet can only be set when MultiNetworks feature gate is enabled",
 		))
 	}
-	if template.Spec.Template.Spec.Network.NSXVPC.IsDefined() && webhook.NetworkProvider != manager.NSXVPCNetworkProvider {
-		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("spec", "template", "spec", "network", "nsxVPC"),
-			"nsxVPC can only be set when network provider is NSX-VPC",
-		))
+
+	// A VSphereClusterTemplate does not belong to any Cluster, so there is no spec.network.provider
+	// to resolve. When the ClusterNetworkProvider gate is enabled, skip the provider-based check and
+	// rely on per-cluster validation at VSphereCluster admission time instead.
+	if !feature.Gates.Enabled(feature.ClusterNetworkProvider) &&
+		template.Spec.Template.Spec.Network.NSXVPC.IsDefined() {
+		np, err := webhook.NetworkProviderFactory.ForCluster(ctx, &vmwarev1.VSphereCluster{})
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(
+				field.NewPath("spec", "template", "spec", "network", "nsxVPC"),
+				err,
+			))
+			return allErrs
+		}
+		if np.Name() != manager.NSXVPCNetworkProvider {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "template", "spec", "network", "nsxVPC"),
+				fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+			))
+		}
 	}
 
 	return allErrs
 }
 
 // validate aggregates all validations for the VSphereClusterTemplate.
-func (webhook *VSphereClusterTemplate) validate(template *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
-	allErrs := webhook.validateClusterTemplateNetwork(template)
+func (webhook *VSphereClusterTemplate) validate(ctx context.Context, template *vmwarev1.VSphereClusterTemplate) (admission.Warnings, error) {
+	allErrs := webhook.validateClusterTemplateNetwork(ctx, template)
 	allErrs = append(allErrs, validateFailureDomainsControlPlaneSelector(
 		template.Spec.Template.Spec.FailureDomains.ControlPlane.Selector,
 		field.NewPath("spec", "template", "spec", "failureDomains", "controlPlane", "selector"),

--- a/internal/webhooks/vmware/vsphereclustertemplate_test.go
+++ b/internal/webhooks/vmware/vsphereclustertemplate_test.go
@@ -18,6 +18,7 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -103,7 +104,18 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
-			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+			errMsg:          fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+		},
+		{
+			name: "gate on: nsxVPC check is skipped for cluster templates",
+			template: createVSphereClusterTemplate("test-template", vmwarev1.Network{
+				NSXVPC: vmwarev1.NSXVPC{
+					CreateSubnetSet: ptr.To(true),
+				},
+			}, vmwarev1.FailureDomainsSpec{}),
+			networkProvider: manager.VDSNetworkProvider,
+			featureGates:    map[string]bool{"MultiNetworks": true, "ClusterNetworkProvider": true},
+			wantErr:         false,
 		},
 		{
 			name: "failed creation with nsxVPC when network provider is NSX",
@@ -116,7 +128,7 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 			featureGates:    map[string]bool{"MultiNetworks": true},
 			wantErr:         true,
 			errType:         &apierrors.StatusError{},
-			errMsg:          "nsxVPC can only be set when network provider is NSX-VPC",
+			errMsg:          fmt.Sprintf("nsxVPC can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
 		},
 		{
 			name: "successful creation with valid control plane selector and feature gate enabled",
@@ -181,7 +193,7 @@ func TestVSphereClusterTemplate_ValidateCreate(t *testing.T) {
 			setupFeatureGates(t, tc.featureGates)
 
 			webhook := &VSphereClusterTemplate{
-				NetworkProvider: tc.networkProvider,
+				NetworkProviderFactory: newTestNetworkProviderFactory(t, tc.networkProvider),
 			}
 
 			_, err := webhook.ValidateCreate(context.Background(), tc.template)
@@ -245,7 +257,7 @@ func TestVSphereClusterTemplate_ValidateUpdate(t *testing.T) {
 			setupFeatureGates(t, tc.featureGates)
 
 			webhook := &VSphereClusterTemplate{
-				NetworkProvider: tc.networkProvider,
+				NetworkProviderFactory: newTestNetworkProviderFactory(t, tc.networkProvider),
 			}
 
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldTemplate, tc.newTemplate)
@@ -267,7 +279,7 @@ func TestVSphereClusterTemplate_ValidateUpdate(t *testing.T) {
 func TestVSphereClusterTemplate_ValidateDelete(t *testing.T) {
 	g := NewWithT(t)
 
-	webhook := &VSphereClusterTemplate{}
+	webhook := &VSphereClusterTemplate{NetworkProviderFactory: newTestNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 	template := createVSphereClusterTemplate("test-template", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{})
 
 	warnings, err := webhook.ValidateDelete(context.Background(), template)

--- a/internal/webhooks/vmware/vspheremachine.go
+++ b/internal/webhooks/vmware/vspheremachine.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
@@ -38,8 +39,10 @@ import (
 
 // VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
 type VSphereMachine struct {
-	// NetworkProvider is the network provider used by Supervisor based clusters
-	NetworkProvider string
+	// Client is used by NetworkProviderFactory.ForObject to resolve the owning Cluster / VSphereCluster.
+	Client client.Client
+	// NetworkProviderFactory resolves the network provider for the owning cluster.
+	NetworkProviderFactory manager.NetworkProviderFactory
 }
 
 var _ admission.Validator[*vmwarev1.VSphereMachine] = &VSphereMachine{}
@@ -52,15 +55,20 @@ func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachine) ValidateCreate(_ context.Context, objTyped *vmwarev1.VSphereMachine) (admission.Warnings, error) {
-	allErrs := validateNetwork(webhook.NetworkProvider, objTyped.Spec.Network, field.NewPath("spec", "network"))
+func (webhook *VSphereMachine) ValidateCreate(ctx context.Context, objTyped *vmwarev1.VSphereMachine) (admission.Warnings, error) {
+	np, err := webhook.NetworkProviderFactory.ForObject(ctx, webhook.Client, objTyped)
+	if err != nil {
+		return nil, err
+	}
+
+	allErrs := validateNetwork(np.Name(), objTyped.Spec.Network, field.NewPath("spec", "network"))
 	allErrs = append(allErrs, validatePolicies(objTyped.Spec.Policies, field.NewPath("spec", "policies"))...)
 
 	return nil, webhooks.AggregateObjErrors(objTyped.GroupVersionKind().GroupKind(), objTyped.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *VSphereMachine) ValidateUpdate(_ context.Context, oldTyped, newTyped *vmwarev1.VSphereMachine) (admission.Warnings, error) {
+func (webhook *VSphereMachine) ValidateUpdate(ctx context.Context, oldTyped, newTyped *vmwarev1.VSphereMachine) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
 	newSpec, oldSpec := newTyped.Spec, oldTyped.Spec
@@ -90,7 +98,12 @@ func (webhook *VSphereMachine) ValidateUpdate(_ context.Context, oldTyped, newTy
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "network", "interfaces"), "cannot be modified"))
 	}
 
-	allErrs = append(allErrs, validateNetwork(webhook.NetworkProvider, newSpec.Network, field.NewPath("spec", "network"))...)
+	np, err := webhook.NetworkProviderFactory.ForObject(ctx, webhook.Client, newTyped)
+	if err != nil {
+		return nil, err
+	}
+
+	allErrs = append(allErrs, validateNetwork(np.Name(), newSpec.Network, field.NewPath("spec", "network"))...)
 	allErrs = append(allErrs, validatePolicies(newSpec.Policies, field.NewPath("spec", "policies"))...)
 
 	return nil, webhooks.AggregateObjErrors(newTyped.GroupVersionKind().GroupKind(), newTyped.Name, allErrs)
@@ -136,7 +149,7 @@ func validateNetwork(networkProvider string, network vmwarev1.VSphereMachineNetw
 				if network.Interfaces.Primary.IsDefined() {
 					allErrs = append(allErrs, field.Forbidden(
 						fldPath.Child("interfaces", "primary"),
-						"primary interface can not be set when network provider is vsphere-network"))
+						fmt.Sprintf("primary interface can not be set when network provider is %s", manager.VDSNetworkProvider)))
 				}
 				for i, secondaryInterface := range network.Interfaces.Secondary {
 					secondaryNetGVK := secondaryInterface.NetworkRef.GroupVersionKind()

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -18,6 +18,7 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -73,7 +74,7 @@ func TestVSphereMachine_ValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			webhook := &VSphereMachine{}
+			webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 			_, err := webhook.ValidateUpdate(context.Background(), tc.oldVSphereMachine, tc.vsphereMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -180,7 +181,7 @@ func TestVSphereMachine_ValidateCreate_MultiNetwork(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "primary interface can not be set when network provider is vsphere-network",
+			wantErrMsg: fmt.Sprintf("primary interface can not be set when network provider is %s", manager.VDSNetworkProvider),
 		},
 		{
 			name:            "secondary interface with wrong type for VDS provider",
@@ -328,7 +329,7 @@ func TestVSphereMachine_ValidateCreate_MultiNetwork(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, tc.featureGate)
-			webhook := &VSphereMachine{NetworkProvider: tc.networkProvider}
+			webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, tc.networkProvider)}
 			obj := &vmwarev1.VSphereMachine{Spec: vmwarev1.VSphereMachineSpec{Network: tc.network}}
 			_, err := webhook.ValidateCreate(context.Background(), obj)
 			if tc.wantErr {
@@ -378,7 +379,7 @@ func TestVSphereMachine_ValidateUpdate_MultiNetwork(t *testing.T) {
 		},
 	})
 
-	webhook := &VSphereMachine{NetworkProvider: manager.NSXVPCNetworkProvider}
+	webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.NSXVPCNetworkProvider)}
 	_, err := webhook.ValidateUpdate(context.Background(), oldVSphereMachine, newVSphereMachine)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("cannot be modified"))
@@ -406,7 +407,7 @@ func TestVSphereMachine_ValidateCreate_InfrastructurePolicies(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.InfrastructurePolicies, tc.featureGate)
-			webhook := &VSphereMachine{}
+			webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 			obj := &vmwarev1.VSphereMachine{
 				Spec: vmwarev1.VSphereMachineSpec{
 					Policies: []vmwarev1.PolicyRef{
@@ -674,7 +675,7 @@ func TestVSphereMachine_ValidateCreate_VLANs(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "vlans can only be set when network provider is NSX-VPC",
+			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
 		},
 		{
 			name:            "vlans name duplicate with primary interface name",
@@ -750,7 +751,7 @@ func TestVSphereMachine_ValidateCreate_VLANs(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, true)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.VLANSubinterface, tc.featureGate)
-			webhook := &VSphereMachine{NetworkProvider: tc.networkProvider}
+			webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, tc.networkProvider)}
 			vm := &vmwarev1.VSphereMachine{
 				Spec: vmwarev1.VSphereMachineSpec{Network: tc.networkSpec},
 			}
@@ -811,7 +812,7 @@ func TestVSphereMachine_ValidateUpdate_VLANs(t *testing.T) {
 		},
 	}
 
-	webhook := &VSphereMachine{NetworkProvider: manager.NSXVPCNetworkProvider}
+	webhook := &VSphereMachine{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.NSXVPCNetworkProvider)}
 	_, err := webhook.ValidateUpdate(context.Background(), oldVSphereMachine, newVSphereMachine)
 	g.Expect(err).NotTo(HaveOccurred())
 }

--- a/internal/webhooks/vmware/vspheremachinetemplate.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate.go
@@ -19,6 +19,7 @@ package vmware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,10 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware/conversion"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
@@ -39,8 +42,10 @@ import (
 
 // VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
 type VSphereMachineTemplate struct {
-	// NetworkProvider is the network provider used by Supervisor based clusters
-	NetworkProvider string
+	// Client is used by NetworkProviderFactory.ForObject to resolve the owning Cluster / VSphereCluster.
+	Client client.Client
+	// NetworkProviderFactory resolves the network provider for the owning cluster.
+	NetworkProviderFactory manager.NetworkProviderFactory
 }
 
 var _ admission.Defaulter[*vmwarev1.VSphereMachineTemplate] = &VSphereMachineTemplate{}
@@ -107,8 +112,22 @@ func (webhook *VSphereMachineTemplate) ValidateUpdate(ctx context.Context, oldOb
 	return webhook.validate(ctx, nil, newObj)
 }
 
-func (webhook *VSphereMachineTemplate) validate(_ context.Context, _, newVSphereMachineTemplate *vmwarev1.VSphereMachineTemplate) (admission.Warnings, error) {
-	allErrs := validateNetwork(webhook.NetworkProvider, newVSphereMachineTemplate.Spec.Template.Spec.Network, field.NewPath("spec", "template", "spec", "network"))
+func (webhook *VSphereMachineTemplate) validate(ctx context.Context, _, newVSphereMachineTemplate *vmwarev1.VSphereMachineTemplate) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+
+	// Provider-specific network validation requires an owning Cluster. ClusterClass
+	// templates are not bound to a Cluster yet, so skip validateNetwork when the
+	// cluster-name label is missing. Other validations still run.
+	np, err := webhook.NetworkProviderFactory.ForObject(ctx, webhook.Client, newVSphereMachineTemplate)
+	switch {
+	case errors.Is(err, manager.ErrNoOwningCluster):
+		// Skip validateNetwork.
+	case err != nil:
+		return nil, err
+	default:
+		allErrs = append(allErrs, validateNetwork(np.Name(), newVSphereMachineTemplate.Spec.Template.Spec.Network, field.NewPath("spec", "template", "spec", "network"))...)
+	}
+
 	allErrs = append(allErrs, validatePolicies(newVSphereMachineTemplate.Spec.Template.Spec.Policies, field.NewPath("spec", "template", "spec", "policies"))...)
 
 	// Validate namingStrategy

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -18,6 +18,7 @@ package vmware
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -95,10 +96,98 @@ func TestVSphereMachineTemplate_Validate(t *testing.T) {
 				},
 			}
 
-			webhook := &VSphereMachineTemplate{}
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 			_, err := webhook.validate(context.Background(), nil, vSphereMachineTemplate)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestVSphereMachineTemplate_Validate_NoOwningCluster(t *testing.T) {
+	// Network config that would fail validateNetwork for VDS (primary interfaces are forbidden).
+	networkWithPrimary := vmwarev1.VSphereMachineNetworkSpec{
+		Interfaces: vmwarev1.InterfacesSpec{
+			Primary: vmwarev1.InterfaceSpec{
+				NetworkRef: vmwarev1.InterfaceNetworkReference{
+					Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnetSet.Kind,
+					APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+					Name:       "primary-subnetset",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		obj     *vmwarev1.VSphereMachineTemplate
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "skips validateNetwork when cluster-name label is missing",
+			obj: &vmwarev1.VSphereMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cc-template"},
+				Spec: vmwarev1.VSphereMachineTemplateSpec{
+					Template: vmwarev1.VSphereMachineTemplateResource{
+						Spec: vmwarev1.VSphereMachineSpec{Network: networkWithPrimary},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "still validates namingStrategy when cluster-name label is missing",
+			obj: &vmwarev1.VSphereMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cc-template"},
+				Spec: vmwarev1.VSphereMachineTemplateSpec{
+					Template: vmwarev1.VSphereMachineTemplateResource{
+						Spec: vmwarev1.VSphereMachineSpec{
+							Network: networkWithPrimary,
+							Naming:  vmwarev1.VirtualMachineNamingSpec{Template: "{{ invalid"},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid VirtualMachine name template",
+		},
+		{
+			name: "still validates policies when cluster-name label is missing",
+			obj: &vmwarev1.VSphereMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cc-template"},
+				Spec: vmwarev1.VSphereMachineTemplateSpec{
+					Template: vmwarev1.VSphereMachineTemplateResource{
+						Spec: vmwarev1.VSphereMachineSpec{
+							Network: networkWithPrimary,
+							Policies: []vmwarev1.PolicyRef{
+								{Name: "policy-1", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "policies can only be set when feature gate InfrastructurePolicies is enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterNetworkProvider, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, true)
+
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestNetworkProviderFactory(t, manager.VDSNetworkProvider)}
+			_, err := webhook.validate(context.Background(), nil, tc.obj)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errMsg))
+				}
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -188,7 +277,7 @@ func TestVSphereMachineTemplate_ValidateInterfaces(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "primary interface can not be set when network provider is vsphere-network",
+			wantErrMsg: fmt.Sprintf("primary interface can not be set when network provider is %s", manager.VDSNetworkProvider),
 		},
 		{
 			name:            "secondary interface with wrong type for VDS provider",
@@ -285,7 +374,7 @@ func TestVSphereMachineTemplate_ValidateInterfaces(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, tc.featureGate)
-			webhook := &VSphereMachineTemplate{NetworkProvider: tc.networkProvider}
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, tc.networkProvider)}
 			obj := &vmwarev1.VSphereMachineTemplate{
 				Spec: vmwarev1.VSphereMachineTemplateSpec{
 					Template: vmwarev1.VSphereMachineTemplateResource{
@@ -394,7 +483,7 @@ func TestVSphereMachineTemplate_ValidateUpdate_Immutability(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			webhook := &VSphereMachineTemplate{}
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 			ctx := context.Background()
 			if tc.req != nil {
 				ctx = admission.NewContextWithRequest(ctx, *tc.req)
@@ -435,7 +524,7 @@ func TestVSphereMachineTemplate_ValidatePoliciesFeatureGate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.InfrastructurePolicies, tc.featureGate)
-			webhook := &VSphereMachineTemplate{}
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, manager.VDSNetworkProvider)}
 			obj := &vmwarev1.VSphereMachineTemplate{
 				Spec: vmwarev1.VSphereMachineTemplateSpec{
 					Template: vmwarev1.VSphereMachineTemplateResource{
@@ -707,7 +796,7 @@ func TestVSphereMachineTemplate_ValidateVLANs(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "vlans can only be set when network provider is NSX-VPC",
+			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
 		},
 		{
 			name:            "vlans name duplicate with primary interface name",
@@ -783,7 +872,7 @@ func TestVSphereMachineTemplate_ValidateVLANs(t *testing.T) {
 			g := NewWithT(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.MultiNetworks, true)
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.VLANSubinterface, tc.featureGate)
-			webhook := &VSphereMachineTemplate{NetworkProvider: tc.networkProvider}
+			webhook := &VSphereMachineTemplate{NetworkProviderFactory: newTestStaticNetworkProviderFactory(t, tc.networkProvider)}
 			obj := &vmwarev1.VSphereMachineTemplate{
 				Spec: vmwarev1.VSphereMachineTemplateSpec{
 					Template: vmwarev1.VSphereMachineTemplateResource{

--- a/main.go
+++ b/main.go
@@ -612,6 +612,12 @@ func main() {
 	}
 	managerOpts.Converter = converter
 
+	// Convert legacy --network-provider flag values (NSX, NSX-VPC, vsphere-network)
+	// to canonical PascalCase names before the rest of the codebase sees them.
+	if managerOpts.NetworkProvider != "" {
+		managerOpts.NetworkProvider = manager.ConvertNetworkProviderName(managerOpts.NetworkProvider)
+	}
+
 	mgr, err := manager.New(ctx, managerOpts)
 	if err != nil {
 		setupLog.Error(err, "Error creating manager")
@@ -668,10 +674,10 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 		return err
 	}
 
-	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, false, concurrency(vSphereClusterConcurrency)); err != nil {
+	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, false, concurrency(vSphereClusterConcurrency), nil); err != nil {
 		return err
 	}
-	if err := controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, false, concurrency(vSphereMachineConcurrency)); err != nil {
+	if err := controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, false, concurrency(vSphereMachineConcurrency), nil); err != nil {
 		return err
 	}
 	if err := controllers.AddVMControllerToManager(ctx, controllerCtx, mgr, clusterCache, concurrency(vSphereVMConcurrency)); err != nil {
@@ -685,26 +691,40 @@ func setupVAPIControllers(ctx context.Context, controllerCtx *capvcontext.Contro
 }
 
 func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext, mgr ctrlmgr.Manager, clusterCache clustercache.ClusterCache, secretCachingClient client.Client) error {
-	if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
+	// Build a single NetworkProviderFactory based on the ClusterNetworkProvider feature gate.
+	// When enabled, the provider is resolved per-cluster from VSphereCluster.spec.network.provider;
+	// otherwise the static provider built from the --network-provider flag is used.
+	var networkProviderFactory manager.NetworkProviderFactory
+	var err error
+	if feature.Gates.Enabled(feature.ClusterNetworkProvider) {
+		networkProviderFactory, err = manager.NewPerClusterNetworkProviderFactory(ctx, controllerCtx.Client)
+	} else {
+		networkProviderFactory, err = manager.NewStaticNetworkProviderFactory(ctx, controllerCtx.Client, controllerCtx.NetworkProvider)
+	}
+	if err != nil {
+		return pkgerrors.Wrap(err, "failed to create a network provider factory")
+	}
+
+	if err := (&vmwarewebhooks.VSphereMachineTemplate{}).SetupWebhookWithManager(mgr, mgr.GetClient(), networkProviderFactory); err != nil {
 		return err
 	}
-	if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
+	if err := (&vmwarewebhooks.VSphereMachine{}).SetupWebhookWithManager(mgr, mgr.GetClient(), networkProviderFactory); err != nil {
 		return err
 	}
-	if err := (&vmwarewebhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
+	if err := (&vmwarewebhooks.VSphereClusterTemplate{}).SetupWebhookWithManager(mgr, networkProviderFactory); err != nil {
 		return err
 	}
-	if err := (&vmwarewebhooks.VSphereCluster{}).SetupWebhookWithManager(mgr, controllerCtx.NetworkProvider); err != nil {
+	if err := (&vmwarewebhooks.VSphereCluster{}).SetupWebhookWithManager(mgr, networkProviderFactory); err != nil {
 		return err
 	}
 	if err := (&vmwarewebhooks.ProviderServiceAccount{}).SetupWebhookWithManager(mgr); err != nil {
 		return err
 	}
-	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereClusterConcurrency)); err != nil {
+	if err := controllers.AddClusterControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereClusterConcurrency), networkProviderFactory); err != nil {
 		return err
 	}
 
-	if err := controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereMachineConcurrency)); err != nil {
+	if err := controllers.AddMachineControllerToManager(ctx, controllerCtx, mgr, true, concurrency(vSphereMachineConcurrency), networkProviderFactory); err != nil {
 		return err
 	}
 
@@ -722,7 +742,7 @@ func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.
 		}
 	}
 
-	return vmware.AddServiceDiscoveryControllerToManager(ctx, controllerCtx, mgr, clusterCache, concurrency(serviceDiscoveryConcurrency))
+	return vmware.AddServiceDiscoveryControllerToManager(ctx, controllerCtx, mgr, clusterCache, concurrency(serviceDiscoveryConcurrency), networkProviderFactory)
 }
 
 func setupChecks(mgr ctrlmgr.Manager) {

--- a/pkg/context/vmware/machine_context.go
+++ b/pkg/context/vmware/machine_context.go
@@ -41,6 +41,11 @@ type SupervisorMachineContext struct {
 	VSphereCluster *vmwarev1.VSphereCluster
 	VSphereMachine *vmwarev1.VSphereMachine
 	VMModifiers    []VMModifier
+
+	// ConfigureControlPlaneVMReadinessProbe indicates whether a TCP readiness probe should be
+	// configured on control plane VMs. It is resolved per-cluster from the network provider's
+	// SupportsVMReadinessProbe().
+	ConfigureControlPlaneVMReadinessProbe bool
 }
 
 // String returns VSphereMachineGroupVersionKind VSphereMachineNamespace/VSphereMachineName.

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -27,18 +27,43 @@ import (
 )
 
 const (
-	// NSXVPCNetworkProvider identifies the nsx-vpc network provider.
-	NSXVPCNetworkProvider = "NSX-VPC"
-	// NSXNetworkProvider identifies the NSX network provider.
-	NSXNetworkProvider = "NSX"
-	// VDSNetworkProvider identifies the VDS network provider.
-	VDSNetworkProvider = "vsphere-network"
-	// DummyLBNetworkProvider identifies the Dummy network provider.
-	DummyLBNetworkProvider = "DummyLBNetworkProvider"
+	// NSXVPCNetworkProvider identifies the NSX VPC network provider.
+	NSXVPCNetworkProvider = network.VPCNetworkProviderName
+	// NSXNetworkProvider identifies the NSX Tier-1 network provider.
+	NSXNetworkProvider = network.NSXTier1NetworkProviderName
+	// VDSNetworkProvider identifies the vSphere Distributed Switch network provider.
+	VDSNetworkProvider = network.VSphereDistributedNetworkProviderName
+	// DummyLBNetworkProvider identifies the Dummy LB network provider.
+	DummyLBNetworkProvider = network.DummyLBNetworkProviderName
+
+	// Legacy global network provider names (pre-rename values of --network-provider).
+	// The current flag values reuse NSXNetworkProvider / NSXVPCNetworkProvider / VDSNetworkProvider
+	// (NSXTier1 / VPC / VSphereDistributed), matching VSphereCluster.spec.network.provider.
+	legacyNSXNetworkProvider    = "NSX"
+	legacyNSXVPCNetworkProvider = "NSX-VPC"
+	legacyVDSNetworkProvider    = "vsphere-network"
 )
+
+var legacyToNetworkProviderName = map[string]string{
+	legacyNSXNetworkProvider:    NSXNetworkProvider,
+	legacyNSXVPCNetworkProvider: NSXVPCNetworkProvider,
+	legacyVDSNetworkProvider:    VDSNetworkProvider,
+}
+
+// ConvertNetworkProviderName converts a legacy --network-provider flag value to the
+// canonical PascalCase name used by CAPV. It is intended for CLI / startup boundary
+// use only (e.g. main.go), not for runtime resolution of spec.network.provider or
+// other internal APIs. Unknown names are returned unchanged.
+func ConvertNetworkProviderName(name string) string {
+	if converted, ok := legacyToNetworkProviderName[name]; ok {
+		return converted
+	}
+	return name
+}
 
 // GetNetworkProvider will return a network provider instance based on the environment
 // the cfg is used to initialize a client that talks directly to api-server without using the cache.
+// networkProvider must be a canonical PascalCase name; legacy flag values are not accepted here.
 func GetNetworkProvider(ctx context.Context, client client.Client, networkProvider string) (services.NetworkProvider, error) {
 	log := ctrl.LoggerFrom(ctx)
 

--- a/pkg/manager/network_factory.go
+++ b/pkg/manager/network_factory.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+)
+
+// ErrNetworkProviderEmpty is returned when a VSphereCluster does not yet have a
+// network provider set on spec.network.provider. Callers should wait and retry
+// until the value is populated.
+var ErrNetworkProviderEmpty = errors.New("network provider is empty, wait for a valid value")
+
+// ErrNoOwningCluster is returned when an object has no cluster.x-k8s.io/cluster-name
+// label, so the owning Cluster cannot be resolved. This is expected for ClusterClass
+// templates that are not yet bound to a Cluster. Callers that only need the provider
+// for optional validation (e.g. VSphereMachineTemplate webhooks) may skip that
+// validation; callers that require a provider (e.g. VSphereMachine) should treat
+// this as an error.
+var ErrNoOwningCluster = fmt.Errorf("missing %q label, cannot resolve the owning Cluster", clusterv1.ClusterNameLabel)
+
+// NetworkProviderFactory resolves the NetworkProvider to use for a given VSphereCluster.
+type NetworkProviderFactory interface {
+	// ForCluster returns the NetworkProvider that should be used for the given VSphereCluster.
+	ForCluster(ctx context.Context, cluster *vmwarev1.VSphereCluster) (services.NetworkProvider, error)
+
+	// ForObject resolves the NetworkProvider for a cluster-scoped object
+	// (e.g. VSphereMachine) by reading the cluster.x-k8s.io/cluster-name label,
+	// loading Cluster → VSphereCluster, then calling ForCluster.
+	// The static factory may ignore the object and return the flag-based provider.
+	// The per-cluster factory returns ErrNoOwningCluster when the cluster-name
+	// label is missing (e.g. ClusterClass templates).
+	ForObject(ctx context.Context, c client.Client, obj metav1.Object) (services.NetworkProvider, error)
+}
+
+// perClusterNetworkProviderFactory resolves the NetworkProvider from the
+// VSphereCluster's spec.network.provider field. It is used when the
+// ClusterNetworkProvider feature gate is enabled.
+type perClusterNetworkProviderFactory struct {
+	registry map[string]services.NetworkProvider
+}
+
+// NewPerClusterNetworkProviderFactory returns a NetworkProviderFactory that
+// resolves the provider per-cluster from spec.network.provider. The registry is
+// pre-built for the in-scope provider names.
+func NewPerClusterNetworkProviderFactory(ctx context.Context, client client.Client) (NetworkProviderFactory, error) {
+	registry := map[string]services.NetworkProvider{}
+	for _, name := range []string{VDSNetworkProvider, NSXNetworkProvider, NSXVPCNetworkProvider} {
+		np, err := GetNetworkProvider(ctx, client, name)
+		if err != nil {
+			return nil, err
+		}
+		registry[name] = np
+	}
+	return &perClusterNetworkProviderFactory{registry: registry}, nil
+}
+
+// ForCluster returns the NetworkProvider matching the cluster's spec.network.provider.
+func (f *perClusterNetworkProviderFactory) ForCluster(_ context.Context, cluster *vmwarev1.VSphereCluster) (services.NetworkProvider, error) {
+	provider := cluster.Spec.Network.Provider
+	if provider == "" {
+		return nil, ErrNetworkProviderEmpty
+	}
+	np, ok := f.registry[provider]
+	if !ok {
+		return nil, fmt.Errorf("unknown network provider %q", provider)
+	}
+	return np, nil
+}
+
+// ForObject resolves the owning Cluster via the cluster.x-k8s.io/cluster-name label,
+// loads the VSphereCluster from Cluster.spec.infrastructureRef, then calls ForCluster.
+func (f *perClusterNetworkProviderFactory) ForObject(ctx context.Context, c client.Client, obj metav1.Object) (services.NetworkProvider, error) {
+	vsphereCluster, err := getVSphereClusterForObject(ctx, c, obj)
+	if err != nil {
+		return nil, err
+	}
+	return f.ForCluster(ctx, vsphereCluster)
+}
+
+// staticNetworkProviderFactory always returns the provider built from the
+// --network-provider flag. It is used when the ClusterNetworkProvider feature
+// gate is disabled, preserving the previous behavior.
+type staticNetworkProviderFactory struct {
+	networkProvider services.NetworkProvider
+}
+
+// NewStaticNetworkProviderFactory returns a NetworkProviderFactory that always
+// returns the provider built from the given flag value.
+func NewStaticNetworkProviderFactory(ctx context.Context, client client.Client, networkProvider string) (NetworkProviderFactory, error) {
+	np, err := GetNetworkProvider(ctx, client, networkProvider)
+	if err != nil {
+		return nil, err
+	}
+	return &staticNetworkProviderFactory{networkProvider: np}, nil
+}
+
+// ForCluster always returns the statically configured NetworkProvider.
+func (f *staticNetworkProviderFactory) ForCluster(_ context.Context, _ *vmwarev1.VSphereCluster) (services.NetworkProvider, error) {
+	return f.networkProvider, nil
+}
+
+// ForObject always returns the statically configured NetworkProvider without
+// loading the owning Cluster or VSphereCluster.
+func (f *staticNetworkProviderFactory) ForObject(_ context.Context, _ client.Client, _ metav1.Object) (services.NetworkProvider, error) {
+	return f.networkProvider, nil
+}
+
+// getVSphereClusterForObject loads the owning Cluster via the
+// cluster.x-k8s.io/cluster-name label and then the VSphereCluster referenced by
+// Cluster.spec.infrastructureRef.
+func getVSphereClusterForObject(ctx context.Context, c client.Client, obj metav1.Object) (*vmwarev1.VSphereCluster, error) {
+	clusterName, ok := obj.GetLabels()[clusterv1.ClusterNameLabel]
+	if !ok || clusterName == "" {
+		return nil, ErrNoOwningCluster
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: clusterName}, cluster); err != nil {
+		return nil, fmt.Errorf("failed to get Cluster %s: %w", klog.KRef(obj.GetNamespace(), clusterName), err)
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() {
+		return nil, fmt.Errorf("Cluster %s does not have a spec.infrastructureRef set", klog.KObj(cluster)) //nolint:staticcheck // Cluster is a Kubernetes resource kind.
+	}
+
+	vsphereCluster := &vmwarev1.VSphereCluster{}
+	key := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}
+	if err := c.Get(ctx, key, vsphereCluster); err != nil {
+		return nil, fmt.Errorf("failed to get VSphereCluster %s: %w", klog.KRef(key.Namespace, key.Name), err)
+	}
+
+	return vsphereCluster, nil
+}

--- a/pkg/manager/network_factory_test.go
+++ b/pkg/manager/network_factory_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+)
+
+func clusterWithProvider(provider string) *vmwarev1.VSphereCluster {
+	return &vmwarev1.VSphereCluster{
+		Spec: vmwarev1.VSphereClusterSpec{
+			Network: vmwarev1.Network{
+				Provider: provider,
+			},
+		},
+	}
+}
+
+func TestPerClusterNetworkProviderFactory(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+
+	factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("empty provider returns ErrNetworkProviderEmpty", func(t *testing.T) {
+		g := NewWithT(t)
+		np, err := factory.ForCluster(ctx, clusterWithProvider(""))
+		g.Expect(err).To(MatchError(ErrNetworkProviderEmpty))
+		g.Expect(errors.Is(err, ErrNetworkProviderEmpty)).To(BeTrue())
+		g.Expect(np).To(BeNil())
+	})
+
+	t.Run("known providers return a singleton", func(t *testing.T) {
+		g := NewWithT(t)
+		for _, name := range []string{VDSNetworkProvider, NSXNetworkProvider, NSXVPCNetworkProvider} {
+			np1, err := factory.ForCluster(ctx, clusterWithProvider(name))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(np1).ToNot(BeNil())
+			g.Expect(np1.Name()).To(Equal(name))
+
+			np2, err := factory.ForCluster(ctx, clusterWithProvider(name))
+			g.Expect(err).ToNot(HaveOccurred())
+			// The same singleton instance should be returned on every call.
+			g.Expect(np2).To(BeIdenticalTo(np1))
+		}
+	})
+
+	t.Run("unknown provider returns an error", func(t *testing.T) {
+		g := NewWithT(t)
+		np, err := factory.ForCluster(ctx, clusterWithProvider("does-not-exist"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown network provider"))
+		g.Expect(np).To(BeNil())
+	})
+}
+
+func TestStaticNetworkProviderFactory(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+
+	factory, err := NewStaticNetworkProviderFactory(ctx, c, VDSNetworkProvider)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The static factory always returns the flag provider, regardless of the
+	// cluster's spec.network.provider value (including empty).
+	np1, err := factory.ForCluster(ctx, clusterWithProvider(""))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(np1).ToNot(BeNil())
+	g.Expect(np1.Name()).To(Equal(VDSNetworkProvider))
+
+	np2, err := factory.ForCluster(ctx, clusterWithProvider(NSXVPCNetworkProvider))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(np2).To(BeIdenticalTo(np1))
+
+	// ForObject ignores the object and returns the same static provider.
+	np3, err := factory.ForObject(ctx, c, &vmwarev1.VSphereMachine{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(np3).To(BeIdenticalTo(np1))
+}
+
+func TestPerClusterNetworkProviderFactory_ForObject(t *testing.T) {
+	const (
+		namespace   = "test-ns"
+		clusterName = "test-cluster"
+		vsphereName = "test-cluster-infra"
+	)
+
+	machine := func(withLabel bool) *vmwarev1.VSphereMachine {
+		labels := map[string]string{}
+		if withLabel {
+			labels[clusterv1.ClusterNameLabel] = clusterName
+		}
+		return &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "test-machine",
+				Labels:    labels,
+			},
+		}
+	}
+
+	cluster := func(withInfraRef bool) *clusterv1.Cluster {
+		c := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName},
+		}
+		if withInfraRef {
+			c.Spec.InfrastructureRef = clusterv1.ContractVersionedObjectReference{
+				APIGroup: vmwarev1.GroupVersion.Group,
+				Kind:     "VSphereCluster",
+				Name:     vsphereName,
+			}
+		}
+		return c
+	}
+
+	vsphereCluster := func(provider string) *vmwarev1.VSphereCluster {
+		return &vmwarev1.VSphereCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vsphereName},
+			Spec:       vmwarev1.VSphereClusterSpec{Network: vmwarev1.Network{Provider: provider}},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		obj          *vmwarev1.VSphereMachine
+		initObjs     []client.Object
+		wantProvider string
+		wantErr      bool
+		wantErrIs    error
+		errSubstring string
+	}{
+		{
+			name:      "missing cluster-name label",
+			obj:       machine(false),
+			wantErr:   true,
+			wantErrIs: ErrNoOwningCluster,
+		},
+		{
+			name:         "Cluster not found",
+			obj:          machine(true),
+			wantErr:      true,
+			errSubstring: "failed to get Cluster",
+		},
+		{
+			name:         "Cluster has no infrastructureRef",
+			obj:          machine(true),
+			initObjs:     []client.Object{cluster(false)},
+			wantErr:      true,
+			errSubstring: "does not have a spec.infrastructureRef set",
+		},
+		{
+			name:         "VSphereCluster not found",
+			obj:          machine(true),
+			initObjs:     []client.Object{cluster(true)},
+			wantErr:      true,
+			errSubstring: "failed to get VSphereCluster",
+		},
+		{
+			name:      "spec.network.provider is empty",
+			obj:       machine(true),
+			initObjs:  []client.Object{cluster(true), vsphereCluster("")},
+			wantErr:   true,
+			wantErrIs: ErrNetworkProviderEmpty,
+		},
+		{
+			name:         "spec.network.provider is set",
+			obj:          machine(true),
+			initObjs:     []client.Object{cluster(true), vsphereCluster(NSXVPCNetworkProvider)},
+			wantProvider: NSXVPCNetworkProvider,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			scheme := runtime.NewScheme()
+			g.Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+			g.Expect(vmwarev1.AddToScheme(scheme)).To(Succeed())
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.initObjs...).Build()
+
+			factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			np, err := factory.ForObject(ctx, c, tc.obj)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				if tc.wantErrIs != nil {
+					g.Expect(errors.Is(err, tc.wantErrIs)).To(BeTrue())
+				}
+				if tc.errSubstring != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errSubstring))
+				}
+				g.Expect(np).To(BeNil())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(np.Name()).To(Equal(tc.wantProvider))
+		})
+	}
+}

--- a/pkg/manager/network_test.go
+++ b/pkg/manager/network_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestConvertNetworkProviderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "legacy NSX",
+			input:    legacyNSXNetworkProvider,
+			expected: NSXNetworkProvider,
+		},
+		{
+			name:     "legacy NSX-VPC",
+			input:    legacyNSXVPCNetworkProvider,
+			expected: NSXVPCNetworkProvider,
+		},
+		{
+			name:     "legacy vsphere-network",
+			input:    legacyVDSNetworkProvider,
+			expected: VDSNetworkProvider,
+		},
+		{
+			name:     "PascalCase name is unchanged",
+			input:    NSXNetworkProvider,
+			expected: NSXNetworkProvider,
+		},
+		{
+			name:     "VPC is unchanged",
+			input:    NSXVPCNetworkProvider,
+			expected: NSXVPCNetworkProvider,
+		},
+		{
+			name:     "VSphereDistributed is unchanged",
+			input:    VDSNetworkProvider,
+			expected: VDSNetworkProvider,
+		},
+		{
+			name:     "unknown name is unchanged",
+			input:    "unknown-provider",
+			expected: "unknown-provider",
+		},
+		{
+			name:     "empty name is unchanged",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ConvertNetworkProviderName(tt.input)).To(Equal(tt.expected))
+		})
+	}
+}

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -102,6 +102,9 @@ type ResourcePolicyService interface {
 
 // NetworkProvider provision network resources and configures VM based on network type.
 type NetworkProvider interface {
+	// Name returns the canonical provider name (e.g. VSphereDistributed, NSXTier1, VPC).
+	Name() string
+
 	// SupportsIPv6DualStack indicates whether this provider supports IPv6 and dual-stack.
 	SupportsIPv6DualStack() bool
 

--- a/pkg/services/network/constants.go
+++ b/pkg/services/network/constants.go
@@ -24,6 +24,17 @@ import (
 )
 
 const (
+	// VPCNetworkProviderName is the canonical name for the NSX VPC network provider.
+	VPCNetworkProviderName = "VPC"
+	// NSXTier1NetworkProviderName is the canonical name for the NSX Tier-1 network provider.
+	NSXTier1NetworkProviderName = "NSXTier1"
+	// VSphereDistributedNetworkProviderName is the canonical name for the VDS network provider.
+	VSphereDistributedNetworkProviderName = "VSphereDistributed"
+	// DummyLBNetworkProviderName is the canonical name for the Dummy LB network provider.
+	DummyLBNetworkProviderName = "DummyLBNetworkProvider"
+	// DummyNetworkProviderName is the canonical name for the Dummy network provider.
+	DummyNetworkProviderName = "DummyNetworkProvider"
+
 	// NSXTVNetSelectorKey is also defined in VM Operator.
 	NSXTVNetSelectorKey = "ncp.vmware.com/virtual-network-name"
 

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -37,6 +37,10 @@ func DummyNetworkProvider() services.NetworkProvider {
 	return &dummyNetworkProvider{}
 }
 
+func (np *dummyNetworkProvider) Name() string {
+	return DummyNetworkProviderName
+}
+
 func (np *dummyNetworkProvider) SupportsIPv6DualStack() bool {
 	return false
 }
@@ -81,6 +85,10 @@ type dummyLBNetworkProvider struct {
 // DummyLBNetworkProvider returns an instance of dummy network provider that has a LB.
 func DummyLBNetworkProvider() services.NetworkProvider {
 	return &dummyLBNetworkProvider{}
+}
+
+func (np *dummyLBNetworkProvider) Name() string {
+	return DummyLBNetworkProviderName
 }
 
 func (np *dummyLBNetworkProvider) HasLoadBalancer() bool {

--- a/pkg/services/network/netop_provider.go
+++ b/pkg/services/network/netop_provider.go
@@ -45,6 +45,10 @@ func NetOpNetworkProvider(client client.Client) services.NetworkProvider {
 	}
 }
 
+func (np *netopNetworkProvider) Name() string {
+	return VSphereDistributedNetworkProviderName
+}
+
 func (np *netopNetworkProvider) SupportsIPv6DualStack() bool {
 	return false
 }

--- a/pkg/services/network/nsxt_provider.go
+++ b/pkg/services/network/nsxt_provider.go
@@ -55,6 +55,10 @@ func NsxtNetworkProvider(client client.Client, disableFW string) services.Networ
 	}
 }
 
+func (np *nsxtNetworkProvider) Name() string {
+	return NSXTier1NetworkProviderName
+}
+
 func (np *nsxtNetworkProvider) SupportsIPv6DualStack() bool {
 	return false
 }

--- a/pkg/services/network/nsxt_vpc_provider.go
+++ b/pkg/services/network/nsxt_vpc_provider.go
@@ -57,6 +57,10 @@ func NSXTVpcNetworkProvider(client client.Client) services.NetworkProvider {
 	}
 }
 
+func (vp *nsxtVPCNetworkProvider) Name() string {
+	return VPCNetworkProviderName
+}
+
 func (vp *nsxtVPCNetworkProvider) SupportsIPv6DualStack() bool {
 	return feature.Gates.Enabled(feature.IPv6DualStack)
 }

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -56,8 +56,7 @@ const (
 
 // VmopMachineService reconciles VM Operator VM.
 type VmopMachineService struct {
-	Client                                client.Client
-	ConfigureControlPlaneVMReadinessProbe bool
+	Client client.Client
 }
 
 // GetMachinesInCluster returns a list of VSphereMachine objects belonging to the cluster.
@@ -620,7 +619,7 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 	// Not all network providers (for example, NSX-VPC) provide support for VM
 	// readiness probes. The flag PerformsVMReadinessProbe is used to determine
 	// whether a VM readiness probe should be conducted.
-	if v.ConfigureControlPlaneVMReadinessProbe && infrautilv1.IsControlPlaneMachine(supervisorMachineCtx.Machine) && ptr.Deref(supervisorMachineCtx.Cluster.Status.Initialization.ControlPlaneInitialized, false) {
+	if supervisorMachineCtx.ConfigureControlPlaneVMReadinessProbe && infrautilv1.IsControlPlaneMachine(supervisorMachineCtx.Machine) && ptr.Deref(supervisorMachineCtx.Cluster.Status.Initialization.ControlPlaneInitialized, false) {
 		vmOperatorVM.Spec.ReadinessProbe = &vmoprvhub.VirtualMachineReadinessProbeSpec{
 			TCPSocket: &vmoprvhub.TCPSocketAction{
 				Port: intstr.FromInt(defaultAPIBindPort),

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -198,7 +198,8 @@ var _ = Describe("VirtualMachine tests", func() {
 		clusterContext, controllerManagerContext := util.CreateClusterContext(cluster, vsphereCluster)
 		supervisorMachineContext = util.CreateMachineContext(clusterContext, machine, vsphereMachine)
 		supervisorMachineContext.ControllerManagerContext = controllerManagerContext
-		vmService = VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: network.DummyLBNetworkProvider().SupportsVMReadinessProbe()}
+		supervisorMachineContext.ConfigureControlPlaneVMReadinessProbe = network.DummyLBNetworkProvider().SupportsVMReadinessProbe()
+		vmService = VmopMachineService{Client: controllerManagerContext.Client}
 	})
 
 	Context("Reconcile VirtualMachine", func() {
@@ -1289,7 +1290,7 @@ var _ = Describe("GetMachinesInCluster", func() {
 	}
 
 	controllerManagerContext := fake.NewControllerManagerContext(initObjs...)
-	vmService := VmopMachineService{Client: controllerManagerContext.Client, ConfigureControlPlaneVMReadinessProbe: network.DummyLBNetworkProvider().SupportsVMReadinessProbe()}
+	vmService := VmopMachineService{Client: controllerManagerContext.Client}
 
 	It("returns a list of VMs belonging to the cluster", func() {
 		objs, err := vmService.GetMachinesInCluster(context.TODO(),

--- a/webhooks/vmware/alias.go
+++ b/webhooks/vmware/alias.go
@@ -18,40 +18,42 @@ package vmware
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/internal/webhooks/vmware"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
 )
 
 // VSphereMachine implements a validation and defaulting webhook for VSphereMachine.
 type VSphereMachine struct{}
 
 // SetupWebhookWithManager sets up VSphereMachine webhooks.
-func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
-	return (&vmware.VSphereMachine{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachine) SetupWebhookWithManager(mgr ctrl.Manager, client client.Client, networkProviderFactory manager.NetworkProviderFactory) error {
+	return (&vmware.VSphereMachine{Client: client, NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr)
 }
 
 // VSphereMachineTemplate implements a validation webhook for VSphereMachineTemplate.
 type VSphereMachineTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereMachineTemplate webhooks.
-func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
-	return (&vmware.VSphereMachineTemplate{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager, client client.Client, networkProviderFactory manager.NetworkProviderFactory) error {
+	return (&vmware.VSphereMachineTemplate{Client: client, NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr)
 }
 
 // VSphereCluster implements a validation and defaulting webhook for VSphereCluster.
 type VSphereCluster struct{}
 
 // SetupWebhookWithManager sets up VSphereCluster webhooks.
-func (webhook *VSphereCluster) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
-	return (&vmware.VSphereCluster{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereCluster) SetupWebhookWithManager(mgr ctrl.Manager, networkProviderFactory manager.NetworkProviderFactory) error {
+	return (&vmware.VSphereCluster{NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr)
 }
 
 // VSphereClusterTemplate implements a validation and defaulting webhook for VSphereClusterTemplate.
 type VSphereClusterTemplate struct{}
 
 // SetupWebhookWithManager sets up VSphereClusterTemplate webhooks.
-func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager, networkProvider string) error {
-	return (&vmware.VSphereClusterTemplate{NetworkProvider: networkProvider}).SetupWebhookWithManager(mgr)
+func (webhook *VSphereClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager, networkProviderFactory manager.NetworkProviderFactory) error {
+	return (&vmware.VSphereClusterTemplate{NetworkProviderFactory: networkProviderFactory}).SetupWebhookWithManager(mgr)
 }
 
 // ProviderServiceAccount implements a converter for ProviderServiceAccount.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Implement the CAPV portion of the VKS cluster transition (VDS / NSX T1 -> NSX VPC) by introducing per-cluster network provider resolution behind the ClusterNetworkProvider feature gate.
- Add VSphereCluster.spec.network.provider to v1beta1 and v1beta2 with enum validation (vsphere-distributed, nsx-tier1, vpc) and a CEL immutability rule.
- Add NetworkProviderFactory with per-cluster and static implementations.
- Resolve the network provider lazily per reconcile in controllers; requeue when spec.network.provider is empty.
- Resolve the provider per-cluster in VSphereMachine and VSphereMachineTemplate webhooks when the gate is enabled; skip provider-based checks on VSphereClusterTemplate.
- Move control-plane VM readiness probe configuration to per-cluster machine context instead of manager startup.
- Rename pkg/manager network provider constant values to the new names (vpc, nsx-tier1, vsphere-distributed).
With the gate disabled, behavior is unchanged: a static factory backed by --network-provider drives all resolution.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
