### PR TITLE
(POC, not for official review) feat: add host maintenance mode POC behind HostMaintenanceMode feature gate

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -87,6 +87,12 @@ const (
 	//
 	// alpha: v1.17
 	VLANSubinterface featuregate.Feature = "VLANSubinterface"
+
+	// HostMaintenanceMode is a feature gate for host maintenance mode handling in CAPV.
+	// When enabled, CAPV pauses CAPI Machines during host maintenance and handles recovery upon power-on.
+	//
+	// alpha: v1.17
+	HostMaintenanceMode featuregate.Feature = "HostMaintenanceMode"
 )
 
 var (
@@ -104,6 +110,7 @@ var (
 		NodeAutoPlacement:      {Default: false, PreRelease: featuregate.Alpha},
 		ClusterNetworkProvider: {Default: false, PreRelease: featuregate.Alpha},
 		MultiNetworks:          {Default: false, PreRelease: featuregate.Alpha},
+		HostMaintenanceMode:    {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	supervisorVersionedGates = map[featuregate.Feature]featuregate.VersionedSpecs{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -50,6 +50,13 @@ const (
 	// cluster are in maintenance mode.
 	MaintenanceAnnotationLabel = "capv." + infrav1.GroupName + "/maintenance"
 
+	// PausedForHostMMTrackingAnnotation is the tracking annotation applied by CAPV on
+	// a CAPI Machine when paused due to host maintenance mode.
+	PausedForHostMMTrackingAnnotation = "capv." + infrav1.GroupName + "/paused-for-host-mmode"
+
+	// HostInMaintenanceReason is the reason set on conditions when host maintenance is active.
+	HostInMaintenanceReason = "HostInMaintenance"
+
 	// NodeLabelPrefix is the prefix for node labels.
 	NodeLabelPrefix = "node.cluster.x-k8s.io"
 

--- a/pkg/services/vmoperator/vmopmachine.go
+++ b/pkg/services/vmoperator/vmopmachine.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -42,6 +44,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
@@ -144,6 +147,13 @@ func (v *VmopMachineService) ReconcileDelete(ctx context.Context, machineCtx cap
 	// Next, check to see if it's in the process of being deleted
 	if vmOperatorVM.GetDeletionTimestamp() != nil {
 		supervisorMachineCtx.VSphereMachine.Status.Phase = vmwarev1.VSphereMachinePhaseDeleting
+		return nil
+	}
+
+	// When HostMaintenanceMode feature gate is enabled, skip VM deletion if the VM is in host maintenance mode.
+	if feature.Gates.Enabled(feature.HostMaintenanceMode) && isInfraInMaintenance(vmOperatorVM) {
+		log.Info("VirtualMachine is in host maintenance mode (InfraInMaintenance), skipping deletion to protect VM state",
+			"virtualMachine", klog.KObj(vmOperatorVM), "vsphereMachine", klog.KObj(supervisorMachineCtx.VSphereMachine))
 		return nil
 	}
 
@@ -355,6 +365,13 @@ func (v *VmopMachineService) ReconcileNormal(ctx context.Context, machineCtx cap
 		})
 		// TODO: what to do if AlreadyExists error
 		return false, err
+	}
+
+	// Evaluate Host Maintenance Mode pausing and unpausing if feature gate is enabled.
+	if vmOperatorVM.ResourceVersion != "" {
+		if isPaused, err := v.reconcileHostMaintenanceMode(ctx, supervisorMachineCtx, vmOperatorVM); err != nil || isPaused {
+			return isPaused, err
+		}
 	}
 
 	// Update the VM's state to Pending
@@ -1054,4 +1071,127 @@ func (v *VmopMachineService) checkVirtualMachineGroupMembership(vmOperatorVMGrou
 		}
 	}
 	return false
+}
+
+const (
+	// UnpauseTimeoutForHostMM is the maximum boot grace period (5 minutes) after VM power-on before forcing unpause.
+	UnpauseTimeoutForHostMM = 5 * time.Minute
+)
+
+// isInfraInMaintenance returns true if the VirtualMachine's PowerStateSynced condition
+// is False with Reason "InfraInMaintenance".
+func isInfraInMaintenance(vm *vmoprvhub.VirtualMachine) bool {
+	if vm == nil {
+		return false
+	}
+	c := meta.FindStatusCondition(vm.Status.Conditions, vmoprvhub.VirtualMachinePowerStateSynced)
+	return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "InfraInMaintenance"
+}
+
+// reconcileHostMaintenanceMode evaluates whether the VirtualMachine is in host maintenance mode
+// and manages pausing or unpausing the parent CAPI Machine. Returns (isPaused, error).
+func (v *VmopMachineService) reconcileHostMaintenanceMode(
+	ctx context.Context,
+	supervisorMachineCtx *vmware.SupervisorMachineContext,
+	vm *vmoprvhub.VirtualMachine,
+) (bool, error) {
+	if !feature.Gates.Enabled(feature.HostMaintenanceMode) || supervisorMachineCtx.Machine == nil {
+		return false, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	machine := supervisorMachineCtx.Machine
+
+	inMaintenance := isInfraInMaintenance(vm)
+
+	// Case 1: VirtualMachine is currently in host maintenance mode.
+	if inMaintenance {
+		log.Info("VirtualMachine is in host maintenance mode (InfraInMaintenance), ensuring CAPI Machine is paused",
+			"virtualMachine", klog.KObj(vm), "machine", klog.KObj(machine))
+
+		patchHelper, err := patch.NewHelper(machine, v.Client)
+		if err != nil {
+			return false, pkgerrors.Wrap(err, "failed to create patch helper for CAPI Machine")
+		}
+
+		if machine.Annotations == nil {
+			machine.Annotations = map[string]string{}
+		}
+
+		machine.Annotations[constants.PausedForHostMMTrackingAnnotation] = "true"
+		machine.Annotations[clusterv1.PausedAnnotation] = "true"
+
+		if err := patchHelper.Patch(ctx, machine); err != nil {
+			return false, pkgerrors.Wrap(err, "failed to pause CAPI Machine for host maintenance mode")
+		}
+
+		conditions.Set(supervisorMachineCtx.VSphereMachine, metav1.Condition{
+			Type:    infrav1.VSphereMachineVirtualMachineProvisionedCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  constants.HostInMaintenanceReason,
+			Message: "VirtualMachine is in host maintenance mode (InfraInMaintenance)",
+		})
+		supervisorMachineCtx.VSphereMachine.Status.Phase = vmwarev1.VSphereMachinePhasePending
+
+		return true, nil
+	}
+
+	// Case 2: VirtualMachine recovered from host maintenance mode, but CAPI Machine is still paused by CAPV tracking annotation.
+	if machine.Annotations != nil && machine.Annotations[constants.PausedForHostMMTrackingAnnotation] == "true" {
+		shouldUnpause, reason := v.shouldUnpauseMachineForHostMM(ctx, supervisorMachineCtx, vm)
+		if !shouldUnpause {
+			log.Info("VirtualMachine recovered from maintenance mode, waiting for Node reconnection or 5-minute boot grace period before unpausing",
+				"machine", klog.KObj(machine))
+			return true, nil
+		}
+
+		log.Info("Unpausing CAPI Machine post host maintenance recovery",
+			"machine", klog.KObj(machine), "reason", reason)
+
+		patchHelper, err := patch.NewHelper(machine, v.Client)
+		if err != nil {
+			return false, pkgerrors.Wrap(err, "failed to create patch helper for CAPI Machine")
+		}
+
+		delete(machine.Annotations, constants.PausedForHostMMTrackingAnnotation)
+		delete(machine.Annotations, clusterv1.PausedAnnotation)
+
+		if err := patchHelper.Patch(ctx, machine); err != nil {
+			return false, pkgerrors.Wrap(err, "failed to unpause CAPI Machine post host maintenance mode")
+		}
+	}
+
+	return false, nil
+}
+
+// shouldUnpauseMachineForHostMM implements the Dual-Trigger Unpause Safeguard.
+func (v *VmopMachineService) shouldUnpauseMachineForHostMM(
+	ctx context.Context,
+	supervisorMachineCtx *vmware.SupervisorMachineContext,
+	vm *vmoprvhub.VirtualMachine,
+) (bool, string) {
+	// Fast Path (Node Reconnection Guard):
+	// Check if Kubelet/Node has reconnected and reported Ready=True.
+	if nodeName := supervisorMachineCtx.Machine.Status.NodeRef.Name; nodeName != "" {
+		node := &corev1.Node{}
+		nodeKey := client.ObjectKey{Name: nodeName}
+		if err := v.Client.Get(ctx, nodeKey, node); err == nil {
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+					return true, "Node reconnected and reported Ready=True (Fast Path)"
+				}
+			}
+		}
+	}
+
+	// Fallback Path (Boot Grace Period / 5-min timeout):
+	// Check PowerStateSynced condition transition time when VM powered back on.
+	c := meta.FindStatusCondition(vm.Status.Conditions, vmoprvhub.VirtualMachinePowerStateSynced)
+	if c != nil && c.Status == metav1.ConditionTrue {
+		if time.Since(c.LastTransitionTime.Time) >= UnpauseTimeoutForHostMM {
+			return true, "5-minute Post-Power-On Boot Grace Period elapsed (Fallback Path)"
+		}
+	}
+
+	return false, ""
 }

--- a/pkg/services/vmoperator/vmopmachine_test.go
+++ b/pkg/services/vmoperator/vmopmachine_test.go
@@ -39,10 +39,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2"
 	vmwarev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/supervisor/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-vsphere/feature"
+	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/fake"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context/vmware"
 	vmoprvhub "sigs.k8s.io/cluster-api-provider-vsphere/pkg/conversion/api/vmoperator/hub"
@@ -1462,4 +1464,212 @@ func Test_getPolicies_FeatureGateDisabled(t *testing.T) {
 	}
 	got := getPolicies(sm)
 	NewWithT(t).Expect(got).To(BeNil())
+}
+
+func Test_HostMaintenanceMode(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	t.Run("isInfraInMaintenance returns true when condition PowerStateSynced is False with Reason InfraInMaintenance", func(t *testing.T) {
+		vm := &vmoprvhub.VirtualMachine{
+			Status: vmoprvhub.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmoprvhub.VirtualMachinePowerStateSynced,
+						Status: metav1.ConditionFalse,
+						Reason: "InfraInMaintenance",
+					},
+				},
+			},
+		}
+		g.Expect(isInfraInMaintenance(vm)).To(BeTrue())
+	})
+
+	t.Run("isInfraInMaintenance returns false when condition PowerStateSynced is True", func(t *testing.T) {
+		vm := &vmoprvhub.VirtualMachine{
+			Status: vmoprvhub.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmoprvhub.VirtualMachinePowerStateSynced,
+						Status: metav1.ConditionTrue,
+						Reason: "Synced",
+					},
+				},
+			},
+		}
+		g.Expect(isInfraInMaintenance(vm)).To(BeFalse())
+	})
+
+	t.Run("reconcileHostMaintenanceMode pauses machine when InfraInMaintenance and FeatureGate is enabled", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.HostMaintenanceMode, true)
+
+		scheme := runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
+		_ = vmwarev1.AddToScheme(scheme)
+		_ = clusterv1.AddToScheme(scheme)
+
+		machine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+		}
+		vsphereMachine := &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+		}
+
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(machine, vsphereMachine).Build()
+		vmService := VmopMachineService{Client: fakeClient}
+
+		smCtx := &vmware.SupervisorMachineContext{
+			BaseMachineContext: &capvcontext.BaseMachineContext{
+				Machine: machine,
+			},
+			VSphereMachine: vsphereMachine,
+		}
+
+		vm := &vmoprvhub.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-machine",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Status: vmoprvhub.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmoprvhub.VirtualMachinePowerStateSynced,
+						Status: metav1.ConditionFalse,
+						Reason: "InfraInMaintenance",
+					},
+				},
+			},
+		}
+
+		isPaused, err := vmService.reconcileHostMaintenanceMode(ctx, smCtx, vm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(isPaused).To(BeTrue())
+
+		// Verify Machine has tracking annotation and paused annotation.
+		updatedMachine := &clusterv1.Machine{}
+		err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-machine", Namespace: "default"}, updatedMachine)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedMachine.Annotations).To(HaveKeyWithValue("capv.infrastructure.cluster.x-k8s.io/paused-for-host-mmode", "true"))
+		g.Expect(updatedMachine.Annotations).To(HaveKeyWithValue("cluster.x-k8s.io/paused", "true"))
+	})
+
+	t.Run("reconcileHostMaintenanceMode unpauses machine when Node is Ready (Fast Path)", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.HostMaintenanceMode, true)
+
+		scheme := runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
+		_ = vmwarev1.AddToScheme(scheme)
+		_ = clusterv1.AddToScheme(scheme)
+
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		machine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"capv.infrastructure.cluster.x-k8s.io/paused-for-host-mmode": "true",
+					"cluster.x-k8s.io/paused":                                     "true",
+				},
+			},
+			Status: clusterv1.MachineStatus{
+				NodeRef: clusterv1.MachineNodeReference{Name: "test-node"},
+			},
+		}
+		vsphereMachine := &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+		}
+
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(node, machine, vsphereMachine).Build()
+		vmService := VmopMachineService{Client: fakeClient}
+
+		smCtx := &vmware.SupervisorMachineContext{
+			BaseMachineContext: &capvcontext.BaseMachineContext{Machine: machine},
+			VSphereMachine:     vsphereMachine,
+		}
+
+		vm := &vmoprvhub.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default", ResourceVersion: "2"},
+			Status: vmoprvhub.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               vmoprvhub.VirtualMachinePowerStateSynced,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Synced",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+
+		isPaused, err := vmService.reconcileHostMaintenanceMode(ctx, smCtx, vm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(isPaused).To(BeFalse())
+
+		// Verify annotations were removed.
+		updatedMachine := &clusterv1.Machine{}
+		err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-machine", Namespace: "default"}, updatedMachine)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updatedMachine.Annotations).ToNot(HaveKey("capv.infrastructure.cluster.x-k8s.io/paused-for-host-mmode"))
+		g.Expect(updatedMachine.Annotations).ToNot(HaveKey("cluster.x-k8s.io/paused"))
+	})
+
+	t.Run("ReconcileDelete skips deletion when InfraInMaintenance and FeatureGate is enabled", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, feature.HostMaintenanceMode, true)
+
+		scheme := runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
+		_ = vmwarev1.AddToScheme(scheme)
+		_ = clusterv1.AddToScheme(scheme)
+		_ = vmoprvhub.AddToScheme(scheme)
+
+		vsphereMachine := &vmwarev1.VSphereMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+			Spec:       vmwarev1.VSphereMachineSpec{},
+		}
+		machine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+		}
+		vm := &vmoprvhub.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+			Status: vmoprvhub.VirtualMachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   vmoprvhub.VirtualMachinePowerStateSynced,
+						Status: metav1.ConditionFalse,
+						Reason: "InfraInMaintenance",
+					},
+				},
+			},
+		}
+
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(machine, vsphereMachine, vm).Build()
+		vmService := VmopMachineService{Client: fakeClient}
+
+		smCtx := &vmware.SupervisorMachineContext{
+			BaseMachineContext: &capvcontext.BaseMachineContext{Machine: machine},
+			VSphereMachine:     vsphereMachine,
+		}
+
+		err := vmService.ReconcileDelete(ctx, smCtx)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify VirtualMachine was NOT deleted from client.
+		existingVM := &vmoprvhub.VirtualMachine{}
+		err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-machine", Namespace: "default"}, existingVM)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
 }


### PR DESCRIPTION
- Introduce HostMaintenanceMode feature gate in feature/feature.go
- Add tracking annotation and condition reason constants in pkg/constants
- Update VmopMachineService.ReconcileDelete to skip VM deletion when VM is in InfraInMaintenance
- Add reconcileHostMaintenanceMode to pause CAPI Machines during maintenance and implement dual-trigger unpause safeguard (NodeReconnectionGuard & 5-min BootGracePeriod)
- Add comprehensive unit tests in vmopmachine_test.go
 

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
