### PR TITLE
🐛 Fix image loading for KCP adoption e2e test

### DIFF
--- a/test/framework/image_preloading.go
+++ b/test/framework/image_preloading.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/httpstream" //nolint:staticcheck // Let's migrate this to the new package after we did the same in core Cluster API.
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/remotecommand"
@@ -121,37 +123,40 @@ func (eh *loadImagesEventHandler) loadImagesViaPod(ctx context.Context, clusterP
 		return
 	}
 
-	Byf("Loading images to Node %s via Pod %s", pod.Spec.NodeName, klog.KObj(pod))
+	_ = wait.PollUntilContextCancel(ctx, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		Byf("Loading images to Node %s via Pod %s", pod.Spec.NodeName, klog.KObj(pod))
 
-	// Open source tar file.
-	reader, writer := io.Pipe()
-	file, err := os.Open(filepath.Clean(sourceFile))
-	if err != nil {
-		Byf("Failed loading images to Node %s via Pod %s: failed to load source file %s: %v", pod.Spec.NodeName, klog.KObj(pod), sourceFile, err)
-		return
-	}
-
-	// Use go routine to pipe source file content into then stdin.
-	go func(file *os.File, writer io.WriteCloser) {
-		defer writer.Close()
-		defer file.Close()
-		// Ignoring the error here because the execPod command should fail in case of
-		// failure copying over the data.
-		_, err := io.Copy(writer, file)
+		// Open source tar file.
+		reader, writer := io.Pipe()
+		file, err := os.Open(filepath.Clean(sourceFile))
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "Failed to copy file data to io.Pipe: %v\n", err)
+			Byf("Failed loading images to Node %s via Pod %s: failed to load source file %s: %v", pod.Spec.NodeName, klog.KObj(pod), sourceFile, err)
+			return false, nil
 		}
-	}(file, writer)
 
-	// Load the container images using ctr and delete the file.
-	loadCommand := "ctr -n k8s.io images import -"
+		// Use go routine to pipe source file content into then stdin.
+		go func(file *os.File, writer io.WriteCloser) {
+			defer writer.Close()
+			defer file.Close()
+			// Ignoring the error here because the execPod command should fail in case of
+			// failure copying over the data.
+			_, err := io.Copy(writer, file)
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "Failed to copy file data to io.Pipe: %v\n", err)
+			}
+		}(file, writer)
 
-	if err := execPod(ctx, clusterProxy, pod.Namespace, pod.Name, containerName, loadCommand, reader); err != nil {
-		Byf("Failed loading images to Node %s via Pod %s: %s", pod.Spec.NodeName, klog.KObj(pod), err)
-		eh.imageLoadPods.Delete(pod.GetUID()) // Delete so we try again on next update.
-		return
-	}
-	Byf("Succeeded loading images to Node %s via Pod %s", pod.Spec.NodeName, klog.KObj(pod))
+		// Load the container images using ctr and delete the file.
+		loadCommand := "ctr -n k8s.io images import -"
+
+		if err := execPod(ctx, clusterProxy, pod.Namespace, pod.Name, containerName, loadCommand, reader); err != nil {
+			Byf("Failed loading images to Node %s via Pod %s: %s", pod.Spec.NodeName, klog.KObj(pod), err)
+			eh.imageLoadPods.Delete(pod.GetUID()) // Delete so we try again on next update.
+			return false, nil
+		}
+		Byf("Succeeded loading images to Node %s via Pod %s", pod.Spec.NodeName, klog.KObj(pod))
+		return true, nil
+	})
 }
 
 // execPod executes a command at a pod.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We have some flakes where image loading fails and then there is no retry (or only if the Pod changes).

Example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-vsphere-e2e-supervisor-main/2074629760352260096

Triage link: https://storage.googleapis.com/k8s-triage/index.html?text=Machines%20must%20be%20replaced%20with%20rollout&job=.*cluster-api.*vsphere.*e2e.*main&xtest=hack_e2e_sh

Relevant log:
```
STEP: Loading images to Node kcp-infra-adop-nkcns via Pod kube-system/image-preloader-ttv4k - /home/prow/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.14.0-alpha.0/framework/ginkgoextensions/output.go:35 @ 07/07/26 23:50:22.736
STEP: Failed loading images to Node kcp-infra-adop-nkcns via Pod kube-system/image-preloader-ttv4k: running command "ctr -n k8s.io images import -" stdout="", stderr="": error reading from error stream: next reader: websocket: close 1006 
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
