### PR TITLE
✨ Remove YEAR from copyright header boilerplate

### DIFF
--- a/hack/boilerplate/README.md
+++ b/hack/boilerplate/README.md
@@ -1,3 +1,3 @@
 # Boilerplate utilities
 
-The boilerplate validation utilities have been copied and adapted from upstream Kubernetes, see [boilerplate](https://github.com/kubernetes/kubernetes/blob/4dfd73940396730caf331e35cbb28235d233f2a0/hack/boilerplate).
+The boilerplate validation utilities have been copied and adapted from upstream Kubernetes, see https://github.com/kubernetes/kubernetes/blob/4dfd73940396730caf331e35cbb28235d233f2a0/hack/boilerplate.

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.bzl.txt
+++ b/hack/boilerplate/boilerplate.bzl.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -115,22 +115,11 @@ def file_passes(filename, refs, regexs):
     # trim our file to the same number of lines as the reference file
     data = data[:len(ref)]
 
-    p = regexs["year"]
-    for d in data:
-        if p.search(d):
-            if generated:
-                print('File %s has the YEAR field, but it should not be in generated file' %
-                      filename, file=verbose_out)
-            else:
-                print('File %s has the YEAR field, but missing the year of date' %
-                      filename, file=verbose_out)
-            return False
-
     if not generated:
-        # Replace all occurrences of the regex "2014|2015|2016|2017|2018" with "YEAR"
+        # Remove all occurrences of the year (regex "Copyright (2014|2015|2016|2017|2018) ")
         p = regexs["date"]
         for i, d in enumerate(data):
-            (data[i], found) = p.subn('YEAR', d)
+            (data[i], found) = p.subn('Copyright ', d)
             if found != 0:
                 break
 
@@ -143,6 +132,7 @@ def file_passes(filename, refs, regexs):
             for line in difflib.unified_diff(ref, data, 'reference', filename, lineterm=''):
                 print(line, file=verbose_out)
             print(file=verbose_out)
+
         return False
 
     return True
@@ -154,7 +144,9 @@ skipped_dirs = ['_output', '.git', "hack/boilerplate/test"]
 
 # list all the files contain 'DO NOT EDIT', but are not generated
 skipped_ungenerated_files = [
-    'hack/lib/swagger.sh', 'hack/boilerplate/boilerplate.py']
+    'hack/lib/swagger.sh',
+    'hack/boilerplate/boilerplate.py',
+    ]
 
 def normalize_files(files):
     newfiles = []
@@ -195,16 +187,17 @@ def get_files(extensions):
     return outfiles
 
 def get_dates():
-    years = datetime.datetime.now().year
-    return '(%s)' % '|'.join((str(year) for year in range(2014, years+1)))
+    # After 2026, we no longer allow new files to include the year in the copyright header.
+    final_year = 2026
+    return " (%s) " % "|".join(str(year) for year in range(2014, final_year + 1))
 
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # get_dates return 2014, 2015, 2016, 2017, or 2018 until the current year as a regex like: "(2014|2015|2016|2017|2018)";
-    # company holder names can be anything
-    regexs["date"] = re.compile(get_dates())
+    # get_dates return 2014, 2015, 2016, 2017, ..., 2026
+    # as a regex like: "(2014|2015|2016|2017|2018|...|2026)";
+    regexs["date"] = re.compile("Copyright" + get_dates())
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate_test.py
+++ b/hack/boilerplate/boilerplate_test.py
@@ -49,4 +49,4 @@ class TestBoilerplate(unittest.TestCase):
     sys.stdout = old_stdout
 
     self.assertEquals(
-        output, ['././fail.go', '././fail.py'])
+        output, ['././fail.go', '././fail.py', '././fail_2027.go'])

--- a/hack/boilerplate/test/fail_2027.go
+++ b/hack/boilerplate/test/fail_2027.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2027 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,3 +13,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package test

--- a/hack/boilerplate/test/pass.go
+++ b/hack/boilerplate/test/pass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/test/pass_2026.go
+++ b/hack/boilerplate/test/pass_2026.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,3 +13,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package test


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Same as https://github.com/kubernetes-sigs/cluster-api/pull/13889

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
