### PR TITLE
✨ Support Externally Managed Network Provider

### DIFF
--- a/api/supervisor/v1beta1/vspherecluster_types.go
+++ b/api/supervisor/v1beta1/vspherecluster_types.go
@@ -173,7 +173,7 @@ type Network struct {
 	// provider is the network provider used by the cluster.
 	// The value is immutable once set.
 	// +optional
-	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC
+	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC;ExternallyManaged
 	Provider string `json:"provider,omitempty"`
 }
 

--- a/api/supervisor/v1beta2/vspherecluster_types.go
+++ b/api/supervisor/v1beta2/vspherecluster_types.go
@@ -175,7 +175,7 @@ type Network struct {
 	// provider is the network provider used by the cluster.
 	// The value is immutable once set.
 	// +optional
-	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC
+	// +kubebuilder:validation:Enum=VSphereDistributed;NSXTier1;VPC;ExternallyManaged
 	Provider string `json:"provider,omitempty"`
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,6 +138,14 @@ rules:
 - apiGroups:
   - crd.nsx.vmware.com
   resources:
+  - subnets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - crd.nsx.vmware.com
+  resources:
   - subnetsets
   - subnetsets/status
   verbs:

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -143,6 +143,7 @@ spec:
                     - VSphereDistributed
                     - NSXTier1
                     - VPC
+                    - ExternallyManaged
                     type: string
                 type: object
                 x-kubernetes-validations:
@@ -469,6 +470,7 @@ spec:
                     - VSphereDistributed
                     - NSXTier1
                     - VPC
+                    - ExternallyManaged
                     type: string
                 type: object
                 x-kubernetes-validations:

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -155,6 +155,7 @@ spec:
                             - VSphereDistributed
                             - NSXTier1
                             - VPC
+                            - ExternallyManaged
                             type: string
                         type: object
                         x-kubernetes-validations:
@@ -354,6 +355,7 @@ spec:
                             - VSphereDistributed
                             - NSXTier1
                             - VPC
+                            - ExternallyManaged
                             type: string
                         type: object
                         x-kubernetes-validations:

--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -214,6 +214,21 @@ func (r *serviceDiscoveryReconciler) Reconcile(ctx context.Context, req reconcil
 			klog.KObj(vsphereCluster))
 	}
 
+	// ExternallyManaged (and any provider that does not support the supervisor
+	// headless Service) skips ServiceDiscovery entirely. Mark ready so the skip
+	// is an explicit, observable success. Do this before waiting on guest-cluster
+	// connectivity since we will not touch the guest.
+	if !np.SupportsSupervisorService() {
+		log.Info("Skipping supervisor Service/Endpoints reconciliation; network provider does not support supervisor service")
+		deprecatedv1beta1conditions.MarkTrue(vsphereCluster, vmwarev1.ServiceDiscoveryReadyV1Beta1Condition)
+		conditions.Set(vsphereCluster, metav1.Condition{
+			Type:   vmwarev1.VSphereClusterServiceDiscoveryReadyCondition,
+			Status: metav1.ConditionTrue,
+			Reason: vmwarev1.VSphereClusterServiceDiscoveryReadyReason,
+		})
+		return reconcile.Result{}, nil
+	}
+
 	// We cannot proceed until we are able to access the target cluster. Until
 	// then just return a no-op and wait for the next sync.
 	guestClient, err := r.clusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))

--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -214,6 +214,20 @@ func (r *serviceDiscoveryReconciler) Reconcile(ctx context.Context, req reconcil
 			klog.KObj(vsphereCluster))
 	}
 
+	// ExternallyManaged (and any provider that does not support the supervisor
+	// headless Service) skips ServiceDiscovery entirely. Mark ready so the skip
+	// is an explicit, observable success. Do this before waiting on guest-cluster
+	// connectivity since we will not touch the guest.
+	if !np.SupportsSupervisorService() {
+		deprecatedv1beta1conditions.MarkTrue(vsphereCluster, vmwarev1.ServiceDiscoveryReadyV1Beta1Condition)
+		conditions.Set(vsphereCluster, metav1.Condition{
+			Type:   vmwarev1.VSphereClusterServiceDiscoveryReadyCondition,
+			Status: metav1.ConditionTrue,
+			Reason: vmwarev1.VSphereClusterServiceDiscoveryReadyReason,
+		})
+		return reconcile.Result{}, nil
+	}
+
 	// We cannot proceed until we are able to access the target cluster. Until
 	// then just return a no-op and wait for the next sync.
 	guestClient, err := r.clusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))

--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -82,6 +82,8 @@ const (
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vmoperator.vmware.com,resources=virtualmachineimages;virtualmachineimages/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=crd.nsx.vmware.com,resources=subnetsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes;events;configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -57,6 +57,12 @@ const (
 	// alpha: v1.17
 	ClusterNetworkProvider featuregate.Feature = "ClusterNetworkProvider"
 
+	// ExternallyManagedProvider gates setting VSphereCluster.spec.network.provider to
+	// ExternallyManaged and registering the ExternallyManaged network provider.
+	//
+	// alpha: v1.17
+	ExternallyManagedProvider featuregate.Feature = "ExternallyManagedProvider"
+
 	// InfrastructurePolicies is a feature gate for the Support for Supervisor infrastructure policies.
 	// When enabled, VSphereMachine.spec.policies are validated on admission and
 	// mapped to the underlying VirtualMachine spec.
@@ -100,10 +106,11 @@ var (
 	}
 
 	supervisorGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		NamespaceScopedZones:   {Default: false, PreRelease: featuregate.Alpha},
-		NodeAutoPlacement:      {Default: false, PreRelease: featuregate.Alpha},
-		ClusterNetworkProvider: {Default: false, PreRelease: featuregate.Alpha},
-		MultiNetworks:          {Default: false, PreRelease: featuregate.Alpha},
+		NamespaceScopedZones:      {Default: false, PreRelease: featuregate.Alpha},
+		NodeAutoPlacement:         {Default: false, PreRelease: featuregate.Alpha},
+		ClusterNetworkProvider:    {Default: false, PreRelease: featuregate.Alpha},
+		ExternallyManagedProvider: {Default: false, PreRelease: featuregate.Alpha},
+		MultiNetworks:             {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	supervisorVersionedGates = map[featuregate.Feature]featuregate.VersionedSpecs{

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -54,8 +54,14 @@ const (
 	// for supervisor. When enabled, the network provider is resolved per-cluster from
 	// VSphereCluster.spec.network.provider instead of the static --network-provider flag.
 	//
-	// alpha: v1.17
+	// alpha: v1.18
 	ClusterNetworkProvider featuregate.Feature = "ClusterNetworkProvider"
+
+	// ExternallyManagedProvider gates setting VSphereCluster.spec.network.provider to
+	// ExternallyManaged and registering the ExternallyManaged network provider.
+	//
+	// alpha: v1.18
+	ExternallyManagedProvider featuregate.Feature = "ExternallyManagedProvider"
 
 	// InfrastructurePolicies is a feature gate for the Support for Supervisor infrastructure policies.
 	// When enabled, VSphereMachine.spec.policies are validated on admission and
@@ -100,10 +106,11 @@ var (
 	}
 
 	supervisorGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		NamespaceScopedZones:   {Default: false, PreRelease: featuregate.Alpha},
-		NodeAutoPlacement:      {Default: false, PreRelease: featuregate.Alpha},
-		ClusterNetworkProvider: {Default: false, PreRelease: featuregate.Alpha},
-		MultiNetworks:          {Default: false, PreRelease: featuregate.Alpha},
+		NamespaceScopedZones:      {Default: false, PreRelease: featuregate.Alpha},
+		NodeAutoPlacement:         {Default: false, PreRelease: featuregate.Alpha},
+		ClusterNetworkProvider:    {Default: false, PreRelease: featuregate.Alpha},
+		ExternallyManagedProvider: {Default: false, PreRelease: featuregate.Alpha},
+		MultiNetworks:             {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	supervisorVersionedGates = map[featuregate.Feature]featuregate.VersionedSpecs{

--- a/internal/webhooks/vmware/vspherecluster.go
+++ b/internal/webhooks/vmware/vspherecluster.go
@@ -92,6 +92,13 @@ func (webhook *VSphereCluster) validateClusterNetwork(ctx context.Context, clust
 			))
 			return allErrs
 		}
+
+		if cluster.Spec.Network.Provider == manager.ExternallyManagedNetworkProvider && !feature.Gates.Enabled(feature.ExternallyManagedProvider) {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "network", "provider"),
+				"provider ExternallyManaged can only be set when feature gate ExternallyManagedProvider is enabled",
+			))
+		}
 	} else if cluster.Spec.Network.Provider != "" {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("spec", "network", "provider"),

--- a/internal/webhooks/vmware/vspherecluster_test.go
+++ b/internal/webhooks/vmware/vspherecluster_test.go
@@ -167,6 +167,24 @@ func TestVSphereCluster_ValidateCreate(t *testing.T) {
 			errMsg:         "spec.network.provider must be set",
 		},
 		{
+			name: "ExternallyManaged rejected when ExternallyManagedProvider gate is off",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
+				Provider: manager.ExternallyManagedNetworkProvider,
+			}, vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"ClusterNetworkProvider": true, "ExternallyManagedProvider": false},
+			wantErr:      true,
+			errType:      &apierrors.StatusError{},
+			errMsg:       "provider ExternallyManaged can only be set when feature gate ExternallyManagedProvider is enabled",
+		},
+		{
+			name: "ExternallyManaged accepted when ExternallyManagedProvider and ClusterNetworkProvider gates are on",
+			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{
+				Provider: manager.ExternallyManagedNetworkProvider,
+			}, vmwarev1.FailureDomainsSpec{}),
+			featureGates: map[string]bool{"ClusterNetworkProvider": true, "ExternallyManagedProvider": true},
+			wantErr:      false,
+		},
+		{
 			name: "successful VSphereCluster creation with valid control plane selector and feature gate enabled",
 			vsphereCluster: createVSphereCluster("test-cluster", vmwarev1.Network{}, vmwarev1.FailureDomainsSpec{
 				ControlPlane: vmwarev1.FailureDomainsControlPlaneSpec{
@@ -392,6 +410,9 @@ func setupFeatureGates(t *testing.T, featureGates map[string]bool) {
 		}
 		if featureName == "ClusterNetworkProvider" {
 			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterNetworkProvider, enabled)
+		}
+		if featureName == "ExternallyManagedProvider" {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ExternallyManagedProvider, enabled)
 		}
 	}
 }

--- a/internal/webhooks/vmware/vspheremachine.go
+++ b/internal/webhooks/vmware/vspheremachine.go
@@ -160,6 +160,16 @@ func validateNetwork(networkProvider string, network vmwarev1.VSphereMachineNetw
 							fmt.Sprintf("only supports %s", pkgnetwork.NetworkGVKNetOperator)))
 					}
 				}
+			case manager.ExternallyManagedNetworkProvider:
+				// ExternallyManaged skips provider-specific reference-kind and
+				// secondary placement validation. Schema-level checks
+				// (name uniqueness, CRD markers) still apply below.
+				// Primary is required: it carries the workload network on eth0.
+				if !network.Interfaces.Primary.IsDefined() {
+					allErrs = append(allErrs, field.Required(
+						fldPath.Child("interfaces", "primary"),
+						"primary interface must be defined"))
+				}
 			default:
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("interfaces"), fmt.Sprintf("interfaces can not be set when network provider is %s", networkProvider)))
 			}
@@ -195,11 +205,11 @@ func validateVLANs(networkProvider string, network vmwarev1.VSphereMachineNetwor
 			"vlans can only be set when feature gate VLANSubinterface is enabled"))
 		return allErrs
 	}
-	// vlan sub-interfaces feature only supports NSX-VPC Provider
-	if networkProvider != manager.NSXVPCNetworkProvider {
+	// vlan sub-interfaces are supported by NSX-VPC and ExternallyManaged providers
+	if networkProvider != manager.NSXVPCNetworkProvider && networkProvider != manager.ExternallyManagedNetworkProvider {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath.Child("vlans"),
-			fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider)))
+			fmt.Sprintf("vlans can only be set when network provider is %s or %s", manager.NSXVPCNetworkProvider, manager.ExternallyManagedNetworkProvider)))
 		return allErrs
 	}
 	// vlan sub-interfaces only can link to a secondary interface

--- a/internal/webhooks/vmware/vspheremachine.go
+++ b/internal/webhooks/vmware/vspheremachine.go
@@ -160,6 +160,29 @@ func validateNetwork(networkProvider string, network vmwarev1.VSphereMachineNetw
 							fmt.Sprintf("only supports %s", pkgnetwork.NetworkGVKNetOperator)))
 					}
 				}
+			case manager.ExternallyManagedNetworkProvider:
+				// ExternallyManaged skips provider-specific reference-kind and
+				// secondary placement validation. Schema-level checks
+				// (name uniqueness, CRD markers) still apply below.
+				// Primary is required: it carries the workload network on eth0.
+				if !network.Interfaces.Primary.IsDefined() {
+					allErrs = append(allErrs, field.Required(
+						fldPath.Child("interfaces", "primary"),
+						"primary interface must be defined"))
+				}
+				// Routes are not propagated onto VirtualMachine interfaces.
+				if len(network.Interfaces.Primary.Routes) > 0 {
+					allErrs = append(allErrs, field.Forbidden(
+						fldPath.Child("interfaces", "primary", "routes"),
+						"routes cannot be set when network provider is ExternallyManaged"))
+				}
+				for i, secondaryInterface := range network.Interfaces.Secondary {
+					if len(secondaryInterface.Routes) > 0 {
+						allErrs = append(allErrs, field.Forbidden(
+							fldPath.Child("interfaces", "secondary").Index(i).Child("routes"),
+							"routes cannot be set when network provider is ExternallyManaged"))
+					}
+				}
 			default:
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("interfaces"), fmt.Sprintf("interfaces can not be set when network provider is %s", networkProvider)))
 			}
@@ -195,11 +218,11 @@ func validateVLANs(networkProvider string, network vmwarev1.VSphereMachineNetwor
 			"vlans can only be set when feature gate VLANSubinterface is enabled"))
 		return allErrs
 	}
-	// vlan sub-interfaces feature only supports NSX-VPC Provider
-	if networkProvider != manager.NSXVPCNetworkProvider {
+	// vlan sub-interfaces are supported by NSX-VPC and ExternallyManaged providers
+	if networkProvider != manager.NSXVPCNetworkProvider && networkProvider != manager.ExternallyManagedNetworkProvider {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath.Child("vlans"),
-			fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider)))
+			fmt.Sprintf("vlans can only be set when network provider is %s or %s", manager.NSXVPCNetworkProvider, manager.ExternallyManagedNetworkProvider)))
 		return allErrs
 	}
 	// vlan sub-interfaces only can link to a secondary interface

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -323,6 +323,100 @@ func TestVSphereMachine_ValidateCreate_MultiNetwork(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "interface name is already in use",
 		},
+		{
+			name:            "ExternallyManaged accepts cross-provider primary and secondary interfaces",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "ExternallyManaged rejects missing primary interface",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "primary interface must be defined",
+		},
+		{
+			name:            "ExternallyManaged rejects duplicate interface names",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: pkgnetwork.PrimaryInterfaceName,
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interface name is already in use",
+		},
+		{
+			name:            "ExternallyManaged interfaces rejected when MultiNetworks is off",
+			featureGate:     false,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interfaces can only be set when feature gate MultiNetworks is enabled",
+		},
 	}
 
 	for _, tc := range tests {
@@ -675,7 +769,43 @@ func TestVSphereMachine_ValidateCreate_VLANs(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s or %s", manager.NSXVPCNetworkProvider, manager.ExternallyManagedNetworkProvider),
+		},
+		{
+			name:            "valid vlans for ExternallyManaged network provider",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			networkSpec: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{
+						{
+							Name: "eth1",
+							InterfaceSpec: vmwarev1.InterfaceSpec{
+								NetworkRef: vmwarev1.InterfaceNetworkReference{
+									Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+									APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+									Name:       "management-network",
+								},
+							},
+						},
+					},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vlan101",
+						ID:   ptr.To[int32](101),
+						Link: "eth1",
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name:            "vlans name duplicate with primary interface name",

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -323,6 +323,154 @@ func TestVSphereMachine_ValidateCreate_MultiNetwork(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "interface name is already in use",
 		},
+		{
+			name:            "ExternallyManaged accepts cross-provider primary and secondary interfaces",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "ExternallyManaged rejects missing primary interface",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "primary interface must be defined",
+		},
+		{
+			name:            "ExternallyManaged rejects duplicate interface names",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: pkgnetwork.PrimaryInterfaceName,
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interface name is already in use",
+		},
+		{
+			name:            "ExternallyManaged interfaces rejected when MultiNetworks is off",
+			featureGate:     false,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interfaces can only be set when feature gate MultiNetworks is enabled",
+		},
+		{
+			name:            "ExternallyManaged rejects routes on primary interface",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+						Routes: []vmwarev1.RouteSpec{{
+							To:  "10.0.0.0/8",
+							Via: "10.0.0.1",
+						}},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "routes cannot be set when network provider is ExternallyManaged",
+		},
+		{
+			name:            "ExternallyManaged rejects routes on secondary interface",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+							Routes: []vmwarev1.RouteSpec{{
+								To:  "192.168.0.0/16",
+								Via: "192.168.0.1",
+							}},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "routes cannot be set when network provider is ExternallyManaged",
+		},
 	}
 
 	for _, tc := range tests {
@@ -675,7 +823,43 @@ func TestVSphereMachine_ValidateCreate_VLANs(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s or %s", manager.NSXVPCNetworkProvider, manager.ExternallyManagedNetworkProvider),
+		},
+		{
+			name:            "valid vlans for ExternallyManaged network provider",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			networkSpec: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{
+						{
+							Name: "eth1",
+							InterfaceSpec: vmwarev1.InterfaceSpec{
+								NetworkRef: vmwarev1.InterfaceNetworkReference{
+									Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+									APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+									Name:       "management-network",
+								},
+							},
+						},
+					},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vlan101",
+						ID:   ptr.To[int32](101),
+						Link: "eth1",
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name:            "vlans name duplicate with primary interface name",

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -368,6 +368,100 @@ func TestVSphereMachineTemplate_ValidateInterfaces(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:            "ExternallyManaged accepts cross-provider primary and secondary interfaces",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "ExternallyManaged rejects missing primary interface",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "primary interface must be defined",
+		},
+		{
+			name:            "ExternallyManaged rejects duplicate interface names",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: pkgnetwork.PrimaryInterfaceName,
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+								APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interface name is already in use",
+		},
+		{
+			name:            "ExternallyManaged interfaces rejected when MultiNetworks is off",
+			featureGate:     false,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			network: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "interfaces can only be set when feature gate MultiNetworks is enabled",
+		},
 	}
 
 	for _, tc := range tests {
@@ -796,7 +890,43 @@ func TestVSphereMachineTemplate_ValidateVLANs(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s", manager.NSXVPCNetworkProvider),
+			wantErrMsg: fmt.Sprintf("vlans can only be set when network provider is %s or %s", manager.NSXVPCNetworkProvider, manager.ExternallyManagedNetworkProvider),
+		},
+		{
+			name:            "valid vlans for ExternallyManaged network provider",
+			featureGate:     true,
+			networkProvider: manager.ExternallyManagedNetworkProvider,
+			networkSpec: vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       pkgnetwork.NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: pkgnetwork.NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{
+						{
+							Name: "eth1",
+							InterfaceSpec: vmwarev1.InterfaceSpec{
+								NetworkRef: vmwarev1.InterfaceNetworkReference{
+									Kind:       pkgnetwork.NetworkGVKNetOperator.Kind,
+									APIVersion: pkgnetwork.NetworkGVKNetOperator.GroupVersion().String(),
+									Name:       "management-network",
+								},
+							},
+						},
+					},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vlan101",
+						ID:   ptr.To[int32](101),
+						Link: "eth1",
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name:            "vlans name duplicate with primary interface name",

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -19,7 +19,6 @@ package manager
 import (
 	"context"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
@@ -33,6 +32,9 @@ const (
 	NSXNetworkProvider = network.NSXTier1NetworkProviderName
 	// VDSNetworkProvider identifies the vSphere Distributed Switch network provider.
 	VDSNetworkProvider = network.VSphereDistributedNetworkProviderName
+	// ExternallyManagedNetworkProvider identifies the ExternallyManaged network provider.
+	// Used when network objects are provisioned and managed externally and CAPV only attaches VMs.
+	ExternallyManagedNetworkProvider = network.ExternallyManagedNetworkProviderName
 	// DummyLBNetworkProvider identifies the Dummy LB network provider.
 	DummyLBNetworkProvider = network.DummyLBNetworkProviderName
 
@@ -64,25 +66,20 @@ func ConvertNetworkProviderName(name string) string {
 // GetNetworkProvider will return a network provider instance based on the environment
 // the cfg is used to initialize a client that talks directly to api-server without using the cache.
 // networkProvider must be a canonical PascalCase name; legacy flag values are not accepted here.
-func GetNetworkProvider(ctx context.Context, client client.Client, networkProvider string) (services.NetworkProvider, error) {
-	log := ctrl.LoggerFrom(ctx)
-
+func GetNetworkProvider(_ context.Context, client client.Client, networkProvider string) (services.NetworkProvider, error) {
 	switch networkProvider {
 	case NSXVPCNetworkProvider:
-		log.Info("Pick NSX-VPC network provider")
 		return network.NSXTVpcNetworkProvider(client), nil
 	case NSXNetworkProvider:
 		// TODO: disableFirewall not configurable
-		log.Info("Pick NSX-T network provider")
 		return network.NsxtNetworkProvider(client, "false"), nil
 	case VDSNetworkProvider:
-		log.Info("Pick NetOp (VDS) network provider")
 		return network.NetOpNetworkProvider(client), nil
+	case ExternallyManagedNetworkProvider:
+		return network.ExternallyManagedNetworkProvider(client), nil
 	case DummyLBNetworkProvider:
-		log.Info("Pick Dummy network provider")
 		return network.DummyLBNetworkProvider(), nil
 	default:
-		log.Info("NetworkProvider not set. Pick Dummy network provider")
 		return network.DummyNetworkProvider(), nil
 	}
 }

--- a/pkg/manager/network.go
+++ b/pkg/manager/network.go
@@ -33,6 +33,9 @@ const (
 	NSXNetworkProvider = network.NSXTier1NetworkProviderName
 	// VDSNetworkProvider identifies the vSphere Distributed Switch network provider.
 	VDSNetworkProvider = network.VSphereDistributedNetworkProviderName
+	// ExternallyManagedNetworkProvider identifies the ExternallyManaged network provider.
+	// Used when network objects are provisioned and managed externally and CAPV only attaches VMs.
+	ExternallyManagedNetworkProvider = network.ExternallyManagedNetworkProviderName
 	// DummyLBNetworkProvider identifies the Dummy LB network provider.
 	DummyLBNetworkProvider = network.DummyLBNetworkProviderName
 
@@ -78,6 +81,9 @@ func GetNetworkProvider(ctx context.Context, client client.Client, networkProvid
 	case VDSNetworkProvider:
 		log.Info("Pick NetOp (VDS) network provider")
 		return network.NetOpNetworkProvider(client), nil
+	case ExternallyManagedNetworkProvider:
+		log.Info("Pick ExternallyManaged network provider")
+		return network.ExternallyManagedNetworkProvider(client), nil
 	case DummyLBNetworkProvider:
 		log.Info("Pick Dummy network provider")
 		return network.DummyLBNetworkProvider(), nil

--- a/pkg/manager/network_factory.go
+++ b/pkg/manager/network_factory.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
 )
 
@@ -69,7 +70,11 @@ type perClusterNetworkProviderFactory struct {
 // pre-built for the in-scope provider names.
 func NewPerClusterNetworkProviderFactory(ctx context.Context, client client.Client) (NetworkProviderFactory, error) {
 	registry := map[string]services.NetworkProvider{}
-	for _, name := range []string{VDSNetworkProvider, NSXNetworkProvider, NSXVPCNetworkProvider} {
+	names := []string{VDSNetworkProvider, NSXNetworkProvider, NSXVPCNetworkProvider}
+	if feature.Gates.Enabled(feature.ExternallyManagedProvider) {
+		names = append(names, ExternallyManagedNetworkProvider)
+	}
+	for _, name := range names {
 		np, err := GetNetworkProvider(ctx, client, name)
 		if err != nil {
 			return nil, err

--- a/pkg/manager/network_factory_test.go
+++ b/pkg/manager/network_factory_test.go
@@ -25,11 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 )
 
 func clusterWithProvider(provider string) *vmwarev1.VSphereCluster {
@@ -79,6 +81,28 @@ func TestPerClusterNetworkProviderFactory(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("unknown network provider"))
 		g.Expect(np).To(BeNil())
+	})
+
+	t.Run("ExternallyManaged is rejected when gate is disabled", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ExternallyManagedProvider, false)
+		factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+		np, err := factory.ForCluster(ctx, clusterWithProvider(ExternallyManagedNetworkProvider))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown network provider"))
+		g.Expect(np).To(BeNil())
+	})
+
+	t.Run("ExternallyManaged is registered when gate is enabled", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ExternallyManagedProvider, true)
+		factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+		np, err := factory.ForCluster(ctx, clusterWithProvider(ExternallyManagedNetworkProvider))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(np).ToNot(BeNil())
+		g.Expect(np.Name()).To(Equal(ExternallyManagedNetworkProvider))
 	})
 }
 

--- a/pkg/manager/network_factory_test.go
+++ b/pkg/manager/network_factory_test.go
@@ -25,11 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 )
 
 func clusterWithProvider(provider string) *vmwarev1.VSphereCluster {
@@ -79,6 +81,28 @@ func TestPerClusterNetworkProviderFactory(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("unknown network provider"))
 		g.Expect(np).To(BeNil())
+	})
+
+	t.Run("ExternallyManaged is rejected when gate is disabled", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ExternallyManagedProvider, false)
+		factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+		np, err := factory.ForCluster(ctx, clusterWithProvider(ExternallyManagedNetworkProvider))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown network provider"))
+		g.Expect(np).To(BeNil())
+	})
+
+	t.Run("ExternallyManaged is registered when gate is enabled", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.ExternallyManagedProvider, true)
+		factory, err := NewPerClusterNetworkProviderFactory(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+		np, err := factory.ForCluster(ctx, clusterWithProvider(ExternallyManagedNetworkProvider))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(np).ToNot(BeNil())
+		g.Expect(np.SupportsSupervisorService()).To(BeFalse())
 	})
 }
 

--- a/pkg/manager/network_test.go
+++ b/pkg/manager/network_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestConvertNetworkProviderName(t *testing.T) {
@@ -76,4 +78,17 @@ func TestConvertNetworkProviderName(t *testing.T) {
 			g.Expect(ConvertNetworkProviderName(tt.input)).To(Equal(tt.expected))
 		})
 	}
+}
+
+func TestGetNetworkProviderExternallyManaged(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	c := fake.NewClientBuilder().Build()
+
+	np, err := GetNetworkProvider(ctx, c, ExternallyManagedNetworkProvider)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(np).ToNot(BeNil())
+	g.Expect(np.HasLoadBalancer()).To(BeFalse())
+	g.Expect(np.SupportsVMReadinessProbe()).To(BeFalse())
+	g.Expect(np.SupportsSupervisorService()).To(BeFalse())
 }

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -19,7 +19,6 @@ package services
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,20 +113,17 @@ type NetworkProvider interface {
 	// SupportsVMReadinessProbe indicates whether this provider support vm readiness probe.
 	SupportsVMReadinessProbe() bool
 
+	// SupportsSupervisorService indicates whether the ServiceDiscovery controller should
+	// reconcile the default/supervisor headless Service/Endpoints in the target cluster.
+	SupportsSupervisorService() bool
+
 	// ProvisionClusterNetwork creates network resource for a given cluster
 	// This operation should be idempotent
 	ProvisionClusterNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext) error
-
-	// GetClusterNetworkName returns the name of a valid cluster network if one exists
-	// Returns an empty string if the operation is not supported
-	GetClusterNetworkName(ctx context.Context, clusterCtx *vmware.ClusterContext) (string, error)
 
 	// GetVMServiceAnnotations returns the annotations, if any, to place on a VM Service.
 	GetVMServiceAnnotations(ctx context.Context, clusterCtx *vmware.ClusterContext) (map[string]string, error)
 
 	// ConfigureVirtualMachine configures a VM for the particular network
 	ConfigureVirtualMachine(ctx context.Context, clusterCtx *vmware.ClusterContext, machine *vmwarev1.VSphereMachine, vm *vmoprvhub.VirtualMachine) error
-
-	// VerifyNetworkStatus verifies the status of the network after vnet creation
-	VerifyNetworkStatus(ctx context.Context, clusterCtx *vmware.ClusterContext, obj runtime.Object) error
 }

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -114,6 +114,10 @@ type NetworkProvider interface {
 	// SupportsVMReadinessProbe indicates whether this provider support vm readiness probe.
 	SupportsVMReadinessProbe() bool
 
+	// SupportsSupervisorService indicates whether the ServiceDiscovery controller should
+	// reconcile the default/supervisor headless Service/Endpoints in the target cluster.
+	SupportsSupervisorService() bool
+
 	// ProvisionClusterNetwork creates network resource for a given cluster
 	// This operation should be idempotent
 	ProvisionClusterNetwork(ctx context.Context, clusterCtx *vmware.ClusterContext) error

--- a/pkg/services/network/constants.go
+++ b/pkg/services/network/constants.go
@@ -30,6 +30,8 @@ const (
 	NSXTier1NetworkProviderName = "NSXTier1"
 	// VSphereDistributedNetworkProviderName is the canonical name for the VDS network provider.
 	VSphereDistributedNetworkProviderName = "VSphereDistributed"
+	// ExternallyManagedNetworkProviderName is the canonical name for the ExternallyManaged network provider.
+	ExternallyManagedNetworkProviderName = "ExternallyManaged"
 	// DummyLBNetworkProviderName is the canonical name for the Dummy LB network provider.
 	DummyLBNetworkProviderName = "DummyLBNetworkProvider"
 	// DummyNetworkProviderName is the canonical name for the Dummy network provider.

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -53,6 +53,10 @@ func (np *dummyNetworkProvider) SupportsVMReadinessProbe() bool {
 	return true
 }
 
+func (np *dummyNetworkProvider) SupportsSupervisorService() bool {
+	return true
+}
+
 func (np *dummyNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
 	conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
 		Type:   vmwarev1.VSphereClusterNetworkReadyCondition,

--- a/pkg/services/network/dummy_provider.go
+++ b/pkg/services/network/dummy_provider.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
@@ -53,6 +52,10 @@ func (np *dummyNetworkProvider) SupportsVMReadinessProbe() bool {
 	return true
 }
 
+func (np *dummyNetworkProvider) SupportsSupervisorService() bool {
+	return true
+}
+
 func (np *dummyNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
 	conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
 		Type:   vmwarev1.VSphereClusterNetworkReadyCondition,
@@ -62,20 +65,12 @@ func (np *dummyNetworkProvider) ProvisionClusterNetwork(_ context.Context, clust
 	return nil
 }
 
-func (np *dummyNetworkProvider) GetClusterNetworkName(_ context.Context, _ *vmware.ClusterContext) (string, error) {
-	return "", nil
-}
-
 func (np *dummyNetworkProvider) ConfigureVirtualMachine(_ context.Context, _ *vmware.ClusterContext, _ *vmwarev1.VSphereMachine, _ *vmoprvhub.VirtualMachine) error {
 	return nil
 }
 
 func (np *dummyNetworkProvider) GetVMServiceAnnotations(_ context.Context, _ *vmware.ClusterContext) (map[string]string, error) {
 	return map[string]string{}, nil
-}
-
-func (np *dummyNetworkProvider) VerifyNetworkStatus(_ context.Context, _ *vmware.ClusterContext, _ runtime.Object) error {
-	return nil
 }
 
 type dummyLBNetworkProvider struct {

--- a/pkg/services/network/externally_managed_provider.go
+++ b/pkg/services/network/externally_managed_provider.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+
+	pkgerrors "github.com/pkg/errors"
+	nsxvpcv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
+	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+)
+
+// externallyManagedNetworkProvider propagates VSphereMachine interface specs
+// into VirtualMachine network interfaces without provisioning networks or LBs.
+type externallyManagedNetworkProvider struct {
+	client client.Client
+}
+
+// ExternallyManagedNetworkProvider returns an ExternallyManaged network provider.
+func ExternallyManagedNetworkProvider(client client.Client) services.NetworkProvider {
+	return &externallyManagedNetworkProvider{
+		client: client,
+	}
+}
+
+func (np *externallyManagedNetworkProvider) Name() string {
+	return ExternallyManagedNetworkProviderName
+}
+
+// SupportsIPv6DualStack is unreachable for this provider: the VMService LB path
+// and ServiceDiscovery address discovery that consume it are both skipped.
+// Dual-stack is instead derived per-interface from the referenced Subnet / SubnetSet.
+func (np *externallyManagedNetworkProvider) SupportsIPv6DualStack() bool {
+	return false
+}
+
+func (np *externallyManagedNetworkProvider) HasLoadBalancer() bool {
+	return false
+}
+
+func (np *externallyManagedNetworkProvider) SupportsVMReadinessProbe() bool {
+	return false
+}
+
+func (np *externallyManagedNetworkProvider) SupportsSupervisorService() bool {
+	return false
+}
+
+// ProvisionClusterNetwork creates nothing; network objects are provisioned and
+// managed externally, so they are assumed ready. It marks the network ready
+// condition True.
+func (np *externallyManagedNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
+	deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyV1Beta1Condition)
+	conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
+		Type:   vmwarev1.VSphereClusterNetworkReadyCondition,
+		Status: metav1.ConditionTrue,
+		Reason: vmwarev1.VSphereClusterNetworkReadyReason,
+	})
+	return nil
+}
+
+func (np *externallyManagedNetworkProvider) GetClusterNetworkName(_ context.Context, _ *vmware.ClusterContext) (string, error) {
+	return "", nil
+}
+
+func (np *externallyManagedNetworkProvider) GetVMServiceAnnotations(_ context.Context, _ *vmware.ClusterContext) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (np *externallyManagedNetworkProvider) VerifyNetworkStatus(_ context.Context, _ *vmware.ClusterContext, _ runtime.Object) error {
+	return nil
+}
+
+// ConfigureVirtualMachine straight-propagates machine interfaces and VLANs onto the VM.
+// Interface routes are not propagated. Primary is required (workload network on eth0).
+func (np *externallyManagedNetworkProvider) ConfigureVirtualMachine(ctx context.Context, _ *vmware.ClusterContext, machine *vmwarev1.VSphereMachine, vm *vmoprvhub.VirtualMachine) error {
+	primary := machine.Spec.Network.Interfaces.Primary
+	if !primary.IsDefined() {
+		return pkgerrors.New("primary interface must be defined")
+	}
+
+	vm.Spec.Network = &vmoprvhub.VirtualMachineNetworkSpec{}
+
+	primaryIPAMModes, err := np.ipamModesForInterface(ctx, machine.Namespace, primary.NetworkRef)
+	if err != nil {
+		return err
+	}
+	vm.Spec.Network.Interfaces = append(vm.Spec.Network.Interfaces, vmInterfaceFromSpec(
+		PrimaryInterfaceName,
+		primary,
+		"", // gateway4
+		"", // gateway6
+		primaryIPAMModes,
+	))
+
+	for _, secondary := range machine.Spec.Network.Interfaces.Secondary {
+		ipamModes, err := np.ipamModesForInterface(ctx, machine.Namespace, secondary.NetworkRef)
+		if err != nil {
+			return err
+		}
+		vm.Spec.Network.Interfaces = append(vm.Spec.Network.Interfaces, vmInterfaceFromSpec(
+			secondary.Name,
+			secondary.InterfaceSpec,
+			"None",
+			"None",
+			ipamModes,
+		))
+	}
+
+	return setVLANs(machine, vm)
+}
+
+func vmInterfaceFromSpec(name string, iface vmwarev1.InterfaceSpec, gateway4, gateway6 string, ipamModes []corev1.IPFamily) vmoprvhub.VirtualMachineNetworkInterfaceSpec {
+	var mtu *int64
+	if iface.MTU != 0 {
+		mtu = ptr.To(int64(iface.MTU))
+	}
+	return vmoprvhub.VirtualMachineNetworkInterfaceSpec{
+		Name: name,
+		Network: &vmoprvhub.PartialObjectRef{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       iface.NetworkRef.Kind,
+				APIVersion: iface.NetworkRef.APIVersion,
+			},
+			Name: iface.NetworkRef.Name,
+		},
+		MTU:       mtu,
+		Gateway4:  gateway4,
+		Gateway6:  gateway6,
+		IPAMModes: ipamModes,
+	}
+}
+
+// ipamModesForInterface derives IPAMModes from a referenced Subnet or SubnetSet
+// when the IPv6DualStack feature gate is enabled. Other network refs leave IPAMModes unset.
+func (np *externallyManagedNetworkProvider) ipamModesForInterface(ctx context.Context, namespace string, networkRef vmwarev1.InterfaceNetworkReference) ([]corev1.IPFamily, error) {
+	if !feature.Gates.Enabled(feature.IPv6DualStack) {
+		return nil, nil
+	}
+
+	gvk := networkRef.GroupVersionKind()
+	switch gvk {
+	case NetworkGVKNSXTVPCSubnet:
+		subnet := &nsxvpcv1.Subnet{}
+		if err := np.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: networkRef.Name}, subnet); err != nil {
+			return nil, pkgerrors.Wrapf(err, "failed to get Subnet %s", klog.KRef(namespace, networkRef.Name))
+		}
+		return ipamModesFromIPAddressType(subnet.Spec.IPAddressType), nil
+	case NetworkGVKNSXTVPCSubnetSet:
+		subnetSet := &nsxvpcv1.SubnetSet{}
+		if err := np.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: networkRef.Name}, subnetSet); err != nil {
+			return nil, pkgerrors.Wrapf(err, "failed to get SubnetSet %s", klog.KRef(namespace, networkRef.Name))
+		}
+		return ipamModesFromIPAddressType(subnetSet.Spec.IPAddressType), nil
+	default:
+		return nil, nil
+	}
+}
+
+func ipamModesFromIPAddressType(ipAddressType nsxvpcv1.IPAddressType) []corev1.IPFamily {
+	switch ipAddressType {
+	case nsxvpcv1.IPAddressTypeIPv6:
+		return []corev1.IPFamily{corev1.IPv6Protocol}
+	case nsxvpcv1.IPAddressTypeIPv4IPv6:
+		return []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+	case nsxvpcv1.IPAddressTypeIPv4, "":
+		// Empty/unset defaults to IPv4 per the Subnet/SubnetSet CRD default.
+		return []corev1.IPFamily{corev1.IPv4Protocol}
+	default:
+		return []corev1.IPFamily{corev1.IPv4Protocol}
+	}
+}

--- a/pkg/services/network/externally_managed_provider.go
+++ b/pkg/services/network/externally_managed_provider.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+
+	pkgerrors "github.com/pkg/errors"
+	nsxvpcv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
+	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services"
+)
+
+// externallyManagedNetworkProvider propagates VSphereMachine interface specs
+// into VirtualMachine network interfaces without provisioning networks or LBs.
+type externallyManagedNetworkProvider struct {
+	client client.Client
+}
+
+// ExternallyManagedNetworkProvider returns an ExternallyManaged network provider.
+func ExternallyManagedNetworkProvider(client client.Client) services.NetworkProvider {
+	return &externallyManagedNetworkProvider{
+		client: client,
+	}
+}
+
+func (np *externallyManagedNetworkProvider) Name() string {
+	return ExternallyManagedNetworkProviderName
+}
+
+// SupportsIPv6DualStack reports whether IPv6 dual-stack is enabled. This
+// provider derives dual-stack per-interface from Subnet/SubnetSet IPAddressType
+// when the IPv6DualStack feature gate is enabled.
+func (np *externallyManagedNetworkProvider) SupportsIPv6DualStack() bool {
+	return feature.Gates.Enabled(feature.IPv6DualStack)
+}
+
+// HasLoadBalancer is false: CAPV will not create a VirtualMachineService for
+// the control plane VIP; the Cluster's spec.controlPlaneEndpoint is pre-set.
+func (np *externallyManagedNetworkProvider) HasLoadBalancer() bool {
+	return false
+}
+
+// SupportsVMReadinessProbe is false: no TCP-based readiness probe is configured
+// on control plane VMs, as this probe is typically used to perform endpoint
+// health checks for the VirtualMachineService-managed Load Balancer.
+func (np *externallyManagedNetworkProvider) SupportsVMReadinessProbe() bool {
+	return false
+}
+
+func (np *externallyManagedNetworkProvider) SupportsSupervisorService() bool {
+	return false
+}
+
+// ProvisionClusterNetwork creates nothing; network objects are provisioned and
+// managed externally, so they are assumed ready. It marks the network ready
+// condition True.
+func (np *externallyManagedNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
+	deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyV1Beta1Condition)
+	conditions.Set(clusterCtx.VSphereCluster, metav1.Condition{
+		Type:   vmwarev1.VSphereClusterNetworkReadyCondition,
+		Status: metav1.ConditionTrue,
+		Reason: vmwarev1.VSphereClusterNetworkReadyReason,
+	})
+	return nil
+}
+
+// GetVMServiceAnnotations returns an empty map. CAPV does not create a
+// VirtualMachineService, so these annotations are unused; an empty map keeps
+// the call site uniform with other providers.
+func (np *externallyManagedNetworkProvider) GetVMServiceAnnotations(_ context.Context, _ *vmware.ClusterContext) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// ConfigureVirtualMachine straight-propagates machine interfaces and VLANs onto the VM.
+// Interface routes are not propagated (and are rejected by the VSphereMachine webhook).
+// Primary is required (workload network on eth0).
+func (np *externallyManagedNetworkProvider) ConfigureVirtualMachine(ctx context.Context, _ *vmware.ClusterContext, machine *vmwarev1.VSphereMachine, vm *vmoprvhub.VirtualMachine) error {
+	primary := machine.Spec.Network.Interfaces.Primary
+	if !primary.IsDefined() {
+		return pkgerrors.New("primary interface must be defined")
+	}
+
+	vm.Spec.Network = &vmoprvhub.VirtualMachineNetworkSpec{}
+
+	primaryIPAMModes, err := np.ipamModesForInterface(ctx, machine.Namespace, primary.NetworkRef)
+	if err != nil {
+		return err
+	}
+	vm.Spec.Network.Interfaces = append(vm.Spec.Network.Interfaces, vmInterfaceFromSpec(
+		PrimaryInterfaceName,
+		primary,
+		"", // gateway4
+		"", // gateway6
+		primaryIPAMModes,
+	))
+
+	for _, secondary := range machine.Spec.Network.Interfaces.Secondary {
+		ipamModes, err := np.ipamModesForInterface(ctx, machine.Namespace, secondary.NetworkRef)
+		if err != nil {
+			return err
+		}
+		vm.Spec.Network.Interfaces = append(vm.Spec.Network.Interfaces, vmInterfaceFromSpec(
+			secondary.Name,
+			secondary.InterfaceSpec,
+			"None",
+			"None",
+			ipamModes,
+		))
+	}
+
+	return setVLANs(machine, vm)
+}
+
+func vmInterfaceFromSpec(name string, iface vmwarev1.InterfaceSpec, gateway4, gateway6 string, ipamModes []corev1.IPFamily) vmoprvhub.VirtualMachineNetworkInterfaceSpec {
+	var mtu *int64
+	if iface.MTU != 0 {
+		mtu = ptr.To(int64(iface.MTU))
+	}
+	return vmoprvhub.VirtualMachineNetworkInterfaceSpec{
+		Name: name,
+		Network: &vmoprvhub.PartialObjectRef{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       iface.NetworkRef.Kind,
+				APIVersion: iface.NetworkRef.APIVersion,
+			},
+			Name: iface.NetworkRef.Name,
+		},
+		MTU:       mtu,
+		Gateway4:  gateway4,
+		Gateway6:  gateway6,
+		IPAMModes: ipamModes,
+	}
+}
+
+// ipamModesForInterface derives IPAMModes from a referenced Subnet or SubnetSet
+// when the IPv6DualStack feature gate is enabled. Other network refs leave IPAMModes unset.
+func (np *externallyManagedNetworkProvider) ipamModesForInterface(ctx context.Context, namespace string, networkRef vmwarev1.InterfaceNetworkReference) ([]corev1.IPFamily, error) {
+	if !feature.Gates.Enabled(feature.IPv6DualStack) {
+		return nil, nil
+	}
+
+	gvk := networkRef.GroupVersionKind()
+	switch gvk {
+	case NetworkGVKNSXTVPCSubnet:
+		subnet := &nsxvpcv1.Subnet{}
+		if err := np.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: networkRef.Name}, subnet); err != nil {
+			return nil, pkgerrors.Wrapf(err, "failed to get Subnet %s", klog.KRef(namespace, networkRef.Name))
+		}
+		return ipamModesFromIPAddressType(subnet.Spec.IPAddressType), nil
+	case NetworkGVKNSXTVPCSubnetSet:
+		subnetSet := &nsxvpcv1.SubnetSet{}
+		if err := np.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: networkRef.Name}, subnetSet); err != nil {
+			return nil, pkgerrors.Wrapf(err, "failed to get SubnetSet %s", klog.KRef(namespace, networkRef.Name))
+		}
+		return ipamModesFromIPAddressType(subnetSet.Spec.IPAddressType), nil
+	default:
+		return nil, nil
+	}
+}
+
+func ipamModesFromIPAddressType(ipAddressType nsxvpcv1.IPAddressType) []corev1.IPFamily {
+	switch ipAddressType {
+	case nsxvpcv1.IPAddressTypeIPv6:
+		return []corev1.IPFamily{corev1.IPv6Protocol}
+	case nsxvpcv1.IPAddressTypeIPv4IPv6:
+		return []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+	case nsxvpcv1.IPAddressTypeIPv4, "":
+		// Empty/unset defaults to IPv4 per the Subnet/SubnetSet CRD default.
+		return []corev1.IPFamily{corev1.IPv4Protocol}
+	default:
+		return []corev1.IPFamily{corev1.IPv4Protocol}
+	}
+}

--- a/pkg/services/network/netop_provider.go
+++ b/pkg/services/network/netop_provider.go
@@ -62,6 +62,10 @@ func (np *netopNetworkProvider) SupportsVMReadinessProbe() bool {
 	return true
 }
 
+func (np *netopNetworkProvider) SupportsSupervisorService() bool {
+	return true
+}
+
 // ProvisionClusterNetwork marks the VSphereClusterNetworkReadyCondition true.
 func (np *netopNetworkProvider) ProvisionClusterNetwork(_ context.Context, clusterCtx *vmware.ClusterContext) error {
 	deprecatedv1beta1conditions.MarkTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyV1Beta1Condition)

--- a/pkg/services/network/network_suite_test.go
+++ b/pkg/services/network/network_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package network_test
+package network
 
 import (
 	"os"

--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -1464,3 +1464,432 @@ var _ = Describe("NSXT VPC Provider DualStack", func() {
 		Expect(createdSubnetSet.Spec.IPAddressType).To(BeEmpty())
 	})
 })
+
+var _ = Describe("ExternallyManaged network provider", func() {
+	var (
+		ctx            = context.Background()
+		clusterCtx     *vmware.ClusterContext
+		np             services.NetworkProvider
+		client         runtimeclient.Client
+		cluster        *clusterv1.Cluster
+		vSphereCluster *vmwarev1.VSphereCluster
+		vm             *vmoprvhub.VirtualMachine
+		machine        *vmwarev1.VSphereMachine
+		scheme         *runtime.Scheme
+		dummyNs        = "dummy-ns"
+		dummyCluster   = "dummy-cluster"
+		dummyVM        = "dummy-vm"
+	)
+
+	BeforeEach(func() {
+		cluster = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dummyCluster,
+				Namespace: dummyNs,
+			},
+		}
+		vSphereCluster = &vmwarev1.VSphereCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dummyCluster,
+				Namespace: dummyNs,
+			},
+		}
+		clusterCtx, _ = util.CreateClusterContext(cluster, vSphereCluster)
+		vm = &vmoprvhub.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: dummyNs,
+				Name:      dummyVM,
+			},
+		}
+		machine = &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: dummyNs,
+				Name:      dummyVM,
+			},
+		}
+		scheme = runtime.NewScheme()
+		Expect(nsxvpcv1.AddToScheme(scheme)).To(Succeed())
+		Expect(netopv1.AddToScheme(scheme)).To(Succeed())
+		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		np = ExternallyManagedNetworkProvider(client)
+	})
+
+	It("HasLoadBalancer returns false", func() {
+		Expect(np.HasLoadBalancer()).To(BeFalse())
+	})
+
+	It("SupportsVMReadinessProbe returns false", func() {
+		Expect(np.SupportsVMReadinessProbe()).To(BeFalse())
+	})
+
+	It("SupportsSupervisorService returns false", func() {
+		Expect(np.SupportsSupervisorService()).To(BeFalse())
+	})
+
+	It("GetClusterNetworkName returns empty", func() {
+		name, err := np.GetClusterNetworkName(ctx, clusterCtx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(name).To(BeEmpty())
+	})
+
+	It("GetVMServiceAnnotations returns empty map", func() {
+		annotations, err := np.GetVMServiceAnnotations(ctx, clusterCtx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(annotations).To(Equal(map[string]string{}))
+	})
+
+	It("ProvisionClusterNetwork creates nothing and marks network ready", func() {
+		err := np.ProvisionClusterNetwork(ctx, clusterCtx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyCondition)).To(BeTrue())
+		Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyV1Beta1Condition)).To(BeTrue())
+
+		subnetList := &nsxvpcv1.SubnetList{}
+		Expect(client.List(ctx, subnetList)).To(Succeed())
+		Expect(subnetList.Items).To(BeEmpty())
+	})
+
+	Context("ConfigureVirtualMachine", func() {
+		var oldGates map[string]bool
+
+		BeforeEach(func() {
+			oldGates = map[string]bool{
+				string(feature.IPv6DualStack):    feature.Gates.Enabled(feature.IPv6DualStack),
+				string(feature.VLANSubinterface): feature.Gates.Enabled(feature.VLANSubinterface),
+			}
+		})
+
+		AfterEach(func() {
+			for k, v := range oldGates {
+				val := "false"
+				if v {
+					val = "true"
+				}
+				Expect(feature.Gates.(featuregate.MutableFeatureGate).Set(k + "=" + val)).To(Succeed())
+			}
+		})
+
+		It("errors when primary interface is missing", func() {
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("primary interface must be defined"))
+		})
+
+		It("propagates name/MTU/network and not routes; sets secondary gateways to None", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+						MTU: 1600,
+						Routes: []vmwarev1.RouteSpec{{
+							To:  "10.0.0.0/8",
+							Via: "10.0.0.1",
+						}},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+							MTU: 1700,
+							Routes: []vmwarev1.RouteSpec{{
+								To:  "192.168.0.0/16",
+								Via: "192.168.0.1",
+							}},
+						},
+					}},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(2))
+
+			Expect(vm.Spec.Network.Interfaces[0].Name).To(Equal(PrimaryInterfaceName))
+			Expect(*vm.Spec.Network.Interfaces[0].MTU).To(Equal(int64(1600)))
+			Expect(vm.Spec.Network.Interfaces[0].Network.Name).To(Equal("workload-subnet"))
+			Expect(vm.Spec.Network.Interfaces[0].Network.Kind).To(Equal(NetworkGVKNSXTVPCSubnet.Kind))
+			Expect(vm.Spec.Network.Interfaces[0].Routes).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[0].Gateway4).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[0].Gateway6).To(BeEmpty())
+
+			Expect(vm.Spec.Network.Interfaces[1].Name).To(Equal("eth1"))
+			Expect(*vm.Spec.Network.Interfaces[1].MTU).To(Equal(int64(1700)))
+			Expect(vm.Spec.Network.Interfaces[1].Network.Name).To(Equal("management-network"))
+			Expect(vm.Spec.Network.Interfaces[1].Network.Kind).To(Equal(NetworkGVKNetOperator.Kind))
+			Expect(vm.Spec.Network.Interfaces[1].Routes).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[1].Gateway4).To(Equal("None"))
+			Expect(vm.Spec.Network.Interfaces[1].Gateway6).To(Equal("None"))
+		})
+
+		DescribeTable("derives IPAMModes from Subnet/SubnetSet ipAddressType when IPv6DualStack is enabled",
+			func(kind string, apiVersion string, createObj func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object, ipType nsxvpcv1.IPAddressType, expected []corev1.IPFamily) {
+				Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+				name := "test-net"
+				obj := createObj(name, ipType)
+				client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj).Build()
+				np = ExternallyManagedNetworkProvider(client)
+
+				machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+					Interfaces: vmwarev1.InterfacesSpec{
+						Primary: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       kind,
+								APIVersion: apiVersion,
+								Name:       name,
+							},
+						},
+					},
+				}
+
+				err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal(expected))
+			},
+			Entry("Subnet IPv4", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4, []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("Subnet IPv6", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv6, []corev1.IPFamily{corev1.IPv6Protocol}),
+			Entry("Subnet dual-stack", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4IPv6, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}),
+			Entry("Subnet defaulted/empty", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressType(""), []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("SubnetSet IPv4", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4, []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("SubnetSet IPv6", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv6, []corev1.IPFamily{corev1.IPv6Protocol}),
+			Entry("SubnetSet dual-stack", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4IPv6, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}),
+			Entry("SubnetSet defaulted/empty", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressType(""), []corev1.IPFamily{corev1.IPv4Protocol}),
+		)
+
+		It("leaves IPAMModes unset when IPv6DualStack is disabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			subnet := &nsxvpcv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: "workload-subnet"},
+				Spec:       nsxvpcv1.SubnetSpec{IPAddressType: nsxvpcv1.IPAddressTypeIPv4IPv6},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnet).Build()
+			np = ExternallyManagedNetworkProvider(client)
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
+		})
+
+		It("leaves IPAMModes unset for Network and VirtualNetwork refs", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNetOperator.Kind,
+							APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+							Name:       "vds-network",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNSXT.Kind,
+								APIVersion: NetworkGVKNSXT.GroupVersion().String(),
+								Name:       "nsx-vnet",
+							},
+						},
+					}},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
+			Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(BeNil())
+		})
+
+		It("errors when referenced Subnet is missing", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "missing-subnet",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get Subnet"))
+		})
+
+		It("errors when referenced SubnetSet is missing", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnetSet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+							Name:       "missing-subnetset",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get SubnetSet"))
+		})
+
+		It("supports mixed-provider refs (VPC Subnet on eth0 + VDS Network on eth1)", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			subnet := &nsxvpcv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: "supervisor-workload"},
+				Spec:       nsxvpcv1.SubnetSpec{IPAddressType: nsxvpcv1.IPAddressTypeIPv4IPv6},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnet).Build()
+			np = ExternallyManagedNetworkProvider(client)
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "supervisor-workload",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							MTU: 1700,
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(2))
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}))
+			Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(BeNil())
+			Expect(vm.Spec.Network.Interfaces[1].Gateway4).To(Equal("None"))
+			Expect(vm.Spec.Network.Interfaces[1].Gateway6).To(Equal("None"))
+		})
+
+		It("propagates VLANs when VLANSubinterface is enabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("VLANSubinterface=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vl100",
+						ID:   ptr.To(int32(100)),
+						Link: "eth1",
+					},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.VLANs).To(HaveLen(1))
+			Expect(vm.Spec.Network.VLANs[0].Name).To(Equal("vl100"))
+			Expect(vm.Spec.Network.VLANs[0].ID).To(Equal(int64(100)))
+			Expect(vm.Spec.Network.VLANs[0].Link).To(Equal("eth1"))
+		})
+
+		It("errors when VLANs are set but VLANSubinterface is disabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("VLANSubinterface=false")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vl100",
+						ID:   ptr.To(int32(100)),
+						Link: "eth1",
+					},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("VLANs cannot be used as feature gate VLANSubinterface is not enabled"))
+		})
+	})
+})

--- a/pkg/services/network/network_test.go
+++ b/pkg/services/network/network_test.go
@@ -103,6 +103,18 @@ func (m *MockNSXTVpcNetworkProvider) ProvisionClusterNetwork(ctx context.Context
 	return nil
 }
 
+func getClusterNetworkName(ctx context.Context, np services.NetworkProvider, clusterCtx *vmware.ClusterContext) (string, error) {
+	return np.(interface {
+		GetClusterNetworkName(context.Context, *vmware.ClusterContext) (string, error)
+	}).GetClusterNetworkName(ctx, clusterCtx)
+}
+
+func verifyNetworkStatus(ctx context.Context, np services.NetworkProvider, clusterCtx *vmware.ClusterContext, obj runtime.Object) error {
+	return np.(interface {
+		VerifyNetworkStatus(context.Context, *vmware.ClusterContext, runtime.Object) error
+	}).VerifyNetworkStatus(ctx, clusterCtx, obj)
+}
+
 func createUnReadyNsxtVirtualNetwork(ctx *vmware.ClusterContext, status ncpv1.VirtualNetworkStatus) *ncpv1.VirtualNetwork {
 	// create an nsxt vnet with unready status caused by certain reasons from ncp
 	cluster := ctx.VSphereCluster
@@ -792,9 +804,7 @@ var _ = Describe("Network provider", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should succeed", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vnet).To(BeEmpty())
+				Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyCondition)).To(BeTrue())
 			})
 		})
 
@@ -825,7 +835,7 @@ var _ = Describe("Network provider", func() {
 			})
 
 			It("should not update vnet with whitelist_source_ranges in spec", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				vnet, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vnet).To(Equal(GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
 
@@ -865,7 +875,7 @@ var _ = Describe("Network provider", func() {
 			})
 
 			It("should create vnet without whitelist_source_ranges in spec", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				vnet, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vnet).To(Equal(GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
 
@@ -891,7 +901,7 @@ var _ = Describe("Network provider", func() {
 			})
 
 			It("should update vnet with whitelist_source_ranges in spec", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				vnet, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vnet).To(Equal(GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
 
@@ -924,7 +934,7 @@ var _ = Describe("Network provider", func() {
 			})
 
 			It("should create new vnet with whitelist_source_ranges in spec", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				vnet, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vnet).To(Equal(GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
 
@@ -954,7 +964,7 @@ var _ = Describe("Network provider", func() {
 			})
 
 			It("should not update vnet with whitelist_source_ranges in spec", func() {
-				vnet, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				vnet, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vnet).To(Equal(GetNSXTVirtualNetworkName(clusterCtx.VSphereCluster.Name)))
 
@@ -1001,7 +1011,7 @@ var _ = Describe("Network provider", func() {
 				nsxNp, _ = NsxtNetworkProvider(client, "false").(*nsxtNetworkProvider)
 				np = nsxNp
 
-				err = np.VerifyNetworkStatus(ctx, clusterCtx, vnetObj)
+				err = verifyNetworkStatus(ctx, np, clusterCtx, vnetObj)
 
 				expectedErrorMessage := fmt.Sprintf("virtual network ready status is: '%s' in cluster %s. reason: %s, message: %s",
 					"False", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster}, testNetworkNotRealizedReason, testNetworkNotRealizedMessage)
@@ -1019,7 +1029,7 @@ var _ = Describe("Network provider", func() {
 				nsxNp, _ = NsxtNetworkProvider(client, "false").(*nsxtNetworkProvider)
 				np = nsxNp
 
-				err = np.VerifyNetworkStatus(ctx, clusterCtx, vnetObj)
+				err = verifyNetworkStatus(ctx, np, clusterCtx, vnetObj)
 
 				expectedErrorMessage := fmt.Sprintf("virtual network ready status in cluster %s has not been set", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster})
 				Expect(err).To(MatchError(expectedErrorMessage))
@@ -1060,7 +1070,7 @@ var _ = Describe("Network provider", func() {
 				initialSubnetSet.Status = status
 
 				// Presumably there's code here that might modify the SubnetSet...
-				subnetset, err := np.GetClusterNetworkName(ctx, clusterCtx)
+				subnetset, err := getClusterNetworkName(ctx, np, clusterCtx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(subnetset).To(Equal(clusterCtx.VSphereCluster.Name))
 
@@ -1169,7 +1179,7 @@ var _ = Describe("Network provider", func() {
 					Status: status,
 				}
 				client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnetsetObj).Build()
-				err = np.VerifyNetworkStatus(ctx, clusterCtx, subnetsetObj)
+				err = verifyNetworkStatus(ctx, np, clusterCtx, subnetsetObj)
 				expectedErrorMessage := fmt.Sprintf("subnetset ready status is: '%s' in cluster %s. reason: %s, message: %s",
 					"False", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster}, testNetworkNotRealizedReason, testNetworkNotRealizedMessage)
 				Expect(err).To(MatchError(expectedErrorMessage))
@@ -1188,7 +1198,7 @@ var _ = Describe("Network provider", func() {
 					Status: status,
 				}
 				client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnetsetObj).Build()
-				err = np.VerifyNetworkStatus(ctx, clusterCtx, subnetsetObj)
+				err = verifyNetworkStatus(ctx, np, clusterCtx, subnetsetObj)
 				expectedErrorMessage := fmt.Sprintf("subnetset ready status in cluster %s has not been set", apitypes.NamespacedName{Namespace: dummyNs, Name: dummyCluster})
 				Expect(err).To(MatchError(expectedErrorMessage))
 				Expect(conditions.IsFalse(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyCondition)).To(BeTrue())
@@ -1225,7 +1235,7 @@ var _ = Describe("Network provider", func() {
 			It("VerifyNetworkStatus should skip validation and return nil", func() {
 				// Pass a dummy SubnetSet object
 				dummySubnetSet := &nsxvpcv1.SubnetSet{}
-				err := np.VerifyNetworkStatus(ctx, clusterCtx, dummySubnetSet)
+				err := verifyNetworkStatus(ctx, np, clusterCtx, dummySubnetSet)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -1462,5 +1472,436 @@ var _ = Describe("NSXT VPC Provider DualStack", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(createdSubnetSet.Spec.IPAddressType).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ExternallyManaged network provider", func() {
+	var (
+		ctx            = context.Background()
+		clusterCtx     *vmware.ClusterContext
+		np             services.NetworkProvider
+		client         runtimeclient.Client
+		cluster        *clusterv1.Cluster
+		vSphereCluster *vmwarev1.VSphereCluster
+		vm             *vmoprvhub.VirtualMachine
+		machine        *vmwarev1.VSphereMachine
+		scheme         *runtime.Scheme
+		dummyNs        = "dummy-ns"
+		dummyCluster   = "dummy-cluster"
+		dummyVM        = "dummy-vm"
+	)
+
+	BeforeEach(func() {
+		cluster = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dummyCluster,
+				Namespace: dummyNs,
+			},
+		}
+		vSphereCluster = &vmwarev1.VSphereCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dummyCluster,
+				Namespace: dummyNs,
+			},
+		}
+		clusterCtx, _ = util.CreateClusterContext(cluster, vSphereCluster)
+		vm = &vmoprvhub.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: dummyNs,
+				Name:      dummyVM,
+			},
+		}
+		machine = &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: dummyNs,
+				Name:      dummyVM,
+			},
+		}
+		scheme = runtime.NewScheme()
+		Expect(nsxvpcv1.AddToScheme(scheme)).To(Succeed())
+		Expect(netopv1.AddToScheme(scheme)).To(Succeed())
+		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		np = ExternallyManagedNetworkProvider(client)
+	})
+
+	It("HasLoadBalancer returns false", func() {
+		Expect(np.HasLoadBalancer()).To(BeFalse())
+	})
+
+	It("SupportsVMReadinessProbe returns false", func() {
+		Expect(np.SupportsVMReadinessProbe()).To(BeFalse())
+	})
+
+	It("SupportsSupervisorService returns false", func() {
+		Expect(np.SupportsSupervisorService()).To(BeFalse())
+	})
+
+	It("GetVMServiceAnnotations returns empty map", func() {
+		annotations, err := np.GetVMServiceAnnotations(ctx, clusterCtx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(annotations).To(Equal(map[string]string{}))
+	})
+
+	It("ProvisionClusterNetwork creates nothing and marks network ready", func() {
+		err := np.ProvisionClusterNetwork(ctx, clusterCtx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.VSphereClusterNetworkReadyCondition)).To(BeTrue())
+		Expect(deprecatedv1beta1conditions.IsTrue(clusterCtx.VSphereCluster, vmwarev1.ClusterNetworkReadyV1Beta1Condition)).To(BeTrue())
+
+		subnetList := &nsxvpcv1.SubnetList{}
+		Expect(client.List(ctx, subnetList)).To(Succeed())
+		Expect(subnetList.Items).To(BeEmpty())
+	})
+
+	Context("ConfigureVirtualMachine", func() {
+		var oldGates map[string]bool
+
+		BeforeEach(func() {
+			oldGates = map[string]bool{
+				string(feature.IPv6DualStack):    feature.Gates.Enabled(feature.IPv6DualStack),
+				string(feature.VLANSubinterface): feature.Gates.Enabled(feature.VLANSubinterface),
+			}
+		})
+
+		AfterEach(func() {
+			for k, v := range oldGates {
+				val := "false"
+				if v {
+					val = "true"
+				}
+				Expect(feature.Gates.(featuregate.MutableFeatureGate).Set(k + "=" + val)).To(Succeed())
+			}
+		})
+
+		It("errors when primary interface is missing", func() {
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("primary interface must be defined"))
+		})
+
+		It("propagates name/MTU/network and not routes; sets secondary gateways to None", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+						MTU: 1600,
+						Routes: []vmwarev1.RouteSpec{{
+							To:  "10.0.0.0/8",
+							Via: "10.0.0.1",
+						}},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+							MTU: 1700,
+							Routes: []vmwarev1.RouteSpec{{
+								To:  "192.168.0.0/16",
+								Via: "192.168.0.1",
+							}},
+						},
+					}},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(2))
+
+			Expect(vm.Spec.Network.Interfaces[0].Name).To(Equal(PrimaryInterfaceName))
+			Expect(*vm.Spec.Network.Interfaces[0].MTU).To(Equal(int64(1600)))
+			Expect(vm.Spec.Network.Interfaces[0].Network.Name).To(Equal("workload-subnet"))
+			Expect(vm.Spec.Network.Interfaces[0].Network.Kind).To(Equal(NetworkGVKNSXTVPCSubnet.Kind))
+			Expect(vm.Spec.Network.Interfaces[0].Network.APIVersion).To(Equal(NetworkGVKNSXTVPCSubnet.GroupVersion().String()))
+			Expect(vm.Spec.Network.Interfaces[0].Routes).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[0].Gateway4).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[0].Gateway6).To(BeEmpty())
+
+			Expect(vm.Spec.Network.Interfaces[1].Name).To(Equal("eth1"))
+			Expect(*vm.Spec.Network.Interfaces[1].MTU).To(Equal(int64(1700)))
+			Expect(vm.Spec.Network.Interfaces[1].Network.Name).To(Equal("management-network"))
+			Expect(vm.Spec.Network.Interfaces[1].Network.Kind).To(Equal(NetworkGVKNetOperator.Kind))
+			Expect(vm.Spec.Network.Interfaces[1].Network.APIVersion).To(Equal(NetworkGVKNetOperator.GroupVersion().String()))
+			Expect(vm.Spec.Network.Interfaces[1].Routes).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[1].Gateway4).To(Equal("None"))
+			Expect(vm.Spec.Network.Interfaces[1].Gateway6).To(Equal("None"))
+		})
+
+		DescribeTable("derives IPAMModes from Subnet/SubnetSet ipAddressType when IPv6DualStack is enabled",
+			func(kind string, apiVersion string, createObj func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object, ipType nsxvpcv1.IPAddressType, expected []corev1.IPFamily) {
+				Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+				name := "test-net"
+				obj := createObj(name, ipType)
+				client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj).Build()
+				np = ExternallyManagedNetworkProvider(client)
+
+				machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+					Interfaces: vmwarev1.InterfacesSpec{
+						Primary: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       kind,
+								APIVersion: apiVersion,
+								Name:       name,
+							},
+						},
+					},
+				}
+
+				err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal(expected))
+			},
+			Entry("Subnet IPv4", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4, []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("Subnet IPv6", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv6, []corev1.IPFamily{corev1.IPv6Protocol}),
+			Entry("Subnet dual-stack", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4IPv6, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}),
+			Entry("Subnet defaulted/empty", NetworkGVKNSXTVPCSubnet.Kind, NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.Subnet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressType(""), []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("SubnetSet IPv4", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4, []corev1.IPFamily{corev1.IPv4Protocol}),
+			Entry("SubnetSet IPv6", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv6, []corev1.IPFamily{corev1.IPv6Protocol}),
+			Entry("SubnetSet dual-stack", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressTypeIPv4IPv6, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}),
+			Entry("SubnetSet defaulted/empty", NetworkGVKNSXTVPCSubnetSet.Kind, NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+				func(name string, ipType nsxvpcv1.IPAddressType) runtime.Object {
+					return &nsxvpcv1.SubnetSet{ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: name}, Spec: nsxvpcv1.SubnetSetSpec{IPAddressType: ipType}}
+				}, nsxvpcv1.IPAddressType(""), []corev1.IPFamily{corev1.IPv4Protocol}),
+		)
+
+		It("leaves IPAMModes unset when IPv6DualStack is disabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			subnet := &nsxvpcv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: "workload-subnet"},
+				Spec:       nsxvpcv1.SubnetSpec{IPAddressType: nsxvpcv1.IPAddressTypeIPv4IPv6},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnet).Build()
+			np = ExternallyManagedNetworkProvider(client)
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
+		})
+
+		It("leaves IPAMModes unset for Network and VirtualNetwork refs", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNetOperator.Kind,
+							APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+							Name:       "vds-network",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNSXT.Kind,
+								APIVersion: NetworkGVKNSXT.GroupVersion().String(),
+								Name:       "nsx-vnet",
+							},
+						},
+					}},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(BeNil())
+			Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(BeNil())
+		})
+
+		It("errors when referenced Subnet is missing", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "missing-subnet",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get Subnet"))
+		})
+
+		It("errors when referenced SubnetSet is missing", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnetSet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnetSet.GroupVersion().String(),
+							Name:       "missing-subnetset",
+						},
+					},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get SubnetSet"))
+		})
+
+		It("supports mixed-provider refs (VPC Subnet on eth0 + VDS Network on eth1)", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=true")).To(Succeed())
+			subnet := &nsxvpcv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: dummyNs, Name: "supervisor-workload"},
+				Spec:       nsxvpcv1.SubnetSpec{IPAddressType: nsxvpcv1.IPAddressTypeIPv4IPv6},
+			}
+			client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(subnet).Build()
+			np = ExternallyManagedNetworkProvider(client)
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "supervisor-workload",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							MTU: 1700,
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+			}
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.Interfaces).To(HaveLen(2))
+			Expect(vm.Spec.Network.Interfaces[0].Network.Kind).To(Equal(NetworkGVKNSXTVPCSubnet.Kind))
+			Expect(vm.Spec.Network.Interfaces[0].Network.APIVersion).To(Equal(NetworkGVKNSXTVPCSubnet.GroupVersion().String()))
+			Expect(vm.Spec.Network.Interfaces[0].IPAMModes).To(Equal([]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}))
+			Expect(vm.Spec.Network.Interfaces[0].Gateway4).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[0].Gateway6).To(BeEmpty())
+			Expect(vm.Spec.Network.Interfaces[1].Network.Kind).To(Equal(NetworkGVKNetOperator.Kind))
+			Expect(vm.Spec.Network.Interfaces[1].Network.APIVersion).To(Equal(NetworkGVKNetOperator.GroupVersion().String()))
+			Expect(vm.Spec.Network.Interfaces[1].IPAMModes).To(BeNil())
+			Expect(vm.Spec.Network.Interfaces[1].Gateway4).To(Equal("None"))
+			Expect(vm.Spec.Network.Interfaces[1].Gateway6).To(Equal("None"))
+		})
+
+		It("propagates VLANs when VLANSubinterface is enabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("IPv6DualStack=false")).To(Succeed())
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("VLANSubinterface=true")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vl100",
+						ID:   ptr.To(int32(100)),
+						Link: "eth1",
+					},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vm.Spec.Network.VLANs).To(HaveLen(1))
+			Expect(vm.Spec.Network.VLANs[0].Name).To(Equal("vl100"))
+			Expect(vm.Spec.Network.VLANs[0].ID).To(Equal(int64(100)))
+			Expect(vm.Spec.Network.VLANs[0].Link).To(Equal("eth1"))
+		})
+
+		It("errors when VLANs are set but VLANSubinterface is disabled", func() {
+			Expect(feature.Gates.(featuregate.MutableFeatureGate).Set("VLANSubinterface=false")).To(Succeed())
+			machine.Spec.Network = vmwarev1.VSphereMachineNetworkSpec{
+				Interfaces: vmwarev1.InterfacesSpec{
+					Primary: vmwarev1.InterfaceSpec{
+						NetworkRef: vmwarev1.InterfaceNetworkReference{
+							Kind:       NetworkGVKNSXTVPCSubnet.Kind,
+							APIVersion: NetworkGVKNSXTVPCSubnet.GroupVersion().String(),
+							Name:       "workload-subnet",
+						},
+					},
+					Secondary: []vmwarev1.SecondaryInterfaceSpec{{
+						Name: "eth1",
+						InterfaceSpec: vmwarev1.InterfaceSpec{
+							NetworkRef: vmwarev1.InterfaceNetworkReference{
+								Kind:       NetworkGVKNetOperator.Kind,
+								APIVersion: NetworkGVKNetOperator.GroupVersion().String(),
+								Name:       "management-network",
+							},
+						},
+					}},
+				},
+				VLANs: []vmwarev1.VLANSpec{
+					{
+						Name: "vl100",
+						ID:   ptr.To(int32(100)),
+						Link: "eth1",
+					},
+				},
+			}
+
+			err := np.ConfigureVirtualMachine(ctx, clusterCtx, machine, vm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("VLANs cannot be used as feature gate VLANSubinterface is not enabled"))
+		})
 	})
 })

--- a/pkg/services/network/nsxt_provider.go
+++ b/pkg/services/network/nsxt_provider.go
@@ -71,6 +71,10 @@ func (np *nsxtNetworkProvider) SupportsVMReadinessProbe() bool {
 	return true
 }
 
+func (np *nsxtNetworkProvider) SupportsSupervisorService() bool {
+	return true
+}
+
 // GetNSXTVirtualNetworkName returns the name of the NSX-T vnet object.
 func GetNSXTVirtualNetworkName(clusterName string) string {
 	return fmt.Sprintf("%s-vnet", clusterName)

--- a/pkg/services/network/nsxt_vpc_provider.go
+++ b/pkg/services/network/nsxt_vpc_provider.go
@@ -76,6 +76,10 @@ func (vp *nsxtVPCNetworkProvider) SupportsVMReadinessProbe() bool {
 	return false
 }
 
+func (vp *nsxtVPCNetworkProvider) SupportsSupervisorService() bool {
+	return true
+}
+
 // verifyNsxtVpcSubnetSetStatus checks the status conditions of a given SubnetSet within a cluster context.
 // If the subnet isn't ready, it is marked as false, and the function returns an error.
 // If the subnet is ready, the function updates the VSphereCluster with a "true" status and returns nil.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Allow clusters to attach VMs to networks provisioned outside CAPV, without CAPV managing network objects or load balancers, behind the ExternallyManagedProvider feature gate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
