### PR TITLE
🐛 Align VM interface IPAMModes configuration with capability gating

### DIFF
--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -433,7 +433,7 @@ var _ = Describe("Network provider", func() {
 					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}))
 				})
 
-				It("should set IPAMModes to IPv4 only for dual-stack if feature gate is disabled", func() {
+				It("should set IPAMModes to nil if feature gate is disabled", func() {
 					Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
 
 					clusterCtx.Cluster.Spec.ClusterNetwork = clusterv1.ClusterNetwork{
@@ -443,7 +443,7 @@ var _ = Describe("Network provider", func() {
 					}
 					err = np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
 				})
 
 				It("should return error if cluster IP family cannot be determined", func() {
@@ -475,7 +475,7 @@ var _ = Describe("Network provider", func() {
 					Expect(vm.Spec.Network.Interfaces[0].Network.TypeMeta.APIVersion).To(Equal(nsxvpcv1.SchemeGroupVersion.String()))
 					Expect(vm.Spec.Network.Interfaces[0].Gateway4).To(BeEmpty())
 					Expect(vm.Spec.Network.Interfaces[0].Gateway6).To(BeEmpty())
-					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
 				})
 			})
 
@@ -532,7 +532,7 @@ var _ = Describe("Network provider", func() {
 					Expect(vm.Spec.Network.Interfaces[0].Network.TypeMeta.APIVersion).To(Equal(nsxvpcv1.SchemeGroupVersion.String()))
 					Expect(vm.Spec.Network.Interfaces[0].Gateway4).To(BeEmpty())
 					Expect(vm.Spec.Network.Interfaces[0].Gateway6).To(BeEmpty())
-					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+					Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
 
 					// Verify first secondary interface
 					Expect(vm.Spec.Network.Interfaces[1].Name).To(Equal("eth1"))
@@ -545,7 +545,7 @@ var _ = Describe("Network provider", func() {
 					Expect(vm.Spec.Network.Interfaces[1].Network.Name).To(Equal("secondary-subnetset"))
 					Expect(vm.Spec.Network.Interfaces[1].Gateway4).To(Equal("None"))
 					Expect(vm.Spec.Network.Interfaces[1].Gateway6).To(Equal("None"))
-					Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+					Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(BeNil())
 
 					// Verify second secondary interface
 					Expect(vm.Spec.Network.Interfaces[2].Name).To(Equal("eth2"))
@@ -556,7 +556,7 @@ var _ = Describe("Network provider", func() {
 					Expect(vm.Spec.Network.Interfaces[2].Network.Name).To(Equal("another-secondary-subnetset"))
 					Expect(vm.Spec.Network.Interfaces[2].Gateway4).To(Equal("None"))
 					Expect(vm.Spec.Network.Interfaces[2].Gateway6).To(Equal("None"))
-					Expect(vm.Spec.Network.Interfaces[2].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol}))
+					Expect(vm.Spec.Network.Interfaces[2].IPAMModes).To(BeNil())
 				})
 
 				It("should add primary and secondary network interfaces", func() {

--- a/pkg/services/network/nsxt_vpc_provider.go
+++ b/pkg/services/network/nsxt_vpc_provider.go
@@ -311,7 +311,7 @@ func (vp *nsxtVPCNetworkProvider) ConfigureVirtualMachine(_ context.Context, clu
 // Note: This function is feature gated by IPv6DualStack.
 func getIPAMModes(clusterCtx *vmware.ClusterContext) ([]corev1.IPFamily, error) {
 	if !feature.Gates.Enabled(feature.IPv6DualStack) {
-		return []corev1.IPFamily{corev1.IPv4Protocol}, nil
+		return nil, nil
 	}
 	ipFamily, err := infrautilv1.DetermineClusterIPFamily(clusterCtx.Cluster)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the Network Provider's VirtualMachine configuration logic with vm-operator's capability gating design for WorkloadIPv6.
In vm-operator (specifically within pkg/crd/crd.go), the ipamModes field is dynamically removed from the VirtualMachine CRD schema if the WorkloadIPv6 capability is disabled. Previously, our provider code explicitly initialized ipamModes with [IPv4] even when feature gates were off. Because a non-empty slice defeats the omitempty JSON tag, the field was serialized into the final YAML, causing unknown field / admission webhook rejection errors on clusters where the WorkloadIPv6 schema is hidden.

For context, the previous implementation (which I authored) explicitly set ipamModes to [IPv4] by design for two main reasons:

- Predictability: We wanted the network provider to have full control over the IPAM configuration, as leaving it unset means relying on the underlying provider's default behavior, which may not always be deterministic.

- K8s Implementation Assumption: We initially assumed vm-operator followed the standard Kubernetes pattern of using an internal dropDisabledFields strategy—where the API server gracefully accepts the explicit default value [IPv4] but clears/drops it internally if the feature gate is off, thereby preserving template portability.

However, we checked the final implementation of vm-operator and found that it uses an alternative approach: it dynamically alters the OpenAPI Schema to completely remove the field. To honor this specific schema-stripping behavior, we need to adapt our provider to return nil under gated conditions, relying on omitempty to cleanly omit the field.


This change is structurally safe and will not lead to an invalid state (e.g., trying to use IPv6 features while they are disabled downstream) due to the strictness of the CAPV FSS lifecycle.

Our CAPV IPv6DualStack feature gate is actually stricter than the downstream WorkloadIPv6. The VKS manages these capabilities by validating three layers of gates:

- The supervisor's IPv6 capability.
- The VKS IPv6 capability.
- The vm-operator v1alpha6 capability.

VKS will only set our CAPV IPv6 and DualStack FSS to true when all three of these checks are enabled. Consequently, it is impossible for the CAPV IPv6/DualStack FSS to be enabled while WorkloadIPv6 is disabled. Therefore, returning nil when the CAPV gate is inactive is a robust and deterministic way to handle single-stack environments.

Testing Done
Verified that on standard IPv4 clusters (feature gate off), ipamModes is omitted and the VM provisions successfully.
Verified that on IPv4 clusters (feature gate on), ipamModes is populated with the [IPv4].
Verified that on Dual-Stack clusters (feature gate on), ipamModes is populated with t [IPv4, IPv6].
Ran full unit test suite in network_test.go to confirm all modified assertions pass cleanly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
