### PR TITLE
🌱 Set nodeDeletionTimeoutSeconds: 0 in cluster templates and e2e tests

### DIFF
--- a/packaging/flavorgen/flavors/clusterclass_generators.go
+++ b/packaging/flavorgen/flavors/clusterclass_generators.go
@@ -98,6 +98,9 @@ func getControlPlaneClass() clusterv1.ControlPlaneClass {
 				Name:       fmt.Sprintf("%s-template", env.ClusterClassNameVar),
 			},
 		},
+		Deletion: clusterv1.ControlPlaneClassMachineDeletionSpec{
+			NodeDeletionTimeoutSeconds: new(int32(0)),
+		},
 	}
 }
 
@@ -114,6 +117,9 @@ func getVMWareControlPlaneClass() clusterv1.ControlPlaneClass {
 				Kind:       util.TypeToKind(&vmwarev1.VSphereMachineTemplate{}),
 				Name:       fmt.Sprintf("%s-template", env.ClusterClassNameVar),
 			},
+		},
+		Deletion: clusterv1.ControlPlaneClassMachineDeletionSpec{
+			NodeDeletionTimeoutSeconds: new(int32(0)),
 		},
 	}
 }
@@ -136,6 +142,9 @@ func getWorkersClass() clusterv1.WorkersClass {
 						Name:       fmt.Sprintf("%s-worker-machinetemplate", env.ClusterClassNameVar),
 						APIVersion: infrav1.GroupVersion.String(),
 					},
+				},
+				Deletion: clusterv1.MachineDeploymentClassMachineDeletionSpec{
+					NodeDeletionTimeoutSeconds: new(int32(0)),
 				},
 			},
 		},
@@ -160,6 +169,9 @@ func getVMWareWorkersClass() clusterv1.WorkersClass {
 						Name:       fmt.Sprintf("%s-worker-machinetemplate", env.ClusterClassNameVar),
 						APIVersion: vmwarev1.GroupVersion.String(),
 					},
+				},
+				Deletion: clusterv1.MachineDeploymentClassMachineDeletionSpec{
+					NodeDeletionTimeoutSeconds: new(int32(0)),
 				},
 			},
 		},

--- a/packaging/flavorgen/flavors/generators.go
+++ b/packaging/flavorgen/flavors/generators.go
@@ -691,6 +691,9 @@ func newMachineDeployment(cluster clusterv1.Cluster, machineTemplate client.Obje
 						Kind:     machineTemplate.GetObjectKind().GroupVersionKind().Kind,
 						Name:     machineTemplate.GetName(),
 					},
+					Deletion: clusterv1.MachineDeletionSpec{
+						NodeDeletionTimeoutSeconds: new(int32(0)),
+					},
 				},
 			},
 		},
@@ -715,6 +718,9 @@ func newKubeadmControlplane(infraTemplate client.Object, files []bootstrapv1.Fil
 						APIGroup: infraTemplate.GetObjectKind().GroupVersionKind().Group,
 						Kind:     infraTemplate.GetObjectKind().GroupVersionKind().Kind,
 						Name:     infraTemplate.GetName(),
+					},
+					Deletion: controlplanev1.KubeadmControlPlaneMachineTemplateDeletionSpec{
+						NodeDeletionTimeoutSeconds: new(int32(0)),
 					},
 				},
 			},
@@ -741,6 +747,9 @@ func newIgnitionKubeadmControlplane(infraTemplate infrav1.VSphereMachineTemplate
 						APIGroup: infraTemplate.GroupVersionKind().Group,
 						Kind:     infraTemplate.Kind,
 						Name:     infraTemplate.Name,
+					},
+					Deletion: controlplanev1.KubeadmControlPlaneMachineTemplateDeletionSpec{
+						NodeDeletionTimeoutSeconds: new(int32(0)),
 					},
 				},
 			},

--- a/packaging/flavorgen/flavors/util/helpers.go
+++ b/packaging/flavorgen/flavors/util/helpers.go
@@ -92,52 +92,11 @@ func regexVar(str string) string {
 	return "((?m:\\" + str + "$))"
 }
 
-func isZeroValue(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		return v.Len() == 0 || v.IsZero()
-	case reflect.Struct:
-		return v.IsZero() || v.IsNil() || v.IsZero()
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0 || v.IsNil()
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Pointer:
-		return v.IsNil() || v.IsZero()
-	}
-	return false
-}
-
-func deleteZeroValues(o map[string]interface{}) map[string]interface{} {
-	for k, v := range o {
-		val := reflect.ValueOf(v)
-		if v == nil || isZeroValue(val) || !val.IsValid() {
-			delete(o, k)
-			continue
-		}
-		if val.Kind() == reflect.Map {
-			newMap := v.(map[string]interface{})
-			newMap = deleteZeroValues(newMap)
-			if isZeroValue(reflect.ValueOf(newMap)) {
-				delete(o, k)
-			}
-			continue
-		}
-	}
-	return o
-}
-
 func GenerateObjectYAML(obj runtime.Object, replacements []Replacement) string {
 	data, err := toUnstructured(obj, obj.GetObjectKind().GroupVersionKind())
 	if err != nil {
 		panic(err)
 	}
-
-	data.Object = deleteZeroValues(data.Object)
 
 	for _, v := range replacements {
 		v := v

--- a/templates/cluster-template-external-loadbalancer.yaml
+++ b/templates/cluster-template-external-loadbalancer.yaml
@@ -130,6 +130,8 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     spec:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -190,6 +192,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: '${CLUSTER_NAME}-md-0'
       clusterName: '${CLUSTER_NAME}'
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -268,6 +272,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -587,6 +592,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template-ignition.yaml
+++ b/templates/cluster-template-ignition.yaml
@@ -288,6 +288,8 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     spec:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -409,6 +411,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: '${CLUSTER_NAME}-md-0'
       clusterName: '${CLUSTER_NAME}'
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -487,6 +491,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -806,6 +811,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template-node-ipam.yaml
+++ b/templates/cluster-template-node-ipam.yaml
@@ -266,6 +266,8 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     spec:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -326,6 +328,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: '${CLUSTER_NAME}-md-0'
       clusterName: '${CLUSTER_NAME}'
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -404,6 +408,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -723,6 +728,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template-supervisor.yaml
+++ b/templates/cluster-template-supervisor.yaml
@@ -222,6 +222,8 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     spec:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: vmware.infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -283,6 +285,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: '${CLUSTER_NAME}-md-0'
       clusterName: '${CLUSTER_NAME}'
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: vmware.infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -352,6 +356,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -671,6 +676,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template-topology-supervisor.yaml
+++ b/templates/cluster-template-topology-supervisor.yaml
@@ -158,6 +158,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -477,6 +478,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -173,6 +173,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -492,6 +493,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -254,6 +254,8 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     spec:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -314,6 +316,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: '${CLUSTER_NAME}-md-0'
       clusterName: '${CLUSTER_NAME}'
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
@@ -392,6 +396,7 @@ data:
       name: csi.vsphere.vmware.com
     spec:
       attachRequired: true
+      podInfoOnMount: false
     ---
     apiVersion: v1
     kind: ServiceAccount
@@ -711,6 +716,7 @@ data:
           app: vsphere-csi-controller
       strategy:
         rollingUpdate:
+          maxSurge: 0
           maxUnavailable: 1
         type: RollingUpdate
       template:

--- a/templates/clusterclass-template-supervisor.yaml
+++ b/templates/clusterclass-template-supervisor.yaml
@@ -10,6 +10,8 @@ metadata:
   name: '${CLUSTER_CLASS_NAME}'
 spec:
   controlPlane:
+    deletion:
+      nodeDeletionTimeoutSeconds: 0
     machineInfrastructure:
       templateRef:
         apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2
@@ -207,6 +209,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
       class: ${CLUSTER_CLASS_NAME}-worker
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructure:
         templateRef:
           apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta2

--- a/templates/clusterclass-template.yaml
+++ b/templates/clusterclass-template.yaml
@@ -10,6 +10,8 @@ metadata:
   name: '${CLUSTER_CLASS_NAME}'
 spec:
   controlPlane:
+    deletion:
+      nodeDeletionTimeoutSeconds: 0
     machineInfrastructure:
       templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -237,6 +239,8 @@ spec:
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_CLASS_NAME}-worker-bootstrap-template
       class: ${CLUSTER_CLASS_NAME}-worker
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
       infrastructure:
         templateRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta2


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
