### PR TITLE
✨ Enable Fast Clone / Template Replication across Mutually Exclusive Datastores to Accelerate Multi-FD Cluster Creation

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -87,6 +87,14 @@ const (
 	//
 	// alpha: v1.17
 	VLANSubinterface featuregate.Feature = "VLANSubinterface"
+
+	// TemplateAutoReplicate is a feature gate for automatically replicating a
+	// VM template into a failure domain's local datastore when no local copy
+	// already exists, avoiding a slow cross-datastore clone. Disabled,
+	// template resolution is unchanged.
+	//
+	// alpha: v1.17
+	TemplateAutoReplicate featuregate.Feature = "TemplateAutoReplicate"
 )
 
 var (
@@ -96,7 +104,8 @@ var (
 	}
 
 	govmomiGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		NodeAntiAffinity: {Default: false, PreRelease: featuregate.Alpha},
+		NodeAntiAffinity:      {Default: false, PreRelease: featuregate.Alpha},
+		TemplateAutoReplicate: {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	supervisorGates = map[featuregate.Feature]featuregate.FeatureSpec{

--- a/pkg/services/govmomi/template/replicator/replicator.go
+++ b/pkg/services/govmomi/template/replicator/replicator.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package replicator implements template.ReplicaRequester with a
+// ConfigMap-based lock (plain ConfigMaps work on any cluster; a
+// coordination.k8s.io Lease isn't guaranteed to exist) and an async
+// govmomi clone task to do the actual copy.
+package replicator
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // used only to derive a short, stable lock name
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/vmware/govmomi/fault"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/template"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+)
+
+type Replicator struct {
+	Client client.Client
+
+	// Namespace for the lock ConfigMap. Always the manager's own, not the
+	// calling VSphereVM's: workload clusters live in separate namespaces,
+	// but a given template+datastore pair should only ever have one lock.
+	Namespace string
+}
+
+var _ template.ReplicaRequester = &Replicator{}
+
+const (
+	// claimTimeout is how long a "claiming" placeholder (see tryClaim) is
+	// honored before another caller can steal it. Covers a crash between
+	// claiming the work and recording the real task ID.
+	claimTimeout = 2 * time.Minute
+
+	taskPlaceholderClaiming = "claiming"
+
+	annotationTask      = "capv.infrastructure.cluster.x-k8s.io/replica-task"
+	annotationClaimedAt = "capv.infrastructure.cluster.x-k8s.io/replica-claimed-at"
+)
+
+// RequestReplica implements template.ReplicaRequester. Non-blocking: a
+// single round trip per call, whether that means checking on an in-flight
+// clone or starting a new one. A failed attempt just releases the lock; the
+// next call for this template and datastore, from whatever Machine makes
+// it, starts over cleanly.
+func (r *Replicator) RequestReplica(ctx context.Context, sess *session.Session, templateName string, master *object.VirtualMachine, pool *object.ResourcePool, datastore *object.Datastore) error {
+	name := lockName(templateName, datastore.Reference())
+
+	lock, err := r.getOrCreateLock(ctx, name)
+	if err != nil {
+		return pkgerrors.Wrap(err, "unable to get or create template replica lock")
+	}
+	if lock == nil {
+		return nil // lost the create race; whoever won will drive it forward
+	}
+
+	return r.startOrCheckClone(ctx, sess, master, pool, datastore, lock)
+}
+
+// ReleaseIfDone cleans up a lock left behind once the Machine that called
+// RequestReplica never comes back to notice the task finished. Only
+// deletes when it can confirm the lock is no longer needed.
+func (r *Replicator) ReleaseIfDone(ctx context.Context, sess *session.Session, templateName string, datastore *object.Datastore) {
+	log := ctrl.LoggerFrom(ctx)
+
+	name := lockName(templateName, datastore.Reference())
+
+	var lock corev1.ConfigMap
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: name}, &lock); err != nil {
+		return
+	}
+
+	taskID := lock.Annotations[annotationTask]
+	if taskID == "" || taskID == taskPlaceholderClaiming {
+		return // claim in progress elsewhere; don't act on a guess
+	}
+
+	state, _, err := r.checkTask(ctx, sess, taskID)
+	if err != nil {
+		return // transient read failure; nothing to clean up for certain yet
+	}
+	if state == types.TaskInfoStateRunning || state == types.TaskInfoStateQueued {
+		return
+	}
+
+	if err := r.releaseLock(ctx, &lock); err != nil {
+		log.V(4).Info("best-effort template replica lock cleanup failed", "lock", name, "error", err)
+	}
+}
+
+// lockName deterministically names the lock for copying templateName onto
+// datastore, so concurrent requests for the same pair contend on the same
+// object. Keyed by name rather than a specific VM's MoRef: any existing
+// copy of the template works equally well as a clone source, and which one
+// gets picked can change from call to call.
+func lockName(templateName string, datastore types.ManagedObjectReference) string {
+	h := sha1.New() //nolint:gosec // name generation only
+	_, _ = fmt.Fprintf(h, "%s/%s", templateName, datastore.Value)
+	return "capv-tpl-replica-" + hex.EncodeToString(h.Sum(nil))[:20]
+}
+
+// getOrCreateLock returns the lock ConfigMap for name, creating it if
+// needed. A nil lock with no error means creation raced with another caller
+// who won.
+func (r *Replicator) getOrCreateLock(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+	var lock corev1.ConfigMap
+	err := r.Client.Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: name}, &lock)
+	switch {
+	case apierrors.IsNotFound(err):
+		return r.createLock(ctx, name)
+	case err != nil:
+		return nil, err
+	}
+	return &lock, nil
+}
+
+func (r *Replicator) createLock(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+	lock := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: r.Namespace,
+		},
+	}
+	touchLock(lock)
+
+	if err := r.Client.Create(ctx, lock); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil, nil // lost the race between our Get and Create
+		}
+		return nil, err
+	}
+	return lock, nil
+}
+
+// tryClaim atomically claims the right to start the next task, so at most
+// one caller ever proceeds to call govmomi.
+func (r *Replicator) tryClaim(ctx context.Context, lock *corev1.ConfigMap) (bool, error) {
+	if existing := lock.Annotations[annotationTask]; existing != "" {
+		if existing != taskPlaceholderClaiming {
+			return false, nil // a real task is already tracked
+		}
+		if !claimExpired(lock) {
+			return false, nil // someone else's claim is still fresh
+		}
+		// stale claim, likely from a crash before the task was started; steal it
+	}
+
+	lock.Annotations[annotationTask] = taskPlaceholderClaiming
+	touchLock(lock)
+	if err := r.Client.Update(ctx, lock); err != nil {
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func touchLock(lock *corev1.ConfigMap) {
+	if lock.Annotations == nil {
+		lock.Annotations = map[string]string{}
+	}
+	lock.Annotations[annotationClaimedAt] = time.Now().UTC().Format(time.RFC3339)
+}
+
+func claimExpired(lock *corev1.ConfigMap) bool {
+	claimedAt, err := time.Parse(time.RFC3339, lock.Annotations[annotationClaimedAt])
+	if err != nil {
+		return true
+	}
+	return time.Now().After(claimedAt.Add(claimTimeout))
+}
+
+func (r *Replicator) releaseLock(ctx context.Context, lock *corev1.ConfigMap) error {
+	if err := r.Client.Delete(ctx, lock); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// startOrCheckClone checks on a clone task already recorded on lock, or
+// starts a new one if none is in flight yet. The Template flag goes into
+// the clone spec itself rather than a later Reconfigure call: once a VM is
+// marked as a template, not everything about it can still be changed.
+func (r *Replicator) startOrCheckClone(ctx context.Context, sess *session.Session, master *object.VirtualMachine, pool *object.ResourcePool, datastore *object.Datastore, lock *corev1.ConfigMap) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if taskID := lock.Annotations[annotationTask]; taskID != "" && taskID != taskPlaceholderClaiming {
+		state, taskFault, err := r.checkTask(ctx, sess, taskID)
+		if err != nil {
+			return err
+		}
+		switch state {
+		case types.TaskInfoStateSuccess:
+			log.V(4).Info("template replica created", "template", master.InventoryPath)
+			return r.releaseLock(ctx, lock)
+		case types.TaskInfoStateError:
+			// DuplicateName means the VM already exists: a lost task
+			// reference to an already-succeeded clone looks the same on
+			// retry, so treat it as success.
+			var dupName *types.DuplicateName
+			if _, ok := fault.As(taskFault, &dupName); ok {
+				log.V(4).Info("template replica already exists at destination", "template", master.InventoryPath, "existing", dupName.Object.Value)
+				return r.releaseLock(ctx, lock)
+			}
+			log.V(2).Info("template replica clone failed; will retry on the next request", "template", master.InventoryPath)
+			return r.releaseLock(ctx, lock)
+		default:
+			return nil // still running/queued
+		}
+	}
+
+	claimed, err := r.tryClaim(ctx, lock)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+
+	task, err := r.startClone(ctx, sess, master, pool, datastore)
+	if err != nil {
+		log.V(2).Info("unable to start template replica clone; will retry on the next request", "template", master.InventoryPath, "error", err)
+		return r.releaseLock(ctx, lock)
+	}
+	lock.Annotations[annotationTask] = task.Reference().Value
+	touchLock(lock)
+	return r.Client.Update(ctx, lock)
+}
+
+func (r *Replicator) startClone(ctx context.Context, sess *session.Session, master *object.VirtualMachine, pool *object.ResourcePool, datastore *object.Datastore) (*object.Task, error) {
+	var moMaster mo.VirtualMachine
+	if err := master.Properties(ctx, master.Reference(), []string{"name"}, &moMaster); err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to read master template properties")
+	}
+
+	cluster, err := pool.Owner(ctx)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to determine owning cluster for resource pool")
+	}
+	// NewComputeResource, not *ClusterComputeResource, so this also works
+	// for a resource pool owned by a standalone host.
+	computeResource := object.NewComputeResource(pool.Client(), cluster.Reference())
+	hosts, err := computeResource.Hosts(ctx)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to list hosts for owning cluster")
+	}
+
+	// Needs a host that actually mounts the target datastore, not just any
+	// host in the cluster, or placement breaks even with Datastore set.
+	dsRef := datastore.Reference()
+	var moDS mo.Datastore
+	if err := datastore.Properties(ctx, dsRef, []string{"host"}, &moDS); err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to read hosts accessible to target datastore")
+	}
+	dsHosts := make(map[types.ManagedObjectReference]bool, len(moDS.Host))
+	for _, h := range moDS.Host {
+		dsHosts[h.Key] = true
+	}
+	var hostRef *types.ManagedObjectReference
+	for _, h := range hosts {
+		if ref := h.Reference(); dsHosts[ref] {
+			hostRef = &ref
+			break
+		}
+	}
+	if hostRef == nil {
+		return nil, fmt.Errorf("datastore %q is not accessible from any host in cluster %q", dsRef.Value, cluster.Reference().Value)
+	}
+
+	// The replica keeps the master's name (that's how FindTemplate finds it
+	// later), which means it needs its own subfolder per datastore to avoid
+	// name collisions.
+	defaultFolder, err := sess.Finder.FolderOrDefault(ctx, "")
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to resolve default VM folder for template replica")
+	}
+	folder, err := ensureReplicaFolder(ctx, defaultFolder, dsRef.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	poolRef := pool.Reference()
+	spec := types.VirtualMachineCloneSpec{
+		Location: types.VirtualMachineRelocateSpec{
+			Datastore: &dsRef,
+			Pool:      &poolRef,
+			Host:      hostRef,
+		},
+		Template: true,
+		PowerOn:  false,
+	}
+
+	task, err := master.Clone(ctx, folder, moMaster.Name, spec)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to start template replica clone")
+	}
+	return task, nil
+}
+
+// replicaFolderName is the shared parent folder for all CAPV-managed
+// template replicas; each datastore gets its own subfolder under it.
+const replicaFolderName = "capv-template-replicas"
+
+// ensureReplicaFolder returns the per-datastore replica folder under root,
+// creating the shared parent and the datastore-specific child if either is
+// missing.
+func ensureReplicaFolder(ctx context.Context, root *object.Folder, datastoreDir string) (*object.Folder, error) {
+	parent, err := ensureChildFolder(ctx, root, replicaFolderName)
+	if err != nil {
+		return nil, err
+	}
+	return ensureChildFolder(ctx, parent, datastoreDir)
+}
+
+func ensureChildFolder(ctx context.Context, parent *object.Folder, name string) (*object.Folder, error) {
+	if existing, err := findChildFolder(ctx, parent, name); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return existing, nil
+	}
+
+	folder, err := parent.CreateFolder(ctx, name)
+	if err != nil {
+		// Probably lost a race to create it; check again before giving up.
+		if existing, findErr := findChildFolder(ctx, parent, name); findErr == nil && existing != nil {
+			return existing, nil
+		}
+		return nil, pkgerrors.Wrapf(err, "unable to create %q folder", name)
+	}
+	return folder, nil
+}
+
+func findChildFolder(ctx context.Context, parent *object.Folder, name string) (*object.Folder, error) {
+	children, err := parent.Children(ctx)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to list children of parent folder")
+	}
+	for _, child := range children {
+		folder, ok := child.(*object.Folder)
+		if !ok {
+			continue
+		}
+		var moFolder mo.Folder
+		if err := folder.Properties(ctx, folder.Reference(), []string{"name"}, &moFolder); err != nil {
+			continue
+		}
+		if moFolder.Name == name {
+			return folder, nil
+		}
+	}
+	return nil, nil
+}
+
+// checkTask does a single, non-blocking read of a task's state and fault. A
+// task vCenter no longer remembers is reported as TaskInfoStateError rather
+// than a propagated error, so callers retry fresh instead of getting stuck.
+func (r *Replicator) checkTask(ctx context.Context, sess *session.Session, taskMoRefValue string) (types.TaskInfoState, types.BaseMethodFault, error) {
+	ref := types.ManagedObjectReference{Type: "Task", Value: taskMoRefValue}
+	var moTask mo.Task
+	if err := property.DefaultCollector(sess.Client.Client).RetrieveOne(ctx, ref, []string{"info"}, &moTask); err != nil {
+		if fault.Is(err, &types.ManagedObjectNotFound{}) {
+			return types.TaskInfoStateError, nil, nil
+		}
+		return "", nil, pkgerrors.Wrapf(err, "unable to read status of task %q", taskMoRefValue)
+	}
+	if moTask.Info.Error != nil {
+		return types.TaskInfoStateError, moTask.Info.Error.Fault, nil
+	}
+	return moTask.Info.State, nil, nil
+}

--- a/pkg/services/govmomi/template/replicator/replicator_test.go
+++ b/pkg/services/govmomi/template/replicator/replicator_test.go
@@ -1,0 +1,541 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/template"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+)
+
+const testNamespace = "test-ns"
+
+// localDatastore mirrors the identically-named helper in the template
+// package's own tests: an isolated local datastore on cluster's first host,
+// so replicas placed there are provably not shared with another datastore.
+func localDatastore(ctx context.Context, model *simulator.Model, finder *find.Finder, clusterPath string) (ds *object.Datastore, dsName string, cluster *object.ClusterComputeResource, pool *object.ResourcePool, err error) {
+	cluster, err = finder.ClusterComputeResource(ctx, clusterPath)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("finding cluster %q: %w", clusterPath, err)
+	}
+	hosts, err := cluster.Hosts(ctx)
+	if err != nil || len(hosts) == 0 {
+		return nil, "", nil, nil, fmt.Errorf("listing hosts for cluster %q: %w", clusterPath, err)
+	}
+	host := hosts[0]
+
+	dss, err := host.ConfigManager().DatastoreSystem(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting datastore system: %w", err)
+	}
+	dsName = "local-ds-" + strings.ReplaceAll(strings.Trim(clusterPath, "/"), "/", "-")
+	dsDir, err := os.MkdirTemp("", "vcsim-local-ds-")
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("creating temp dir for local datastore: %w", err)
+	}
+	ds, err = dss.CreateLocalDatastore(ctx, dsName, dsDir)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("creating local datastore on %q: %w", clusterPath, err)
+	}
+
+	dc, err := finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting datacenter: %w", err)
+	}
+	simCtx := model.Service.Context
+	dcObj, ok := simCtx.Map.Get(dc.Reference()).(*simulator.Datacenter)
+	if !ok {
+		return nil, "", nil, nil, fmt.Errorf("unexpected type for datacenter object in simulator registry")
+	}
+	simCtx.Map.AddReference(simCtx, dcObj, &dcObj.Datastore, ds.Reference())
+
+	pool, err = cluster.ResourcePool(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting resource pool for %q: %w", clusterPath, err)
+	}
+	return ds, dsName, cluster, pool, nil
+}
+
+func createTemplateOn(ctx context.Context, client *vim25.Client, finder *find.Finder, cluster *object.ClusterComputeResource, pool *object.ResourcePool, dsName, templateName string) (*object.VirtualMachine, error) {
+	dc, err := finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting datacenter: %w", err)
+	}
+	folders, err := dc.Folders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting datacenter folders: %w", err)
+	}
+	hosts, err := cluster.Hosts(ctx)
+	if err != nil || len(hosts) == 0 {
+		return nil, fmt.Errorf("listing hosts for cluster: %w", err)
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		Name: templateName,
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: fmt.Sprintf("[%s]", dsName),
+		},
+		NumCPUs:  1,
+		MemoryMB: 128,
+	}
+	task, err := folders.VmFolder.CreateVM(ctx, spec, pool, hosts[0])
+	if err != nil {
+		return nil, fmt.Errorf("creating vm %q on datastore %q: %w", templateName, dsName, err)
+	}
+	res, err := task.WaitForResult(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for vm creation %q on datastore %q: %w", templateName, dsName, err)
+	}
+	vm := object.NewVirtualMachine(client, res.Result.(types.ManagedObjectReference))
+	if err := vm.MarkAsTemplate(ctx); err != nil {
+		return nil, fmt.Errorf("marking %q as template on datastore %q: %w", templateName, dsName, err)
+	}
+	return vm, nil
+}
+
+func newFakeClient() client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+// vmDatastores returns the set of datastore MoRef values vm's files live on.
+func vmDatastores(ctx context.Context, g *WithT, vm *object.VirtualMachine) map[string]bool {
+	var moVM mo.VirtualMachine
+	g.Expect(vm.Properties(ctx, vm.Reference(), []string{"datastore"}, &moVM)).To(Succeed())
+	out := make(map[string]bool, len(moVM.Datastore))
+	for _, ds := range moVM.Datastore {
+		out[ds.Value] = true
+	}
+	return out
+}
+
+func Test_Replicator_RequestReplica(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = 2
+	model.ClusterHost = 1
+	model.Host = 0
+	g := NewWithT(t)
+	g.Expect(model.Create()).To(Succeed())
+	defer model.Remove()
+
+	srv := model.Service.NewServer()
+	defer srv.Close()
+
+	c, err := govmomi.NewClient(ctx, srv.URL, true)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	finder := find.NewFinder(c.Client)
+	dc, err := finder.DefaultDatacenter(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	finder.SetDatacenter(dc)
+
+	datastore0, ds0, cluster0, pool0, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C0")
+	g.Expect(err).ToNot(HaveOccurred())
+	datastore1, ds1, _, pool1, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C1")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ds0).ToNot(Equal(ds1))
+	_ = datastore0
+
+	sess := &session.Session{Client: c, Finder: finder}
+
+	t.Run("fresh replica: clones master into the target datastore and marks it, then releases the lock", func(t *testing.T) {
+		g := NewWithT(t)
+		const name = "fresh-replica"
+
+		master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+
+		g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+		// Drive the async state machine forward by re-invoking RequestReplica,
+		// exactly as repeated Machine reconciles would.
+		g.Eventually(func(g Gomega) {
+			g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+			var lock corev1.ConfigMap
+			err := r.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore1.Reference())}, &lock)
+			g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+			g.Expect(err).To(HaveOccurred(), "lock should be deleted once the clone completes")
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+
+		candidates, err := finder.VirtualMachineList(ctx, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(candidates).To(HaveLen(2), "master plus the one new replica")
+
+		var replica *object.VirtualMachine
+		ds1Ref := datastore1.Reference().Value
+		for _, c := range candidates {
+			if vmDatastores(ctx, g, c)[ds1Ref] {
+				replica = c
+			}
+		}
+		g.Expect(replica).ToNot(BeNil(), "expected a new local replica on datastore1")
+
+		var moReplica mo.VirtualMachine
+		g.Expect(replica.Properties(ctx, replica.Reference(), []string{"config"}, &moReplica)).To(Succeed())
+		g.Expect(moReplica.Config.Template).To(BeTrue())
+	})
+
+	t.Run("concurrent call while a request is in flight is a no-op", func(t *testing.T) {
+		g := NewWithT(t)
+		const name = "concurrent-request"
+
+		master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+
+		g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+		lockKey := client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore1.Reference())}
+		var first corev1.ConfigMap
+		g.Expect(r.Client.Get(ctx, lockKey, &first)).To(Succeed())
+		firstTask := first.Annotations[annotationTask]
+		g.Expect(firstTask).ToNot(BeEmpty())
+
+		// A second, concurrent call (simulating another Machine's reconcile
+		// hitting the same missing-replica condition) must not start a
+		// second clone task.
+		g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+		var second corev1.ConfigMap
+		g.Expect(r.Client.Get(ctx, lockKey, &second)).To(Succeed())
+		g.Expect(second.Annotations[annotationTask]).To(Equal(firstTask), "must not have started a second task")
+	})
+
+	t.Run("lost track of an in-flight task: recovers by releasing and retrying, not stuck forever", func(t *testing.T) {
+		g := NewWithT(t)
+		const name = "lost-task"
+
+		master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+		lockKey := client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore1.Reference())}
+
+		g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+		// Simulate vCenter having pruned the task from its history.
+		var lock corev1.ConfigMap
+		g.Expect(r.Client.Get(ctx, lockKey, &lock)).To(Succeed())
+		lock.Annotations[annotationTask] = "task-does-not-exist-9999"
+		g.Expect(r.Client.Update(ctx, &lock)).To(Succeed())
+
+		g.Eventually(func(g Gomega) {
+			g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+			var l corev1.ConfigMap
+			err := r.Client.Get(ctx, lockKey, &l)
+			g.Expect(err).To(HaveOccurred(), "lock should be deleted once a fresh retry completes")
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+
+		candidates, err := finder.VirtualMachineList(ctx, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(candidates).To(HaveLen(2), "master plus exactly one replica from the successful retry")
+	})
+
+	t.Run("true concurrent callers never produce more than one replica", func(t *testing.T) {
+		g := NewWithT(t)
+		const name = "true-concurrency"
+		const concurrency = 8
+
+		master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+
+		start := make(chan struct{})
+		errs := make(chan error, concurrency)
+		var wg sync.WaitGroup
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs <- r.RequestReplica(ctx, sess, name, master, pool1, datastore1)
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+
+		g.Eventually(func(g Gomega) {
+			g.Expect(r.RequestReplica(ctx, sess, name, master, pool1, datastore1)).To(Succeed())
+
+			var lock corev1.ConfigMap
+			err := r.Client.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore1.Reference())}, &lock)
+			g.Expect(err).To(HaveOccurred(), "lock should be deleted once the (single) clone completes")
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+
+		candidates, err := finder.VirtualMachineList(ctx, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(candidates).To(HaveLen(2), "master plus exactly one replica: concurrency must never produce duplicates")
+	})
+
+	t.Run("single-Machine failure domain: lock is still cleaned up even though nobody calls RequestReplica a second time", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, true)
+		const name = "single-machine-lifecycle"
+
+		master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+		lockKey := client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore1.Reference())}
+
+		// One Machine's Clone() call: no local replica yet, falls back to
+		// master, fires RequestReplica once. It never calls FindTemplate again.
+		found, err := template.FindTemplate(ctx, sess, name, pool1, datastore1, r)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found.Reference()).To(Equal(master.Reference()), "falls back to master while the replica clones in the background")
+
+		// Let the background clone finish without ever calling RequestReplica
+		// again; nobody in this scenario does.
+		g.Eventually(func(g Gomega) {
+			var lock corev1.ConfigMap
+			g.Expect(r.Client.Get(ctx, lockKey, &lock)).To(Succeed())
+			taskID := lock.Annotations[annotationTask]
+			g.Expect(taskID).ToNot(BeEmpty())
+			state, _, err := r.checkTask(ctx, sess, taskID)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(state).To(Equal(types.TaskInfoStateSuccess))
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+
+		// The lock is still sitting there; nothing has told it the task
+		// succeeded yet.
+		var existingLock corev1.ConfigMap
+		g.Expect(r.Client.Get(ctx, lockKey, &existingLock)).To(Succeed())
+
+		// A later Machine's FindTemplate call discovers the completed
+		// replica via the normal fast path, which must trigger ReleaseIfDone.
+		found, err = template.FindTemplate(ctx, sess, name, pool1, datastore1, r)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found.Reference()).ToNot(Equal(master.Reference()), "must now resolve to the completed local replica")
+
+		err = r.Client.Get(ctx, lockKey, &corev1.ConfigMap{})
+		g.Expect(err).To(HaveOccurred(), "lock must be cleaned up once a FindTemplate call confirms the replica is in place")
+	})
+}
+
+// Test_Replicator_MultipleFailureDomains reproduces 3 failure domains all
+// needing a replica of the same template at once, the actual multi-cluster
+// scenario this feature exists for. Every replica shares the master's name,
+// so if they all landed in one folder they'd collide; each must land in its
+// own per-datastore subfolder instead.
+func Test_Replicator_MultipleFailureDomains(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = 3
+	model.ClusterHost = 1
+	model.Host = 0
+	g.Expect(model.Create()).To(Succeed())
+	defer model.Remove()
+
+	srv := model.Service.NewServer()
+	defer srv.Close()
+
+	c, err := govmomi.NewClient(ctx, srv.URL, true)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	finder := find.NewFinder(c.Client)
+	dc, err := finder.DefaultDatacenter(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	finder.SetDatacenter(dc)
+
+	const name = "multi-failure-domain"
+	datastore0, ds0, cluster0, pool0, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C0")
+	g.Expect(err).ToNot(HaveOccurred())
+	datastore1, _, _, pool1, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C1")
+	g.Expect(err).ToNot(HaveOccurred())
+	datastore2, _, _, pool2, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C2")
+	g.Expect(err).ToNot(HaveOccurred())
+	_ = datastore0
+
+	master, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	sess := &session.Session{Client: c, Finder: finder}
+	r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+
+	for _, target := range []struct {
+		pool      *object.ResourcePool
+		datastore *object.Datastore
+	}{
+		{pool1, datastore1},
+		{pool2, datastore2},
+	} {
+		g.Expect(r.RequestReplica(ctx, sess, name, master, target.pool, target.datastore)).To(Succeed())
+		lockKey := client.ObjectKey{Namespace: testNamespace, Name: lockName(name, target.datastore.Reference())}
+		g.Eventually(func(g Gomega) {
+			g.Expect(r.RequestReplica(ctx, sess, name, master, target.pool, target.datastore)).To(Succeed())
+			err := r.Client.Get(ctx, lockKey, &corev1.ConfigMap{})
+			g.Expect(err).To(HaveOccurred(), "lock should be deleted once this datastore's clone completes")
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+	}
+
+	candidates, err := finder.VirtualMachineList(ctx, name)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(candidates).To(HaveLen(3), "master plus one replica per failure domain, no collisions")
+}
+
+// Test_Replicator_SameClusterMultipleDatastores reproduces a single cluster
+// with two datastores that both need their own local replica, the exact
+// case the user flagged: a cluster commonly has several datastores, and
+// different Machine clones in that same failure domain (one pinned via
+// Spec.Datastore, another landing elsewhere via storage-policy selection)
+// can each need a replica on a different one. Keying the lock/folder by
+// cluster instead of datastore would collapse these into one shared
+// replica, and the second RequestReplica call would either be a permanent
+// no-op (locked out by the first's already-satisfied lock) or collide on a
+// shared folder.
+func Test_Replicator_SameClusterMultipleDatastores(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = 1
+	model.ClusterHost = 1
+	model.Host = 0
+	g.Expect(model.Create()).To(Succeed())
+	defer model.Remove()
+
+	srv := model.Service.NewServer()
+	defer srv.Close()
+
+	c, err := govmomi.NewClient(ctx, srv.URL, true)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	finder := find.NewFinder(c.Client)
+	dc, err := finder.DefaultDatacenter(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	finder.SetDatacenter(dc)
+
+	const name = "same-cluster-multi-datastore"
+	cluster, err := finder.ClusterComputeResource(ctx, "/DC0/host/DC0_C0")
+	g.Expect(err).ToNot(HaveOccurred())
+	pool, err := cluster.ResourcePool(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The master lives on the cluster's built-in default datastore. Two more
+	// datastores, A and B, are attached to that SAME cluster/pool; neither
+	// holds the master. Mirrors two Machine clones in the same failure
+	// domain that land on different datastores and each need their own
+	// local replica.
+	defaultDS, err := finder.DefaultDatastore(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	master, err := createTemplateOn(ctx, c.Client, finder, cluster, pool, defaultDS.Name(), name)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	datastoreA, _, _, _, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C0")
+	g.Expect(err).ToNot(HaveOccurred())
+	datastoreB, err := secondLocalDatastore(ctx, model, dc, cluster, "local-ds-b")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(datastoreA.Reference()).ToNot(Equal(datastoreB.Reference()))
+
+	sess := &session.Session{Client: c, Finder: finder}
+	r := &Replicator{Client: newFakeClient(), Namespace: testNamespace}
+
+	for _, datastore := range []*object.Datastore{datastoreA, datastoreB} {
+		g.Expect(r.RequestReplica(ctx, sess, name, master, pool, datastore)).To(Succeed())
+		lockKey := client.ObjectKey{Namespace: testNamespace, Name: lockName(name, datastore.Reference())}
+		g.Eventually(func(g Gomega) {
+			g.Expect(r.RequestReplica(ctx, sess, name, master, pool, datastore)).To(Succeed())
+			err := r.Client.Get(ctx, lockKey, &corev1.ConfigMap{})
+			g.Expect(err).To(HaveOccurred(), "lock should be deleted once this datastore's clone completes")
+		}, 10*time.Second, 50*time.Millisecond).Should(Succeed())
+	}
+
+	candidates, err := finder.VirtualMachineList(ctx, name)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(candidates).To(HaveLen(3), "master plus one independent replica per datastore, all in the same cluster, no collision")
+
+	for _, datastore := range []*object.Datastore{datastoreA, datastoreB} {
+		dsRef := datastore.Reference().Value
+		var found bool
+		for _, cand := range candidates {
+			if vmDatastores(ctx, g, cand)[dsRef] {
+				found = true
+			}
+		}
+		g.Expect(found).To(BeTrue(), "expected a replica specifically on this datastore, not just anywhere in the cluster")
+	}
+}
+
+// secondLocalDatastore creates one more isolated local datastore on
+// cluster's first host, for tests that already have a first one from
+// localDatastore and need a second, differently-named one on the same
+// cluster.
+func secondLocalDatastore(ctx context.Context, model *simulator.Model, dc *object.Datacenter, cluster *object.ClusterComputeResource, dsName string) (*object.Datastore, error) {
+	hosts, err := cluster.Hosts(ctx)
+	if err != nil || len(hosts) == 0 {
+		return nil, fmt.Errorf("listing hosts for cluster: %w", err)
+	}
+	dss, err := hosts[0].ConfigManager().DatastoreSystem(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting datastore system: %w", err)
+	}
+	dsDir, err := os.MkdirTemp("", "vcsim-local-ds-")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir for local datastore: %w", err)
+	}
+	ds, err := dss.CreateLocalDatastore(ctx, dsName, dsDir)
+	if err != nil {
+		return nil, fmt.Errorf("creating local datastore: %w", err)
+	}
+	simCtx := model.Service.Context
+	dcObj, ok := simCtx.Map.Get(dc.Reference()).(*simulator.Datacenter)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for datacenter object in simulator registry")
+	}
+	simCtx.Map.AddReference(simCtx, dcObj, &dcObj.Datastore, ds.Reference())
+	return ds, nil
+}

--- a/pkg/services/govmomi/template/template.go
+++ b/pkg/services/govmomi/template/template.go
@@ -19,23 +19,49 @@ package template
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
-// FindTemplate finds a template based either on a UUID or name.
-func FindTemplate(ctx context.Context, session *session.Session, templateID string) (*object.VirtualMachine, error) {
+// ReplicaRequester asynchronously clones master onto datastore when no copy
+// of it exists there yet. Locality is per-datastore, not per-cluster (see
+// vcenter.Clone). Implementations must not block: RequestReplica is called
+// opportunistically and the copy just becomes visible on a later call.
+type ReplicaRequester interface {
+	RequestReplica(ctx context.Context, session *session.Session, templateName string, master *object.VirtualMachine, pool *object.ResourcePool, datastore *object.Datastore) error
+
+	// ReleaseIfDone cleans up bookkeeping left behind by a prior
+	// RequestReplica call once a local copy confirms it's ready, since a
+	// VSphereVM only calls FindTemplate once. Must not block, and must be
+	// safe to call with nothing to clean up.
+	ReleaseIfDone(ctx context.Context, session *session.Session, templateName string, datastore *object.Datastore)
+}
+
+// FindTemplate finds a template by UUID or name. When TemplateAutoReplicate
+// is enabled and preferredDatastore is given, a copy already on that
+// datastore is preferred over a slow cross-datastore clone, and one is
+// requested in the background if missing. Otherwise, behavior is unchanged
+// from before this gate existed.
+func FindTemplate(ctx context.Context, session *session.Session, templateID string, preferredPool *object.ResourcePool, preferredDatastore *object.Datastore, requester ReplicaRequester) (*object.VirtualMachine, error) {
 	tpl, err := findTemplateByInstanceUUID(ctx, session, templateID)
 	if err != nil {
 		return nil, err
 	}
 	if tpl != nil {
 		return tpl, nil
+	}
+	if preferredDatastore != nil && feature.Gates.Enabled(feature.TemplateAutoReplicate) {
+		return findOrRequestLocalCopy(ctx, session, templateID, preferredPool, preferredDatastore, requester)
 	}
 	return findTemplateByName(ctx, session, templateID)
 }
@@ -57,6 +83,9 @@ func findTemplateByInstanceUUID(ctx context.Context, session *session.Session, t
 	return nil, nil
 }
 
+// findTemplateByName is the original lookup, exactly as it was before
+// TemplateAutoReplicate existed: it errors if templateID resolves to more
+// than one VM, with no notion of datastore locality.
 func findTemplateByName(ctx context.Context, session *session.Session, templateID string) (*object.VirtualMachine, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Find template by name", "name", templateID)
@@ -65,6 +94,95 @@ func findTemplateByName(ctx context.Context, session *session.Session, templateI
 		return nil, pkgerrors.Wrapf(err, "unable to find template by name %q", templateID)
 	}
 	return tpl, nil
+}
+
+// findOrRequestLocalCopy prefers a copy of templateID already on
+// preferredDatastore, however it got there (placed by an admin or cloned
+// earlier by CAPV). If none exists yet, a copy is requested in the
+// background and any existing copy is returned so the caller can proceed
+// without waiting for it.
+func findOrRequestLocalCopy(ctx context.Context, session *session.Session, templateID string, preferredPool *object.ResourcePool, preferredDatastore *object.Datastore, requester ReplicaRequester) (*object.VirtualMachine, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(5).Info("Find template by name", "name", templateID)
+
+	// Every VM sharing this name, not just one: a local copy is cloned with
+	// the master's own name (see replicator.Replicator), so the
+	// single-result Finder.VirtualMachine can't be used here.
+	candidates, err := session.Finder.VirtualMachineList(ctx, templateID)
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "unable to find template by name %q", templateID)
+	}
+	ambiguousErr := pkgerrors.Wrapf(fmt.Errorf("path '%s' resolves to multiple vms", templateID), "unable to find template by name %q", templateID)
+
+	local := filterLocalTemplates(ctx, candidates, preferredDatastore)
+	switch len(local) {
+	case 1:
+		if requester != nil {
+			requester.ReleaseIfDone(ctx, session, templateID, preferredDatastore)
+		}
+		return local[0], nil
+	case 0:
+		master := candidates[0] // any existing copy works as the clone source
+		requestReplica(ctx, log, requester, session, templateID, master, preferredPool, preferredDatastore)
+		return master, nil
+	default:
+		return nil, ambiguousErr
+	}
+}
+
+// requestReplica never returns an error: a failed or slow copy request must
+// not affect the Machine being cloned right now, which already has a
+// correct answer (master) to proceed with.
+func requestReplica(ctx context.Context, log logr.Logger, requester ReplicaRequester, session *session.Session, templateName string, master *object.VirtualMachine, pool *object.ResourcePool, datastore *object.Datastore) {
+	if requester == nil {
+		log.V(4).Info("no local template copy available and no ReplicaRequester configured; skipping",
+			"template", templateName, "datastore", datastore.InventoryPath)
+		return
+	}
+	if err := requester.RequestReplica(ctx, session, templateName, master, pool, datastore); err != nil {
+		log.V(2).Info("failed to request template copy",
+			"template", templateName, "datastore", datastore.InventoryPath, "error", err)
+	}
+}
+
+// filterLocalTemplates returns the subset of candidates that reside on
+// datastore exactly (not just the same cluster; see ReplicaRequester).
+// Returns nil if datastore is nil, same as no local candidates.
+func filterLocalTemplates(ctx context.Context, candidates []*object.VirtualMachine, datastore *object.Datastore) []*object.VirtualMachine {
+	log := ctrl.LoggerFrom(ctx)
+
+	if datastore == nil {
+		return nil
+	}
+	dsRef := datastore.Reference()
+
+	var matches []*object.VirtualMachine
+	for _, c := range candidates {
+		on, err := vmOnDatastore(ctx, c, dsRef)
+		if err != nil {
+			log.V(4).Info("unable to read datastore property for candidate template; skipping", "template", c.InventoryPath, "error", err)
+			continue
+		}
+		if on {
+			matches = append(matches, c)
+		}
+	}
+	return matches
+}
+
+// vmOnDatastore reports whether vm's config files reside on the datastore
+// identified by dsRef.
+func vmOnDatastore(ctx context.Context, vm *object.VirtualMachine, dsRef types.ManagedObjectReference) (bool, error) {
+	var moVM mo.VirtualMachine
+	if err := vm.Properties(ctx, vm.Reference(), []string{"datastore"}, &moVM); err != nil {
+		return false, err
+	}
+	for _, ds := range moVM.Datastore {
+		if ds == dsRef {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func isValidUUID(str string) bool {

--- a/pkg/services/govmomi/template/template_test.go
+++ b/pkg/services/govmomi/template/template_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+)
+
+// localDatastore creates an isolated local datastore on the given cluster's
+// first host and returns it (both as an *object.Datastore and its name), the
+// cluster, and its (default) resource pool. Used to reproduce a topology
+// where each failure domain has its own storage that cannot be shared with
+// any other failure domain.
+func localDatastore(ctx context.Context, model *simulator.Model, finder *find.Finder, clusterPath string) (ds *object.Datastore, dsName string, cluster *object.ClusterComputeResource, pool *object.ResourcePool, err error) {
+	cluster, err = finder.ClusterComputeResource(ctx, clusterPath)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("finding cluster %q: %w", clusterPath, err)
+	}
+	hosts, err := cluster.Hosts(ctx)
+	if err != nil || len(hosts) == 0 {
+		return nil, "", nil, nil, fmt.Errorf("listing hosts for cluster %q: %w", clusterPath, err)
+	}
+	host := hosts[0]
+
+	dss, err := host.ConfigManager().DatastoreSystem(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting datastore system: %w", err)
+	}
+	dsName = "local-ds-" + strings.ReplaceAll(strings.Trim(clusterPath, "/"), "/", "-")
+	dsDir, err := os.MkdirTemp("", "vcsim-local-ds-")
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("creating temp dir for local datastore: %w", err)
+	}
+	ds, err = dss.CreateLocalDatastore(ctx, dsName, dsDir)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("creating local datastore on %q: %w", clusterPath, err)
+	}
+
+	// vcsim's HostDatastoreSystem.add() registers the new datastore onto the
+	// owning ComputeResource (cluster) but NOT onto the Datacenter's own
+	// Datastore list, and Folder.CreateVM resolves "[dsName]" against the
+	// latter. Patch it in directly via the simulator's internal registry
+	// (only possible/needed because this is an in-process test).
+	dc, err := finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting datacenter: %w", err)
+	}
+	simCtx := model.Service.Context
+	dcObj, ok := simCtx.Map.Get(dc.Reference()).(*simulator.Datacenter)
+	if !ok {
+		return nil, "", nil, nil, fmt.Errorf("unexpected type for datacenter object in simulator registry")
+	}
+	simCtx.Map.AddReference(simCtx, dcObj, &dcObj.Datastore, ds.Reference())
+
+	pool, err = cluster.ResourcePool(ctx)
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("getting resource pool for %q: %w", clusterPath, err)
+	}
+	return ds, dsName, cluster, pool, nil
+}
+
+// createTemplateOn creates a powered-off VM named templateName on dsName and
+// marks it as a template.
+func createTemplateOn(ctx context.Context, client *vim25.Client, finder *find.Finder, cluster *object.ClusterComputeResource, pool *object.ResourcePool, dsName, templateName string) (*object.VirtualMachine, error) {
+	dc, err := finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting datacenter: %w", err)
+	}
+	folders, err := dc.Folders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting datacenter folders: %w", err)
+	}
+	hosts, err := cluster.Hosts(ctx)
+	if err != nil || len(hosts) == 0 {
+		return nil, fmt.Errorf("listing hosts for cluster: %w", err)
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		Name: templateName,
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: fmt.Sprintf("[%s]", dsName),
+		},
+		NumCPUs:  1,
+		MemoryMB: 128,
+	}
+	task, err := folders.VmFolder.CreateVM(ctx, spec, pool, hosts[0])
+	if err != nil {
+		return nil, fmt.Errorf("creating vm %q on datastore %q: %w", templateName, dsName, err)
+	}
+	res, err := task.WaitForResult(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for vm creation %q on datastore %q: %w", templateName, dsName, err)
+	}
+	vm := object.NewVirtualMachine(client, res.Result.(types.ManagedObjectReference))
+	if err := vm.MarkAsTemplate(ctx); err != nil {
+		return nil, fmt.Errorf("marking %q as template on datastore %q: %w", templateName, dsName, err)
+	}
+	return vm, nil
+}
+
+// Test_FindTemplate_LocalityPreference reproduces a cross-cluster-HA
+// topology where each failure domain has its own isolated local datastore,
+// and asserts FindTemplate's behavior across every local/global match count
+// with TemplateAutoReplicate enabled, plus the gate-disabled baseline.
+func Test_FindTemplate_LocalityPreference(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	model.Datacenter = 1
+	model.Cluster = 2
+	model.ClusterHost = 1
+	model.Host = 0
+	// Leave the VPX default (Datastore: 1) for the model's own default VMs to
+	// land on; we attach an additional, isolated local datastore per cluster
+	// below for our own test templates.
+	g.Expect(model.Create()).To(Succeed())
+	defer model.Remove()
+
+	srv := model.Service.NewServer()
+	defer srv.Close()
+
+	// Establish a real, authenticated govmomi client against the simulator
+	// (srv.URL already carries the simulator's generated credentials).
+	c, err := govmomi.NewClient(ctx, srv.URL, true)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	finder := find.NewFinder(c.Client)
+	dc, err := finder.DefaultDatacenter(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	finder.SetDatacenter(dc)
+
+	datastore0, ds0, cluster0, pool0, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C0")
+	g.Expect(err).ToNot(HaveOccurred())
+	datastore1, ds1, cluster1, pool1, err := localDatastore(ctx, model, finder, "/DC0/host/DC0_C1")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ds0).ToNot(Equal(ds1), "the two clusters must have different, isolated datastores")
+
+	sess := &session.Session{
+		Client: c,
+		Finder: finder,
+	}
+
+	t.Run("exactly one local match: used directly, per datastore", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, true)
+		const name = "replicated-template"
+
+		vm0, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		vm1, err := createTemplateOn(ctx, c.Client, finder, cluster1, pool1, ds1, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		found, err := FindTemplate(ctx, sess, name, pool0, datastore0, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found.Reference()).To(Equal(vm0.Reference()))
+
+		found, err = FindTemplate(ctx, sess, name, pool1, datastore1, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found.Reference()).To(Equal(vm1.Reference()))
+	})
+
+	t.Run("more than one global match, no datastore given: same ambiguity error as today", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, true)
+		const name = "replicated-template-no-pool"
+
+		_, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = createTemplateOn(ctx, c.Client, finder, cluster1, pool1, ds1, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = FindTemplate(ctx, sess, name, nil, nil, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(ContainSubstring("unable to find template by name")))
+	})
+
+	t.Run("zero local matches, exactly one global match: falls back to it while a copy clones in the background", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, true)
+		const name = "single-template-not-on-cluster1"
+
+		vm0, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// datastore1 has no local copy of this template; must still resolve
+		// to the one that exists globally.
+		found, err := FindTemplate(ctx, sess, name, pool1, datastore1, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found.Reference()).To(Equal(vm0.Reference()))
+	})
+
+	t.Run("more than one local match: same ambiguity error as today, not a silent guess", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, true)
+		const name = "colliding-template"
+
+		// Two independent VMs, same name, both genuinely local to
+		// datastore0: a real misconfiguration, not the intended
+		// one-copy-per-datastore pattern.
+		_, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = FindTemplate(ctx, sess, name, pool0, datastore0, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(ContainSubstring("unable to find template by name")))
+	})
+
+	t.Run("gate disabled: no locality preference, same behavior as before this feature existed", func(t *testing.T) {
+		g := NewWithT(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.TemplateAutoReplicate, false)
+		const name = "gate-off-template"
+
+		// Two same-named VMs across datastores: with the gate on, one of
+		// these would resolve cleanly via locality preference. With it off,
+		// this must error exactly as the original single-result Finder call
+		// always has.
+		_, err := createTemplateOn(ctx, c.Client, finder, cluster0, pool0, ds0, name)
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = createTemplateOn(ctx, c.Client, finder, cluster1, pool1, ds1, name)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = FindTemplate(ctx, sess, name, pool0, datastore0, nil)
+		g.Expect(err).To(HaveOccurred(), "with the gate off, template resolution must be unaware of datastore locality")
+	})
+}

--- a/pkg/services/govmomi/vcenter/clone.go
+++ b/pkg/services/govmomi/vcenter/clone.go
@@ -41,6 +41,7 @@ import (
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/extra"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/template"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/govmomi/template/replicator"
 )
 
 const (
@@ -83,7 +84,25 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 			return err
 		}
 	}
-	tpl, err := template.FindTemplate(ctx, vmCtx.GetSession(), vmCtx.VSphereVM.Spec.Template)
+	pool, err := vmCtx.Session.Finder.ResourcePoolOrDefault(ctx, vmCtx.VSphereVM.Spec.ResourcePool)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "unable to get resource pool for %q", vmCtx)
+	}
+
+	// Resolved before FindTemplate so locality can be judged against the exact datastore this clone will land on.
+	datastoreRef, err := resolveDatastore(ctx, vmCtx, pool)
+	if err != nil {
+		return err
+	}
+	targetDatastore := object.NewDatastore(vmCtx.Session.Client.Client, *datastoreRef)
+
+	// vmCtx.Namespace, not vmCtx.VSphereVM.Namespace: workload clusters live
+	// in separate namespaces but must contend on the same lock.
+	replicaRequester := &replicator.Replicator{
+		Client:    vmCtx.Client,
+		Namespace: vmCtx.Namespace,
+	}
+	tpl, err := template.FindTemplate(ctx, vmCtx.GetSession(), vmCtx.VSphereVM.Spec.Template, pool, targetDatastore, replicaRequester)
 	if err != nil {
 		return err
 	}
@@ -130,11 +149,6 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 	folder, err := vmCtx.Session.Finder.FolderOrDefault(ctx, vmCtx.VSphereVM.Spec.Folder)
 	if err != nil {
 		return pkgerrors.Wrapf(err, "unable to get folder for %q", vmCtx)
-	}
-
-	pool, err := vmCtx.Session.Finder.ResourcePoolOrDefault(ctx, vmCtx.VSphereVM.Spec.ResourcePool)
-	if err != nil {
-		return pkgerrors.Wrapf(err, "unable to get resource pool for %q", vmCtx)
 	}
 
 	devices, err := tpl.Device(ctx)
@@ -262,103 +276,6 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 		spec.Config.MemoryReservationLockedToMax = ptr.To(true)
 	}
 
-	var datastoreRef *types.ManagedObjectReference
-	if vmCtx.VSphereVM.Spec.Datastore != "" {
-		datastore, err := vmCtx.Session.Finder.Datastore(ctx, vmCtx.VSphereVM.Spec.Datastore)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "unable to get datastore %s for %q", vmCtx.VSphereVM.Spec.Datastore, vmCtx)
-		}
-		datastoreRef = types.NewReference(datastore.Reference())
-		spec.Location.Datastore = datastoreRef
-	}
-
-	var storageProfileID string
-	if vmCtx.VSphereVM.Spec.StoragePolicyName != "" {
-		pbmClient, err := pbm.NewClient(ctx, vmCtx.Session.Client.Client)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "unable to create pbm client for %q", vmCtx)
-		}
-
-		storageProfileID, err = pbmClient.ProfileIDByName(ctx, vmCtx.VSphereVM.Spec.StoragePolicyName)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "unable to get storageProfileID from name %s for %q", vmCtx.VSphereVM.Spec.StoragePolicyName, vmCtx)
-		}
-
-		var hubs []pbmTypes.PbmPlacementHub
-
-		// If there's a Datastore configured, it should be the only one for which we check if it matches the requirements of the Storage Policy
-		if datastoreRef != nil {
-			hubs = append(hubs, pbmTypes.PbmPlacementHub{
-				HubType: datastoreRef.Type,
-				HubId:   datastoreRef.Value,
-			})
-		} else {
-			// Otherwise we should get just the Datastores connected to our pool
-			cluster, err := pool.Owner(ctx)
-			if err != nil {
-				return pkgerrors.Wrapf(err, "failed to get owning cluster of resourcepool %q to calculate datastore based on storage policy", pool)
-			}
-
-			dsList, err := object.NewComputeResource(vmCtx.Session.Client.Client, cluster.Reference()).Datastores(ctx)
-			if err != nil {
-				return pkgerrors.Wrapf(err, "unable to list datastores from owning cluster of requested resourcepool")
-			}
-
-			var refs []types.ManagedObjectReference
-			for i := range dsList {
-				refs = append(refs, dsList[i].Reference())
-			}
-
-			var datastores []mo.Datastore
-			if err := property.DefaultCollector(vmCtx.Session.Client.Client).Retrieve(ctx, refs, []string{"summary"}, &datastores); err != nil {
-				return pkgerrors.Wrapf(err, "unable to collect datastore properties to validate maintenance mode")
-			}
-
-			for _, ds := range datastores {
-				if ds.Summary.MaintenanceMode != string(types.DatastoreSummaryMaintenanceModeStateNormal) {
-					log.V(4).Info("datastore is in maintenance mode, skipping", "datastore", ds.Summary.Name)
-					continue
-				}
-
-				hubs = append(hubs, pbmTypes.PbmPlacementHub{
-					HubType: ds.Reference().Type,
-					HubId:   ds.Reference().Value,
-				})
-			}
-		}
-
-		var constraints []pbmTypes.BasePbmPlacementRequirement //nolint:prealloc
-		constraints = append(constraints, &pbmTypes.PbmPlacementCapabilityProfileRequirement{ProfileId: pbmTypes.PbmProfileId{UniqueId: storageProfileID}})
-		result, err := pbmClient.CheckRequirements(ctx, hubs, nil, constraints)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "unable to check requirements for storage policy")
-		}
-
-		if len(result.CompatibleDatastores()) == 0 {
-			return fmt.Errorf("no compatible datastores found for storage policy: %s", vmCtx.VSphereVM.Spec.StoragePolicyName)
-		}
-
-		// If datastoreRef is nil here it means that the user didn't specify a Datastore. So we should
-		// select one of the datastores of the owning cluster of the resource pool that matched the
-		// requirements of the storage policy.
-		if datastoreRef == nil {
-			r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // We won't need cryptographically secure randomness here.
-			ds := result.CompatibleDatastores()[r.Intn(len(result.CompatibleDatastores()))]
-			datastoreRef = &types.ManagedObjectReference{Type: ds.HubType, Value: ds.HubId}
-		}
-	}
-
-	// if datastoreRef is nil here, means that user didn't specified a datastore NOR a
-	// storagepolicy, so we should select the default
-	if datastoreRef == nil {
-		// if no datastore defined through VM spec or storage policy, use default
-		datastore, err := vmCtx.Session.Finder.DefaultDatastore(ctx)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "unable to get default datastore for %q", vmCtx)
-		}
-		datastoreRef = types.NewReference(datastore.Reference())
-	}
-
 	disks := devices.SelectByType((*types.VirtualDisk)(nil))
 	isLinkedClone := snapshotRef != nil
 	spec.Location.Disk = getDiskLocators(disks, *datastoreRef, isLinkedClone)
@@ -418,6 +335,111 @@ func Clone(ctx context.Context, vmCtx *capvcontext.VMContext, bootstrapData []by
 		log.Error(err, "Failed to patch VSphereVM (best-effort)")
 	}
 	return nil
+}
+
+// resolveDatastore determines the datastore a clone into pool should land
+// on: explicit Spec.Datastore, else one compatible with
+// Spec.StoragePolicyName, else the default. Resolved ahead of the clone
+// spec so FindTemplate can use the same datastore for locality.
+func resolveDatastore(ctx context.Context, vmCtx *capvcontext.VMContext, pool *object.ResourcePool) (*types.ManagedObjectReference, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var datastoreRef *types.ManagedObjectReference
+	if vmCtx.VSphereVM.Spec.Datastore != "" {
+		datastore, err := vmCtx.Session.Finder.Datastore(ctx, vmCtx.VSphereVM.Spec.Datastore)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "unable to get datastore %s for %q", vmCtx.VSphereVM.Spec.Datastore, vmCtx)
+		}
+		datastoreRef = types.NewReference(datastore.Reference())
+	}
+
+	if vmCtx.VSphereVM.Spec.StoragePolicyName != "" {
+		pbmClient, err := pbm.NewClient(ctx, vmCtx.Session.Client.Client)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "unable to create pbm client for %q", vmCtx)
+		}
+
+		storageProfileID, err := pbmClient.ProfileIDByName(ctx, vmCtx.VSphereVM.Spec.StoragePolicyName)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "unable to get storageProfileID from name %s for %q", vmCtx.VSphereVM.Spec.StoragePolicyName, vmCtx)
+		}
+
+		var hubs []pbmTypes.PbmPlacementHub
+
+		// If there's a Datastore configured, it should be the only one for which we check if it matches the requirements of the Storage Policy
+		if datastoreRef != nil {
+			hubs = append(hubs, pbmTypes.PbmPlacementHub{
+				HubType: datastoreRef.Type,
+				HubId:   datastoreRef.Value,
+			})
+		} else {
+			// Otherwise we should get just the Datastores connected to our pool
+			cluster, err := pool.Owner(ctx)
+			if err != nil {
+				return nil, pkgerrors.Wrapf(err, "failed to get owning cluster of resourcepool %q to calculate datastore based on storage policy", pool)
+			}
+
+			dsList, err := object.NewComputeResource(vmCtx.Session.Client.Client, cluster.Reference()).Datastores(ctx)
+			if err != nil {
+				return nil, pkgerrors.Wrapf(err, "unable to list datastores from owning cluster of requested resourcepool")
+			}
+
+			var refs []types.ManagedObjectReference
+			for i := range dsList {
+				refs = append(refs, dsList[i].Reference())
+			}
+
+			var datastores []mo.Datastore
+			if err := property.DefaultCollector(vmCtx.Session.Client.Client).Retrieve(ctx, refs, []string{"summary"}, &datastores); err != nil {
+				return nil, pkgerrors.Wrapf(err, "unable to collect datastore properties to validate maintenance mode")
+			}
+
+			for _, ds := range datastores {
+				if ds.Summary.MaintenanceMode != string(types.DatastoreSummaryMaintenanceModeStateNormal) {
+					log.V(4).Info("datastore is in maintenance mode, skipping", "datastore", ds.Summary.Name)
+					continue
+				}
+
+				hubs = append(hubs, pbmTypes.PbmPlacementHub{
+					HubType: ds.Reference().Type,
+					HubId:   ds.Reference().Value,
+				})
+			}
+		}
+
+		var constraints []pbmTypes.BasePbmPlacementRequirement //nolint:prealloc
+		constraints = append(constraints, &pbmTypes.PbmPlacementCapabilityProfileRequirement{ProfileId: pbmTypes.PbmProfileId{UniqueId: storageProfileID}})
+		result, err := pbmClient.CheckRequirements(ctx, hubs, nil, constraints)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "unable to check requirements for storage policy")
+		}
+
+		if len(result.CompatibleDatastores()) == 0 {
+			return nil, fmt.Errorf("no compatible datastores found for storage policy: %s", vmCtx.VSphereVM.Spec.StoragePolicyName)
+		}
+
+		// If datastoreRef is nil here it means that the user didn't specify a Datastore. So we should
+		// select one of the datastores of the owning cluster of the resource pool that matched the
+		// requirements of the storage policy.
+		if datastoreRef == nil {
+			r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // We won't need cryptographically secure randomness here.
+			ds := result.CompatibleDatastores()[r.Intn(len(result.CompatibleDatastores()))]
+			datastoreRef = &types.ManagedObjectReference{Type: ds.HubType, Value: ds.HubId}
+		}
+	}
+
+	// if datastoreRef is nil here, means that user didn't specified a datastore NOR a
+	// storagepolicy, so we should select the default
+	if datastoreRef == nil {
+		// if no datastore defined through VM spec or storage policy, use default
+		datastore, err := vmCtx.Session.Finder.DefaultDatastore(ctx)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "unable to get default datastore for %q", vmCtx)
+		}
+		datastoreRef = types.NewReference(datastore.Reference())
+	}
+
+	return datastoreRef, nil
 }
 
 func newVMFlagInfo() *types.VirtualMachineFlagInfo {


### PR DESCRIPTION
**What this PR does / why we need it:**

Right now `FindTemplate` just resolves a template by name/UUID and clones from wherever it lives — even if that's on a totally different datastore than the failure domain we're cloning into. For full clones that means copying the whole disk across the storage fabric for every Machine, every time.

This adds an alpha gate, `TemplateAutoReplicate` (off by default), that prefers a local copy of the template on the target datastore if one's already there, and kicks off a background clone to create one if not (the current Machine still clones from wherever the template is in the meantime, so nothing blocks on it).

- `FindTemplate` takes a pool/datastore now. Gate off (or no datastore given), existing behaviour is retained.
- New `template/replicator` package does the actual background clone, coordinated through a ConfigMap lock, so concurrent Machines targeting the same template+datastore don't race and clone twice.
- `vcenter.Clone` resolves the datastore earlier than before so it can pass it into `FindTemplate`.

Fixes #4128