### PR TITLE
🐛 Keep IPAddressClaim in the KCP infra adoption e2e test

### DIFF
--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -54,6 +54,7 @@ type setupOptions struct {
 	additionalVCSimServer     bool
 	useMOID                   bool
 	skip                      bool
+	skipCleanupIPAddressClaim bool
 }
 
 // SetupOption is a configuration option supplied to Setup.
@@ -100,6 +101,13 @@ func WithMOID(t bool) SetupOption {
 func SkipIf(t bool) SetupOption {
 	return func(o *setupOptions) {
 		o.skip = t
+	}
+}
+
+// SkipCleanupIPAddressClaim defines when to skip the cleanup of IPAddressClaim in AfterEach.
+func SkipCleanupIPAddressClaim(t bool) SetupOption {
+	return func(o *setupOptions) {
+		o.skipCleanupIPAddressClaim = t
 	}
 }
 
@@ -231,7 +239,7 @@ func Setup(specName string, f func(testSpecificSettings func() testSettings), op
 			// Cleanup IPs/controlPlaneEndpoint created by the IPAddressManager.
 			// Note: we cannot cleanup IPs using VCSim in a separate kind management cluster,
 			// because the test deletes the management cluster before we would reach this code.
-			if !options.additionalVCSimServer {
+			if !options.additionalVCSimServer && !options.skipCleanupIPAddressClaim {
 				Expect(testSpecificIPAddressManager.Cleanup(ctx, testSpecificIPAddressClaims)).To(Succeed())
 			}
 		}

--- a/test/e2e/kcp_infra_adoption_test.go
+++ b/test/e2e/kcp_infra_adoption_test.go
@@ -56,11 +56,15 @@ const (
 )
 
 var _ = Describe("When testing KCP infra adoption 1CP [vcsim] [supervisor]", func() {
-	Setup(kcpAdoptionSpecName+"-1-cp", KCPInfraAdoptionTest(kcpAdoptionSpecName+"-1-cp", 1), SkipIf(testMode == GovmomiTestMode))
+	// Note: We have to keep the IPAddressClaim after the test completes because we do not clean up VMs at the end of the test,
+	// so the IP would then be used by multiple tests at the same time which leads to connectivity and cert validation errors.
+	Setup(kcpAdoptionSpecName+"-1-cp", KCPInfraAdoptionTest(kcpAdoptionSpecName+"-1-cp", 1), SkipIf(testMode == GovmomiTestMode), SkipCleanupIPAddressClaim(true))
 })
 
 var _ = Describe("When testing KCP infra adoption 3CP [vcsim] [supervisor]", func() {
-	Setup(kcpAdoptionSpecName+"-3-cp", KCPInfraAdoptionTest(kcpAdoptionSpecName+"-3-cp", 3), SkipIf(testMode == GovmomiTestMode))
+	// Note: We have to keep the IPAddressClaim after the test completes because we do not clean up VMs at the end of the test,
+	// so the IP would then be used by multiple tests at the same time which leads to connectivity and cert validation errors.
+	Setup(kcpAdoptionSpecName+"-3-cp", KCPInfraAdoptionTest(kcpAdoptionSpecName+"-3-cp", 3), SkipIf(testMode == GovmomiTestMode), SkipCleanupIPAddressClaim(true))
 })
 
 func KCPInfraAdoptionTest(specName string, controlPlaneMachineCount int64) func(testSpecificSettingsGetter func() testSettings) {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Lead to all sorts of issues in CI, e.g.:
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-e2e-supervisor-main/2071507062969339904
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-e2e-supervisor-main/2071480909357387776


```
Unexpected error:
    <*fmt.wrapError | 0x39047a7d6420>: 
    failed to get server groups: Get "https://192.168.36.0:6443/api": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "kubernetes") - error from a previous attempt: read tcp 10.35.90.15:50742->192.168.36.0:6443: read: connection reset by peer
    {
        msg: "failed to get server groups: Get \"https://192.168.36.0:6443/api\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\") - error from a previous attempt: read tcp 10.35.90.15:50742->192.168.36.0:6443: read: connection reset by peer",
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
