### PR TITLE
✨ Omit apiVersion from PolicyRef and map internally in CAPV

### DIFF
--- a/api/supervisor/v1beta1/vspheremachine_types.go
+++ b/api/supervisor/v1beta1/vspheremachine_types.go
@@ -108,7 +108,8 @@ type VSphereMachineSpec struct {
 	NamingStrategy *VirtualMachineNamingStrategy `json:"namingStrategy,omitempty"`
 }
 
-// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine.
+// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+// ApiVersion is omitted from the PolicyRef by intention.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -125,15 +126,6 @@ type PolicyRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 	Kind string `json:"kind,omitempty"`
-
-	// apiVersion is the fully qualified group/version of the infrastructure policy resource
-	// (for example vsphere.policy.vmware.com/v1alpha1).
-	// apiVersion must be fully qualified domain name followed by / and a version.
-	// +required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=317
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // VSphereMachineNetworkSpec defines the network configuration of a VSphereMachine.

--- a/api/supervisor/v1beta1/vspheremachine_types.go
+++ b/api/supervisor/v1beta1/vspheremachine_types.go
@@ -109,7 +109,6 @@ type VSphereMachineSpec struct {
 }
 
 // PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-// ApiVersion is omitted from the PolicyRef by intention.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.

--- a/api/supervisor/v1beta1/zz_generated.conversion.go
+++ b/api/supervisor/v1beta1/zz_generated.conversion.go
@@ -662,7 +662,6 @@ func Convert_v1beta2_Network_To_v1beta1_Network(in *v1beta2.Network, out *Networ
 func autoConvert_v1beta1_PolicyRef_To_v1beta2_PolicyRef(in *PolicyRef, out *v1beta2.PolicyRef, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -674,7 +673,6 @@ func Convert_v1beta1_PolicyRef_To_v1beta2_PolicyRef(in *PolicyRef, out *v1beta2.
 func autoConvert_v1beta2_PolicyRef_To_v1beta1_PolicyRef(in *v1beta2.PolicyRef, out *PolicyRef, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 

--- a/api/supervisor/v1beta2/vspheremachine_types.go
+++ b/api/supervisor/v1beta2/vspheremachine_types.go
@@ -124,7 +124,8 @@ type VSphereMachineSpec struct {
 	Policies []PolicyRef `json:"policies,omitempty"`
 }
 
-// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine.
+// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+// ApiVersion is omitted from the PolicyRef by intention.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -141,15 +142,6 @@ type PolicyRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 	Kind string `json:"kind,omitempty"`
-
-	// apiVersion is the fully qualified group/version of the infrastructure policy resource
-	// (for example vsphere.policy.vmware.com/v1alpha1).
-	// apiVersion must be fully qualified domain name followed by / and a version.
-	// +required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=317
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // VSphereMachineNetworkSpec defines the network configuration of a VSphereMachine.

--- a/api/supervisor/v1beta2/vspheremachine_types.go
+++ b/api/supervisor/v1beta2/vspheremachine_types.go
@@ -125,7 +125,6 @@ type VSphereMachineSpec struct {
 }
 
 // PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-// ApiVersion is omitted from the PolicyRef by intention.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -350,18 +350,10 @@ spec:
                 description: policies specifies a list of optional infrastructure
                   policies to be applied to the virtual machine.
                 items:
-                  description: PolicyRef identifies an optional infrastructure policy
-                    to specify for the virtual machine.
+                  description: |-
+                    PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+                    ApiVersion is omitted from the PolicyRef by intention.
                   properties:
-                    apiVersion:
-                      description: |-
-                        apiVersion is the fully qualified group/version of the infrastructure policy resource
-                        (for example vsphere.policy.vmware.com/v1alpha1).
-                        apiVersion must be fully qualified domain name followed by / and a version.
-                      maxLength: 317
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                      type: string
                     kind:
                       description: |-
                         kind of the infrastructure policy object being referenced.
@@ -379,7 +371,6 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
-                  - apiVersion
                   - kind
                   - name
                   type: object
@@ -1295,18 +1286,10 @@ spec:
                 description: policies specifies a list of optional infrastructure
                   policies to be applied to the virtual machine.
                 items:
-                  description: PolicyRef identifies an optional infrastructure policy
-                    to specify for the virtual machine.
+                  description: |-
+                    PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+                    ApiVersion is omitted from the PolicyRef by intention.
                   properties:
-                    apiVersion:
-                      description: |-
-                        apiVersion is the fully qualified group/version of the infrastructure policy resource
-                        (for example vsphere.policy.vmware.com/v1alpha1).
-                        apiVersion must be fully qualified domain name followed by / and a version.
-                      maxLength: 317
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                      type: string
                     kind:
                       description: |-
                         kind of the infrastructure policy object being referenced.
@@ -1324,7 +1307,6 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
-                  - apiVersion
                   - kind
                   - name
                   type: object

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -350,9 +350,8 @@ spec:
                 description: policies specifies a list of optional infrastructure
                   policies to be applied to the virtual machine.
                 items:
-                  description: |-
-                    PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-                    ApiVersion is omitted from the PolicyRef by intention.
+                  description: PolicyRef identifies an optional infrastructure policy
+                    to specify for the virtual machine by name and kind.
                   properties:
                     kind:
                       description: |-
@@ -1286,9 +1285,8 @@ spec:
                 description: policies specifies a list of optional infrastructure
                   policies to be applied to the virtual machine.
                 items:
-                  description: |-
-                    PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-                    ApiVersion is omitted from the PolicyRef by intention.
+                  description: PolicyRef identifies an optional infrastructure policy
+                    to specify for the virtual machine by name and kind.
                   properties:
                     kind:
                       description: |-

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -346,18 +346,10 @@ spec:
                         description: policies specifies a list of optional infrastructure
                           policies to be applied to the virtual machine.
                         items:
-                          description: PolicyRef identifies an optional infrastructure
-                            policy to specify for the virtual machine.
+                          description: |-
+                            PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+                            ApiVersion is omitted from the PolicyRef by intention.
                           properties:
-                            apiVersion:
-                              description: |-
-                                apiVersion is the fully qualified group/version of the infrastructure policy resource
-                                (for example vsphere.policy.vmware.com/v1alpha1).
-                                apiVersion must be fully qualified domain name followed by / and a version.
-                              maxLength: 317
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                              type: string
                             kind:
                               description: |-
                                 kind of the infrastructure policy object being referenced.
@@ -375,7 +367,6 @@ spec:
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                           required:
-                          - apiVersion
                           - kind
                           - name
                           type: object
@@ -845,18 +836,10 @@ spec:
                         description: policies specifies a list of optional infrastructure
                           policies to be applied to the virtual machine.
                         items:
-                          description: PolicyRef identifies an optional infrastructure
-                            policy to specify for the virtual machine.
+                          description: |-
+                            PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
+                            ApiVersion is omitted from the PolicyRef by intention.
                           properties:
-                            apiVersion:
-                              description: |-
-                                apiVersion is the fully qualified group/version of the infrastructure policy resource
-                                (for example vsphere.policy.vmware.com/v1alpha1).
-                                apiVersion must be fully qualified domain name followed by / and a version.
-                              maxLength: 317
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                              type: string
                             kind:
                               description: |-
                                 kind of the infrastructure policy object being referenced.
@@ -874,7 +857,6 @@ spec:
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                           required:
-                          - apiVersion
                           - kind
                           - name
                           type: object

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -346,9 +346,9 @@ spec:
                         description: policies specifies a list of optional infrastructure
                           policies to be applied to the virtual machine.
                         items:
-                          description: |-
-                            PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-                            ApiVersion is omitted from the PolicyRef by intention.
+                          description: PolicyRef identifies an optional infrastructure
+                            policy to specify for the virtual machine by name and
+                            kind.
                           properties:
                             kind:
                               description: |-
@@ -836,9 +836,9 @@ spec:
                         description: policies specifies a list of optional infrastructure
                           policies to be applied to the virtual machine.
                         items:
-                          description: |-
-                            PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
-                            ApiVersion is omitted from the PolicyRef by intention.
+                          description: PolicyRef identifies an optional infrastructure
+                            policy to specify for the virtual machine by name and
+                            kind.
                           properties:
                             kind:
                               description: |-

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -578,9 +578,8 @@ var _ = Describe("Reconciliation tests", func() {
 			})
 			infraMachine.Spec.Policies = []vmwarev1.PolicyRef{
 				{
-					Name:       "policy-1",
-					Kind:       "ComputePolicy",
-					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+					Name: "policy-1",
+					Kind: "ComputePolicy",
 				},
 			}
 			Expect(k8sClient.Create(ctx, infraMachine)).To(Succeed())
@@ -592,9 +591,8 @@ var _ = Describe("Reconciliation tests", func() {
 			}, time.Second*30).Should(Succeed())
 
 			infraMachine.Spec.Policies = append(infraMachine.Spec.Policies, vmwarev1.PolicyRef{
-				Name:       "policy-2",
-				Kind:       "ComputePolicy",
-				APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+				Name: "policy-2",
+				Kind: "ComputePolicy",
 			})
 			err := k8sClient.Update(ctx, infraMachine)
 			Expect(err).To(HaveOccurred())
@@ -613,9 +611,8 @@ var _ = Describe("Reconciliation tests", func() {
 							ClassName: "test-class",
 							Policies: []vmwarev1.PolicyRef{
 								{
-									Name:       "policy-1",
-									Kind:       "ComputePolicy",
-									APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+									Name: "policy-1",
+									Kind: "ComputePolicy",
 								},
 							},
 						},
@@ -631,9 +628,8 @@ var _ = Describe("Reconciliation tests", func() {
 			}, time.Second*30).Should(Succeed())
 
 			machineTemplate.Spec.Template.Spec.Policies = append(machineTemplate.Spec.Template.Spec.Policies, vmwarev1.PolicyRef{
-				Name:       "policy-2",
-				Kind:       "ComputePolicy",
-				APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+				Name: "policy-2",
+				Kind: "ComputePolicy",
 			})
 			err = k8sClient.Update(ctx, machineTemplate)
 			Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -410,7 +410,7 @@ func TestVSphereMachine_ValidateCreate_InfrastructurePolicies(t *testing.T) {
 			obj := &vmwarev1.VSphereMachine{
 				Spec: vmwarev1.VSphereMachineSpec{
 					Policies: []vmwarev1.PolicyRef{
-						{Name: "policy-1", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+						{Name: "policy-1", Kind: "ComputePolicy"},
 					},
 				},
 			}

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -441,7 +441,7 @@ func TestVSphereMachineTemplate_ValidatePoliciesFeatureGate(t *testing.T) {
 					Template: vmwarev1.VSphereMachineTemplateResource{
 						Spec: vmwarev1.VSphereMachineSpec{
 							Policies: []vmwarev1.PolicyRef{
-								{Name: "policy-1", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+								{Name: "policy-1", Kind: "ComputePolicy"},
 							},
 						},
 					},

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -639,7 +639,11 @@ func (v *VmopMachineService) reconcileVMOperatorVM(ctx context.Context, supervis
 
 	// Only set spec.policies on create as the field is immutable.
 	if vmOperatorVM.CreationTimestamp.IsZero() {
-		vmOperatorVM.Spec.Policies = getPolicies(supervisorMachineCtx)
+		policies, err := getPolicies(supervisorMachineCtx)
+		if err != nil {
+			return err
+		}
+		vmOperatorVM.Spec.Policies = policies
 	}
 
 	// Apply hooks to modify the VM spec
@@ -1018,25 +1022,51 @@ func getTopologyLabels(supervisorMachineCtx *vmware.SupervisorMachineContext, fa
 	return nil
 }
 
-func getPolicies(supervisorMachineCtx *vmware.SupervisorMachineContext) []vmoprvhub.PolicySpec {
+// Refer to vm-operator policy GroupVersion info in https://github.com/vmware-tanzu/vm-operator/blob/main/external/vsphere-policy/api/v1alpha1/groupversion_info.go
+const (
+	policyAPIGroup    = "vsphere.policy.vmware.com"
+	policyAPIV1Alpha1 = "v1alpha1"
+	computePolicyKind = "ComputePolicy"
+)
+
+// policyKindToAPIVersion maps policy Kinds to their fully qualified APIVersion.
+// Currently, vm-operator v1alpha5 requires apiVersion to be set, but not honoring it,
+// see https://github.com/vmware-tanzu/vm-operator/blob/main/controllers/vspherepolicy/policyevaluation/policyevaluation_controller.go#L544-L559.
+// CAPV uses a hard-coded mapping maintained internally to keep the
+// API clean by omitting apiVersion fields.
+//
+// This mapping will only be necessary as the vm-operator API design evolves.
+// The apiVersion field in vm-operator policies could be a legacy design, and
+// keeping this mapping internal to CAPV gives us the flexibility to adapt to
+// future API changes (such as keeping apiVersion, moving to apiGroup, or dropping
+// the field entirely) without breaking the CAPV API.
+var policyKindToAPIVersion = map[string]string{
+	computePolicyKind: policyAPIGroup + "/" + policyAPIV1Alpha1,
+}
+
+func getPolicies(supervisorMachineCtx *vmware.SupervisorMachineContext) ([]vmoprvhub.PolicySpec, error) {
 	// Assign policies when the feature gate is enabled.
 	if !feature.Gates.Enabled(feature.InfrastructurePolicies) {
-		return nil
+		return nil, nil
 	}
 
 	refs := supervisorMachineCtx.VSphereMachine.Spec.Policies
 	if len(refs) == 0 {
-		return nil
+		return nil, nil
 	}
 	result := make([]vmoprvhub.PolicySpec, 0, len(refs))
 	for _, ref := range refs {
+		apiVersion, ok := policyKindToAPIVersion[ref.Kind]
+		if !ok {
+			return nil, fmt.Errorf("unknown policy kind %q", ref.Kind)
+		}
 		result = append(result, vmoprvhub.PolicySpec{
 			Name:       ref.Name,
 			Kind:       ref.Kind,
-			APIVersion: ref.APIVersion,
+			APIVersion: apiVersion,
 		})
 	}
-	return result
+	return result, nil
 }
 
 // getMachineDeploymentName returns the MachineDeployment name for a Cluster.

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -753,14 +753,12 @@ var _ = Describe("VirtualMachine tests", func() {
 
 				vsphereMachine.Spec.Policies = []vmwarev1.PolicyRef{
 					{
-						Name:       "policy-a",
-						Kind:       "ComputePolicy",
-						APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+						Name: "policy-a",
+						Kind: computePolicyKind,
 					},
 					{
-						Name:       "policy-b",
-						Kind:       "ComputePolicy",
-						APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+						Name: "policy-b",
+						Kind: computePolicyKind,
 					},
 				}
 
@@ -773,12 +771,12 @@ var _ = Describe("VirtualMachine tests", func() {
 				Expect(vmopVM.Spec.Policies).To(HaveLen(2))
 				Expect(vmopVM.Spec.Policies[0]).To(Equal(vmoprv1alpha5.PolicySpec{
 					Name:       "policy-a",
-					Kind:       "ComputePolicy",
+					Kind:       computePolicyKind,
 					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
 				}))
 				Expect(vmopVM.Spec.Policies[1]).To(Equal(vmoprv1alpha5.PolicySpec{
 					Name:       "policy-b",
-					Kind:       "ComputePolicy",
+					Kind:       computePolicyKind,
 					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
 				}))
 
@@ -800,7 +798,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			expectedRequeue = true
 
 			vsphereMachine.Spec.Policies = []vmwarev1.PolicyRef{
-				{Name: "policy-a", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+				{Name: "policy-a", Kind: computePolicyKind},
 			}
 
 			By("VirtualMachine is created (gate off)")
@@ -1379,8 +1377,18 @@ func Test_virtualMachineObjectKey(t *testing.T) {
 func Test_getPolicies(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.InfrastructurePolicies, true)
 
-	policyGVK := func(name, kind, apiVersion string) vmwarev1.PolicyRef {
-		return vmwarev1.PolicyRef{Name: name, Kind: kind, APIVersion: apiVersion}
+	// Add test-only policy mappings to the map for testing purposes
+	policyKindToAPIVersion["APolicy"] = policyAPIGroup + "/" + policyAPIV1Alpha1
+	policyKindToAPIVersion["BPolicy"] = policyAPIGroup + "/" + policyAPIV1Alpha1
+	policyKindToAPIVersion["ZPolicy"] = policyAPIGroup + "/v1alpha2"
+	defer func() {
+		delete(policyKindToAPIVersion, "APolicy")
+		delete(policyKindToAPIVersion, "BPolicy")
+		delete(policyKindToAPIVersion, "ZPolicy")
+	}()
+
+	policyGK := func(name, kind string) vmwarev1.PolicyRef {
+		return vmwarev1.PolicyRef{Name: name, Kind: kind}
 	}
 	const (
 		apiV1 = "vsphere.policy.vmware.com/v1alpha1"
@@ -1404,32 +1412,32 @@ func Test_getPolicies(t *testing.T) {
 		{
 			name: "single ComputePolicy maps to hub PolicySpec",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("my-compute-policy", "ComputePolicy", apiV1),
+				policyGK("my-compute-policy", computePolicyKind),
 			},
 			want: []vmoprvhub.PolicySpec{
-				{Name: "my-compute-policy", Kind: "ComputePolicy", APIVersion: apiV1},
+				{Name: "my-compute-policy", Kind: computePolicyKind, APIVersion: apiV1},
 			},
 		},
 		{
 			name: "multiple ComputePolicies preserve input order",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("policy-c", "ComputePolicy", apiV1),
-				policyGVK("policy-a", "ComputePolicy", apiV1),
-				policyGVK("policy-b", "ComputePolicy", apiV1),
+				policyGK("policy-c", computePolicyKind),
+				policyGK("policy-a", computePolicyKind),
+				policyGK("policy-b", computePolicyKind),
 			},
 			want: []vmoprvhub.PolicySpec{
-				{Name: "policy-c", Kind: "ComputePolicy", APIVersion: apiV1},
-				{Name: "policy-a", Kind: "ComputePolicy", APIVersion: apiV1},
-				{Name: "policy-b", Kind: "ComputePolicy", APIVersion: apiV1},
+				{Name: "policy-c", Kind: computePolicyKind, APIVersion: apiV1},
+				{Name: "policy-a", Kind: computePolicyKind, APIVersion: apiV1},
+				{Name: "policy-b", Kind: computePolicyKind, APIVersion: apiV1},
 			},
 		},
 		{
 			name: "mixed Kinds and APIVersions preserve input order",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("alpha", "ZPolicy", apiV2),
-				policyGVK("beta", "APolicy", apiV1),
-				policyGVK("alpha", "APolicy", apiV1),
-				policyGVK("alpha", "BPolicy", apiV1),
+				policyGK("alpha", "ZPolicy"),
+				policyGK("beta", "APolicy"),
+				policyGK("alpha", "APolicy"),
+				policyGK("alpha", "BPolicy"),
 			},
 			want: []vmoprvhub.PolicySpec{
 				{Name: "alpha", Kind: "ZPolicy", APIVersion: apiV2},
@@ -1449,10 +1457,28 @@ func Test_getPolicies(t *testing.T) {
 					},
 				},
 			}
-			got := getPolicies(sm)
+			got, err := getPolicies(sm)
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(got).To(Equal(tt.want))
 		})
 	}
+
+	t.Run("unknown policy kind returns error", func(t *testing.T) {
+		g := NewWithT(t)
+		sm := &vmware.SupervisorMachineContext{
+			VSphereMachine: &vmwarev1.VSphereMachine{
+				Spec: vmwarev1.VSphereMachineSpec{
+					Policies: []vmwarev1.PolicyRef{
+						policyGK("policy-unknown", "UnknownPolicy"),
+					},
+				},
+			},
+		}
+		got, err := getPolicies(sm)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown policy kind \"UnknownPolicy\""))
+		g.Expect(got).To(BeNil())
+	})
 }
 
 func Test_getPolicies_FeatureGateDisabled(t *testing.T) {
@@ -1462,11 +1488,12 @@ func Test_getPolicies_FeatureGateDisabled(t *testing.T) {
 		VSphereMachine: &vmwarev1.VSphereMachine{
 			Spec: vmwarev1.VSphereMachineSpec{
 				Policies: []vmwarev1.PolicyRef{
-					{Name: "policy-a", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+					{Name: "policy-a", Kind: computePolicyKind},
 				},
 			},
 		},
 	}
-	got := getPolicies(sm)
+	got, err := getPolicies(sm)
+	NewWithT(t).Expect(err).NotTo(HaveOccurred())
 	NewWithT(t).Expect(got).To(BeNil())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Omit apiVersion from the customer-facing PolicyRef API to keep it clean. Maintain an internal hard-coded mapping of policy Kinds to apiVersions in CAPV, and surface errors for unknown policy kinds.

Currently, vm-operator v1alpha5 requires apiVersion to be set, but not honoring it,
see https://github.com/vmware-tanzu/vm-operator/blob/main/controllers/vspherepolicy/policyevaluation/policyevaluation_controller.go#L544-L559.

This mapping will only be necessary as the vm-operator API design evolves.
The apiVersion field in vm-operator policies could be a legacy design, and
keeping this mapping internal to CAPV gives us the flexibility to adapt to
future API changes (such as keeping apiVersion, moving to apiGroup, or dropping
the field entirely) without breaking the CAPV API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
