### PR TITLE
🐛 Add conversion webhook wiring for VSphereClusterIdentity CRD

### DIFF
--- a/config/default/crd/kustomization.yaml
+++ b/config/default/crd/kustomization.yaml
@@ -24,6 +24,7 @@ patches:
 - path: patches/webhook_in_vspherevms.yaml
 - path: patches/webhook_in_vspherefailuredomains.yaml
 - path: patches/webhook_in_vspheredeploymentzones.yaml
+- path: patches/webhook_in_vsphereclusteridentities.yaml
 - path: patches/webhook_in_vsphereclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
@@ -35,6 +36,7 @@ patches:
 - path: patches/cainjection_in_vspherevms.yaml
 - path: patches/cainjection_in_vspherefailuredomains.yaml
 - path: patches/cainjection_in_vspheredeploymentzones.yaml
+- path: patches/cainjection_in_vsphereclusteridentities.yaml
 - path: patches/cainjection_in_vsphereclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 

--- a/config/default/crd/patches/cainjection_in_vsphereclusteridentities.yaml
+++ b/config/default/crd/patches/cainjection_in_vsphereclusteridentities.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io

--- a/config/default/crd/patches/webhook_in_vsphereclusteridentities.yaml
+++ b/config/default/crd/patches/webhook_in_vsphereclusteridentities.yaml
@@ -1,0 +1,16 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1"]
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert


### PR DESCRIPTION
**What this PR does / why we need it**:

`VSphereClusterIdentity` is the only CRD in the project missing conversion webhook wiring — every other CRD that supports both v1beta1 and v1beta2 (`VSphereCluster`, `VSphereClusterTemplate`, `VSphereMachine`, `VSphereMachineTemplate`, `VSphereVM`, `VSphereDeploymentZone`, `VSphereFailureDomain`) has a `patches/webhook_in_<type>.yaml` and `patches/cainjection_in_<type>.yaml` in `config/default/crd/`, referenced from `config/default/crd/kustomization.yaml`. `VSphereClusterIdentity` has neither the patch files nor the kustomization entries, so its CRD is generated with `spec.conversion.strategy: None`.

The `ConvertTo`/`ConvertFrom` implementations for `VSphereClusterIdentity` already exist in `api/govmomi/v1beta1/conversion.go` (including the `status.deprecated.v1beta1`/`status.v1beta2` mirroring logic), are registered on the scheme, and are already covered by `TestFuzzyConversion/for_VSphereClusterIdentity`. The manager's webhook server also already serves a generic `/convert` handler (mounted as a side effect of any other type's webhook setup calling `Complete()`), so no controller-side code change is needed — this PR only adds the two missing manifest patch files and their two kustomization entries, mirroring `VSphereDeploymentZone` exactly.

Without this, an existing management cluster upgraded across the v1beta1→v1beta2 migration ends up with `VSphereClusterIdentity` objects stuck holding pre-migration status data (old-style `Ready`/`CredentialsAvailable` conditions with `reason` omitted, which is valid under the old schema but not the new one). Because there's no conversion webhook to bridge the two shapes, the new controller can never successfully patch the object's status again — every reconcile fails permanently with:

failed to patch VSphereClusterIdentity <name>: failed to patch status conditions: ... status.conditions[0].reason: Invalid value: "": conditions[0].reason in body should be at least 1 chars long

which in turn blocks every `VSphereCluster`/`VSphereDeploymentZone`/`VSphereFailureDomain` that depends on that identity. Verified the fix resolves this: after patching only the `vsphereclusteridentities` CRD (no other CRD changed), the previously permanently-failing reconcile succeeded on the next attempt, `status.conditions` correctly populated the merged `Available` condition, and downstream `VSphereDeploymentZone`/`VSphereFailureDomain` reconciliation resumed immediately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4105 