### PR TITLE
🐛 Scope policies immutability CEL to VSphereMachine

### DIFF
--- a/api/supervisor/v1beta1/vspheremachine_types.go
+++ b/api/supervisor/v1beta1/vspheremachine_types.go
@@ -38,7 +38,6 @@ type VSphereMachineVolume struct {
 }
 
 // VSphereMachineSpec defines the desired state of VSphereMachine.
-// +kubebuilder:validation:XValidation:rule="has(self.policies) == has(oldSelf.policies) && (!has(self.policies) || self.policies == oldSelf.policies)",message="policies are immutable after creation"
 type VSphereMachineSpec struct {
 	// providerID is the virtual machine's BIOS UUID formatted as
 	// vsphere://12345678-1234-1234-1234-123456789abc.
@@ -435,6 +434,7 @@ type VSphereMachineV1Beta2Status struct {
 // +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".spec.failureDomain",description="Zone"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="IPAddr",type="string",JSONPath=".status.vmIp",description="IP address"
+// +kubebuilder:validation:XValidation:rule="has(self.spec.policies) == has(oldSelf.spec.policies) && (!has(self.spec.policies) || self.spec.policies == oldSelf.spec.policies)",message="policies are immutable after creation"
 type VSphereMachine struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/api/supervisor/v1beta2/vspheremachine_types.go
+++ b/api/supervisor/v1beta2/vspheremachine_types.go
@@ -47,7 +47,6 @@ type VSphereMachineVolume struct {
 }
 
 // VSphereMachineSpec defines the desired state of VSphereMachine.
-// +kubebuilder:validation:XValidation:rule="has(self.policies) == has(oldSelf.policies) && (!has(self.policies) || self.policies == oldSelf.policies)",message="policies are immutable after creation"
 type VSphereMachineSpec struct {
 	// providerID is the virtual machine's BIOS UUID formatted as
 	// vsphere://12345678-1234-1234-1234-123456789abc
@@ -494,6 +493,7 @@ type VLANSpec struct {
 // +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="VSphereMachine is provisioned"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="VSphereMachine phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of VSphereMachine"
+// +kubebuilder:validation:XValidation:rule="has(self.spec.policies) == has(oldSelf.spec.policies) && (!has(self.spec.policies) || self.spec.policies == oldSelf.spec.policies)",message="policies are immutable after creation"
 type VSphereMachine struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -438,10 +438,6 @@ spec:
             - className
             - imageName
             type: object
-            x-kubernetes-validations:
-            - message: policies are immutable after creation
-              rule: has(self.policies) == has(oldSelf.policies) && (!has(self.policies)
-                || self.policies == oldSelf.policies)
           status:
             description: status is the observed state of VSphereMachine.
             properties:
@@ -914,6 +910,10 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: policies are immutable after creation
+          rule: has(self.spec.policies) == has(oldSelf.spec.policies) && (!has(self.spec.policies)
+            || self.spec.policies == oldSelf.spec.policies)
     served: true
     storage: false
     subresources:
@@ -1382,10 +1382,6 @@ spec:
             - className
             - imageName
             type: object
-            x-kubernetes-validations:
-            - message: policies are immutable after creation
-              rule: has(self.policies) == has(oldSelf.policies) && (!has(self.policies)
-                || self.policies == oldSelf.policies)
           status:
             description: status is the observed state of VSphereMachine.
             minProperties: 1
@@ -1906,6 +1902,10 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: policies are immutable after creation
+          rule: has(self.spec.policies) == has(oldSelf.spec.policies) && (!has(self.spec.policies)
+            || self.spec.policies == oldSelf.spec.policies)
     served: true
     storage: true
     subresources:

--- a/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/supervisor/crd/bases/vmware.infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -435,10 +435,6 @@ spec:
                     - className
                     - imageName
                     type: object
-                    x-kubernetes-validations:
-                    - message: policies are immutable after creation
-                      rule: has(self.policies) == has(oldSelf.policies) && (!has(self.policies)
-                        || self.policies == oldSelf.policies)
                 required:
                 - spec
                 type: object
@@ -934,10 +930,6 @@ spec:
                     - className
                     - imageName
                     type: object
-                    x-kubernetes-validations:
-                    - message: policies are immutable after creation
-                      rule: has(self.policies) == has(oldSelf.policies) && (!has(self.policies)
-                        || self.policies == oldSelf.policies)
                 type: object
             required:
             - template

--- a/controllers/vmware/test/controllers_test.go
+++ b/controllers/vmware/test/controllers_test.go
@@ -638,7 +638,7 @@ var _ = Describe("Reconciliation tests", func() {
 			})
 			err = k8sClient.Update(ctx, machineTemplate)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("policies are immutable after creation"))
+			Expect(err.Error()).To(ContainSubstring("VSphereMachineTemplate spec.template.spec field is immutable"))
 		},
 		Entry("With no load balancer", dontUseLoadBalancer),
 		Entry("With load balancer", useLoadBalancer),


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The policies immutability rule lived on VSphereMachineSpec, so it also applied to VSphereMachineTemplate. CAPI topology SSA dry-run updates the existing template before creating a new one, which blocked day-2 cluster updates that add, change, or remove policies. Move the CEL rule to the VSphereMachine root type so only machines stay immutable after create.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
