### PR TITLE
🐛 Default value for graceful shutdown timeout

### DIFF
--- a/pkg/services/govmomi/power.go
+++ b/pkg/services/govmomi/power.go
@@ -68,7 +68,7 @@ func (vms *VMService) isSoftPowerOffTimeoutExceeded(vm *infrav1.VSphereVM) bool 
 	if vm.Spec.GuestSoftPowerOffTimeoutSeconds != 0 {
 		timeout = time.Duration(vm.Spec.GuestSoftPowerOffTimeoutSeconds) * time.Second
 	} else {
-		timeout = infrav1.GuestSoftPowerOffDefaultTimeoutSeconds
+		timeout = infrav1.GuestSoftPowerOffDefaultTimeoutSeconds * time.Second
 	}
 	return timeout.Seconds() > 0 && diff.Seconds() >= timeout.Seconds()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The guestSoftPowerOffTimeoutSeconds value defaults to 300ns instead of 300s causing the trySoft mode of graceful shutdown to immediately timeout and cause a hard shutdown.

This commit fixes that to the correct 300s value.

Fixes #4156
