### PR TITLE
🐛 Fix clusterctl upgrade resource version stable check

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
-	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 )
@@ -90,7 +89,7 @@ var _ = Describe("When performing chained upgrades for workload cluster using Cl
 					resourceVersionInput := framework.ValidateResourceVersionStableInput{
 						ClusterProxy:             proxy,
 						Namespace:                namespace,
-						OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+						OwnerGraphFilterFunction: TMPDropVSphereMachineAndFilterObjectsWithKindAndName(clusterName),
 						WaitToBecomeStable:       e2eConfig.GetIntervals(specName, "wait-resource-versions-become-stable"),
 						WaitToRemainStable:       e2eConfig.GetIntervals(specName, "wait-resource-versions-remain-stable"),
 					}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
xref: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3601

to fix https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-e2e-supervisor-main/2071005832052477952

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
