### PR TITLE
[release-1.17] ✨ Omit apiVersion from PolicyRef

### DIFF
--- a/api/supervisor/v1beta1/vspheremachine_types.go
+++ b/api/supervisor/v1beta1/vspheremachine_types.go
@@ -108,7 +108,7 @@ type VSphereMachineSpec struct {
 	NamingStrategy *VirtualMachineNamingStrategy `json:"namingStrategy,omitempty"`
 }
 
-// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine.
+// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -125,15 +125,6 @@ type PolicyRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 	Kind string `json:"kind,omitempty"`
-
-	// apiVersion is the fully qualified group/version of the infrastructure policy resource
-	// (for example vsphere.policy.vmware.com/v1alpha1).
-	// apiVersion must be fully qualified domain name followed by / and a version.
-	// +required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=317
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // VSphereMachineNetworkSpec defines the network configuration of a VSphereMachine.

--- a/api/supervisor/v1beta1/zz_generated.conversion.go
+++ b/api/supervisor/v1beta1/zz_generated.conversion.go
@@ -662,7 +662,6 @@ func Convert_v1beta2_Network_To_v1beta1_Network(in *v1beta2.Network, out *Networ
 func autoConvert_v1beta1_PolicyRef_To_v1beta2_PolicyRef(in *PolicyRef, out *v1beta2.PolicyRef, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 
@@ -674,7 +673,6 @@ func Convert_v1beta1_PolicyRef_To_v1beta2_PolicyRef(in *PolicyRef, out *v1beta2.
 func autoConvert_v1beta2_PolicyRef_To_v1beta1_PolicyRef(in *v1beta2.PolicyRef, out *PolicyRef, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
 	return nil
 }
 

--- a/api/supervisor/v1beta2/vspheremachine_types.go
+++ b/api/supervisor/v1beta2/vspheremachine_types.go
@@ -124,7 +124,7 @@ type VSphereMachineSpec struct {
 	Policies []PolicyRef `json:"policies,omitempty"`
 }
 
-// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine.
+// PolicyRef identifies an optional infrastructure policy to specify for the virtual machine by name and kind.
 type PolicyRef struct {
 	// name of the infrastructure policy.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -141,15 +141,6 @@ type PolicyRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 	Kind string `json:"kind,omitempty"`
-
-	// apiVersion is the fully qualified group/version of the infrastructure policy resource
-	// (for example vsphere.policy.vmware.com/v1alpha1).
-	// apiVersion must be fully qualified domain name followed by / and a version.
-	// +required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=317
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // VSphereMachineNetworkSpec defines the network configuration of a VSphereMachine.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -351,17 +351,8 @@ spec:
                   policies to be applied to the virtual machine.
                 items:
                   description: PolicyRef identifies an optional infrastructure policy
-                    to specify for the virtual machine.
+                    to specify for the virtual machine by name and kind.
                   properties:
-                    apiVersion:
-                      description: |-
-                        apiVersion is the fully qualified group/version of the infrastructure policy resource
-                        (for example vsphere.policy.vmware.com/v1alpha1).
-                        apiVersion must be fully qualified domain name followed by / and a version.
-                      maxLength: 317
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                      type: string
                     kind:
                       description: |-
                         kind of the infrastructure policy object being referenced.
@@ -379,7 +370,6 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
-                  - apiVersion
                   - kind
                   - name
                   type: object
@@ -1296,17 +1286,8 @@ spec:
                   policies to be applied to the virtual machine.
                 items:
                   description: PolicyRef identifies an optional infrastructure policy
-                    to specify for the virtual machine.
+                    to specify for the virtual machine by name and kind.
                   properties:
-                    apiVersion:
-                      description: |-
-                        apiVersion is the fully qualified group/version of the infrastructure policy resource
-                        (for example vsphere.policy.vmware.com/v1alpha1).
-                        apiVersion must be fully qualified domain name followed by / and a version.
-                      maxLength: 317
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                      type: string
                     kind:
                       description: |-
                         kind of the infrastructure policy object being referenced.
@@ -1324,7 +1305,6 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
-                  - apiVersion
                   - kind
                   - name
                   type: object

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -347,17 +347,9 @@ spec:
                           policies to be applied to the virtual machine.
                         items:
                           description: PolicyRef identifies an optional infrastructure
-                            policy to specify for the virtual machine.
+                            policy to specify for the virtual machine by name and
+                            kind.
                           properties:
-                            apiVersion:
-                              description: |-
-                                apiVersion is the fully qualified group/version of the infrastructure policy resource
-                                (for example vsphere.policy.vmware.com/v1alpha1).
-                                apiVersion must be fully qualified domain name followed by / and a version.
-                              maxLength: 317
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                              type: string
                             kind:
                               description: |-
                                 kind of the infrastructure policy object being referenced.
@@ -375,7 +367,6 @@ spec:
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                           required:
-                          - apiVersion
                           - kind
                           - name
                           type: object
@@ -846,17 +837,9 @@ spec:
                           policies to be applied to the virtual machine.
                         items:
                           description: PolicyRef identifies an optional infrastructure
-                            policy to specify for the virtual machine.
+                            policy to specify for the virtual machine by name and
+                            kind.
                           properties:
-                            apiVersion:
-                              description: |-
-                                apiVersion is the fully qualified group/version of the infrastructure policy resource
-                                (for example vsphere.policy.vmware.com/v1alpha1).
-                                apiVersion must be fully qualified domain name followed by / and a version.
-                              maxLength: 317
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$
-                              type: string
                             kind:
                               description: |-
                                 kind of the infrastructure policy object being referenced.
@@ -874,7 +857,6 @@ spec:
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                           required:
-                          - apiVersion
                           - kind
                           - name
                           type: object

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -578,9 +578,8 @@ var _ = Describe("Reconciliation tests", func() {
 			})
 			infraMachine.Spec.Policies = []vmwarev1.PolicyRef{
 				{
-					Name:       "policy-1",
-					Kind:       "ComputePolicy",
-					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+					Name: "policy-1",
+					Kind: "ComputePolicy",
 				},
 			}
 			Expect(k8sClient.Create(ctx, infraMachine)).To(Succeed())
@@ -592,9 +591,8 @@ var _ = Describe("Reconciliation tests", func() {
 			}, time.Second*30).Should(Succeed())
 
 			infraMachine.Spec.Policies = append(infraMachine.Spec.Policies, vmwarev1.PolicyRef{
-				Name:       "policy-2",
-				Kind:       "ComputePolicy",
-				APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+				Name: "policy-2",
+				Kind: "ComputePolicy",
 			})
 			err := k8sClient.Update(ctx, infraMachine)
 			Expect(err).To(HaveOccurred())
@@ -613,9 +611,8 @@ var _ = Describe("Reconciliation tests", func() {
 							ClassName: "test-class",
 							Policies: []vmwarev1.PolicyRef{
 								{
-									Name:       "policy-1",
-									Kind:       "ComputePolicy",
-									APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+									Name: "policy-1",
+									Kind: "ComputePolicy",
 								},
 							},
 						},
@@ -631,9 +628,8 @@ var _ = Describe("Reconciliation tests", func() {
 			}, time.Second*30).Should(Succeed())
 
 			machineTemplate.Spec.Template.Spec.Policies = append(machineTemplate.Spec.Template.Spec.Policies, vmwarev1.PolicyRef{
-				Name:       "policy-2",
-				Kind:       "ComputePolicy",
-				APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+				Name: "policy-2",
+				Kind: "ComputePolicy",
 			})
 			err = k8sClient.Update(ctx, machineTemplate)
 			Expect(err).To(HaveOccurred())

--- a/internal/webhooks/vmware/vspheremachine_test.go
+++ b/internal/webhooks/vmware/vspheremachine_test.go
@@ -410,7 +410,7 @@ func TestVSphereMachine_ValidateCreate_InfrastructurePolicies(t *testing.T) {
 			obj := &vmwarev1.VSphereMachine{
 				Spec: vmwarev1.VSphereMachineSpec{
 					Policies: []vmwarev1.PolicyRef{
-						{Name: "policy-1", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+						{Name: "policy-1", Kind: "ComputePolicy"},
 					},
 				},
 			}

--- a/internal/webhooks/vmware/vspheremachinetemplate_test.go
+++ b/internal/webhooks/vmware/vspheremachinetemplate_test.go
@@ -441,7 +441,7 @@ func TestVSphereMachineTemplate_ValidatePoliciesFeatureGate(t *testing.T) {
 					Template: vmwarev1.VSphereMachineTemplateResource{
 						Spec: vmwarev1.VSphereMachineSpec{
 							Policies: []vmwarev1.PolicyRef{
-								{Name: "policy-1", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+								{Name: "policy-1", Kind: "ComputePolicy"},
 							},
 						},
 					},

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -1031,9 +1031,8 @@ func getPolicies(supervisorMachineCtx *vmware.SupervisorMachineContext) []vmoprv
 	result := make([]vmoprvhub.PolicySpec, 0, len(refs))
 	for _, ref := range refs {
 		result = append(result, vmoprvhub.PolicySpec{
-			Name:       ref.Name,
-			Kind:       ref.Kind,
-			APIVersion: ref.APIVersion,
+			Name: ref.Name,
+			Kind: ref.Kind,
 		})
 	}
 	return result

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -753,14 +753,12 @@ var _ = Describe("VirtualMachine tests", func() {
 
 				vsphereMachine.Spec.Policies = []vmwarev1.PolicyRef{
 					{
-						Name:       "policy-a",
-						Kind:       "ComputePolicy",
-						APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+						Name: "policy-a",
+						Kind: "ComputePolicy",
 					},
 					{
-						Name:       "policy-b",
-						Kind:       "ComputePolicy",
-						APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+						Name: "policy-b",
+						Kind: "ComputePolicy",
 					},
 				}
 
@@ -772,14 +770,12 @@ var _ = Describe("VirtualMachine tests", func() {
 				vmopVM = getReconciledVM(ctx, vmService, supervisorMachineContext)
 				Expect(vmopVM.Spec.Policies).To(HaveLen(2))
 				Expect(vmopVM.Spec.Policies[0]).To(Equal(vmoprv1alpha5.PolicySpec{
-					Name:       "policy-a",
-					Kind:       "ComputePolicy",
-					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+					Name: "policy-a",
+					Kind: "ComputePolicy",
 				}))
 				Expect(vmopVM.Spec.Policies[1]).To(Equal(vmoprv1alpha5.PolicySpec{
-					Name:       "policy-b",
-					Kind:       "ComputePolicy",
-					APIVersion: "vsphere.policy.vmware.com/v1alpha1",
+					Name: "policy-b",
+					Kind: "ComputePolicy",
 				}))
 
 				By("Running a second reconcile (update path) and verifying policies are preserved")
@@ -800,7 +796,7 @@ var _ = Describe("VirtualMachine tests", func() {
 			expectedRequeue = true
 
 			vsphereMachine.Spec.Policies = []vmwarev1.PolicyRef{
-				{Name: "policy-a", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+				{Name: "policy-a", Kind: "ComputePolicy"},
 			}
 
 			By("VirtualMachine is created (gate off)")
@@ -1379,13 +1375,9 @@ func Test_virtualMachineObjectKey(t *testing.T) {
 func Test_getPolicies(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.InfrastructurePolicies, true)
 
-	policyGVK := func(name, kind, apiVersion string) vmwarev1.PolicyRef {
-		return vmwarev1.PolicyRef{Name: name, Kind: kind, APIVersion: apiVersion}
+	policyGVK := func(name, kind string) vmwarev1.PolicyRef {
+		return vmwarev1.PolicyRef{Name: name, Kind: kind}
 	}
-	const (
-		apiV1 = "vsphere.policy.vmware.com/v1alpha1"
-		apiV2 = "vsphere.policy.vmware.com/v1alpha2"
-	)
 	tests := []struct {
 		name string
 		in   []vmwarev1.PolicyRef
@@ -1404,38 +1396,38 @@ func Test_getPolicies(t *testing.T) {
 		{
 			name: "single ComputePolicy maps to hub PolicySpec",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("my-compute-policy", "ComputePolicy", apiV1),
+				policyGVK("my-compute-policy", "ComputePolicy"),
 			},
 			want: []vmoprvhub.PolicySpec{
-				{Name: "my-compute-policy", Kind: "ComputePolicy", APIVersion: apiV1},
+				{Name: "my-compute-policy", Kind: "ComputePolicy"},
 			},
 		},
 		{
 			name: "multiple ComputePolicies preserve input order",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("policy-c", "ComputePolicy", apiV1),
-				policyGVK("policy-a", "ComputePolicy", apiV1),
-				policyGVK("policy-b", "ComputePolicy", apiV1),
+				policyGVK("policy-c", "ComputePolicy"),
+				policyGVK("policy-a", "ComputePolicy"),
+				policyGVK("policy-b", "ComputePolicy"),
 			},
 			want: []vmoprvhub.PolicySpec{
-				{Name: "policy-c", Kind: "ComputePolicy", APIVersion: apiV1},
-				{Name: "policy-a", Kind: "ComputePolicy", APIVersion: apiV1},
-				{Name: "policy-b", Kind: "ComputePolicy", APIVersion: apiV1},
+				{Name: "policy-c", Kind: "ComputePolicy"},
+				{Name: "policy-a", Kind: "ComputePolicy"},
+				{Name: "policy-b", Kind: "ComputePolicy"},
 			},
 		},
 		{
 			name: "mixed Kinds and APIVersions preserve input order",
 			in: []vmwarev1.PolicyRef{
-				policyGVK("alpha", "ZPolicy", apiV2),
-				policyGVK("beta", "APolicy", apiV1),
-				policyGVK("alpha", "APolicy", apiV1),
-				policyGVK("alpha", "BPolicy", apiV1),
+				policyGVK("alpha", "ZPolicy"),
+				policyGVK("beta", "APolicy"),
+				policyGVK("alpha", "APolicy"),
+				policyGVK("alpha", "BPolicy"),
 			},
 			want: []vmoprvhub.PolicySpec{
-				{Name: "alpha", Kind: "ZPolicy", APIVersion: apiV2},
-				{Name: "beta", Kind: "APolicy", APIVersion: apiV1},
-				{Name: "alpha", Kind: "APolicy", APIVersion: apiV1},
-				{Name: "alpha", Kind: "BPolicy", APIVersion: apiV1},
+				{Name: "alpha", Kind: "ZPolicy"},
+				{Name: "beta", Kind: "APolicy"},
+				{Name: "alpha", Kind: "APolicy"},
+				{Name: "alpha", Kind: "BPolicy"},
 			},
 		},
 	}
@@ -1462,7 +1454,7 @@ func Test_getPolicies_FeatureGateDisabled(t *testing.T) {
 		VSphereMachine: &vmwarev1.VSphereMachine{
 			Spec: vmwarev1.VSphereMachineSpec{
 				Policies: []vmwarev1.PolicyRef{
-					{Name: "policy-a", Kind: "ComputePolicy", APIVersion: "vsphere.policy.vmware.com/v1alpha1"},
+					{Name: "policy-a", Kind: "ComputePolicy"},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cherry-pick of #4124 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
