### PR TITLE
🐛 Apply VM-wide static routes per-device in cloud-init metadata

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -138,12 +138,4 @@ network:
         {{- end }}
       {{- end }}
     {{- end }}
-  {{- if .Routes }}
-  routes:
-  {{- range .Routes }}
-  - to: "{{ .To }}"
-    via: "{{ .Via }}"
-    metric: {{ .Metric }}
-  {{- end }}
-  {{- end }}
 `

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -90,6 +90,11 @@ func GetMachineMetadata(hostname string, vsphereVM infrav1.VSphereVM, ipamState 
 		// not as a top-level network property, so apply the VM-wide routes to
 		// every device instead of rendering them as an invalid top-level key.
 		devices[i].Routes = append(devices[i].Routes, vsphereVM.Spec.Network.Routes...)
+		if i == len(vsphereVM.Spec.Network.Devices)-1 {
+			for j := len(vsphereVM.Spec.Network.Devices); j < len(devices); j++ {
+				devices[j].Routes = append(devices[j].Routes, vsphereVM.Spec.Network.Routes...)
+			}
+		}
 
 		// Add the MAC Address to the network device
 		if len(networkStatuses) > i {

--- a/pkg/util/machines.go
+++ b/pkg/util/machines.go
@@ -86,6 +86,11 @@ func GetMachineMetadata(hostname string, vsphereVM infrav1.VSphereVM, ipamState 
 	for i := range vsphereVM.Spec.Network.Devices {
 		vsphereVM.Spec.Network.Devices[i].DeepCopyInto(&devices[i])
 
+		// netplan (used by cloud-init) only supports static routes per-device,
+		// not as a top-level network property, so apply the VM-wide routes to
+		// every device instead of rendering them as an invalid top-level key.
+		devices[i].Routes = append(devices[i].Routes, vsphereVM.Spec.Network.Routes...)
+
 		// Add the MAC Address to the network device
 		if len(networkStatuses) > i {
 			devices[i].MACAddr = networkStatuses[i].MACAddr
@@ -140,13 +145,11 @@ func GetMachineMetadata(hostname string, vsphereVM infrav1.VSphereVM, ipamState 
 	if err := tpl.Execute(buf, struct {
 		Hostname    string
 		Devices     []infrav1.NetworkDeviceSpec
-		Routes      []infrav1.NetworkRouteSpec
 		WaitForIPv4 bool
 		WaitForIPv6 bool
 	}{
 		Hostname:    hostname, // note that hostname determines the Kubernetes node name
 		Devices:     devices,
-		Routes:      vsphereVM.Spec.Network.Routes,
 		WaitForIPv4: waitForIPv4,
 		WaitForIPv6: waitForIPv6,
 	}); err != nil {

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -485,10 +485,84 @@ network:
       addresses:
       - "192.168.4.21"
       gateway4: "192.168.4.1"
-  routes:
-  - to: "192.168.5.1/24"
-    via: "192.168.4.254"
-    metric: 3
+      routes:
+      - to: "192.168.5.1/24"
+        via: "192.168.4.254"
+        metric: 3
+`,
+		},
+		{
+			name: "2nets+global-static-routes",
+			machine: &infrav1.VSphereVM{
+				Spec: infrav1.VSphereVMSpec{
+					VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
+						Network: infrav1.NetworkSpec{
+							Devices: []infrav1.NetworkDeviceSpec{
+								{
+									NetworkName: "network1",
+									MACAddr:     "00:00:00:00:00",
+									DHCP4:       ptr.To(true),
+									Routes: []infrav1.NetworkRouteSpec{
+										{
+											To:     "192.168.5.1/24",
+											Via:    "192.168.4.254",
+											Metric: ptr.To[int32](3),
+										},
+									},
+								},
+								{
+									NetworkName: "network12",
+									MACAddr:     "00:00:00:00:01",
+									DHCP6:       ptr.To(true),
+								},
+							},
+							Routes: []infrav1.NetworkRouteSpec{
+								{
+									To:     "0.0.0.0/0",
+									Via:    "192.168.4.1",
+									Metric: ptr.To[int32](222),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+instance-id: "test-vm"
+local-hostname: "test-vm"
+wait-on-network:
+  ipv4: true
+  ipv6: true
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+        macaddress: "00:00:00:00:00"
+      set-name: "eth0"
+      wakeonlan: true
+      dhcp4: true
+      dhcp6: false
+      accept-ra: false
+      routes:
+      - to: "192.168.5.1/24"
+        via: "192.168.4.254"
+        metric: 3
+      - to: "0.0.0.0/0"
+        via: "192.168.4.1"
+        metric: 222
+    id1:
+      match:
+        macaddress: "00:00:00:00:01"
+      set-name: "eth1"
+      wakeonlan: true
+      dhcp4: false
+      dhcp6: true
+      accept-ra: true
+      routes:
+      - to: "0.0.0.0/0"
+        via: "192.168.4.1"
+        metric: 222
 `,
 		},
 		{

--- a/pkg/util/machines_test.go
+++ b/pkg/util/machines_test.go
@@ -826,7 +826,7 @@ network:
 `,
 		},
 		{
-			name: "more-network-statuses-than-spec-devices",
+			name: "more-network-statuses-than-spec-devices+global-static-routes",
 			machine: &infrav1.VSphereVM{
 				Spec: infrav1.VSphereVMSpec{
 					VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
@@ -841,6 +841,13 @@ network:
 									NetworkName: "network12",
 									MACAddr:     "00:00:00:00:01",
 									DHCP6:       ptr.To(true),
+								},
+							},
+							Routes: []infrav1.NetworkRouteSpec{
+								{
+									To:     "0.0.0.0/0",
+									Via:    "192.168.4.1",
+									Metric: ptr.To[int32](222),
 								},
 							},
 						},
@@ -869,6 +876,10 @@ network:
       dhcp4: true
       dhcp6: false
       accept-ra: false
+      routes:
+      - to: "0.0.0.0/0"
+        via: "192.168.4.1"
+        metric: 222
     id1:
       match:
         macaddress: "00:00:00:00:cd"
@@ -877,6 +888,10 @@ network:
       dhcp4: false
       dhcp6: true
       accept-ra: true
+      routes:
+      - to: "0.0.0.0/0"
+        via: "192.168.4.1"
+        metric: 222
     id2:
       match:
         macaddress: "00:00:00:00:ef"
@@ -885,6 +900,10 @@ network:
       dhcp4: false
       dhcp6: false
       accept-ra: false
+      routes:
+      - to: "0.0.0.0/0"
+        via: "192.168.4.1"
+        metric: 222
 `,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Motivation:
When `VSphereVM.Spec.Network.Routes` (VM-wide/global static routes) is
set, the generated cloud-init network-config v2 metadata rendered them
as a top-level `routes:` key directly under `network:`. That is not a
valid location for `routes` in the netplan v2 schema used by cloud-init
(routes are only valid nested under an individual device). As a result,
cloud-init fails during `init-local` with `RuntimeError: No handler
found for command 'routes'`, and the guest network never comes up for
any machine using this field. Per-device routes
(`NetworkDeviceSpec.Routes`) were unaffected and already worked
correctly, since they were already rendered in the valid per-device
location.

Approach:
Instead of rendering the VM-wide routes as an invalid top-level key,
merge them into each device's own `.Routes` slice before rendering, so
they end up in the same (valid) per-device `routes:` block that
per-device routes already use. The invalid top-level template block is
removed. When `Spec.Network.Routes` is empty (the common case), the
merge is a no-op and generated metadata is unchanged.

**Which issue(s) this PR fixes**:
Fixes #2170

**Validation**:
Ran `go build ./...` (passes) and `go test ./pkg/util/...` (passes),
including a new test case ("2nets+global-static-routes" in
pkg/util/machines_test.go) that verifies a VM-wide route is merged into
every device's route list alongside any pre-existing per-device routes,
and an updated existing test case that verifies the previously-invalid
top-level `routes:` output is now rendered per-device instead.

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>